### PR TITLE
[ratelimiter] Add IP allowlist

### DIFF
--- a/common/ratelimit/limiter.go
+++ b/common/ratelimit/limiter.go
@@ -13,24 +13,31 @@ type rateLimiter struct {
 	globalRateParams common.GlobalRateParams
 
 	bucketStore BucketStore
+	allowlist   []string
 
 	logger common.Logger
 }
 
-func NewRateLimiter(rateParams common.GlobalRateParams, bucketStore BucketStore, logger common.Logger) common.RateLimiter {
+func NewRateLimiter(rateParams common.GlobalRateParams, bucketStore BucketStore, allowlist []string, logger common.Logger) common.RateLimiter {
 	return &rateLimiter{
 		globalRateParams: rateParams,
 		bucketStore:      bucketStore,
+		allowlist:        allowlist,
 		logger:           logger,
 	}
 }
 
 // Checks whether a request from the given requesterID is allowed
 func (d *rateLimiter) AllowRequest(ctx context.Context, requesterID common.RequesterID, blobSize uint, rate common.RateParam) (bool, error) {
+	for _, id := range d.allowlist {
+		if id == requesterID {
+			// Allow 10x the rate for allowlisted IDs
+			rate = rate * 10
+		}
+	}
 
 	// Retrieve bucket params for the requester ID
 	// This will be from dynamo for Disperser and from local storage for DA node
-
 	bucketParams, err := d.bucketStore.GetItem(ctx, requesterID)
 	if err != nil {
 

--- a/common/ratelimit/limiter_cli.go
+++ b/common/ratelimit/limiter_cli.go
@@ -15,12 +15,14 @@ const (
 	BucketMultipliersFlagName = "bucket-multipliers"
 	CountFailedFlagName       = "count-failed"
 	BucketStoreSizeFlagName   = "bucket-store-size"
+	AllowlistFlagName         = "allowlist"
 )
 
 type Config struct {
 	common.GlobalRateParams
 	BucketStoreSize  int
 	UniformRateParam common.RateParam
+	Allowlist        []string
 }
 
 func RatelimiterCLIFlags(envPrefix string, flagPrefix string) []cli.Flag {
@@ -51,6 +53,13 @@ func RatelimiterCLIFlags(envPrefix string, flagPrefix string) []cli.Flag {
 			Value:    1000,
 			EnvVar:   common.PrefixEnvVar(envPrefix, "BUCKET_STORE_SIZE"),
 			Required: false,
+		},
+		cli.StringSliceFlag{
+			Name:     common.PrefixFlag(flagPrefix, AllowlistFlagName),
+			Usage:    "Allowlist of IPs to bypass rate limiting",
+			EnvVar:   common.PrefixEnvVar(envPrefix, "ALLOWLIST"),
+			Required: false,
+			Value:    &cli.StringSlice{},
 		},
 	}
 }
@@ -97,6 +106,7 @@ func ReadCLIConfig(ctx *cli.Context, flagPrefix string) (Config, error) {
 	cfg.Multipliers = multipliers
 	cfg.GlobalRateParams.CountFailed = ctx.Bool(common.PrefixFlag(flagPrefix, CountFailedFlagName))
 	cfg.BucketStoreSize = ctx.Int(common.PrefixFlag(flagPrefix, BucketStoreSizeFlagName))
+	cfg.Allowlist = ctx.StringSlice(common.PrefixFlag(flagPrefix, AllowlistFlagName))
 
 	err := validateConfig(cfg)
 	if err != nil {

--- a/disperser/cmd/disperserserver/main.go
+++ b/disperser/cmd/disperserserver/main.go
@@ -109,7 +109,7 @@ func RunDisperserServer(ctx *cli.Context) error {
 				return err
 			}
 		}
-		ratelimiter = ratelimit.NewRateLimiter(globalParams, bucketStore, logger)
+		ratelimiter = ratelimit.NewRateLimiter(globalParams, bucketStore, config.RatelimiterConfig.Allowlist, logger)
 	}
 
 	// TODO: create a separate metrics for batcher

--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -80,7 +80,7 @@ func NodeMain(ctx *cli.Context) error {
 		return err
 	}
 
-	ratelimiter := ratelimit.NewRateLimiter(globalParams, bucketStore, logger)
+	ratelimiter := ratelimit.NewRateLimiter(globalParams, bucketStore, []string{}, logger)
 
 	// Creates the GRPC server.
 	server := grpc.NewServer(config, node, logger, ratelimiter)


### PR DESCRIPTION
## Why are these changes needed?
We can use this flag to manually add IPs that can be rate limited at 10x the setting. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
