### PR TITLE
Uncapitalize error strings

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -93,7 +93,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 
 	expirationPollIntervalSec := ctx.GlobalUint64(flags.ExpirationPollIntervalSecFlag.Name)
 	if expirationPollIntervalSec <= minExpirationPollIntervalSec {
-		return nil, errors.New("The expiration-poll-interval flag must be greater than 3 seconds")
+		return nil, errors.New("the expiration-poll-interval flag must be greater than 3 seconds")
 	}
 
 	testMode := ctx.GlobalBool(flags.EnableTestModeFlag.Name)

--- a/node/store.go
+++ b/node/store.go
@@ -22,7 +22,7 @@ const (
 	numBatchesToDeleteAtomically = 8
 )
 
-var ErrBatchAlreadyExist = errors.New("Batch already exists")
+var ErrBatchAlreadyExist = errors.New("batch already exists")
 
 // Store is a key-value database to store blob data (blob header, blob chunks etc).
 type Store struct {

--- a/node/utils.go
+++ b/node/utils.go
@@ -75,7 +75,7 @@ func EncodeBatchExpirationKey(expirationTime int64) []byte {
 // Returns the expiration timestamp encoded in the key.
 func DecodeBatchExpirationKey(key []byte) (int64, error) {
 	if len(key) != len(batchExpirationPrefix)+8 {
-		return 0, errors.New("The expiration key is invalid")
+		return 0, errors.New("the expiration key is invalid")
 	}
 	ts := int64(binary.BigEndian.Uint64(key[len(key)-8:]))
 	return ts, nil

--- a/pkg/encoding/encoder/utils.go
+++ b/pkg/encoding/encoder/utils.go
@@ -76,6 +76,6 @@ func GetLeadingCosetIndex(i uint64, numChunks uint64) (uint32, error) {
 		j := rb.ReverseBitsLimited(uint32(numChunks), uint32(i))
 		return j, nil
 	} else {
-		return 0, errors.New("Cannot create number of frame higher than possible")
+		return 0, errors.New("cannot create number of frame higher than possible")
 	}
 }

--- a/pkg/encoding/utils/reverseBits/reverseBits.go
+++ b/pkg/encoding/utils/reverseBits/reverseBits.go
@@ -26,8 +26,8 @@ const (
 	//bit5
 )
 
-var ErrRBOInvalidLength = errors.New("Length must be power of 2 for RBO")
-var ErrFrRBOListTooLarge = errors.New("Fr RBO list length too large")
+var ErrRBOInvalidLength = errors.New("length must be power of 2 for RBO")
+var ErrFrRBOListTooLarge = errors.New("Fr RBO list length too large") //lint:ignore ST1005 ignore noun
 var ErrG1RBOListTooLarge = errors.New("G1 RBO list length too large")
 
 // bitmagic: binary search through a uint32 to find the index (least bit being 0) of the first set bit.

--- a/pkg/encoding/utils/toeplitz/cir.go
+++ b/pkg/encoding/utils/toeplitz/cir.go
@@ -22,7 +22,7 @@ func NewCircular(v []bls.Fr, fs *kzg.FFTSettings) *Circular {
 // Matrix multiplication between a circular matrix and a vector using FFT
 func (c *Circular) Multiply(x []bls.Fr) ([]bls.Fr, error) {
 	if len(x) != len(c.V) {
-		return nil, errors.New("Dimension inconsistent")
+		return nil, errors.New("dimension inconsistent")
 	}
 	n := len(x)
 
@@ -58,7 +58,7 @@ func (c *Circular) Multiply(x []bls.Fr) ([]bls.Fr, error) {
 // function allows for using precomputed FFT as its input.
 func (c *Circular) MultiplyPoints(x []bls.G1Point, inv bool, usePrecompute bool) ([]bls.G1Point, error) {
 	if len(x) != len(c.V) {
-		return nil, errors.New("Dimension inconsistent. Input != vector")
+		return nil, errors.New("dimension inconsistent. Input != vector")
 	}
 	n := len(x)
 
@@ -109,7 +109,7 @@ func (c *Circular) GetFFTCoeff() ([]bls.Fr, error) {
 // Hadamard product between 2 vectors, one contains G1 points, the other contains Fr element
 func HadamardPoints(a []bls.G1Point, b []bls.Fr, u []bls.G1Point) error {
 	if len(a) != len(b) {
-		return errors.New("Dimension inconsistent. Cannot do Hadamard Product on Points")
+		return errors.New("dimension inconsistent. Cannot do Hadamard Product on Points")
 	}
 
 	for i := 0; i < len(a); i++ {
@@ -121,7 +121,7 @@ func HadamardPoints(a []bls.G1Point, b []bls.Fr, u []bls.G1Point) error {
 // Hadamard product between 2 vectors containing Fr elements
 func Hadamard(a, b, u []bls.Fr) error {
 	if len(a) != len(b) {
-		return errors.New("Dimension inconsistent. Cannot do Hadamard Product on Fr")
+		return errors.New("dimension inconsistent. Cannot do Hadamard Product on Fr")
 	}
 
 	for i := 0; i < len(a); i++ {

--- a/pkg/encoding/utils/toeplitz/cir_test.go
+++ b/pkg/encoding/utils/toeplitz/cir_test.go
@@ -68,7 +68,7 @@ func TestMultiplyCircular_InvalidDimensions(t *testing.T) {
 	x[2] = bls.ToFr("3")
 	x[3] = bls.ToFr("4")
 	_, err := c.Multiply(x)
-	assert.EqualError(t, err, "Dimension inconsistent")
+	assert.EqualError(t, err, "dimension inconsistent")
 }
 
 func TestMultiplyPointsCircular(t *testing.T) {
@@ -109,7 +109,7 @@ func TestMultiplyPointsCircular_InvalidDimension(t *testing.T) {
 	x[3] = bls.GenG1
 
 	_, err := c.MultiplyPoints(x, false, true)
-	assert.EqualError(t, err, "Dimension inconsistent. Input != vector")
+	assert.EqualError(t, err, "dimension inconsistent. Input != vector")
 }
 
 func TestHadamard_InvalidDimension(t *testing.T) {
@@ -122,7 +122,7 @@ func TestHadamard_InvalidDimension(t *testing.T) {
 
 	c := make([]bls.Fr, 3)
 	err := toeplitz.Hadamard(a, b, c)
-	assert.EqualError(t, err, "Dimension inconsistent. Cannot do Hadamard Product on Fr")
+	assert.EqualError(t, err, "dimension inconsistent. Cannot do Hadamard Product on Fr")
 
 	// TODO: This causes a panic because there are no checks on the size of c
 	// b = make([]bls.Fr, 2)
@@ -145,7 +145,7 @@ func TestHadamardPoint_InvalidDimension(t *testing.T) {
 
 	c := make([]bls.G1Point, 3)
 	err := toeplitz.HadamardPoints(a, b, c)
-	assert.EqualError(t, err, "Dimension inconsistent. Cannot do Hadamard Product on Points")
+	assert.EqualError(t, err, "dimension inconsistent. Cannot do Hadamard Product on Points")
 
 	// TODO: This causes a panic because there are no checks on the size of c
 	// b = make([]bls.Fr, 2)


### PR DESCRIPTION
## Why are these changes needed?

> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context. 
https://staticcheck.dev/docs/checks/#ST1005

Found with `staticcheck ./...`

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
