### PR TITLE
Fix the bytes accounting at DA Node

### DIFF
--- a/node/store.go
+++ b/node/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/node/leveldb"
-	"github.com/Layr-Labs/eigenda/pkg/kzg/bn254"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"google.golang.org/protobuf/proto"
 )
@@ -132,14 +131,6 @@ func (s *Store) deleteNBatches(currentTimeUnixSec int64, numBatches int) (int, e
 		blobHeaderIter := s.db.NewIterator(EncodeBlobHeaderKeyPrefix(batchHeaderHash))
 		for blobHeaderIter.Next() {
 			expiredKeys = append(expiredKeys, copyBytes(blobHeaderIter.Key()))
-
-			// Collect the size in bytes for all the quorums of the blob.
-			var protoBlobHeader node.BlobHeader
-			if proto.Unmarshal(blobHeaderIter.Value(), &protoBlobHeader) == nil {
-				for _, qh := range protoBlobHeader.GetQuorumHeaders() {
-					size += int(qh.GetEncodedBlobLength() * bn254.BYTES_PER_COEFFICIENT)
-				}
-			}
 		}
 		blobHeaderIter.Release()
 
@@ -147,6 +138,7 @@ func (s *Store) deleteNBatches(currentTimeUnixSec int64, numBatches int) (int, e
 		blobIter := s.db.NewIterator(bytes.NewBuffer(hash).Bytes())
 		for blobIter.Next() {
 			expiredKeys = append(expiredKeys, copyBytes(blobIter.Key()))
+			size += len(blobIter.Value())
 		}
 		blobIter.Release()
 	}
@@ -256,12 +248,12 @@ func (s *Store) StoreBatch(ctx context.Context, header *core.BatchHeader, blobs 
 					log.Error("Cannot serialize chunk:", "err", err)
 					return nil, err
 				}
-				size += chunk.Size()
 			}
 			chunkBytes, err := encodeChunks(bundleRaw)
 			if err != nil {
 				return nil, err
 			}
+			size += len(chunkBytes)
 
 			keys = append(keys, key)
 			values = append(values, chunkBytes)

--- a/node/store_test.go
+++ b/node/store_test.go
@@ -52,7 +52,7 @@ func CreateBatch(t *testing.T) (*core.BatchHeader, []*core.BlobMessage, []*pb.Bl
 	}
 	chunk1 := &core.Chunk{
 		Proof:  commitment,
-		Coeffs: []core.Symbol{},
+		Coeffs: []core.Symbol{bn254.ONE},
 	}
 
 	blobMessage := []*core.BlobMessage{


### PR DESCRIPTION
## Why are these changes needed?
The GC is subtracting the size of entire blob, not the size of the blob at the Node.

TESTED: locally verified that adding and removing batch will add/remove the same number of bytes from the counter.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
