### PR TITLE
[GithubAction] Push Operator Node Images

### DIFF
--- a/.github/workflows/docker-publish-opr-node-images.yaml
+++ b/.github/workflows/docker-publish-opr-node-images.yaml
@@ -13,6 +13,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  CACHE-FROM: /tmp/.buildx-cache
+  CACHE-TO: /tmp/.buildx-cache-new
 
 jobs:
   build-and-push:
@@ -71,14 +73,14 @@ jobs:
         file: ./node/plugin/Dockerfile
         push: true
         tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-nodeplugin:${{ steps.set_tag.outputs.tag }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new
+        cache-from: type=local,src=${{ env.CACHE-FROM }}
+        cache-to: type=local,dest=${{ env.CACHE-TO }}
       if: ${{ success() }}
 
     - name: Update cache
       uses: actions/cache@v2
       with:
-        path: /tmp/.buildx-cache-new
+        path: ${{ env.CACHE-TO }}
         key: ${{ runner.os }}-buildx-${{ steps.set_tag.outputs.tag }}
         restore-keys: |
           ${{ runner.os }}-buildx-

--- a/.github/workflows/docker-publish-opr-node-images.yaml
+++ b/.github/workflows/docker-publish-opr-node-images.yaml
@@ -59,7 +59,7 @@ jobs:
       with:
         file: ./node/cmd/Dockerfile
         push: true
-        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-node:${{ github.event.inputs.commit_sha }}
+        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-node:${{ steps.set_tag.outputs.tag }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
       if: ${{ success() }}
@@ -70,7 +70,7 @@ jobs:
         context: .
         file: ./node/plugin/Dockerfile
         push: true
-        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-nodeplugin:${{ github.event.inputs.commit_sha }}
+        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-nodeplugin:${{ steps.set_tag.outputs.tag }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
       if: ${{ success() }}
@@ -79,6 +79,6 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache-new
-        key: ${{ runner.os }}-buildx-${{ github.event.inputs.commit_sha }}
+        key: ${{ runner.os }}-buildx-${{ steps.set_tag.outputs.tag }}
         restore-keys: |
           ${{ runner.os }}-buildx-

--- a/.github/workflows/docker-publish-opr-node-images.yaml
+++ b/.github/workflows/docker-publish-opr-node-images.yaml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Set Tag Name
       id: set_tag
-      run: echo "::set-output name=tag::${{ github.event.inputs.release_tag || github.event.inputs.commit_sha }}"
+      run: echo "tag=${{ github.event.inputs.release_tag || github.event.inputs.commit_sha }}" >> $GITHUB_OUTPUT
       if: ${{ success() }}
 
     - name: Build and Push Opr Node Image

--- a/.github/workflows/docker-publish-opr-node-images.yaml
+++ b/.github/workflows/docker-publish-opr-node-images.yaml
@@ -1,15 +1,18 @@
-name: Push Operator Docker images to GHCR
+name: Push Docker images to GHCR with Caching
 
 on:
   workflow_dispatch:
     inputs:
+      commit_sha:
+        description: 'Specific Commit SHA (Required)'
+        required: true
       release_tag:
         description: 'Release Tag (Optional)'
         required: false
         default: ''
 
 env:
-  REGISTRY: ghcr.io  # Setting the registry environment variable
+  REGISTRY: ghcr.io
 
 jobs:
   build-and-push:
@@ -17,10 +20,11 @@ jobs:
     permissions:
       contents: read
       packages: write
-
     steps:
-    - name: Checkout repository
+    - name: Checkout repository at specified commit
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.commit_sha }}
 
     - name: Setup Buildx
       uses: docker/setup-buildx-action@v1
@@ -32,9 +36,10 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ github.event.inputs.commit_sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
+      if: ${{ success() }}
 
     - name: Log into registry ${{ env.REGISTRY }}
       uses: docker/login-action@v2
@@ -42,35 +47,38 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ success() }}
 
     - name: Set Tag Name
       id: set_tag
-      run: echo "::set-output name=tag::${{ github.event.inputs.release_tag || github.sha }}"
+      run: echo "::set-output name=tag::${{ github.event.inputs.release_tag || github.event.inputs.commit_sha }}"
+      if: ${{ success() }}
 
     - name: Build and Push Opr Node Image
       uses: docker/build-push-action@v2
       with:
-        context: .
         file: ./node/cmd/Dockerfile
         push: true
-        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-node:${{ steps.set_tag.outputs.tag }}
+        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-node:${{ github.event.inputs.commit_sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
+      if: ${{ success() }}
 
-    - name: Build and Push Opr Plugin Image
+    - name: Build and Push NodePlugin Image
       uses: docker/build-push-action@v2
       with:
         context: .
         file: ./node/plugin/Dockerfile
         push: true
-        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-nodeplugin:${{ steps.set_tag.outputs.tag }}
+        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-nodeplugin:${{ github.event.inputs.commit_sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
+      if: ${{ success() }}
 
     - name: Update cache
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache-new
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ github.event.inputs.commit_sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-

--- a/.github/workflows/docker-publish-opr-node-images.yaml
+++ b/.github/workflows/docker-publish-opr-node-images.yaml
@@ -1,0 +1,76 @@
+name: Push Operator Docker images to GHCR
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release Tag (Optional)'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io  # Setting the registry environment variable
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        install: true
+        driver-opts: image=moby/buildkit:master
+
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set Tag Name
+      id: set_tag
+      run: echo "::set-output name=tag::${{ github.event.inputs.release_tag || github.sha }}"
+
+    - name: Build and Push Opr Node Image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./node/cmd/Dockerfile
+        push: true
+        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-node:${{ steps.set_tag.outputs.tag }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+    - name: Build and Push Opr Plugin Image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./node/plugin/Dockerfile
+        push: true
+        tags: ${{ env.REGISTRY }}/layr-labs/eigenda/opr-nodeplugin:${{ steps.set_tag.outputs.tag }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+    - name: Update cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache-new
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-


### PR DESCRIPTION
## Why are these changes needed?
Needed to push operator node images to public ghcr. 
Invoking Role: Oncall
Steps: 
1. Verify Test Results for PreProd run and obtain commit-sha for that (TBD: one place look up for commit-sha to TestResult)
2. Provide Commit Sha and Release Tag as input parameters to this action
3. Run workflow

## Alternative Considered:
1. Writing this github action in eigenda-devops 
2. PreProd environment rel has a github action(cronjob) which will publish eigenda components update and run some test
3. If this PreProd environment rel succeeds then publish Node specific images from ECR to GHCR 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
