### PR TITLE
Use int64 for size in bytes accounting

### DIFF
--- a/core/data.go
+++ b/core/data.go
@@ -85,10 +85,10 @@ type BlobHeader struct {
 }
 
 // Returns the total encoded size in bytes of the blob across all quorums.
-func (b *BlobHeader) EncodedSizeAllQuorums() int {
-	size := 0
+func (b *BlobHeader) EncodedSizeAllQuorums() int64 {
+	size := int64(0)
 	for _, quorum := range b.QuorumInfos {
-		size += int(quorum.EncodedBlobLength * bn254.BYTES_PER_COEFFICIENT)
+		size += int64(quorum.EncodedBlobLength) * int64(bn254.BYTES_PER_COEFFICIENT)
 	}
 	return size
 }

--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -348,7 +348,11 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 
 	log.Trace("[batcher] Update confirmation info took", "duration", time.Since(stageTimer))
 	b.Metrics.ObserveLatency("UpdateConfirmationInfo", float64(time.Since(stageTimer).Milliseconds()))
-	b.Metrics.IncrementBatchCount(len(batch.BlobMetadata))
+	batchSize := int64(0)
+	for _, blobMeta := range batch.BlobMetadata {
+		batchSize += int64(blobMeta.RequestMetadata.BlobSize)
+	}
+	b.Metrics.IncrementBatchCount(batchSize)
 	return nil
 }
 

--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -107,9 +107,9 @@ func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.BlobMessage, 
 	return sig, nil
 }
 
-func GetStoreChunksRequest(blobMessages []*core.BlobMessage, header *core.BatchHeader) (*node.StoreChunksRequest, int, error) {
+func GetStoreChunksRequest(blobMessages []*core.BlobMessage, header *core.BatchHeader) (*node.StoreChunksRequest, int64, error) {
 	blobs := make([]*node.Blob, len(blobMessages))
-	totalSize := 0
+	totalSize := int64(0)
 	for i, blob := range blobMessages {
 		var err error
 		blobs[i], err = getBlobMessage(blob)

--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -42,7 +42,7 @@ func NewMetrics(httpPort string, logger common.Logger) *Metrics {
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "blobs_total",
-				Help:      "the number and size of total dispersal blob",
+				Help:      "the number and encoded size of total dispersal blobs",
 			},
 			[]string{"state", "data"}, // state is either success or failure
 		),
@@ -50,7 +50,7 @@ func NewMetrics(httpPort string, logger common.Logger) *Metrics {
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "batches_total",
-				Help:      "the number and size of total dispersal batch",
+				Help:      "the number and unencoded size of total dispersal batches",
 			},
 			[]string{"data"},
 		),
@@ -110,7 +110,7 @@ func (g *Metrics) UpdateCompletedBlob(size int, status disperser.BlobStatus) {
 	g.Blob.WithLabelValues("total", "size").Add(float64(size))
 }
 
-func (g *Metrics) IncrementBatchCount(size int) {
+func (g *Metrics) IncrementBatchCount(size int64) {
 	g.Batch.WithLabelValues("number").Inc()
 	g.Batch.WithLabelValues("size").Add(float64(size))
 }

--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -42,7 +42,7 @@ func NewMetrics(httpPort string, logger common.Logger) *Metrics {
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "blobs_total",
-				Help:      "the number and encoded size of total dispersal blobs",
+				Help:      "the number and unencoded size of total dispersal blobs",
 			},
 			[]string{"state", "data"}, // state is either success or failure
 		),

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -121,22 +121,22 @@ func (g *Metrics) ObserveLatency(method, stage string, latencyMs float64) {
 	g.RequestLatency.WithLabelValues(method, stage).Observe(latencyMs)
 }
 
-func (g *Metrics) AddCurrentBatch(batchSize int) {
+func (g *Metrics) AddCurrentBatch(batchSize int64) {
 	g.CurrBatches.WithLabelValues("number").Inc()
 	g.CurrBatches.WithLabelValues("size").Add(float64(batchSize))
 }
 
-func (g *Metrics) RemoveCurrentBatch(batchSize int) {
+func (g *Metrics) RemoveCurrentBatch(batchSize int64) {
 	g.CurrBatches.WithLabelValues("number").Dec()
 	g.CurrBatches.WithLabelValues("size").Sub(float64(batchSize))
 }
 
-func (g *Metrics) RemoveNCurrentBatch(numBatches, totalBatchSize int) {
+func (g *Metrics) RemoveNCurrentBatch(numBatches int, totalBatchSize int64) {
 	g.CurrBatches.WithLabelValues("number").Sub(float64(numBatches))
 	g.CurrBatches.WithLabelValues("size").Sub(float64(totalBatchSize))
 }
 
-func (g *Metrics) AcceptBatches(status string, batchSize int) {
+func (g *Metrics) AcceptBatches(status string, batchSize int64) {
 	g.AccuBatches.WithLabelValues("number", status).Inc()
 	g.AccuBatches.WithLabelValues("size", status).Add(float64(batchSize))
 }

--- a/node/node.go
+++ b/node/node.go
@@ -234,7 +234,7 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 	log := n.Logger
 
 	// Measure num batches received and its size in bytes
-	batchSize := 0
+	batchSize := int64(0)
 	for _, blob := range blobs {
 		batchSize += blob.BlobHeader.EncodedSizeAllQuorums()
 	}

--- a/node/store.go
+++ b/node/store.go
@@ -118,7 +118,7 @@ func (s *Store) deleteNBatches(currentTimeUnixSec int64, numBatches int) (int, e
 	}
 
 	// Calculate the num of bytes (for chunks) that will be purged from the database.
-	size := 0
+	size := int64(0)
 	// Scan for the batch header, blob headers and chunks of each expired batch.
 	for _, hash := range expiredBatches {
 		var batchHeaderHash [32]byte
@@ -138,7 +138,7 @@ func (s *Store) deleteNBatches(currentTimeUnixSec int64, numBatches int) (int, e
 		blobIter := s.db.NewIterator(bytes.NewBuffer(hash).Bytes())
 		for blobIter.Next() {
 			expiredKeys = append(expiredKeys, copyBytes(blobIter.Key()))
-			size += len(blobIter.Value())
+			size += int64(len(blobIter.Value()))
 		}
 		blobIter.Release()
 	}
@@ -216,7 +216,7 @@ func (s *Store) StoreBatch(ctx context.Context, header *core.BatchHeader, blobs 
 	values = append(values, batchHeaderHash[:])
 
 	// Generate key/value pairs for all blob headers and blob chunks .
-	size := 0
+	size := int64(0)
 	for idx, blob := range blobs {
 		// blob header
 		blobHeaderKey, err := EncodeBlobHeaderKey(batchHeaderHash, idx)
@@ -253,7 +253,7 @@ func (s *Store) StoreBatch(ctx context.Context, header *core.BatchHeader, blobs 
 			if err != nil {
 				return nil, err
 			}
-			size += len(chunkBytes)
+			size += int64(len(chunkBytes))
 
 			keys = append(keys, key)
 			values = append(values, chunkBytes)


### PR DESCRIPTION
## Why are these changes needed?
When there are more than about 2GB, the int32 will overflow and result in wrong metrics.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
