### PR TITLE
Use existing context when submitting transaction

### DIFF
--- a/common/ethclient.go
+++ b/common/ethclient.go
@@ -39,5 +39,5 @@ type EthClient interface {
 	TransactionInBlock(ctx context.Context, blockHash common.Hash, index uint) (*types.Transaction, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	EstimateGasPriceAndLimitAndSendTx(ctx context.Context, tx *types.Transaction, tag string, value *big.Int) (*types.Receipt, error)
-	EnsureTransactionEvaled(tx *types.Transaction, tag string) (*types.Receipt, error)
+	EnsureTransactionEvaled(ctx context.Context, tx *types.Transaction, tag string) (*types.Receipt, error)
 }

--- a/common/geth/client.go
+++ b/common/geth/client.go
@@ -180,6 +180,7 @@ func (c *EthClient) EstimateGasPriceAndLimitAndSendTx(
 	}
 
 	receipt, err := c.EnsureTransactionEvaled(
+		ctx,
 		tx,
 		tag,
 	)
@@ -190,8 +191,8 @@ func (c *EthClient) EstimateGasPriceAndLimitAndSendTx(
 	return receipt, err
 }
 
-func (c *EthClient) EnsureTransactionEvaled(tx *types.Transaction, tag string) (*types.Receipt, error) {
-	receipt, err := bind.WaitMined(context.Background(), c.Client, tx)
+func (c *EthClient) EnsureTransactionEvaled(ctx context.Context, tx *types.Transaction, tag string) (*types.Receipt, error) {
+	receipt, err := bind.WaitMined(ctx, c.Client, tx)
 	if err != nil {
 		return nil, fmt.Errorf("EnsureTransactionEvaled: failed to wait for transaction (%s) to mine: %w", tag, err)
 	}

--- a/common/geth/instrumented_client.go
+++ b/common/geth/instrumented_client.go
@@ -550,6 +550,7 @@ func (c *InstrumentedEthClient) EstimateGasPriceAndLimitAndSendTx(
 	}
 
 	receipt, err := c.EnsureTransactionEvaled(
+		ctx,
 		tx,
 		tag,
 	)

--- a/common/mock/ethclient.go
+++ b/common/mock/ethclient.go
@@ -187,7 +187,7 @@ func (mock *MockEthClient) EstimateGasPriceAndLimitAndSendTx(ctx context.Context
 	return result.(*types.Receipt), args.Error(1)
 }
 
-func (mock *MockEthClient) EnsureTransactionEvaled(tx *types.Transaction, tag string) (*types.Receipt, error) {
+func (mock *MockEthClient) EnsureTransactionEvaled(ctx context.Context, tx *types.Transaction, tag string) (*types.Receipt, error) {
 	args := mock.Called()
 	result := args.Get(0)
 	return result.(*types.Receipt), args.Error(1)

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -448,7 +448,7 @@ func (t *Transactor) ConfirmBatch(ctx context.Context, batchHeader core.BatchHea
 	}
 
 	t.Logger.Info("confirming batch onchain")
-	receipt, err := t.EthClient.EstimateGasPriceAndLimitAndSendTx(context.Background(), tx, "ConfirmBatch", nil)
+	receipt, err := t.EthClient.EstimateGasPriceAndLimitAndSendTx(ctx, tx, "ConfirmBatch", nil)
 	if err != nil {
 		t.Logger.Error("Failed to estimate gas price and limit", "err", err)
 		return nil, err

--- a/disperser/eth/confirmer_test.go
+++ b/disperser/eth/confirmer_test.go
@@ -39,7 +39,7 @@ func TestConfirmerTimeout(t *testing.T) {
 	tx := coremock.MockTransactor{}
 	confirmer, err := eth.NewBatchConfirmer(&tx, 100*time.Millisecond)
 	assert.Nil(t, err)
-	tx.On("ConfirmBatch").Return(nil, context.DeadlineExceeded)
+	tx.On("ConfirmBatch").Return(nil, fmt.Errorf("EnsureTransactionEvaled: failed to wait for transaction (%s) to mine: %w", "123", context.DeadlineExceeded)).Once()
 	_, err = confirmer.ConfirmBatch(context.Background(), &core.BatchHeader{
 		ReferenceBlockNumber: 100,
 		BatchRoot:            [32]byte{},


### PR DESCRIPTION
## Why are these changes needed?
Making `EnsureTransactionEvaled` use context passed in from the caller, so that it can be timed out
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
