### PR TITLE
Fix encoded blob size accounting

### DIFF
--- a/disperser/batcher/encoded_blob_store.go
+++ b/disperser/batcher/encoded_blob_store.go
@@ -97,9 +97,12 @@ func (e *encodedBlobStore) PutEncodingResult(result *EncodingResult) error {
 		return fmt.Errorf("PutEncodedBlob: no such key (%s) in requested set", requestID)
 	}
 
+	if _, ok := e.encoded[requestID]; !ok {
+		e.encodedResultSize += getChunksSize(result)
+	}
 	e.encoded[requestID] = result
 	delete(e.requested, requestID)
-	e.encodedResultSize += getChunksSize(result)
+	e.logger.Trace("[PutEncodingResult]", "referenceBlockNumber", result.ReferenceBlockNumber, "requestID", requestID, "encodedSize", e.encodedResultSize)
 
 	return nil
 }
@@ -132,7 +135,7 @@ func (e *encodedBlobStore) GetNewAndDeleteStaleEncodingResults(blockNumber uint)
 			fetched = append(fetched, encodedResult)
 		}
 	}
-	e.logger.Trace("consumed encoded results", "fetched", len(fetched), "stale", staleCount, "blockNumber", blockNumber)
+	e.logger.Trace("consumed encoded results", "fetched", len(fetched), "stale", staleCount, "blockNumber", blockNumber, "encodedSize", e.encodedResultSize)
 
 	return fetched
 }


### PR DESCRIPTION
## Why are these changes needed?
As we added retry mechanism, a given blob can be encoded multiple times across different blocks. 
`encodedResultSize` should be updated accordingly such that we only add to `encodedResultSize` when we add a blob for a new request ID. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
