### PR TITLE
Update metrics

### DIFF
--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -92,7 +92,7 @@ func (a *StdSignatureAggregator) AggregateSignatures(state *IndexedOperatorState
 			socket = op.Socket
 		}
 		if r.Err != nil {
-			a.Logger.Warn("Error returned from messageChan", "operator", operatorIDHex, "socket", socket, "err", r.Err)
+			a.Logger.Warn("[AggregateSignatures] error returned from messageChan", "operator", operatorIDHex, "socket", socket, "err", r.Err)
 			continue
 		}
 
@@ -109,6 +109,8 @@ func (a *StdSignatureAggregator) AggregateSignatures(state *IndexedOperatorState
 			a.Logger.Error("Signature is not valid", "operator", operatorIDHex, "socket", socket, "pubkey", hexutil.Encode(op.PubkeyG2.Serialize()))
 			continue
 		}
+
+		a.Logger.Info("[AggregateSignatures] received signature from operator", "operator", operatorIDHex, "socket", socket)
 
 		for ind, id := range quorumIDs {
 

--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/common/logging"
 	cmock "github.com/Layr-Labs/eigenda/common/mock"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/encoding"
@@ -63,14 +64,15 @@ func makeTestBlob(securityParams []*core.SecurityParam) core.Blob {
 
 func makeBatcher(t *testing.T) (*batcherComponents, *bat.Batcher) {
 	// Common Components
-	logger := &cmock.Logger{}
+	logger, err := logging.GetLogger(logging.DefaultCLIConfig())
+	assert.NoError(t, err)
 
 	// Core Components
 	cst, err := coremock.NewChainDataMock(10)
 	assert.NoError(t, err)
 	cst.On("GetCurrentBlockNumber").Return(uint(10), nil)
 	asgn := &core.StdAssignmentCoordinator{}
-	agg := &core.StdSignatureAggregator{}
+	agg := core.NewStdSignatureAggregator(logger)
 	enc, err := makeTestEncoder()
 	assert.NoError(t, err)
 

--- a/disperser/batcher/encoded_blob_store.go
+++ b/disperser/batcher/encoded_blob_store.go
@@ -102,7 +102,6 @@ func (e *encodedBlobStore) PutEncodingResult(result *EncodingResult) error {
 	}
 	e.encoded[requestID] = result
 	delete(e.requested, requestID)
-	e.logger.Trace("[PutEncodingResult]", "referenceBlockNumber", result.ReferenceBlockNumber, "requestID", requestID, "encodedSize", e.encodedResultSize)
 
 	return nil
 }

--- a/node/grpc/server_load_test.go
+++ b/node/grpc/server_load_test.go
@@ -93,8 +93,9 @@ func TestStoreChunks(t *testing.T) {
 		numTotalChunks += len(blobMessagesByOp[opID][i].Bundles[0])
 	}
 	t.Logf("Batch numTotalChunks: %d", numTotalChunks)
-	req, err := dispatcher.GetStoreChunksRequest(blobMessagesByOp[opID], batchHeader)
+	req, totalSize, err := dispatcher.GetStoreChunksRequest(blobMessagesByOp[opID], batchHeader)
 	assert.NoError(t, err)
+	assert.Equal(t, 50790400, totalSize)
 
 	timer := time.Now()
 	reply, err := server.StoreChunks(context.Background(), req)


### PR DESCRIPTION
## Why are these changes needed?
Updating metrics in several places.

Batcher: 
- separate metrics for different blob status
- removed failed batch count (now that failure is at the blob level, marking the whole batch as failed doesn't make sense)
- fixed the # of signers

Attestation:
- log total size of data dispersed to each operator
- log when batcher receives a signature from an operator

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
