### PR TITLE
Validate chunks in retrieval client

### DIFF
--- a/clients/tests/retrieval_client_test.go
+++ b/clients/tests/retrieval_client_test.go
@@ -122,9 +122,10 @@ func setup(t *testing.T) {
 		SecurityParam: core.SecurityParam{
 			QuorumID:           quorumID,
 			AdversaryThreshold: adversaryThreshold,
+			QuorumThreshold:    quorumThreshold,
 		},
 		QuantizationFactor: quantizationFactor,
-		EncodedBlobLength:  quantizationFactor * chunkLength * numOperators,
+		EncodedBlobLength:  quantizationFactor * params.ChunkLength * numOperators,
 	}
 
 	blobHeader = &core.BlobHeader{


### PR DESCRIPTION
## Why are these changes needed?
Previously, retrieval client only validated the blob header retrieved from DA nodes against the batch root.
It now validates the chunks retrieved from the DA nodes as well.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
