### PR TITLE
Sort blobs feed by batchID/BlobIndex and return Cost in Gas instead of WEI

### DIFF
--- a/disperser/dataapi/blobs_handlers.go
+++ b/disperser/dataapi/blobs_handlers.go
@@ -40,6 +40,14 @@ func (s *server) convertBlobMetadatasToBlobMetadataResponse(ctx context.Context,
 		err               error
 		responseMetadatas = make([]*BlobMetadataResponse, len(metadatas))
 	)
+
+	sort.SliceStable(metadatas, func(i, j int) bool {
+		if metadatas[i].ConfirmationInfo.BatchID != metadatas[j].ConfirmationInfo.BatchID {
+			return metadatas[i].ConfirmationInfo.BatchID < metadatas[j].ConfirmationInfo.BatchID
+		}
+		return metadatas[i].ConfirmationInfo.BlobIndex < metadatas[j].ConfirmationInfo.BlobIndex
+	})
+
 	for i := range metadatas {
 		responseMetadatas[i], err = convertMetadataToBlobMetadataResponse(metadatas[i])
 		if err != nil {
@@ -47,13 +55,6 @@ func (s *server) convertBlobMetadatasToBlobMetadataResponse(ctx context.Context,
 		}
 	}
 
-	sort.SliceStable(responseMetadatas, func(i, j int) bool {
-		if responseMetadatas[i].ConfirmationBlockNumber !=
-			responseMetadatas[j].ConfirmationBlockNumber {
-			return responseMetadatas[i].ConfirmationBlockNumber < responseMetadatas[j].ConfirmationBlockNumber
-		}
-		return responseMetadatas[i].RequestAt < responseMetadatas[j].RequestAt
-	})
 	return responseMetadatas, nil
 }
 

--- a/disperser/dataapi/metrics_handlers.go
+++ b/disperser/dataapi/metrics_handlers.go
@@ -128,7 +128,7 @@ func (s *server) calculateTotalCostGasUsed(ctx context.Context) (float64, error)
 
 	var (
 		totalBlobSize  uint
-		totalCostInWei float64
+		totalGasUsed float64
 		batch          = batches[0]
 	)
 
@@ -153,9 +153,9 @@ func (s *server) calculateTotalCostGasUsed(ctx context.Context) (float64, error)
 	}
 
 	if uint64(totalBlobSize) > 0 {
-		totalCostInWei = float64(batch.GasFees.GasUsed) / float64(totalBlobSize)
+		totalGasUsed = float64(batch.GasFees.GasUsed) / float64(totalBlobSize)
 	}
-	return totalCostInWei, nil
+	return totalGasUsed, nil
 }
 
 func calculateAverageThroughput(values []*PrometheusResultValues, windowSize int64) []*Throughput {

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -50,7 +50,7 @@ type (
 
 	Metric struct {
 		Throughput float64 `json:"throughput"`
-		CostInWei  uint64  `json:"cost_in_wei"`
+		CostInGas  float64 `json:"cost_in_gas"`
 		TotalStake uint64  `json:"total_stake"`
 	}
 

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -184,7 +184,7 @@ func TestFetchMetricsHandler(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, 16555.555555555555, response.Throughput)
-	assert.Equal(t, uint64(85144853442), response.CostInWei)
+	assert.Equal(t, float64(85.14485344239945), response.CostInGas)
 	assert.Equal(t, uint64(6), response.TotalStake)
 }
 


### PR DESCRIPTION
## Why are these changes needed?

- Blob feed ordering by <BatchID, BlobIndex>
- Gas cost on blob explorer (gas/byte, not wei/byte)

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
