### PR TITLE
chore: remove deprecated linter golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ protoc: clean
 	$(PROTOS_DISPERSER)/**/*.proto
 
 lint:
-	golint -set_exit_status ./...
 	go tool fix ./..
 	golangci-lint run
 


### PR DESCRIPTION
## Why are these changes needed?

The linter has been [deprecated](https://github.com/golang/go/issues/38968) for a couple of years