### PR TITLE
Create README.md for api docs root folder

### DIFF
--- a/api/docs/README.md
+++ b/api/docs/README.md
@@ -2,5 +2,5 @@ This folder contains the API documentation for the gRPC services included in the
 - Churner: a hosted service responsible for maintaining the active set of Operators in the EigenDA network based on their delegated TVL.
 - Disperser: the hosted service and primary point of interaction for Rollup users.
 - Node: individual EigenDA nodes ran on the network by EigenLayer Operators.
-- Retriever: a hosted service that retrieves blobs from EigenDA nodes.
+- Retriever: a service that users can run on their own infrastructure, which exposes a gRPC endpoint for retrieval of blobs from EigenDA nodes.
 

--- a/api/docs/README.md
+++ b/api/docs/README.md
@@ -1,0 +1,6 @@
+This folder contains the API documentation for the gRPC services included in the EigenDA platform. Each markdown file contains the protobuf definitions for each respective service including:
+- Churner: a hosted service responsible for maintaining the active set of Operators in the EigenDA network based on their delegated TVL.
+- Disperser: the hosted service and primary point of interaction for Rollup users.
+- Node: individual EigenDA nodes ran on the network by EigenLayer Operators.
+- Retriever: a hosted service that retrieves blobs from EigenDA nodes.
+


### PR DESCRIPTION
Creating a simple README to give context to users on the content and purpose of the API docs.

## Why are these changes needed?

The reader needs some context on the purpose and layout of the API docs.

## Checks

Not applicable for this single README file