### PR TITLE
Remove encoded blob if confirmed

### DIFF
--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -169,17 +169,24 @@ func TestBatcherIterations(t *testing.T) {
 	err = batcher.HandleSingleBatch(ctx)
 	assert.NoError(t, err)
 	// Check that the blob was processed
-	meta, err := blobStore.GetBlobMetadata(ctx, blobKey1)
+	meta1, err := blobStore.GetBlobMetadata(ctx, blobKey1)
 	assert.NoError(t, err)
-	assert.Equal(t, blobKey1, meta.GetBlobKey())
-	assert.Equal(t, requestedAt1, meta.RequestMetadata.RequestedAt)
-	assert.Equal(t, disperser.Confirmed, meta.BlobStatus)
-	assert.Equal(t, meta.ConfirmationInfo.BatchID, uint32(3))
+	assert.Equal(t, blobKey1, meta1.GetBlobKey())
+	assert.Equal(t, requestedAt1, meta1.RequestMetadata.RequestedAt)
+	assert.Equal(t, disperser.Confirmed, meta1.BlobStatus)
+	assert.Equal(t, meta1.ConfirmationInfo.BatchID, uint32(3))
 
-	meta, err = blobStore.GetBlobMetadata(ctx, blobKey2)
+	meta2, err := blobStore.GetBlobMetadata(ctx, blobKey2)
 	assert.NoError(t, err)
-	assert.Equal(t, blobKey2, meta.GetBlobKey())
-	assert.Equal(t, disperser.Confirmed, meta.BlobStatus)
+	assert.Equal(t, blobKey2, meta2.GetBlobKey())
+	assert.Equal(t, disperser.Confirmed, meta2.BlobStatus)
+
+	res, err := components.encodingStreamer.EncodedBlobstore.GetEncodingResult(meta1.GetBlobKey(), 0)
+	assert.ErrorContains(t, err, "no such key")
+	assert.Nil(t, res)
+	res, err = components.encodingStreamer.EncodedBlobstore.GetEncodingResult(meta2.GetBlobKey(), 1)
+	assert.ErrorContains(t, err, "no such key")
+	assert.Nil(t, res)
 }
 
 func TestBlobFailures(t *testing.T) {

--- a/disperser/batcher/encoded_blob_store.go
+++ b/disperser/batcher/encoded_blob_store.go
@@ -118,6 +118,18 @@ func (e *encodedBlobStore) GetEncodingResult(blobKey disperser.BlobKey, quorumID
 	return e.encoded[requestID], nil
 }
 
+func (e *encodedBlobStore) DeleteEncodingResult(blobKey disperser.BlobKey, quorumID core.QuorumID) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	requestID := getRequestID(blobKey, quorumID)
+	if _, ok := e.encoded[requestID]; !ok {
+		return
+	}
+
+	delete(e.encoded, requestID)
+}
+
 // GetNewAndDeleteStaleEncodingResults returns all the fresh encoded results and deletes all the stale results
 func (e *encodedBlobStore) GetNewAndDeleteStaleEncodingResults(blockNumber uint) []*EncodingResult {
 	e.mu.Lock()

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -528,6 +528,12 @@ func (e *EncodingStreamer) CreateBatch() (*batch, error) {
 	}, nil
 }
 
+func (e *EncodingStreamer) RemoveEncodedBlob(metadata *disperser.BlobMetadata) {
+	for _, sp := range metadata.RequestMetadata.SecurityParams {
+		e.EncodedBlobstore.DeleteEncodingResult(metadata.GetBlobKey(), sp.QuorumID)
+	}
+}
+
 func (e *EncodingStreamer) getBatchMetadata(ctx context.Context, metadatas []*disperser.BlobMetadata, blockNumber uint) (*batchMetadata, error) {
 	quorums := make(map[core.QuorumID]QuorumInfo, 0)
 	for _, metadata := range metadatas {


### PR DESCRIPTION
## Why are these changes needed?
For a retry mechanism, we encode a blob again at different reference block number if the blob is in the middle of being dispersed because we don't know the status of that blob yet. 
Once we know the blob has been dispersed successfully, we should remove it from the encoded blob store, so that we don't disperse the same blob again. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
