### PR TITLE
[finalizer] Handle forked transactions

### DIFF
--- a/common/mock/ethclient.go
+++ b/common/mock/ethclient.go
@@ -177,18 +177,30 @@ func (mock *MockEthClient) TransactionInBlock(ctx context.Context, blockHash com
 
 func (mock *MockEthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	args := mock.Called()
-	result := args.Get(0)
-	return result.(*types.Receipt), args.Error(1)
+	var result *types.Receipt
+	if args.Get(0) != nil {
+		result = args.Get(0).(*types.Receipt)
+	}
+
+	return result, args.Error(1)
 }
 
 func (mock *MockEthClient) EstimateGasPriceAndLimitAndSendTx(ctx context.Context, tx *types.Transaction, tag string, value *big.Int) (*types.Receipt, error) {
 	args := mock.Called()
-	result := args.Get(0)
-	return result.(*types.Receipt), args.Error(1)
+	var result *types.Receipt
+	if args.Get(0) != nil {
+		result = args.Get(0).(*types.Receipt)
+	}
+
+	return result, args.Error(1)
 }
 
 func (mock *MockEthClient) EnsureTransactionEvaled(ctx context.Context, tx *types.Transaction, tag string) (*types.Receipt, error) {
 	args := mock.Called()
-	result := args.Get(0)
-	return result.(*types.Receipt), args.Error(1)
+	var result *types.Receipt
+	if args.Get(0) != nil {
+		result = args.Get(0).(*types.Receipt)
+	}
+
+	return result, args.Error(1)
 }

--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -177,12 +177,7 @@ func (b *Batcher) Start(ctx context.Context) error {
 func (b *Batcher) handleFailure(ctx context.Context, blobMetadatas []*disperser.BlobMetadata) error {
 	var result *multierror.Error
 	for _, metadata := range blobMetadatas {
-		var err error
-		if metadata.NumRetries < b.MaxNumRetriesPerBlob {
-			err = b.Queue.IncrementBlobRetryCount(ctx, metadata)
-		} else {
-			err = b.Queue.MarkBlobFailed(ctx, metadata.GetBlobKey())
-		}
+		err := b.Queue.HandleBlobFailure(ctx, metadata, b.MaxNumRetriesPerBlob)
 		if err != nil {
 			b.logger.Error("HandleSingleBatch: error handling blob failure", "err", err)
 			// Append the error

--- a/disperser/batcher/finalizer_test.go
+++ b/disperser/batcher/finalizer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/disperser/batcher"
 	"github.com/Layr-Labs/eigenda/disperser/common/inmem"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,7 @@ func TestFinalizedBlob(t *testing.T) {
 		BlockNumber: new(big.Int).SetUint64(1_000_000),
 	}, nil)
 
-	finalizer := batcher.NewFinalizer(timeout, loopInterval, queue, ethClient, rpcClient, logger)
+	finalizer := batcher.NewFinalizer(timeout, loopInterval, queue, ethClient, rpcClient, 1, logger)
 
 	requestedAt := uint64(time.Now().UnixNano())
 	blob := makeTestBlob([]*core.SecurityParam{{
@@ -116,7 +117,7 @@ func TestUnfinalizedBlob(t *testing.T) {
 		BlockNumber: new(big.Int).SetUint64(1_000_100),
 	}, nil)
 
-	finalizer := batcher.NewFinalizer(timeout, loopInterval, queue, ethClient, rpcClient, logger)
+	finalizer := batcher.NewFinalizer(timeout, loopInterval, queue, ethClient, rpcClient, 1, logger)
 
 	requestedAt := uint64(time.Now().UnixNano())
 	blob := makeTestBlob([]*core.SecurityParam{{
@@ -169,4 +170,96 @@ func TestUnfinalizedBlob(t *testing.T) {
 	metadatas, err = queue.GetBlobMetadataByStatus(ctx, disperser.Finalized)
 	assert.NoError(t, err)
 	assert.Len(t, metadatas, 0)
+}
+
+func TestNoReceipt(t *testing.T) {
+	ctx := context.Background()
+	queue := inmem.NewBlobStore()
+	logger, err := logging.GetLogger(logging.DefaultCLIConfig())
+	assert.NoError(t, err)
+	ethClient := &mock.MockEthClient{}
+	rpcClient := &mock.MockRPCEthClient{}
+
+	latestFinalBlock := int64(1_000_010)
+	rpcClient.On("CallContext", m.Anything, m.Anything, "eth_getBlockByNumber", "finalized", false).
+		Run(func(args m.Arguments) {
+			args[1].(*types.Header).Number = big.NewInt(latestFinalBlock)
+		}).Return(nil)
+	ethClient.On("TransactionReceipt", m.Anything, m.Anything).Return(nil, ethereum.NotFound)
+
+	finalizer := batcher.NewFinalizer(timeout, loopInterval, queue, ethClient, rpcClient, 1, logger)
+
+	requestedAt := uint64(time.Now().UnixNano())
+	blob := makeTestBlob([]*core.SecurityParam{{
+		QuorumID:           0,
+		AdversaryThreshold: 80,
+	}})
+	metadataKey, err := queue.StoreBlob(ctx, &blob, requestedAt)
+	assert.NoError(t, err)
+	batchHeaderHash := [32]byte{1, 2, 3}
+	blobIndex := uint32(10)
+	sigRecordHash := [32]byte{0}
+	inclusionProof := []byte{1, 2, 3, 4, 5}
+	confirmationInfo := &disperser.ConfirmationInfo{
+		BatchHeaderHash:         batchHeaderHash,
+		BlobIndex:               blobIndex,
+		SignatoryRecordHash:     sigRecordHash,
+		ReferenceBlockNumber:    132,
+		BatchRoot:               []byte("hello"),
+		BlobInclusionProof:      inclusionProof,
+		BlobCommitment:          &core.BlobCommitments{},
+		BatchID:                 99,
+		ConfirmationTxnHash:     common.HexToHash("0x123"),
+		ConfirmationBlockNumber: uint32(150),
+		Fee:                     []byte{0},
+	}
+	metadata := &disperser.BlobMetadata{
+		BlobHash:     metadataKey.BlobHash,
+		MetadataHash: metadataKey.MetadataHash,
+		BlobStatus:   disperser.Processing,
+		Expiry:       0,
+		NumRetries:   0,
+		RequestMetadata: &disperser.RequestMetadata{
+			BlobRequestHeader: core.BlobRequestHeader{
+				SecurityParams: blob.RequestHeader.SecurityParams,
+			},
+			BlobSize:    uint(len(blob.Data)),
+			RequestedAt: requestedAt,
+		},
+	}
+	m, err := queue.MarkBlobConfirmed(ctx, metadata, confirmationInfo)
+	assert.NoError(t, err)
+	assert.Equal(t, disperser.Confirmed, m.BlobStatus)
+	err = finalizer.FinalizeBlobs(context.Background())
+	assert.NoError(t, err)
+
+	// status should be kept at confirmed
+	metadatas, err := queue.GetBlobMetadataByStatus(ctx, disperser.Finalized)
+	assert.NoError(t, err)
+	assert.Len(t, metadatas, 0)
+	metadatas, err = queue.GetBlobMetadataByStatus(ctx, disperser.Failed)
+	assert.NoError(t, err)
+	assert.Len(t, metadatas, 0)
+	metadatas, err = queue.GetBlobMetadataByStatus(ctx, disperser.Confirmed)
+	assert.NoError(t, err)
+	assert.Len(t, metadatas, 1)
+	// num retries should be incremented
+	assert.Equal(t, metadatas[0].NumRetries, uint(1))
+
+	// try again
+	err = finalizer.FinalizeBlobs(context.Background())
+	assert.NoError(t, err)
+
+	// status should be transitioned to failed
+	metadatas, err = queue.GetBlobMetadataByStatus(ctx, disperser.Finalized)
+	assert.NoError(t, err)
+	assert.Len(t, metadatas, 0)
+	metadatas, err = queue.GetBlobMetadataByStatus(ctx, disperser.Confirmed)
+	assert.NoError(t, err)
+	assert.Len(t, metadatas, 0)
+	metadatas, err = queue.GetBlobMetadataByStatus(ctx, disperser.Failed)
+	assert.NoError(t, err)
+	assert.Len(t, metadatas, 1)
+	// num retries should be the same
+	assert.Equal(t, metadatas[0].NumRetries, uint(1))
 }

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -138,7 +138,7 @@ func RunBatcher(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	finalizer := batcher.NewFinalizer(config.TimeoutConfig.ChainReadTimeout, config.BatcherConfig.FinalizerInterval, queue, client, rpcClient, logger)
+	finalizer := batcher.NewFinalizer(config.TimeoutConfig.ChainReadTimeout, config.BatcherConfig.FinalizerInterval, queue, client, rpcClient, config.BatcherConfig.MaxNumRetriesPerBlob, logger)
 	batcher, err := batcher.NewBatcher(config.BatcherConfig, config.TimeoutConfig, queue, dispatcher, confirmer, ics, asgn, encoderClient, agg, client, finalizer, logger, metrics)
 	if err != nil {
 		return err

--- a/disperser/common/blobstore/shared_storage.go
+++ b/disperser/common/blobstore/shared_storage.go
@@ -216,6 +216,14 @@ func (s *SharedBlobStore) GetBlobMetadata(ctx context.Context, metadataKey dispe
 	return s.blobMetadataStore.GetBlobMetadata(ctx, metadataKey)
 }
 
+func (s *SharedBlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) error {
+	if metadata.NumRetries < maxRetry {
+		return s.IncrementBlobRetryCount(ctx, metadata)
+	} else {
+		return s.MarkBlobFailed(ctx, metadata.GetBlobKey())
+	}
+}
+
 func getMetadataHash(requestedAt uint64, securityParams []*core.SecurityParam) (string, error) {
 	var str string
 	str = fmt.Sprintf("%d/", requestedAt)

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -181,6 +181,14 @@ func (q *BlobStore) GetBlobMetadata(ctx context.Context, blobKey disperser.BlobK
 	return nil, disperser.ErrBlobNotFound
 }
 
+func (q *BlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) error {
+	if metadata.NumRetries < maxRetry {
+		return q.IncrementBlobRetryCount(ctx, metadata)
+	} else {
+		return q.MarkBlobFailed(ctx, metadata.GetBlobKey())
+	}
+}
+
 // getNewBlobHash generates a new blob key
 func (q *BlobStore) getNewBlobHash() (disperser.BlobHash, error) {
 	var key disperser.BlobHash

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -153,6 +153,8 @@ type BlobStore interface {
 	GetAllBlobMetadataByBatch(ctx context.Context, batchHeaderHash [32]byte) ([]*BlobMetadata, error)
 	// GetBlobMetadata returns a blob metadata given a metadata key
 	GetBlobMetadata(ctx context.Context, blobKey BlobKey) (*BlobMetadata, error)
+	// HandleBlobFailure handles a blob failure by either incrementing the retry count or marking the blob as failed
+	HandleBlobFailure(ctx context.Context, metadata *BlobMetadata, maxRetry uint) error
 }
 
 type Dispatcher interface {


### PR DESCRIPTION
## Why are these changes needed?
If finalizer failed to fetch transaction receipts due to `not found` error, it should assume the transaction has been forked and handle the failure accordingly so that the blobs can be retried.  
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
