### PR TITLE
Fix linter fix tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ protoc: clean
 
 lint:
 	golint -set_exit_status ./...
-	go tool fix ./..
+	go fix ./...
 	golangci-lint run
 
 build: 

--- a/pkg/kzg/bn254/bn254_gnark_test.go
+++ b/pkg/kzg/bn254/bn254_gnark_test.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package bn254
 

--- a/pkg/kzg/fft_g1.go
+++ b/pkg/kzg/fft_g1.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/fk20_multi.go
+++ b/pkg/kzg/fk20_multi.go
@@ -1,7 +1,6 @@
 // Original: https://github.com/ethereum/research/blob/master/kzg_data_availability/fk20_multi.py
 
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/fk20_multi_test.go
+++ b/pkg/kzg/fk20_multi_test.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/fk20_single.go
+++ b/pkg/kzg/fk20_single.go
@@ -1,7 +1,6 @@
 // Original: https://github.com/ethereum/research/blob/master/kzg_data_availability/fk20_single.py
 
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/fk20_single_test.go
+++ b/pkg/kzg/fk20_single_test.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/integration_test.go
+++ b/pkg/kzg/integration_test.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/kzg.go
+++ b/pkg/kzg/kzg.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/kzg_multi_proofs.go
+++ b/pkg/kzg/kzg_multi_proofs.go
@@ -1,7 +1,6 @@
 // Original: https://github.com/ethereum/research/blob/master/kzg_data_availability/kzg_proofs.py
 
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/kzg_multi_proofs_test.go
+++ b/pkg/kzg/kzg_multi_proofs_test.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/kzg_single_proofs.go
+++ b/pkg/kzg/kzg_single_proofs.go
@@ -1,7 +1,6 @@
 // Original: https://github.com/ethereum/research/blob/master/kzg_data_availability/kzg_proofs.py
 
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/kzg_single_proofs_test.go
+++ b/pkg/kzg/kzg_single_proofs_test.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 

--- a/pkg/kzg/setup.go
+++ b/pkg/kzg/setup.go
@@ -1,5 +1,4 @@
 //go:build !bignum_pure && !bignum_hol256
-// +build !bignum_pure,!bignum_hol256
 
 package kzg
 


### PR DESCRIPTION
## Why are these changes needed?

`make lint` contains `go tool fix ./..` which currently doesn't work. Run fix correctly.

```
go tool fix ./..
go fix: warning: no cgo types: exit status 1
go fix: warning: no cgo types: exit status 1
go fix: warning: no cgo types: exit status 1
go fix: warning: no cgo types: exit status 1
go fix: warning: no cgo types: exit status 1
go fix: warning: no cgo types: exit status 1
go fix: warning: no cgo types: exit status 1
```