### PR TITLE
Query the operator stake at current block number

### DIFF
--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -97,6 +97,7 @@ func RunDataApi(ctx *cli.Context) error {
 			sharedStorage,
 			promClient,
 			subgraphClient,
+			tx,
 			chainState,
 			logger,
 			metrics,

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
+
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi/docs"
 	"github.com/gin-contrib/cors"
@@ -79,6 +80,7 @@ type (
 		blobstore      disperser.BlobStore
 		promClient     PrometheusClient
 		subgraphClient SubgraphClient
+		transactor     core.Transactor
 		chainState     core.ChainState
 
 		metrics *Metrics
@@ -90,6 +92,7 @@ func NewServer(
 	blobstore disperser.BlobStore,
 	promClient PrometheusClient,
 	subgraphClient SubgraphClient,
+	transactor core.Transactor,
 	chainState core.ChainState,
 	logger common.Logger,
 	metrics *Metrics,
@@ -102,6 +105,7 @@ func NewServer(
 		blobstore:      blobstore,
 		promClient:     promClient,
 		subgraphClient: subgraphClient,
+		transactor:     transactor,
 		chainState:     chainState,
 		metrics:        metrics,
 	}

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -39,8 +39,9 @@ var (
 	subgraphClient         = dataapi.NewSubgraphClient(mockSubgraphApi)
 	config                 = dataapi.Config{ServerMode: "test", SocketAddr: ":8080"}
 
+	mockTx                          = &coremock.MockTransactor{}
 	mockChainState, _               = coremock.NewChainDataMock(core.OperatorIndex(1))
-	testDataApiServer               = dataapi.NewServer(config, blobstore, prometheusClient, subgraphClient, mockChainState, &commock.Logger{}, dataapi.NewMetrics("9001", &commock.Logger{}))
+	testDataApiServer               = dataapi.NewServer(config, blobstore, prometheusClient, subgraphClient, mockTx, mockChainState, &commock.Logger{}, dataapi.NewMetrics("9001", &commock.Logger{}))
 	expectedBatchHeaderHash         = [32]byte{1, 2, 3}
 	expectedBlobIndex               = uint32(1)
 	expectedRequestedAt             = uint64(5567830000000000000)
@@ -159,6 +160,7 @@ func TestFetchMetricsHandler(t *testing.T) {
 
 	matrix := make(model.Matrix, 0)
 	matrix = append(matrix, s)
+	mockTx.On("GetCurrentBlockNumber").Return(uint32(1), nil)
 	mockSubgraphApi.On("QueryBatches").Return(subgraphBatches, nil)
 	mockSubgraphApi.On("QueryOperators").Return(subgraphOperatorRegistereds, nil)
 	mockPrometheusApi.On("QueryRange").Return(matrix, nil, nil)


### PR DESCRIPTION
## Why are these changes needed?
The current code is buggy: it's using the block number when the operator registered to query the current stake, which is wrong.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
