### PR TITLE
[disperser] More security params validation

### DIFF
--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -81,7 +81,24 @@ func TestDisperseBlobWithInvalidQuorum(t *testing.T) {
 			},
 		},
 	})
-	assert.ErrorContains(t, err, "Invalid request: the quorum_id must be in range [0, 1], but found 2")
+	assert.ErrorContains(t, err, "invalid request: the quorum_id must be in range [0, 1], but found 2")
+
+	_, err = dispersalServer.DisperseBlob(ctx, &pb.DisperseBlobRequest{
+		Data: data,
+		SecurityParams: []*pb.SecurityParams{
+			{
+				QuorumId:           0,
+				AdversaryThreshold: 80,
+				QuorumThreshold:    100,
+			},
+			{
+				QuorumId:           0,
+				AdversaryThreshold: 50,
+				QuorumThreshold:    90,
+			},
+		},
+	})
+	assert.ErrorContains(t, err, "invalid request: security_params must not contain duplicate quorum_id")
 }
 
 func TestGetBlobStatus(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
- Length of security params should not exceed 255
- There shouldn't be any duplicate quorums in the list
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
