### PR TITLE
Run test coverage report on master only

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,14 +46,15 @@ jobs:
           name: coverage
           path: coverage.out
 
-  coverage-report: 
+  coverage-report:
     name: Coverage Report
     needs: unit-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-          
+
       - name: Update coverage badge
+        if: github.ref == 'refs/heads/master'
         uses: ./.github/actions/test-coverage
         with:
           chart: true


### PR DESCRIPTION
## Why are these changes needed?
- PR from fork repo will not have permission to push to wiki
- Run test coverage on master is sufficient

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
