### PR TITLE
Compute the stake by quorums

### DIFF
--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -112,17 +112,41 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 
 	}
 
-	totals := make(map[core.QuorumID]*core.OperatorInfo)
-	for _, id := range quorums {
-		totals[id] = &core.OperatorInfo{
+	totals := map[core.QuorumID]*core.OperatorInfo{
+		0: {
 			Stake: big.NewInt(int64(quorumStake)),
 			Index: d.NumOperators,
+		},
+		1: {
+			Stake: big.NewInt(int64(quorumStake)),
+			Index: d.NumOperators,
+		},
+		2: {
+			Stake: big.NewInt(int64(quorumStake)),
+			Index: d.NumOperators,
+		},
+	}
+
+	if len(quorums) > 0 {
+		totals = make(map[core.QuorumID]*core.OperatorInfo)
+		for _, id := range quorums {
+			totals[id] = &core.OperatorInfo{
+				Stake: big.NewInt(int64(quorumStake)),
+				Index: d.NumOperators,
+			}
 		}
 	}
 
-	operators := make(map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo)
-	for _, id := range quorums {
-		operators[id] = storedOperators
+	operators := map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo{
+		0: storedOperators,
+		1: storedOperators,
+		2: storedOperators,
+	}
+	if len(quorums) > 0 {
+		operators = make(map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo)
+		for _, id := range quorums {
+			operators[id] = storedOperators
+		}
 	}
 
 	operatorState := &core.OperatorState{

--- a/disperser/dataapi/metrics_handlers.go
+++ b/disperser/dataapi/metrics_handlers.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/gammazero/workerpool"
+	"github.com/Layr-Labs/eigenda/core"
 )
 
 const (
@@ -17,18 +17,20 @@ const (
 )
 
 func (s *server) getMetric(ctx context.Context, startTime int64, endTime int64, limit int) (*Metric, error) {
-	operators, err := s.subgraphClient.QueryOperatorsWithLimit(ctx, limit)
-	if err != nil {
-		return nil, err
-	}
-
 	blockNumber, err := s.transactor.GetCurrentBlockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current block number: %w", err)
 	}
-	totalStake, err := s.calculateTotalStake(operators, blockNumber)
+	operatorState, err := s.chainState.GetOperatorState(ctx, uint(blockNumber), []core.QuorumID{core.QuorumID(0)})
 	if err != nil {
 		return nil, err
+	}
+	if len(operatorState.Operators) != 1 {
+		return nil, fmt.Errorf("Requesting for one quorum (quorumID=0), but got %v", operatorState.Operators)
+	}
+	totalStake := big.NewInt(0)
+	for _, op := range operatorState.Operators[0] {
+		totalStake.Add(totalStake, op.Stake)
 	}
 
 	result, err := s.promClient.QueryDisperserBlobSizeBytesPerSecond(ctx, time.Unix(startTime, 0), time.Unix(endTime, 0))
@@ -56,7 +58,7 @@ func (s *server) getMetric(ctx context.Context, startTime int64, endTime int64, 
 	return &Metric{
 		Throughput: troughput,
 		CostInWei:  costInWei,
-		TotalStake: uint64(totalStake),
+		TotalStake: totalStake.Uint64(),
 	}, nil
 }
 
@@ -71,50 +73,6 @@ func (s *server) getThroughput(ctx context.Context, start int64, end int64) ([]*
 	}
 
 	return calculateAverageThroughput(result.Values, avgThroughputWindowSize), nil
-}
-
-func (s *server) calculateTotalStake(operators []*Operator, blockNumber uint32) (int64, error) {
-	var (
-		totalStakeByOperatorChan = make(chan *big.Int, len(operators))
-		pool                     = workerpool.New(maxWorkersGetOperatorState)
-	)
-
-	s.logger.Debug("Number of operators to calculate stake:", len(operators))
-	for _, o := range operators {
-		operatorId, err := ConvertHexadecimalToBytes(o.OperatorId)
-		if err != nil {
-			s.logger.Error("Failed to convert operator id to hex string: ", "operatorId", operatorId, "err", err)
-			return 0, err
-		}
-
-		pool.Submit(func() {
-			operatorState, err := s.chainState.GetOperatorStateByOperator(context.Background(), uint(blockNumber), operatorId)
-			if err != nil {
-				s.logger.Error("Failed to get operator state: ", "operatorId", operatorId, "blockNumber", blockNumber, "err", err)
-				totalStakeByOperatorChan <- big.NewInt(-1)
-				return
-			}
-			totalStake := big.NewInt(0)
-			s.logger.Debug("Operator state:", "operatorId", operatorId, "num quorums", len(operatorState.Totals))
-			for quorumId, total := range operatorState.Totals {
-				s.logger.Debug("Operator stake:", "operatorId", operatorId, "quorum", quorumId, "stake", (*total.Stake).Int64())
-				totalStake.Add(totalStake, total.Stake)
-			}
-			totalStakeByOperatorChan <- totalStake
-		})
-	}
-
-	pool.StopWait()
-	close(totalStakeByOperatorChan)
-
-	totalStake := big.NewInt(0)
-	for total := range totalStakeByOperatorChan {
-		if total.Int64() == -1 {
-			return 0, errors.New("error getting operator state")
-		}
-		totalStake.Add(totalStake, total)
-	}
-	return totalStake.Int64(), nil
 }
 
 func (s *server) calculateTotalCostGasUsedInWei(ctx context.Context) (uint64, error) {

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -185,7 +185,7 @@ func TestFetchMetricsHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, 16555.555555555555, response.Throughput)
 	assert.Equal(t, uint64(85144853442), response.CostInWei)
-	assert.Equal(t, uint64(6), response.TotalStake)
+	assert.Equal(t, uint64(1), response.TotalStake)
 }
 
 func TestFetchMetricsTroughputHandler(t *testing.T) {

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -184,7 +184,7 @@ func TestFetchMetricsHandler(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, 16555.555555555555, response.Throughput)
-	assert.Equal(t, uint64(85144853442), response.CostInWei)
+	assert.Equal(t, float64(85.14485344239945), response.CostInGas)
 	assert.Equal(t, uint64(1), response.TotalStake)
 }
 


### PR DESCRIPTION
## Why are these changes needed?
This is a simpler and more efficient way to compute stake:
- It doesn't need to talk to both graph and eth node
- It doesn't need to issue multiple RPCs (one for each operator) to fetch stakes

It issues just one RPC to just eth node.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
