### PR TITLE
Add ConfirmationTxnHash to feed blobs response

### DIFF
--- a/disperser/dataapi/blobs_handlers.go
+++ b/disperser/dataapi/blobs_handlers.go
@@ -84,6 +84,7 @@ func convertMetadataToBlobMetadataResponse(metadata *disperser.BlobMetadata) (*B
 		BlobCommitment:          metadata.ConfirmationInfo.BlobCommitment,
 		BatchId:                 metadata.ConfirmationInfo.BatchID,
 		ConfirmationBlockNumber: metadata.ConfirmationInfo.ConfirmationBlockNumber,
+		ConfirmationTxnHash:     metadata.ConfirmationInfo.ConfirmationTxnHash.String(),
 		Fee:                     hex.EncodeToString(metadata.ConfirmationInfo.Fee),
 		SecurityParams:          metadata.RequestMetadata.SecurityParams,
 		RequestAt:               ConvertNanosecondToSecond(metadata.RequestMetadata.RequestedAt),

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -42,6 +42,7 @@ type (
 		BlobCommitment          *core.BlobCommitments `json:"blob_commitment"`
 		BatchId                 uint32                `json:"batch_id"`
 		ConfirmationBlockNumber uint32                `json:"confirmation_block_number"`
+		ConfirmationTxnHash     string                `json:"confirmation_txn_hash"`
 		Fee                     string                `json:"fee"`
 		SecurityParams          []*core.SecurityParam `json:"security_params"`
 		RequestAt               uint64                `json:"requested_at"`

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -90,6 +90,7 @@ func TestFetchBlobHandler(t *testing.T) {
 	assert.Equal(t, expectedBlobCommitment, response.BlobCommitment)
 	assert.Equal(t, expectedBatchId, uint32(response.BatchId))
 	assert.Equal(t, expectedConfirmationBlockNumber, uint32(response.ConfirmationBlockNumber))
+	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000123", response.ConfirmationTxnHash)
 	assert.Equal(t, hex.EncodeToString(expectedFee), response.Fee)
 	assert.Equal(t, blob.RequestHeader.SecurityParams, response.SecurityParams)
 	assert.Equal(t, uint64(5567830000), response.RequestAt)


### PR DESCRIPTION
## Why are these changes needed?

Link to etherscan on blob explorer:
- It would nice to be able to go to the chain from blobs.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
