### PR TITLE
Add trusted proxies flag

### DIFF
--- a/common/ratelimit.go
+++ b/common/ratelimit.go
@@ -88,7 +88,7 @@ func GetClientAddressWithTrustedProxies(ctx context.Context, headerName string, 
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok || len(md.Get(headerName)) == 0 {
-		return "", fmt.Errorf("failed to get ip from header")
+		return "", fmt.Errorf("the header %s is not present in the request", headerName)
 	}
 
 	ips := md.Get(headerName)

--- a/common/ratelimit_test.go
+++ b/common/ratelimit_test.go
@@ -1,0 +1,29 @@
+package common_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/common"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestGetClientAddressWithTrustedProxies(t *testing.T) {
+
+	// Make test context
+	md := metadata.Pairs("x-forwarded-for", "proxy1", "x-forwarded-for", "proxy2", "x-forwarded-for", "proxy3")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		t.Fatal("failed to get metadata from context")
+	}
+	assert.Equal(t, []string{"proxy1", "proxy2", "proxy3"}, md.Get("x-forwarded-for"))
+
+	trustedProxies := map[string]struct{}{"proxy1": {}, "proxy2": {}}
+	ip, err := common.GetClientAddressWithTrustedProxies(ctx, "x-forwarded-for", trustedProxies)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "proxy3", ip)
+
+}

--- a/disperser/apiserver/rate_config.go
+++ b/disperser/apiserver/rate_config.go
@@ -55,7 +55,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 		cli.StringSliceFlag{
 			Name:     TrustedProxiesFlagname,
 			Usage:    "The trusted proxies that the request has been forwarded through. If non-empty, the disperser will pull the request IP from the first non-trusted proxy address in the header, reading from right to left.",
-			Required: true,
+			Required: false,
 			EnvVar:   common.PrefixEnvVar(envPrefix, "TRUSTED_PROXIES"),
 		},
 	}

--- a/disperser/apiserver/rate_config.go
+++ b/disperser/apiserver/rate_config.go
@@ -11,6 +11,7 @@ const (
 	TotalUnauthThroughputFlagName   = "auth.total-unauth-throughput"
 	PerUserUnauthThroughputFlagName = "auth.per-user-unauth-throughput"
 	ClientIPHeaderFlagName          = "auth.client-ip-header"
+	TrustedProxiesFlagname          = "auth.trusted-proxies"
 )
 
 type QuorumRateInfo struct {
@@ -21,6 +22,7 @@ type QuorumRateInfo struct {
 type RateConfig struct {
 	QuorumRateInfos map[core.QuorumID]QuorumRateInfo
 	ClientIPHeader  string
+	TruxtedProxies  map[string]struct{}
 }
 
 func CLIFlags(envPrefix string) []cli.Flag {
@@ -45,15 +47,26 @@ func CLIFlags(envPrefix string) []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:     ClientIPHeaderFlagName,
-			Usage:    "The name of the header used to get the client IP address. If set to empty string, the IP address will be taken from the connection. The rightmost value of the header will be used. For AWS, this should be set to 'x-forwarded-for'.",
+			Usage:    "The name of the header used to get the client IP address. If set to empty string, the IP address will be taken from the connection. The rightmost value of the header will be used, unless a list of trusted proxies is provided. For AWS, this should be set to 'x-forwarded-for'.",
 			Required: false,
 			Value:    "",
 			EnvVar:   common.PrefixEnvVar(envPrefix, "CLIENT_IP_HEADER"),
+		},
+		cli.StringSliceFlag{
+			Name:     TrustedProxiesFlagname,
+			Usage:    "The trusted proxies that the request has been forwarded through. If non-empty, the disperser will pull the request IP from the first non-trusted proxy address in the header, reading from right to left.",
+			Required: true,
+			EnvVar:   common.PrefixEnvVar(envPrefix, "TRUSTED_PROXIES"),
 		},
 	}
 }
 
 func ReadCLIConfig(c *cli.Context) RateConfig {
+
+	trustedProxies := make(map[string]struct{})
+	for _, proxy := range c.StringSlice(TrustedProxiesFlagname) {
+		trustedProxies[proxy] = struct{}{}
+	}
 
 	quorumRateInfos := make(map[core.QuorumID]QuorumRateInfo)
 	for ind, quorumID := range c.IntSlice(RegisteredQuorumFlagName) {
@@ -67,5 +80,6 @@ func ReadCLIConfig(c *cli.Context) RateConfig {
 	return RateConfig{
 		QuorumRateInfos: quorumRateInfos,
 		ClientIPHeader:  c.String(ClientIPHeaderFlagName),
+		TruxtedProxies:  trustedProxies,
 	}
 }

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -105,7 +105,7 @@ func (s *DispersalServer) DisperseBlob(ctx context.Context, req *pb.DisperseBlob
 
 	blob := getBlobFromRequest(req)
 
-	origin, err := common.GetClientAddress(ctx, s.rateConfig.ClientIPHeader)
+	origin, err := common.GetClientAddressWithTrustedProxies(ctx, s.rateConfig.ClientIPHeader, s.rateConfig.TruxtedProxies)
 	if err != nil {
 		for _, param := range securityParams {
 			quorumId := string(uint8(param.GetQuorumId()))


### PR DESCRIPTION
## Why are these changes needed?

Adds an option to provide a list of trusted proxies. This may be needed when we switch to cloudfare.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
