### PR TITLE
Node batch verification

### DIFF
--- a/core/data.go
+++ b/core/data.go
@@ -161,7 +161,6 @@ func (cb Bundles) Serialize() ([][][]byte, error) {
 	return data, nil
 }
 
-<<<<<<< HEAD
 // Returns the size of the bundles in bytes.
 func (cb Bundles) Size() int64 {
 	size := int64(0)
@@ -173,9 +172,7 @@ func (cb Bundles) Size() int64 {
 	return size
 }
 
-=======
 // Sample is a chunk with associated metadata used by the Universal Batch Verifier
->>>>>>> organize data struct and add fiat shamir
 type Sample struct {
 	Commitment      *Commitment
 	Chunk           *Chunk

--- a/core/data.go
+++ b/core/data.go
@@ -177,10 +177,10 @@ func (cb Bundles) Size() int64 {
 // Sample is a chunk with associated metadata used by the Universal Batch Verifier
 >>>>>>> organize data struct and add fiat shamir
 type Sample struct {
-	Commitment *Commitment
-	Chunk      *Chunk
-	EvalIndex  ChunkNumber
-	BlobIndex  int
+	Commitment      *Commitment
+	Chunk           *Chunk
+	AssignmentIndex ChunkNumber
+	BlobIndex       int
 }
 
 // SubBatch is a part of the whole Batch with identical Encoding Parameters, i.e. (ChunkLen, NumChunk)

--- a/core/data.go
+++ b/core/data.go
@@ -161,6 +161,7 @@ func (cb Bundles) Serialize() ([][][]byte, error) {
 	return data, nil
 }
 
+<<<<<<< HEAD
 // Returns the size of the bundles in bytes.
 func (cb Bundles) Size() int64 {
 	size := int64(0)
@@ -172,9 +173,18 @@ func (cb Bundles) Size() int64 {
 	return size
 }
 
+=======
+// Sample is a chunk with associated metadata used by the Universal Batch Verifier
+>>>>>>> organize data struct and add fiat shamir
 type Sample struct {
 	Commitment *Commitment
-	Chunk      *Chunk // contain proof and coeffs
+	Chunk      *Chunk
 	EvalIndex  ChunkNumber
 	BlobIndex  int
+}
+
+// SubBatch is a part of the whole Batch with identical Encoding Parameters, i.e. (ChunkLen, NumChunk)
+type SubBatch struct {
+	Samples  []Sample
+	NumBlobs int
 }

--- a/core/data.go
+++ b/core/data.go
@@ -171,3 +171,10 @@ func (cb Bundles) Size() int64 {
 	}
 	return size
 }
+
+type Sample struct {
+	Commitment *Commitment
+	Chunk      *Chunk // contain proof and coeffs
+	EvalIndex  ChunkNumber
+	BlobIndex  int
+}

--- a/core/data.go
+++ b/core/data.go
@@ -181,6 +181,7 @@ type Sample struct {
 }
 
 // SubBatch is a part of the whole Batch with identical Encoding Parameters, i.e. (ChunkLen, NumChunk)
+// Blobs with the same encoding parameters are collected in a single subBatch
 type SubBatch struct {
 	Samples  []Sample
 	NumBlobs int

--- a/core/encoding.go
+++ b/core/encoding.go
@@ -38,8 +38,8 @@ type Encoder interface {
 	// VerifyChunks takes in the chunks, indices, commitments, and encoding parameters and returns an error if the chunks are invalid.
 	VerifyChunks(chunks []*Chunk, indices []ChunkNumber, commitments BlobCommitments, params EncodingParams) error
 
-	// VerifyBatch takes in
-	UniversalVerifyChunks(params EncodingParams, samples []Sample, numBlobs int) error
+	// VerifyBatch takes in the encoding parameters, samples and the number of blobs and returns an error if a chunk in any sample is invalid.
+	UniversalVerifySubBatch(params EncodingParams, samples []Sample, numBlobs int) error
 
 	// VerifyBlobLength takes in the commitments and returns an error if the blob length is invalid.
 	VerifyBlobLength(commitments BlobCommitments) error

--- a/core/encoding.go
+++ b/core/encoding.go
@@ -38,6 +38,9 @@ type Encoder interface {
 	// VerifyChunks takes in the chunks, indices, commitments, and encoding parameters and returns an error if the chunks are invalid.
 	VerifyChunks(chunks []*Chunk, indices []ChunkNumber, commitments BlobCommitments, params EncodingParams) error
 
+	// VerifyBatch takes in
+	UniversalVerifyChunks(params EncodingParams, samples []Sample, numBlobs int) error
+
 	// VerifyBlobLength takes in the commitments and returns an error if the blob length is invalid.
 	VerifyBlobLength(commitments BlobCommitments) error
 

--- a/core/encoding/encoder.go
+++ b/core/encoding/encoder.go
@@ -2,9 +2,7 @@ package encoding
 
 import (
 	"crypto/sha256"
-	"errors"
 	"fmt"
-	"log"
 
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/pkg/encoding/encoder"
@@ -82,24 +80,6 @@ func (e *Encoder) Encode(data []byte, params core.EncodingParams) (core.BlobComm
 			Coeffs: frame.Coeffs,
 			Proof:  frame.Proof,
 		}
-
-		q, _ := encoder.GetLeadingCosetIndex(uint64(ind), uint64(len(chunks)))
-		lc := enc.Fs.ExpandedRootsOfUnity[uint64(q)]
-		ok := frame.Verify(enc.Ks, commit, &lc)
-		if !ok {
-			log.Fatalf("Proof %v failed\n", ind)
-		} else {
-
-			fmt.Println("proof", frame.Proof.String())
-			fmt.Println("commitment", commit.String())
-			for i := 0; i < len(frame.Coeffs); i++ {
-				fmt.Printf("%v ", frame.Coeffs[i].String())
-			}
-			fmt.Println("q", q, lc.String())
-
-			fmt.Println("***************tested frame and pass")
-		}
-
 	}
 
 	length := uint(len(encoder.ToFrArray(data)))
@@ -170,11 +150,7 @@ func (e *Encoder) UniversalVerifyChunks(params core.EncodingParams, samplesCore 
 		samples[i] = sample
 	}
 
-	if e.EncoderGroup.UniversalVerify(encParams, samples, numBlobs) {
-		return nil
-	} else {
-		return errors.New("Universal Verify wrong")
-	}
+	return e.EncoderGroup.UniversalVerify(encParams, samples, numBlobs)
 }
 
 // Decode takes in the chunks, indices, and encoding parameters and returns the decoded blob

--- a/core/encoding/encoder.go
+++ b/core/encoding/encoder.go
@@ -2,6 +2,9 @@ package encoding
 
 import (
 	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log"
 
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/pkg/encoding/encoder"
@@ -60,6 +63,7 @@ func (e *Encoder) Encode(data []byte, params core.EncodingParams) (core.BlobComm
 		}
 	}
 	encParams := toEncParams(params)
+	fmt.Println("encParams", encParams)
 
 	enc, err := e.EncoderGroup.GetKzgEncoder(encParams)
 	if err != nil {
@@ -78,6 +82,24 @@ func (e *Encoder) Encode(data []byte, params core.EncodingParams) (core.BlobComm
 			Coeffs: frame.Coeffs,
 			Proof:  frame.Proof,
 		}
+
+		q, _ := encoder.GetLeadingCosetIndex(uint64(ind), uint64(len(chunks)))
+		lc := enc.Fs.ExpandedRootsOfUnity[uint64(q)]
+		ok := frame.Verify(enc.Ks, commit, &lc)
+		if !ok {
+			log.Fatalf("Proof %v failed\n", ind)
+		} else {
+
+			fmt.Println("proof", frame.Proof.String())
+			fmt.Println("commitment", commit.String())
+			for i := 0; i < len(frame.Coeffs); i++ {
+				fmt.Printf("%v ", frame.Coeffs[i].String())
+			}
+			fmt.Println("q", q, lc.String())
+
+			fmt.Println("***************tested frame and pass")
+		}
+
 	}
 
 	length := uint(len(encoder.ToFrArray(data)))
@@ -129,6 +151,30 @@ func (e *Encoder) VerifyChunks(chunks []*core.Chunk, indices []core.ChunkNumber,
 
 	return nil
 
+}
+
+// convert struct understandable by the crypto library
+func (e *Encoder) UniversalVerifyChunks(params core.EncodingParams, samplesCore []core.Sample, numBlobs int) error {
+	encParams := toEncParams(params)
+
+	samples := make([]kzgEncoder.Sample, len(samplesCore))
+
+	for i, sc := range samplesCore {
+		sample := kzgEncoder.Sample{
+			Commitment: *sc.Commitment.G1Point,
+			Proof:      sc.Chunk.Proof,
+			Row:        sc.BlobIndex,
+			Coeffs:     sc.Chunk.Coeffs,
+			X:          sc.EvalIndex,
+		}
+		samples[i] = sample
+	}
+
+	if e.EncoderGroup.UniversalVerify(encParams, samples, numBlobs) {
+		return nil
+	} else {
+		return errors.New("Universal Verify wrong")
+	}
 }
 
 // Decode takes in the chunks, indices, and encoding parameters and returns the decoded blob

--- a/core/encoding/encoder.go
+++ b/core/encoding/encoder.go
@@ -132,7 +132,7 @@ func (e *Encoder) VerifyChunks(chunks []*core.Chunk, indices []core.ChunkNumber,
 }
 
 // convert struct understandable by the crypto library
-func (e *Encoder) UniversalVerifyChunks(params core.EncodingParams, samplesCore []core.Sample, numBlobs int) error {
+func (e *Encoder) UniversalVerifySubBatch(params core.EncodingParams, samplesCore []core.Sample, numBlobs int) error {
 	encParams := toEncParams(params)
 	samples := make([]kzgEncoder.Sample, len(samplesCore))
 

--- a/core/encoding/encoder.go
+++ b/core/encoding/encoder.go
@@ -2,7 +2,6 @@ package encoding
 
 import (
 	"crypto/sha256"
-	"fmt"
 
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/pkg/encoding/encoder"
@@ -61,7 +60,6 @@ func (e *Encoder) Encode(data []byte, params core.EncodingParams) (core.BlobComm
 		}
 	}
 	encParams := toEncParams(params)
-	fmt.Println("encParams", encParams)
 
 	enc, err := e.EncoderGroup.GetKzgEncoder(encParams)
 	if err != nil {
@@ -136,7 +134,6 @@ func (e *Encoder) VerifyChunks(chunks []*core.Chunk, indices []core.ChunkNumber,
 // convert struct understandable by the crypto library
 func (e *Encoder) UniversalVerifyChunks(params core.EncodingParams, samplesCore []core.Sample, numBlobs int) error {
 	encParams := toEncParams(params)
-
 	samples := make([]kzgEncoder.Sample, len(samplesCore))
 
 	for i, sc := range samplesCore {
@@ -145,7 +142,7 @@ func (e *Encoder) UniversalVerifyChunks(params core.EncodingParams, samplesCore 
 			Proof:      sc.Chunk.Proof,
 			Row:        sc.BlobIndex,
 			Coeffs:     sc.Chunk.Coeffs,
-			X:          sc.EvalIndex,
+			X:          sc.AssignmentIndex,
 		}
 		samples[i] = sample
 	}

--- a/core/encoding/encoder.go
+++ b/core/encoding/encoder.go
@@ -140,7 +140,7 @@ func (e *Encoder) UniversalVerifySubBatch(params core.EncodingParams, samplesCor
 		sample := kzgEncoder.Sample{
 			Commitment: *sc.Commitment.G1Point,
 			Proof:      sc.Chunk.Proof,
-			Row:        sc.BlobIndex,
+			RowIndex:   sc.BlobIndex,
 			Coeffs:     sc.Chunk.Coeffs,
 			X:          sc.AssignmentIndex,
 		}

--- a/core/encoding/encoder.go
+++ b/core/encoding/encoder.go
@@ -137,12 +137,20 @@ func (e *Encoder) UniversalVerifySubBatch(params core.EncodingParams, samplesCor
 	samples := make([]kzgEncoder.Sample, len(samplesCore))
 
 	for i, sc := range samplesCore {
+		x, err := encoder.GetLeadingCosetIndex(
+			uint64(sc.AssignmentIndex),
+			encParams.NumChunks,
+		)
+		if err != nil {
+			return err
+		}
+
 		sample := kzgEncoder.Sample{
 			Commitment: *sc.Commitment.G1Point,
 			Proof:      sc.Chunk.Proof,
 			RowIndex:   sc.BlobIndex,
 			Coeffs:     sc.Chunk.Coeffs,
-			X:          sc.AssignmentIndex,
+			X:          uint(x),
 		}
 		samples[i] = sample
 	}

--- a/core/encoding/mock_encoder.go
+++ b/core/encoding/mock_encoder.go
@@ -27,7 +27,7 @@ func (e *MockEncoder) VerifyChunks(chunks []*core.Chunk, indices []core.ChunkNum
 	return args.Error(0)
 }
 
-func (e *MockEncoder) UniversalVerifyChunks(params core.EncodingParams, samples []core.Sample, numBlobs int) error {
+func (e *MockEncoder) UniversalVerifySubBatch(params core.EncodingParams, samples []core.Sample, numBlobs int) error {
 	args := e.Called(params, samples, numBlobs)
 	time.Sleep(e.Delay)
 	return args.Error(0)

--- a/core/encoding/mock_encoder.go
+++ b/core/encoding/mock_encoder.go
@@ -27,6 +27,12 @@ func (e *MockEncoder) VerifyChunks(chunks []*core.Chunk, indices []core.ChunkNum
 	return args.Error(0)
 }
 
+func (e *MockEncoder) UniversalVerifyChunks(params core.EncodingParams, samples []core.Sample, numBlobs int) error {
+	args := e.Called(params, samples, numBlobs)
+	time.Sleep(e.Delay)
+	return args.Error(0)
+}
+
 func (e *MockEncoder) VerifyBlobLength(commitments core.BlobCommitments) error {
 
 	args := e.Called(commitments)

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -77,7 +77,7 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 			aggPubKey.Add(d.KeyPairs[ind].GetPubKeyG1())
 		}
 
-		stake := ind + 1
+		stake := ind*ind*6 + 32
 		host := "0.0.0.0"
 		dispersalPort := fmt.Sprintf("3%03v", int(2*ind))
 		retrievalPort := fmt.Sprintf("3%03v", int(2*ind+1))

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -77,7 +77,7 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 			aggPubKey.Add(d.KeyPairs[ind].GetPubKeyG1())
 		}
 
-		stake := ind*ind*6 + 32
+		stake := ind + 1
 		host := "0.0.0.0"
 		dispersalPort := fmt.Sprintf("3%03v", int(2*ind))
 		retrievalPort := fmt.Sprintf("3%03v", int(2*ind+1))

--- a/core/mock/validator.go
+++ b/core/mock/validator.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"errors"
 
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/stretchr/testify/mock"
 )
@@ -23,8 +24,8 @@ func NewMockChunkValidator() *MockChunkValidator {
 	return &MockChunkValidator{}
 }
 
-func (v *MockChunkValidator) ValidateBatch(blobs []*core.BlobMessage, operatorState *core.OperatorState) error {
-	args := v.Called(blobs, operatorState)
+func (v *MockChunkValidator) ValidateBatch(blobs []*core.BlobMessage, operatorState *core.OperatorState, pool common.WorkerPool) error {
+	args := v.Called(blobs, operatorState, pool)
 	return args.Error(0)
 }
 

--- a/core/mock/validator.go
+++ b/core/mock/validator.go
@@ -23,6 +23,11 @@ func NewMockChunkValidator() *MockChunkValidator {
 	return &MockChunkValidator{}
 }
 
+func (v *MockChunkValidator) ValidateBatch(blobs []*core.BlobMessage, operatorState *core.OperatorState) error {
+	args := v.Called(blobs, operatorState)
+	return args.Error(0)
+}
+
 func (v *MockChunkValidator) ValidateBlob(blob *core.BlobMessage, operatorState *core.OperatorState) error {
 	args := v.Called(blob, operatorState)
 	return args.Error(0)

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -67,82 +67,88 @@ func makeTestBlob(t *testing.T, length int, securityParams []*core.SecurityParam
 	return blob
 }
 
-// prepareBatch takes in a single blob, encodes it, generates the associated assignments, and the batch header.
+// prepareBatch takes in multiple blob, encodes them, generates the associated assignments, and the batch header.
 // These are the products that a disperser will need in order to disperse data to the DA nodes.
-func prepareBatch(t *testing.T, cst core.IndexedChainState, blob core.Blob, quorumIndex uint, quantizationFactor uint, bn uint) (core.EncodedBlob, core.BatchHeader) {
-
-	quorumID := blob.RequestHeader.SecurityParams[quorumIndex].QuorumID
-	quorums := []core.QuorumID{quorumID}
-
-	state, err := cst.GetOperatorState(context.Background(), bn, quorums)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assignments, info, err := asn.GetAssignments(state, quorumID, quantizationFactor)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	blobSize := uint(len(blob.Data))
-	blobLength := core.GetBlobLength(blobSize)
-	adversaryThreshold := blob.RequestHeader.SecurityParams[quorumIndex].AdversaryThreshold
-	quorumThreshold := blob.RequestHeader.SecurityParams[quorumIndex].QuorumThreshold
-
-	numOperators := uint(len(state.Operators[quorumID]))
-
-	chunkLength, err := asn.GetMinimumChunkLength(numOperators, blobLength, quantizationFactor, quorumThreshold, adversaryThreshold)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	params, err := core.GetEncodingParams(chunkLength, info.TotalChunks)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	commitments, chunks, err := enc.Encode(blob.Data, params)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	quorumHeader := &core.BlobQuorumInfo{
-		SecurityParam: core.SecurityParam{
-			QuorumID:           quorumID,
-			AdversaryThreshold: adversaryThreshold,
-			QuorumThreshold:    quorumThreshold,
-		},
-		QuantizationFactor: quantizationFactor,
-		EncodedBlobLength:  params.ChunkLength * quantizationFactor * numOperators,
-	}
-
-	blobHeader := &core.BlobHeader{
-		BlobCommitments: core.BlobCommitments{
-			Commitment:  commitments.Commitment,
-			LengthProof: commitments.LengthProof,
-			Length:      commitments.Length,
-		},
-		QuorumInfos: []*core.BlobQuorumInfo{quorumHeader},
-	}
+func prepareBatch(t *testing.T, cst core.IndexedChainState, blobs []core.Blob, quorumIndex uint, quantizationFactor uint, bn uint) ([]core.EncodedBlob, core.BatchHeader) {
 
 	batchHeader := core.BatchHeader{
 		ReferenceBlockNumber: bn,
 		BatchRoot:            [32]byte{},
 	}
 
-	var encodedBlob core.EncodedBlob = make(map[core.OperatorID]*core.BlobMessage, len(assignments))
+	numBlob := len(blobs)
+	var encodedBlobs []core.EncodedBlob = make([]core.EncodedBlob, numBlob)
 
-	for id, assignment := range assignments {
-		bundles := map[core.QuorumID]core.Bundle{
-			quorumID: chunks[assignment.StartIndex : assignment.StartIndex+assignment.NumChunks],
+	for z, blob := range blobs {
+		quorumID := blob.RequestHeader.SecurityParams[quorumIndex].QuorumID
+		quorums := []core.QuorumID{quorumID}
+
+		state, err := cst.GetOperatorState(context.Background(), bn, quorums)
+		if err != nil {
+			t.Fatal(err)
 		}
-		encodedBlob[id] = &core.BlobMessage{
-			BlobHeader: blobHeader,
-			Bundles:    bundles,
+
+		assignments, info, err := asn.GetAssignments(state, quorumID, quantizationFactor)
+		if err != nil {
+			t.Fatal(err)
 		}
+
+		blobSize := uint(len(blob.Data))
+		blobLength := core.GetBlobLength(blobSize)
+		adversaryThreshold := blob.RequestHeader.SecurityParams[quorumIndex].AdversaryThreshold
+		quorumThreshold := blob.RequestHeader.SecurityParams[quorumIndex].QuorumThreshold
+
+		numOperators := uint(len(state.Operators[quorumID]))
+
+		chunkLength, err := asn.GetMinimumChunkLength(numOperators, blobLength, quantizationFactor, quorumThreshold, adversaryThreshold)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		params, err := core.GetEncodingParams(chunkLength, info.TotalChunks)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitments, chunks, err := enc.Encode(blob.Data, params)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		quorumHeader := &core.BlobQuorumInfo{
+			SecurityParam: core.SecurityParam{
+				QuorumID:           quorumID,
+				AdversaryThreshold: adversaryThreshold,
+				QuorumThreshold:    quorumThreshold,
+			},
+			QuantizationFactor: quantizationFactor,
+			EncodedBlobLength:  params.ChunkLength * quantizationFactor * numOperators,
+		}
+
+		blobHeader := &core.BlobHeader{
+			BlobCommitments: core.BlobCommitments{
+				Commitment:  commitments.Commitment,
+				LengthProof: commitments.LengthProof,
+				Length:      commitments.Length,
+			},
+			QuorumInfos: []*core.BlobQuorumInfo{quorumHeader},
+		}
+
+		var encodedBlob core.EncodedBlob = make(map[core.OperatorID]*core.BlobMessage, len(assignments))
+		for id, assignment := range assignments {
+			bundles := map[core.QuorumID]core.Bundle{
+				quorumID: chunks[assignment.StartIndex : assignment.StartIndex+assignment.NumChunks],
+			}
+			encodedBlob[id] = &core.BlobMessage{
+				BlobHeader: blobHeader,
+				Bundles:    bundles,
+			}
+		}
+		encodedBlobs[z] = encodedBlob
+
 	}
 
-	return encodedBlob, batchHeader
+	return encodedBlobs, batchHeader
 
 }
 
@@ -155,11 +161,30 @@ func checkBatch(t *testing.T, cst core.IndexedChainState, encodedBlob core.Encod
 	state, _ := cst.GetIndexedOperatorState(context.Background(), header.ReferenceBlockNumber, quorums)
 
 	for id := range state.IndexedOperators {
-
-		blobMessage := encodedBlob[id]
-
 		val.UpdateOperatorID(id)
+		blobMessage := encodedBlob[id]
 		err := val.ValidateBlob(blobMessage, state.OperatorState)
+		assert.NoError(t, err)
+	}
+
+}
+
+// checkBatchByUniversalVerifier runs the verification logic for each DA node in the current OperatorState, and returns an error if any of
+// the DA nodes' validation checks fails
+func checkBatchByUniversalVerifier(t *testing.T, cst core.IndexedChainState, encodedBlobs []core.EncodedBlob, header core.BatchHeader) {
+	val := core.NewChunkValidator(enc, asn, cst, [32]byte{})
+
+	quorums := []core.QuorumID{0}
+	state, _ := cst.GetIndexedOperatorState(context.Background(), header.ReferenceBlockNumber, quorums)
+	numBlob := len(encodedBlobs)
+
+	for id := range state.IndexedOperators {
+		val.UpdateOperatorID(id)
+		var blobMessages []*core.BlobMessage = make([]*core.BlobMessage, numBlob)
+		for z, encodedBlob := range encodedBlobs {
+			blobMessages[z] = encodedBlob[id]
+		}
+		err := val.ValidateBatch(blobMessages, state.OperatorState)
 		assert.NoError(t, err)
 	}
 
@@ -167,6 +192,7 @@ func checkBatch(t *testing.T, cst core.IndexedChainState, encodedBlob core.Encod
 
 func TestCoreLibrary(t *testing.T) {
 
+	numBlob := 5 // must be greater than 0
 	blobLengths := []int{1, 64, 1000}
 	quantizationFactors := []uint{1, 10}
 	operatorCounts := []uint{1, 2, 4, 10, 30}
@@ -184,28 +210,43 @@ func TestCoreLibrary(t *testing.T) {
 		},
 	}
 
-	for _, blobLength := range blobLengths {
-		for _, quantizationFactor := range quantizationFactors {
-			for _, operatorCount := range operatorCounts {
+	quorumIndex := uint(0)
+	bn := uint(0)
+
+	for _, operatorCount := range operatorCounts {
+		cst, err := mock.NewChainDataMock(core.OperatorIndex(operatorCount))
+		assert.NoError(t, err)
+
+		// batch can only be tested per operatorCount, because the assignment would be wrong otherwise
+		for _, blobLength := range blobLengths {
+			batches := make([]core.EncodedBlob, 0)
+			batchHeader := core.BatchHeader{
+				ReferenceBlockNumber: bn,
+				BatchRoot:            [32]byte{},
+			}
+			for _, quantizationFactor := range quantizationFactors {
 				for _, securityParam := range securityParams {
 
 					t.Run(fmt.Sprintf("blobLength=%v, quantizationFactor=%v, operatorCount=%v, securityParams=%v", blobLength, quantizationFactor, operatorCount, securityParam), func(t *testing.T) {
 
-						blob := makeTestBlob(t, blobLength, []*core.SecurityParam{securityParam})
+						blobs := make([]core.Blob, numBlob)
+						for i := 0; i < numBlob; i++ {
+							blobs[i] = makeTestBlob(t, blobLength, []*core.SecurityParam{securityParam})
+						}
 
-						cst, err := mock.NewChainDataMock(core.OperatorIndex(operatorCount))
-						assert.NoError(t, err)
+						batch, header := prepareBatch(t, cst, blobs, quorumIndex, quantizationFactor, bn)
+						batches = append(batches, batch...)
 
-						quorumIndex := uint(0)
-						bn := uint(0)
-
-						batch, header := prepareBatch(t, cst, blob, quorumIndex, quantizationFactor, bn)
-
-						checkBatch(t, cst, batch, header)
+						checkBatch(t, cst, batch[0], header)
 					})
 				}
+
 			}
+			t.Run(fmt.Sprintf("universal verifier operatorCount=%v over %v blobs", operatorCount, len(batches)), func(t *testing.T) {
+				checkBatchByUniversalVerifier(t, cst, batches, batchHeader)
+			})
 		}
+
 	}
 
 }

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -193,7 +193,7 @@ func checkBatchByUniversalVerifier(t *testing.T, cst core.IndexedChainState, enc
 func TestCoreLibrary(t *testing.T) {
 
 	numBlob := 1 // must be greater than 0
-	blobLengths := []int{1, 100, 1000}
+	blobLengths := []int{1, 64, 1000}
 	quantizationFactors := []uint{1, 10}
 	operatorCounts := []uint{1, 2, 4, 10, 30}
 

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -192,8 +192,8 @@ func checkBatchByUniversalVerifier(t *testing.T, cst core.IndexedChainState, enc
 
 func TestCoreLibrary(t *testing.T) {
 
-	numBlob := 5 // must be greater than 0
-	blobLengths := []int{1, 64, 1000}
+	numBlob := 1 // must be greater than 0
+	blobLengths := []int{1, 100, 1000}
 	quantizationFactors := []uint{1, 10}
 	operatorCounts := []uint{1, 2, 4, 10, 30}
 
@@ -216,14 +216,14 @@ func TestCoreLibrary(t *testing.T) {
 	for _, operatorCount := range operatorCounts {
 		cst, err := mock.NewChainDataMock(core.OperatorIndex(operatorCount))
 		assert.NoError(t, err)
-
+		batches := make([]core.EncodedBlob, 0)
+		batchHeader := core.BatchHeader{
+			ReferenceBlockNumber: bn,
+			BatchRoot:            [32]byte{},
+		}
 		// batch can only be tested per operatorCount, because the assignment would be wrong otherwise
 		for _, blobLength := range blobLengths {
-			batches := make([]core.EncodedBlob, 0)
-			batchHeader := core.BatchHeader{
-				ReferenceBlockNumber: bn,
-				BatchRoot:            [32]byte{},
-			}
+
 			for _, quantizationFactor := range quantizationFactors {
 				for _, securityParam := range securityParams {
 
@@ -242,10 +242,11 @@ func TestCoreLibrary(t *testing.T) {
 				}
 
 			}
-			t.Run(fmt.Sprintf("universal verifier operatorCount=%v over %v blobs", operatorCount, len(batches)), func(t *testing.T) {
-				checkBatchByUniversalVerifier(t, cst, batches, batchHeader)
-			})
+
 		}
+		t.Run(fmt.Sprintf("universal verifier operatorCount=%v over %v blobs", operatorCount, len(batches)), func(t *testing.T) {
+			checkBatchByUniversalVerifier(t, cst, batches, batchHeader)
+		})
 
 	}
 

--- a/core/validator.go
+++ b/core/validator.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 )
 
 var (
@@ -10,6 +11,7 @@ var (
 )
 
 type ChunkValidator interface {
+	ValidateBatch([]*BlobMessage, *OperatorState) error
 	ValidateBlob(*BlobMessage, *OperatorState) error
 	UpdateOperatorID(OperatorID)
 }
@@ -113,4 +115,107 @@ func (v *chunkValidator) ValidateBlob(blob *BlobMessage, operatorState *Operator
 
 func (v *chunkValidator) UpdateOperatorID(operatorID OperatorID) {
 	v.operatorID = operatorID
+}
+
+func (v *chunkValidator) ValidateBatch(blobs []*BlobMessage, operatorState *OperatorState) error {
+
+	batchGroup := make(map[EncodingParams][]Sample)
+	numBlobMap := make(map[EncodingParams]int)
+
+	for i, blob := range blobs {
+		if len(blob.Bundles) != len(blob.BlobHeader.QuorumInfos) {
+			return errors.New("number of bundles does not match number of quorums")
+		}
+
+		// Validate the blob length
+		err := v.encoder.VerifyBlobLength(blob.BlobHeader.BlobCommitments)
+		if err != nil {
+			return err
+		}
+		// for each quorum
+		for _, quorumHeader := range blob.BlobHeader.QuorumInfos {
+			// Check if the operator is a member of the quorum
+			if _, ok := operatorState.Operators[quorumHeader.QuorumID]; !ok {
+				continue
+			}
+
+			// Get the assignments for the quorum
+			assignment, info, err := v.assignment.GetOperatorAssignment(
+				operatorState,
+				quorumHeader.QuorumID,
+				quorumHeader.QuantizationFactor,
+				v.operatorID,
+			)
+			if err != nil {
+				return err
+			}
+
+			// Validate the number of chunks
+			if assignment.NumChunks == 0 {
+				continue
+			}
+			if assignment.NumChunks != uint(len(blob.Bundles[quorumHeader.QuorumID])) {
+				return errors.New("number of chunks does not match assignment")
+			}
+
+			chunkLength, err := v.assignment.GetChunkLengthFromHeader(operatorState, quorumHeader)
+			if err != nil {
+				return err
+			}
+
+			// Get the chunk length
+			chunks := blob.Bundles[quorumHeader.QuorumID]
+			for _, chunk := range chunks {
+				if uint(chunk.Length()) != chunkLength {
+					return ErrChunkLengthMismatch
+				}
+			}
+
+			// Validate the chunk length
+			numOperators := uint(len(operatorState.Operators[quorumHeader.QuorumID]))
+			if chunkLength*quorumHeader.QuantizationFactor*numOperators != quorumHeader.EncodedBlobLength {
+				return ErrInvalidHeader
+			}
+
+			// Get Encoding Params
+			params := EncodingParams{ChunkLength: chunkLength, NumChunks: info.TotalChunks}
+
+			// ToDo add a struct
+			_, ok := batchGroup[params]
+			if !ok {
+				batchGroup[params] = make([]Sample, 0)
+				numBlobMap[params] = 1
+			} else {
+				numBlobMap[params] += 1
+			}
+
+			// Check the received chunks against the commitment
+			indices := assignment.GetIndices()
+			fmt.Println("indices", indices)
+			samples := make([]Sample, 0)
+			for ind := range chunks {
+				sample := Sample{
+					Commitment: blob.BlobHeader.BlobCommitments.Commitment,
+					Chunk:      chunks[ind],
+					EvalIndex:  uint(indices[ind]),
+					BlobIndex:  i,
+				}
+				samples = append(samples, sample)
+			}
+			batchGroup[params] = append(batchGroup[params], samples...)
+		}
+	}
+
+	// ToDo parallelize
+	fmt.Println("num batchGroup", len(batchGroup))
+	for params, samples := range batchGroup {
+		numBlobs, _ := numBlobMap[params]
+		err := v.encoder.UniversalVerifyChunks(params, samples, numBlobs)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }

--- a/core/validator.go
+++ b/core/validator.go
@@ -140,10 +140,6 @@ func (v *chunkValidator) ValidateBatch(blobs []*BlobMessage, operatorState *Oper
 		}
 
 		// Validate the blob length
-		// err := v.encoder.VerifyBlobLength(blob.BlobHeader.BlobCommitments)
-		//if err != nil {
-		//	return err
-		//}
 
 		blobCommitmentList[k] = blob.BlobHeader.BlobCommitments
 

--- a/node/grpc/server_test.go
+++ b/node/grpc/server_test.go
@@ -94,6 +94,7 @@ func newTestServer(t *testing.T, mockValidator bool) *grpc.Server {
 	if mockValidator {
 		mockVal := core_mock.NewMockChunkValidator()
 		mockVal.On("ValidateBlob", mock.Anything, mock.Anything).Return(nil)
+		mockVal.On("ValidateBatch", mock.Anything, mock.Anything).Return(nil)
 		val = mockVal
 	} else {
 

--- a/node/grpc/server_test.go
+++ b/node/grpc/server_test.go
@@ -94,7 +94,7 @@ func newTestServer(t *testing.T, mockValidator bool) *grpc.Server {
 	if mockValidator {
 		mockVal := core_mock.NewMockChunkValidator()
 		mockVal.On("ValidateBlob", mock.Anything, mock.Anything).Return(nil)
-		mockVal.On("ValidateBatch", mock.Anything, mock.Anything).Return(nil)
+		mockVal.On("ValidateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		val = mockVal
 	} else {
 

--- a/node/node.go
+++ b/node/node.go
@@ -430,12 +430,12 @@ func buildSdkClients(config *Config, logger common.Logger) (*constructor.Clients
 	return sdkClients, nil
 }
 
-func (n *Node) validateBlob(ctx context.Context, blob *core.BlobMessage, operatorState *core.OperatorState, out chan error) {
-	err := n.Validator.ValidateBlob(blob, operatorState)
-	if err != nil {
-		out <- err
-		return
-	}
+//func (n *Node) validateBlob(ctx context.Context, blob *core.BlobMessage, operatorState *core.OperatorState, out chan error) {
+//	err := n.Validator.ValidateBlob(blob, operatorState)
+//	if err != nil {
+//		out <- err
+//		return
+//	}
 
-	out <- nil
-}
+//	out <- nil
+//}

--- a/node/node.go
+++ b/node/node.go
@@ -25,7 +25,6 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/nodeapi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/gammazero/workerpool"
 )
 
 const (
@@ -322,24 +321,7 @@ func (n *Node) ValidateBatch(ctx context.Context, header *core.BatchHeader, blob
 		return err
 	}
 
-	pool := workerpool.New(n.Config.NumBatchValidators)
-	out := make(chan error, len(blobs))
-	for _, blob := range blobs {
-		blob := blob
-		pool.Submit(func() {
-			n.validateBlob(ctx, blob, operatorState, out)
-		})
-	}
-
-	for i := 0; i < len(blobs); i++ {
-		err := <-out
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-
+	return n.Validator.ValidateBatch(blobs, operatorState)
 }
 
 func (n *Node) updateSocketAddress(ctx context.Context, newSocketAddr string) {

--- a/node/node.go
+++ b/node/node.go
@@ -429,13 +429,3 @@ func buildSdkClients(config *Config, logger common.Logger) (*constructor.Clients
 	sdkClients.PrometheusRegistry.MustRegister(economicMetricsCollector)
 	return sdkClients, nil
 }
-
-//func (n *Node) validateBlob(ctx context.Context, blob *core.BlobMessage, operatorState *core.OperatorState, out chan error) {
-//	err := n.Validator.ValidateBlob(blob, operatorState)
-//	if err != nil {
-//		out <- err
-//		return
-//	}
-
-//	out <- nil
-//}

--- a/pkg/encoding/kzgEncoder/multiframe.go
+++ b/pkg/encoding/kzgEncoder/multiframe.go
@@ -56,6 +56,14 @@ func GenRandomness(params rs.EncodingParams, samples []Sample, m int) (bls.Fr, e
 // m is number of blob, samples is a list of chunks
 // Inside the code, ft stands for first term; st for the second term; tt for the third term
 func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples []Sample, m int) error {
+	// precheck
+	for i, s := range samples {
+		if s.Row >= m {
+			fmt.Printf("sample %v has %v Row, but there are only %v blobs\n", i, s.Row, m)
+			return errors.New("sample.Row and numBlob is inconsistend")
+		}
+	}
+
 	verifier, _ := group.GetKzgVerifier(params)
 	ks := verifier.Ks
 

--- a/pkg/encoding/kzgEncoder/multiframe.go
+++ b/pkg/encoding/kzgEncoder/multiframe.go
@@ -21,31 +21,26 @@ type Sample struct {
 }
 
 // generate a random value using Fiat Shamir transform
+// we can also pseudo randomness generated locally, but we have to ensure no adv can manipulate it
+// Hashing everything takes about 1ms, so Fiat Shamir transform does not incur much cost
 func GenRandomness(params rs.EncodingParams, samples []Sample, m int) (bls.Fr, error) {
-
 	var buffer bytes.Buffer
 	enc := gob.NewEncoder(&buffer)
-	err := enc.Encode(samples)
-	if err != nil {
-		return bls.ZERO, err
-	}
 
-	err = enc.Encode(params)
-	if err != nil {
-		return bls.ZERO, err
-	}
-
-	err = enc.Encode(m)
-	if err != nil {
-		return bls.ZERO, err
+	for _, sample := range samples {
+		err := enc.Encode(sample.Commitment)
+		if err != nil {
+			return bls.ZERO, err
+		}
 	}
 
 	var randomFr bls.Fr
 
-	err = bls.HashToSingleField(&randomFr, buffer.Bytes())
+	err := bls.HashToSingleField(&randomFr, buffer.Bytes())
 	if err != nil {
 		return bls.ZERO, err
 	}
+
 	return randomFr, nil
 }
 

--- a/pkg/encoding/kzgEncoder/multiframe.go
+++ b/pkg/encoding/kzgEncoder/multiframe.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	rs "github.com/Layr-Labs/eigenda/pkg/encoding/encoder"
+	kzg "github.com/Layr-Labs/eigenda/pkg/kzg"
 	bls "github.com/Layr-Labs/eigenda/pkg/kzg/bn254"
 )
 
@@ -15,9 +16,9 @@ import (
 type Sample struct {
 	Commitment bls.G1Point
 	Proof      bls.G1Point
-	Row        int // corresponds to a row in the verification matrix
+	RowIndex   int // corresponds to a row in the verification matrix
 	Coeffs     []bls.Fr
-	X          uint // X is assignment
+	X          uint // X is the same assignment index of chunk in EigenDa
 }
 
 // generate a random value using Fiat Shamir transform
@@ -44,17 +45,128 @@ func GenRandomness(samples []Sample) (bls.Fr, error) {
 	return randomFr, nil
 }
 
+// Every sample has its own randomness, even though multiple samples can come from identical blob
+// Randomnesss for each sample is computed by repeatedly raising the power of the root randomness
+func GenRandomnessVector(samples []Sample) ([]bls.Fr, error) {
+	// root randomness
+	r, err := GenRandomness(samples)
+	if err != nil {
+		return nil, err
+	}
+
+	n := len(samples)
+
+	randomsFr := make([]bls.Fr, n)
+	bls.CopyFr(&randomsFr[0], &r)
+
+	// power of r
+	for j := 0; j < n-1; j++ {
+		bls.MulModFr(&randomsFr[j+1], &randomsFr[j], &r)
+	}
+	return randomsFr, nil
+}
+
+// the rhsG1 comprises of three terms, see https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240/1
+func genRhsG1(samples []Sample, randomsFr []bls.Fr, m int, params rs.EncodingParams, ks *kzg.KZGSettings, proofs []bls.G1Point) (*bls.G1Point, error) {
+	n := len(samples)
+	commits := make([]bls.G1Point, m)
+	D := params.ChunkLen
+
+	var tmp bls.Fr
+
+	// first term
+	// get coeffs to compute the aggregated commitment
+	// note the coeff is affected by how many chunks are validated per blob
+	// if x chunks are sampled from one blob, we need to compute the sum of all x random field element corresponding to each sample
+	aggCommitCoeffs := make([]bls.Fr, m)
+	for k := 0; k < n; k++ {
+		s := samples[k]
+		row := s.RowIndex
+		bls.AddModFr(&aggCommitCoeffs[row], &aggCommitCoeffs[row], &randomsFr[k])
+		bls.CopyG1(&commits[row], &s.Commitment)
+	}
+
+	aggCommit := bls.LinCombG1(commits, aggCommitCoeffs)
+
+	// second term
+	// compute the aggregated interpolation polynomial
+	aggPolyCoeffs := make([]bls.Fr, D)
+
+	// we sum over the weighted coefficients (by the random field element) over all D monomial in all n samples
+	for k := 0; k < n; k++ {
+		coeffs := samples[k].Coeffs
+
+		rk := randomsFr[k]
+		// for each monomial in a given polynomial, multiply its coefficient with the corresponding random field,
+		// then sum it with others. Given ChunkLen (D) is identical for all samples in a subBatch.
+		// The operation is always valid.
+		for j := uint64(0); j < D; j++ {
+			bls.MulModFr(&tmp, &coeffs[j], &rk)
+			bls.AddModFr(&aggPolyCoeffs[j], &aggPolyCoeffs[j], &tmp)
+		}
+	}
+
+	// All samples in a subBatch has identical chunkLen
+	aggPolyG1 := bls.LinCombG1(ks.Srs.G1[:D], aggPolyCoeffs)
+
+	// third term
+	// leading coset is an evaluation index, here we compute the weighted leading coset evaluation by random fields
+	lcCoeffs := make([]bls.Fr, n)
+
+	// get leading coset powers
+	leadingDs := make([]bls.Fr, n)
+
+	for k := 0; k < n; k++ {
+		// It is important to obtain the leading coset index here
+		// As the params from the eigenda Core might not have NumChunks be the power of 2
+		x, err := rs.GetLeadingCosetIndex(
+			uint64(samples[k].X),
+			params.NumChunks,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// got the leading coset field element
+		h := ks.ExpandedRootsOfUnity[x]
+		var hPow bls.Fr
+		bls.CopyFr(&hPow, &bls.ONE)
+
+		// raising the power for each leading coset
+		for j := uint64(0); j < D; j++ {
+			bls.MulModFr(&tmp, &hPow, &h)
+			bls.CopyFr(&hPow, &tmp)
+		}
+		bls.CopyFr(&leadingDs[k], &hPow)
+	}
+
+	// applying the random weights to leading coset elements
+	for k := 0; k < n; k++ {
+		rk := randomsFr[k]
+		bls.MulModFr(&lcCoeffs[k], &rk, &leadingDs[k])
+	}
+
+	offsetG1 := bls.LinCombG1(proofs, lcCoeffs)
+
+	var rhsG1 bls.G1Point
+	bls.SubG1(&rhsG1, aggCommit, aggPolyG1)
+	bls.AddG1(&rhsG1, &rhsG1, offsetG1)
+	return &rhsG1, nil
+}
+
 // UniversalVerify implements batch verification on a set of chunks given the same chunk dimension (chunkLen, numChunk).
 // The details is given in Ethereum Research post whose authors are George Kadianakis, Ansgar Dietrichs, Dankrad Feist
 // https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240
 //
 // m is number of blob, samples is a list of chunks
-// Inside the code, ft stands for first term; st for the second term; tt for the third term
+//
+// The order of samples do not matter.
+// Each sample need not have unique row, it is possible that multiple chunks of the same blob are validated altogether
 func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples []Sample, m int) error {
 	// precheck
 	for i, s := range samples {
-		if s.Row >= m {
-			fmt.Printf("sample %v has %v Row, but there are only %v blobs\n", i, s.Row, m)
+		if s.RowIndex >= m {
+			fmt.Printf("sample %v has %v Row, but there are only %v blobs\n", i, s.RowIndex, m)
 			return errors.New("sample.Row and numBlob is inconsistent")
 		}
 	}
@@ -67,20 +179,10 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 	n := len(samples)
 	fmt.Printf("Batch verify %v frames of %v symbols out of %v blobs \n", n, params.ChunkLen, m)
 
-	r, err := GenRandomness(samples)
+	// generate random field elements to aggregate equality check
+	randomsFr, err := GenRandomnessVector(samples)
 	if err != nil {
 		return err
-	}
-
-	randomsFr := make([]bls.Fr, n)
-	bls.CopyFr(&randomsFr[0], &r)
-
-	// lhs
-	var tmp bls.Fr
-
-	// power of r
-	for j := 0; j < n-1; j++ {
-		bls.MulModFr(&randomsFr[j+1], &randomsFr[j], &r)
 	}
 
 	// array of proofs
@@ -99,71 +201,19 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 	rhsG2 := &bls.GenG2
 
 	// rhs g1
-	// get commitments
-	commits := make([]bls.G1Point, m)
-	// get coeffs
-	ftCoeffs := make([]bls.Fr, m)
-	for k := 0; k < n; k++ {
-		s := samples[k]
-		row := s.Row
-		bls.AddModFr(&ftCoeffs[row], &ftCoeffs[row], &randomsFr[k])
-		bls.CopyG1(&commits[row], &s.Commitment)
+	rhsG1, err := genRhsG1(
+		samples,
+		randomsFr,
+		m,
+		params,
+		ks,
+		proofs,
+	)
+	if err != nil {
+		return err
 	}
 
-	ftG1 := bls.LinCombG1(commits, ftCoeffs)
-
-	// second term
-	stCoeffs := make([]bls.Fr, D)
-	for k := 0; k < n; k++ {
-		coeffs := samples[k].Coeffs
-
-		rk := randomsFr[k]
-		for j := uint64(0); j < D; j++ {
-			bls.MulModFr(&tmp, &coeffs[j], &rk)
-			bls.AddModFr(&stCoeffs[j], &stCoeffs[j], &tmp)
-		}
-	}
-	stG1 := bls.LinCombG1(ks.Srs.G1[:D], stCoeffs)
-
-	// third term
-	ttCoeffs := make([]bls.Fr, n)
-
-	// get leading coset powers
-	leadingDs := make([]bls.Fr, n)
-
-	for k := 0; k < n; k++ {
-		// It is important to obtain the leading coset here
-		// As the params from the eigenda Core might not have NumChunks be the power of 2
-		x, err := rs.GetLeadingCosetIndex(
-			uint64(samples[k].X),
-			params.NumChunks,
-		)
-		if err != nil {
-			return err
-		}
-
-		h := ks.ExpandedRootsOfUnity[x]
-		var hPow bls.Fr
-		bls.CopyFr(&hPow, &bls.ONE)
-
-		for j := uint64(0); j < D; j++ {
-			bls.MulModFr(&tmp, &hPow, &h)
-			bls.CopyFr(&hPow, &tmp)
-		}
-		bls.CopyFr(&leadingDs[k], &hPow)
-	}
-
-	for k := 0; k < n; k++ {
-		rk := randomsFr[k]
-		bls.MulModFr(&ttCoeffs[k], &rk, &leadingDs[k])
-	}
-	ttG1 := bls.LinCombG1(proofs, ttCoeffs)
-
-	var rhsG1 bls.G1Point
-	bls.SubG1(&rhsG1, ftG1, stG1)
-	bls.AddG1(&rhsG1, &rhsG1, ttG1)
-
-	if bls.PairingsVerify(lhsG1, lhsG2, &rhsG1, rhsG2) {
+	if bls.PairingsVerify(lhsG1, lhsG2, rhsG1, rhsG2) {
 		return nil
 	} else {
 		return errors.New("Universal Verify Incorrect paring")

--- a/pkg/encoding/kzgEncoder/multiframe.go
+++ b/pkg/encoding/kzgEncoder/multiframe.go
@@ -24,7 +24,7 @@ type Sample struct {
 // generate a random value using Fiat Shamir transform
 // we can also pseudo randomness generated locally, but we have to ensure no adversary can manipulate it
 // Hashing everything takes about 1ms, so Fiat Shamir transform does not incur much cost
-func GenRandomness(samples []Sample) (bls.Fr, error) {
+func GenRandomFactor(samples []Sample) (bls.Fr, error) {
 	var buffer bytes.Buffer
 	enc := gob.NewEncoder(&buffer)
 
@@ -49,7 +49,7 @@ func GenRandomness(samples []Sample) (bls.Fr, error) {
 // Randomnesss for each sample is computed by repeatedly raising the power of the root randomness
 func GenRandomnessVector(samples []Sample) ([]bls.Fr, error) {
 	// root randomness
-	r, err := GenRandomness(samples)
+	r, err := GenRandomFactor(samples)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/encoding/kzgEncoder/multiframe.go
+++ b/pkg/encoding/kzgEncoder/multiframe.go
@@ -55,10 +55,7 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 	D := params.ChunkLen
 
 	n := len(samples)
-
-	//rInt := uint64(22894)
-	//var r bls.Fr
-	//bls.AsFr(&r, rInt)
+	fmt.Printf("Batch verify %v frames of %v symbols out of %v blobs \n", n, params.ChunkLen, m)
 
 	r, err := GenRandomness(params, samples, m)
 	if err != nil {
@@ -66,10 +63,7 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 	}
 
 	randomsFr := make([]bls.Fr, n)
-	//bls.AsFr(&randomsFr[0], rInt)
 	bls.CopyFr(&randomsFr[0], &r)
-
-	fmt.Println("random", r.String())
 
 	// lhs
 	var tmp bls.Fr
@@ -85,7 +79,6 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 		bls.CopyG1(&proofs[i], &samples[i].Proof)
 	}
 
-	fmt.Printf("len proof %v len ran %v\n", len(proofs), len(randomsFr))
 	// lhs g1
 	lhsG1 := bls.LinCombG1(proofs, randomsFr)
 
@@ -98,9 +91,6 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 	// rhs g1
 	// get commitments
 	commits := make([]bls.G1Point, m)
-	//for k := 0 ; k < n ; k++ {
-	// commits[k] = samples[k].Commitment
-	//}
 	// get coeffs
 	ftCoeffs := make([]bls.Fr, m)
 	for k := 0; k < n; k++ {
@@ -109,7 +99,6 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 		bls.AddModFr(&ftCoeffs[row], &ftCoeffs[row], &randomsFr[k])
 		bls.CopyG1(&commits[row], &s.Commitment)
 	}
-	fmt.Printf("len commit %v len coeff %v\n", len(commits), len(ftCoeffs))
 
 	ftG1 := bls.LinCombG1(commits, ftCoeffs)
 
@@ -169,30 +158,3 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 		return errors.New("Universal Verify Incorrect paring")
 	}
 }
-
-//func SingleVerify(ks *kzg.KZGSettings, commitment *bls.G1Point, x *bls.Fr, coeffs []bls.Fr, proof bls.G1Point) bool {
-//	var xPow bls.Fr
-//	bls.CopyFr(&xPow, &bls.ONE)
-
-//	var tmp bls.Fr
-//	for i := 0; i < len(coeffs); i++ {
-//		bls.MulModFr(&tmp, &xPow, x)
-//		bls.CopyFr(&xPow, &tmp)
-//	}
-
-// [x^n]_2
-//	var xn2 bls.G2Point
-//	bls.MulG2(&xn2, &bls.GenG2, &xPow)
-
-// [s^n - x^n]_2
-//	var xnMinusYn bls.G2Point
-//	bls.SubG2(&xnMinusYn, &ks.Srs.G2[len(coeffs)], &xn2)
-
-// [interpolation_polynomial(s)]_1
-//	is1 := bls.LinCombG1(ks.Srs.G1[:len(coeffs)], coeffs)
-// [commitment - interpolation_polynomial(s)]_1 = [commit]_1 - [interpolation_polynomial(s)]_1
-//	var commitMinusInterpolation bls.G1Point
-//	bls.SubG1(&commitMinusInterpolation, commitment, is1)
-
-//	return bls.PairingsVerify(&commitMinusInterpolation, &bls.GenG2, &proof, &xnMinusYn)
-//}

--- a/pkg/encoding/kzgEncoder/multiframe.go
+++ b/pkg/encoding/kzgEncoder/multiframe.go
@@ -1,0 +1,191 @@
+package kzgEncoder
+
+import (
+	"fmt"
+	"log"
+
+	rs "github.com/Layr-Labs/eigenda/pkg/encoding/encoder"
+	kzg "github.com/Layr-Labs/eigenda/pkg/kzg"
+	bls "github.com/Layr-Labs/eigenda/pkg/kzg/bn254"
+)
+
+type Sample struct {
+	Commitment bls.G1Point
+	Proof      bls.G1Point
+	Row        int
+	Coeffs     []bls.Fr
+	X          uint // X is int , at which index is evaluated
+}
+
+// m is number of blob
+func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples []Sample, m int) bool {
+	verifier, _ := group.GetKzgVerifier(params)
+	ks := verifier.Ks
+
+	for ind, s := range samples {
+		q, err := rs.GetLeadingCosetIndex(
+			uint64(s.X),
+			params.NumChunks,
+		)
+		if err != nil {
+			return false
+		}
+
+		lc := ks.FFTSettings.ExpandedRootsOfUnity[uint64(q)]
+
+		ok := SingleVerify(ks, &s.Commitment, &lc, s.Coeffs, s.Proof)
+		if !ok {
+			fmt.Println("proof", s.Proof.String())
+			fmt.Println("commitment", s.Commitment.String())
+
+			for i := 0; i < len(s.Coeffs); i++ {
+				fmt.Printf("%v ", s.Coeffs[i].String())
+			}
+			fmt.Println("q", q, lc.String())
+
+			log.Fatalf("Proof %v failed\n", ind)
+		} else {
+
+			fmt.Println("&&&&&&&&&&&&&&&&&&tested frame and pass", ind)
+		}
+	}
+
+	D := len(samples[0].Coeffs) // chunkLen
+
+	n := len(samples)
+
+	rInt := uint64(22894)
+	var r bls.Fr
+	bls.AsFr(&r, rInt)
+
+	randomsFr := make([]bls.Fr, n)
+	bls.AsFr(&randomsFr[0], rInt)
+
+	// lhs
+	var tmp bls.Fr
+
+	// power of r
+	for j := 0; j < n-1; j++ {
+		bls.MulModFr(&randomsFr[j+1], &randomsFr[j], &r)
+	}
+
+	// array of proofs
+	proofs := make([]bls.G1Point, n)
+	for i := 0; i < n; i++ {
+		bls.CopyG1(&proofs[i], &samples[i].Proof)
+	}
+
+	fmt.Printf("len proof %v len ran %v\n", len(proofs), len(randomsFr))
+	// lhs g1
+	lhsG1 := bls.LinCombG1(proofs, randomsFr)
+
+	// lhs g2
+	lhsG2 := &ks.Srs.G2[D]
+
+	// rhs g2
+	rhsG2 := &bls.GenG2
+
+	// rhs g1
+	// get commitments
+	commits := make([]bls.G1Point, m)
+	//for k := 0 ; k < n ; k++ {
+	// commits[k] = samples[k].Commitment
+	//}
+	// get coeffs
+	ftCoeffs := make([]bls.Fr, m)
+	for k := 0; k < n; k++ {
+		s := samples[k]
+		row := s.Row
+		bls.AddModFr(&ftCoeffs[row], &ftCoeffs[row], &randomsFr[k])
+		bls.CopyG1(&commits[row], &s.Commitment)
+	}
+	fmt.Printf("len commit %v len coeff %v\n", len(commits), len(ftCoeffs))
+
+	ftG1 := bls.LinCombG1(commits, ftCoeffs)
+
+	// second term
+	stCoeffs := make([]bls.Fr, D)
+	for k := 0; k < n; k++ {
+		coeffs := samples[k].Coeffs
+
+		rk := randomsFr[k]
+		for j := 0; j < D; j++ {
+			bls.MulModFr(&tmp, &coeffs[j], &rk)
+			bls.AddModFr(&stCoeffs[j], &stCoeffs[j], &tmp)
+		}
+	}
+	stG1 := bls.LinCombG1(ks.Srs.G1[:D], stCoeffs)
+
+	// third term
+	ttCoeffs := make([]bls.Fr, n)
+
+	// get leading coset powers
+	leadingDs := make([]bls.Fr, n)
+
+	for k := 0; k < n; k++ {
+		x, err := rs.GetLeadingCosetIndex(
+			uint64(samples[k].X),
+			params.NumChunks,
+		)
+		if err != nil {
+			return false
+		}
+
+		h := ks.ExpandedRootsOfUnity[x]
+		var hPow bls.Fr
+		bls.CopyFr(&hPow, &bls.ONE)
+
+		for j := 0; j < D; j++ {
+			bls.MulModFr(&tmp, &hPow, &h)
+			bls.CopyFr(&hPow, &tmp)
+		}
+		bls.CopyFr(&leadingDs[k], &hPow)
+	}
+
+	//
+	for k := 0; k < n; k++ {
+		rk := randomsFr[k]
+		bls.MulModFr(&ttCoeffs[k], &rk, &leadingDs[k])
+	}
+	ttG1 := bls.LinCombG1(proofs, ttCoeffs)
+
+	var rhsG1 bls.G1Point
+	bls.SubG1(&rhsG1, ftG1, stG1)
+	bls.AddG1(&rhsG1, &rhsG1, ttG1)
+
+	return bls.PairingsVerify(lhsG1, lhsG2, &rhsG1, rhsG2)
+}
+
+func SingleVerify(ks *kzg.KZGSettings, commitment *bls.G1Point, x *bls.Fr, coeffs []bls.Fr, proof bls.G1Point) bool {
+	var xPow bls.Fr
+	bls.CopyFr(&xPow, &bls.ONE)
+
+	var tmp bls.Fr
+	for i := 0; i < len(coeffs); i++ {
+		bls.MulModFr(&tmp, &xPow, x)
+		bls.CopyFr(&xPow, &tmp)
+	}
+
+	// [x^n]_2
+	var xn2 bls.G2Point
+	bls.MulG2(&xn2, &bls.GenG2, &xPow)
+
+	// [s^n - x^n]_2
+	var xnMinusYn bls.G2Point
+	bls.SubG2(&xnMinusYn, &ks.Srs.G2[len(coeffs)], &xn2)
+
+	// [interpolation_polynomial(s)]_1
+	is1 := bls.LinCombG1(ks.Srs.G1[:len(coeffs)], coeffs)
+	// [commitment - interpolation_polynomial(s)]_1 = [commit]_1 - [interpolation_polynomial(s)]_1
+	var commitMinusInterpolation bls.G1Point
+	bls.SubG1(&commitMinusInterpolation, commitment, is1)
+
+	// Verify the pairing equation
+	//
+	// e([commitment - interpolation_polynomial(s)], [1]) = e([proof],  [s^n - x^n])
+	//    equivalent to
+	// e([commitment - interpolation_polynomial]^(-1), [1]) * e([proof],  [s^n - x^n]) = 1_T
+	//
+
+	return bls.PairingsVerify(&commitMinusInterpolation, &bls.GenG2, &proof, &xnMinusYn)
+}

--- a/pkg/encoding/kzgEncoder/multiframe.go
+++ b/pkg/encoding/kzgEncoder/multiframe.go
@@ -23,7 +23,7 @@ type Sample struct {
 // generate a random value using Fiat Shamir transform
 // we can also pseudo randomness generated locally, but we have to ensure no adv can manipulate it
 // Hashing everything takes about 1ms, so Fiat Shamir transform does not incur much cost
-func GenRandomness(params rs.EncodingParams, samples []Sample, m int) (bls.Fr, error) {
+func GenRandomness(samples []Sample) (bls.Fr, error) {
 	var buffer bytes.Buffer
 	enc := gob.NewEncoder(&buffer)
 
@@ -45,7 +45,7 @@ func GenRandomness(params rs.EncodingParams, samples []Sample, m int) (bls.Fr, e
 }
 
 // UniversalVerify implements batch verification on a set of chunks given the same chunk dimension (chunkLen, numChunk).
-// The details is given in Ethereum Research post whose authors are George Kadianakis, George Kadianakis, George Kadianakis
+// The details is given in Ethereum Research post whose authors are George Kadianakis, Ansgar Dietrichs, Dankrad Feist
 // https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240
 //
 // m is number of blob, samples is a list of chunks
@@ -55,7 +55,7 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 	for i, s := range samples {
 		if s.Row >= m {
 			fmt.Printf("sample %v has %v Row, but there are only %v blobs\n", i, s.Row, m)
-			return errors.New("sample.Row and numBlob is inconsistend")
+			return errors.New("sample.Row and numBlob is inconsistent")
 		}
 	}
 
@@ -67,7 +67,7 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 	n := len(samples)
 	fmt.Printf("Batch verify %v frames of %v symbols out of %v blobs \n", n, params.ChunkLen, m)
 
-	r, err := GenRandomness(params, samples, m)
+	r, err := GenRandomness(samples)
 	if err != nil {
 		return err
 	}

--- a/pkg/encoding/kzgEncoder/multiframe_test.go
+++ b/pkg/encoding/kzgEncoder/multiframe_test.go
@@ -41,7 +41,7 @@ func TestUniversalVerify(t *testing.T) {
 				Proof:      f.Proof,
 				RowIndex:   z,
 				Coeffs:     f.Coeffs,
-				X:          uint(i),
+				X:          uint(q),
 			}
 			samples = append(samples, sample)
 		}

--- a/pkg/encoding/kzgEncoder/multiframe_test.go
+++ b/pkg/encoding/kzgEncoder/multiframe_test.go
@@ -1,9 +1,10 @@
-package kzgEncoder
+package kzgEncoder_test
 
 import (
 	"testing"
 
 	rs "github.com/Layr-Labs/eigenda/pkg/encoding/encoder"
+	kzgRs "github.com/Layr-Labs/eigenda/pkg/encoding/kzgEncoder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,13 +13,13 @@ func TestUniversalVerify(t *testing.T) {
 	teardownSuite := setupSuite(t)
 	defer teardownSuite(t)
 
-	group, _ := NewKzgEncoderGroup(kzgConfig)
+	group, _ := kzgRs.NewKzgEncoderGroup(kzgConfig)
 	params := rs.GetEncodingParams(numSys, numPar, uint64(len(GETTYSBURG_ADDRESS_BYTES)))
 	enc, err := group.NewKzgEncoder(params)
 	require.Nil(t, err)
 
 	numBlob := 5
-	samples := make([]Sample, 0)
+	samples := make([]kzgRs.Sample, 0)
 	for z := 0; z < numBlob; z++ {
 		inputFr := rs.ToFrArray(GETTYSBURG_ADDRESS_BYTES)
 
@@ -35,16 +36,16 @@ func TestUniversalVerify(t *testing.T) {
 
 			assert.Equal(t, j, q, "leading coset inconsistency")
 
-			sample = Sample{
-				Commitment: commit,
+			sample := kzgRs.Sample{
+				Commitment: *commit,
 				Proof:      f.Proof,
 				Row:        z,
 				Coeffs:     f.Coeffs,
-				X:          i,
+				X:          uint(i),
 			}
 			samples = append(samples, sample)
 		}
 	}
 
-	assert.True(t, group.UniversalVerify(params, samples, numBlob), "universal batch verification failed\n")
+	assert.True(t, group.UniversalVerify(params, samples, numBlob) == nil, "universal batch verification failed\n")
 }

--- a/pkg/encoding/kzgEncoder/multiframe_test.go
+++ b/pkg/encoding/kzgEncoder/multiframe_test.go
@@ -1,0 +1,50 @@
+package kzgEncoder
+
+import (
+	"testing"
+
+	rs "github.com/Layr-Labs/eigenda/pkg/encoding/encoder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniversalVerify(t *testing.T) {
+	teardownSuite := setupSuite(t)
+	defer teardownSuite(t)
+
+	group, _ := NewKzgEncoderGroup(kzgConfig)
+	params := rs.GetEncodingParams(numSys, numPar, uint64(len(GETTYSBURG_ADDRESS_BYTES)))
+	enc, err := group.NewKzgEncoder(params)
+	require.Nil(t, err)
+
+	numBlob := 5
+	samples := make([]Sample, 0)
+	for z := 0; z < numBlob; z++ {
+		inputFr := rs.ToFrArray(GETTYSBURG_ADDRESS_BYTES)
+
+		commit, _, frames, fIndices, err := enc.Encode(inputFr)
+		require.Nil(t, err)
+
+		// create samples
+		for i := 0; i < len(frames); i++ {
+			f := frames[i]
+			j := fIndices[i]
+
+			q, err := rs.GetLeadingCosetIndex(uint64(i), numSys+numPar)
+			require.Nil(t, err)
+
+			assert.Equal(t, j, q, "leading coset inconsistency")
+
+			sample = Sample{
+				Commitment: commit,
+				Proof:      f.Proof,
+				Row:        z,
+				Coeffs:     f.Coeffs,
+				X:          i,
+			}
+			samples = append(samples, sample)
+		}
+	}
+
+	assert.True(t, group.UniversalVerify(params, samples, numBlob), "universal batch verification failed\n")
+}

--- a/pkg/encoding/kzgEncoder/multiframe_test.go
+++ b/pkg/encoding/kzgEncoder/multiframe_test.go
@@ -39,7 +39,7 @@ func TestUniversalVerify(t *testing.T) {
 			sample := kzgRs.Sample{
 				Commitment: *commit,
 				Proof:      f.Proof,
-				Row:        z,
+				RowIndex:   z,
 				Coeffs:     f.Coeffs,
 				X:          uint(i),
 			}

--- a/pkg/kzg/bn254/bignum_gnark.go
+++ b/pkg/kzg/bn254/bignum_gnark.go
@@ -50,6 +50,14 @@ func AsFr(dst *Fr, i uint64) {
 	(*fr.Element)(dst).SetUint64(i)
 }
 
+func HashToSingleField(dst *Fr, msg []byte) error {
+	DST := []byte("-")
+	randomFr, err := fr.Hash(msg, DST, 1)
+	randomFrBytes := (randomFr[0]).Bytes()
+	FrSetBytes(dst, randomFrBytes[:])
+	return err
+}
+
 func FrStr(b *Fr) string {
 	if b == nil {
 		return "<nil>"


### PR DESCRIPTION
## Why are these changes needed?

This PR adds Batch Chunks verification to reduce the processing time for a node when receiving a batch

The technical details is well documented in https://ethresear.ch/t/a-universal-verification-equation-for-data-availability-sampling/13240#step-by-step-derivation-of-the-universal-equation-11 (A eth research blog)

Important struct:

- Sample: the basic unit for batch verification, for eigenDA it is a chunk
- SubBatch: groups of Samples that has the same dimension

Big changes:

- Add interfaces to both encoding.go and validator.go for batchVerification
- Replace the previous blob-by-blob verification from the node/node.go with the new batch verification
- Parallel processing for each SubBatch

Some suggestions to the following will be helpful:

- Since batchVerification is defined inside core/validator, the parallelization is done inside core (some feedback appreciated)
- Since batchVerification is defined inside core/validator, I removes the "n.Config.NumBatchValidators" which allows clients to specify how many worker thread for verification. Instead I simply spin a goroutine for each subBatch, otherwise I will have to put the numWorker in the core interface (might be it is fine?)
- Although I can use workerpool for parallelization, but it is unnatural to add that dependency in the core 


## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [x] This PR is not tested :(
