### PR TITLE
Fix the accounting for batch size

### DIFF
--- a/core/data.go
+++ b/core/data.go
@@ -160,3 +160,14 @@ func (cb Bundles) Serialize() ([][][]byte, error) {
 	}
 	return data, nil
 }
+
+// Returns the size of the bundles in bytes.
+func (cb Bundles) Size() int {
+	size := 0
+	for _, bundle := range cb {
+		for _, chunk := range bundle {
+			size += chunk.Size()
+		}
+	}
+	return size
+}

--- a/node/node.go
+++ b/node/node.go
@@ -236,7 +236,7 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 	// Measure num batches received and its size in bytes
 	batchSize := 0
 	for _, blob := range blobs {
-		batchSize += blob.BlobHeader.EncodedSizeAllQuorums()
+		batchSize += blob.Bundles.Size()
 	}
 	n.Metrics.AcceptBatches("received", batchSize)
 


### PR DESCRIPTION
## Why are these changes needed?
Same issue as https://github.com/Layr-Labs/eigenda/pull/85: It's counting the entire blob rather than the assigned chunks at the DA Node.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
