### PR TITLE
fix: several typos in the documentation

### DIFF
--- a/docs/design/assignment.md
+++ b/docs/design/assignment.md
@@ -116,7 +116,7 @@ We can therefore satisfy requirement 2 by letting $\rho=1$.
 
 ### Assessment of coding complexity
 
-It turns out that to meet the desired requirements, we do not need to increase the encoding complexity (i.e. decrease chunk size) compared to the default case. Increase in the total number of chunks due to the `ceil()` function can be handled by increasing the number of parity symbols. 
+It turns out that to meet the desired requirements, we do not need to increase the encoding complexity (i.e. decrease chunk size) compared to the default case. An increase in the total number of chunks due to the `ceil()` function can be handled by increasing the number of parity symbols. 
 
 Moreover, the optimization routing described for finding $m$ will serve only to improve beyond the baseline (lower bound), which already achieves desired performance. 
 

--- a/docs/spec/data-model.md
+++ b/docs/spec/data-model.md
@@ -3,7 +3,7 @@
 ### Quorum Information
 
 ```go
-// QuorumID is a unique identifier for a quorum; initially EigenDA wil support upt to 256 quorums
+// QuorumID is a unique identifier for a quorum; initially EigenDA will support up to 256 quorums
 type QuorumID = uint8
 
 // SecurityParam contains the quorum ID and the adversary threshold for the quorum;
@@ -24,11 +24,11 @@ type QuorumResult struct {
 ### Blob Requests
 
 ```go
-// BlobHeader contains the orignal data size of a blob and the security requi
+// BlobHeader contains the original data size of a blob and the security required
 type BlobRequestHeader struct {
 	// BlobSize is the size of the original data in bytes
 	BlobSize uint32
-	// For a blob to be accepted by EigenDA, it satisfy the AdversaryThreshold of each quorum contained in SecurityParams
+	// For a blob to be accepted by EigenDA, it satisfies the AdversaryThreshold of each quorum contained in SecurityParams
 	SecurityParams []SecurityParam
 }
 ```
@@ -79,7 +79,7 @@ type EncodedBatch struct {
 // Chunk is the smallest unit that is distributed to DA nodes, including both data and the associated polynomial opening proofs.
 // A chunk corresponds to a set of evaluations of the global polynomial whose coefficients are used to construct the blob Commitment.
 type Chunk struct {
-	// The Coeffs field contains the coefficients of the polynomial which interolates these evaluations. This is the same as the
+	// The Coeffs field contains the coefficients of the polynomial which interpolates these evaluations. This is the same as the
 	// interpolating polynomial, I(X), used in the KZG multi-reveal (https://dankradfeist.de/ethereum/2020/06/16/kate-polynomial-commitments.html#multiproofs)
 	Coeffs []Symbol
 	Proof  Proof
@@ -113,7 +113,7 @@ type OperatorInfo struct {
 
 // OperatorState contains information about the current state of operators which is stored in the blockchain state
 type OperatorState struct {
-	// Operators is a map from quorum ID to a map from the operators in that quourm to their StoredOperatorInfo. Membership
+	// Operators is a map from quorum ID to a map from the operators in that quorum to their StoredOperatorInfo. Membership
 	// in the map implies membership in the quorum.
 	Operators map[QuorumID]map[OperatorID]*OperatorInfo
 	// Totals is a map from quorum ID to the total stake (Stake) and total count (Index) of all operators in that quorum

--- a/docs/spec/integrations/disperser.md
+++ b/docs/spec/integrations/disperser.md
@@ -35,7 +35,7 @@ func BlobStoreRequestsToPoly(blobStoreRequests []BlobStoreRequest) ([]fr.Element
     return overallPoly, bobIDs, blobDataStartDegrees
 }
 ```
-The disperser returns to each requester the KZG commitment to the `overallPoly` that their data was included in, its start and end degrees, and the the corresponding [DataStoreHeader](../spec/types/node-types.md#datastoreheader) that the blob was included in.
+The disperser returns to each requester the KZG commitment to the `overallPoly` that their data was included in, its start and end degrees, and the corresponding [DataStoreHeader](../spec/types/node-types.md#datastoreheader) that the blob was included in.
 
 ### Encoding
 

--- a/docs/spec/integrations/rollups.md
+++ b/docs/spec/integrations/rollups.md
@@ -21,7 +21,7 @@ When making state claims, validators of the optimistic rollup should resubmit th
 
 ### Revealing Data Onchain during Fraud Proofs (Optimistic rollups)
 
-To keep the interface between EIP-4844 and EigenDA the same, optimistic rollups need to reveal data onchain against the commitment to their own data instead of the concatenated data of all of the `BlobStoreRequests` in the batch. To prove the rollups own data commitment against the batched (concatenated) commitment the was posted onchain in the dataStore header, rollups generate the following proof.
+To keep the interface between EIP-4844 and EigenDA the same, optimistic rollups need to reveal data onchain against the commitment to their own data instead of the concatenated data of all of the `BlobStoreRequests` in the batch. To prove the rollups own data commitment against the batched (concatenated) commitment that was posted onchain in the dataStore header, rollups generate the following proof.
 
 A challenger retrieves the data corresponding to the KZG commitment pointed to by validators of their rollup and parses their rollup's data from the claimed start and end degree. They then prove to a smart contract the commitment to the rollups data, along with their fraud proof, via the [subcommitment proofs](#subcommitment-proof). Note that the rollup's smart contract will implement the verifier described in the proof.
 

--- a/docs/spec/protocol-modules/storage/assignment.md
+++ b/docs/spec/protocol-modules/storage/assignment.md
@@ -4,7 +4,7 @@
 The assignment functionality within EigenDA is carried out by the `AssignmentCoordinator` which is responsible for taking the current OperatorState and the security requirements represented by a given QuorumParams and determining or validating system parameters that will satisfy these security requirements given the OperatorStates. There are two classes of parameters that must be determined or validated:
 
 1) the chunk indices that will be assigned to each DA node.
-2) the length of each chunk (measured in number of symbols). In keeping with the constraint imposed by the Encoding module, all chunks must have the same length, so this is parameter is a scalar.
+2) the length of each chunk (measured in number of symbols). In keeping with the constraint imposed by the Encoding module, all chunks must have the same length, so this parameter is a scalar.
 
 As illustrated in the interface that follows, the assignment of indices does not depend on the security parameters such as quorum threshold and adversary threshold. As these parameters change, the only effect on the resulting assignments will be that the chunk length changes.
 
@@ -104,7 +104,7 @@ Validation with respect to assignments is performed at different layers of the p
 
 ### DA Nodes
 
-When the a DA node receives a `StoreChunks` request, it performs the following validation actions relative to each blob header:
+When the DA node receives a `StoreChunks` request, it performs the following validation actions relative to each blob header:
 - It uses `GetOperatorAssignment` to calculate the chunk indices for which it is responsible, and verifies that each of the chunks that it has received lies on the polynomial at these indices (see [Encoding validation actions](./encoding.md#validation-actions))
 - It validates that the `Length` contained in the `BlobHeader` is valid. (see [Encoding validation actions](./encoding.md#validation-actions))
 - It determines the `ChunkLength` of the received chunks.

--- a/docs/spec/protocol-modules/storage/overview.md
+++ b/docs/spec/protocol-modules/storage/overview.md
@@ -27,7 +27,7 @@ we need to be able to reconstruct from $U_q \setminus U_a$.
 The guarantee is upheld by two smaller modules of encoding and assignment.
 
 #### Encoding
-Encoding is used to take a data blob and transform it into an extended representation consisting of a collection of chunks, such that the original blob can be reconstructed from any sufficiently large group of chunks. This must be done in a verifiable manner so that the agent performing the encoding does need not to be a trusted actor. See [Encoding](./encoding.md) for details and validation actions.
+Encoding is used to take a data blob and transform it into an extended representation consisting of a collection of chunks, such that the original blob can be reconstructed from any sufficiently large group of chunks. This must be done in a verifiable manner so that the agent performing the encoding does not need to be a trusted actor. See [Encoding](./encoding.md) for details and validation actions.
 
 #### Assignment
 The acceptance guarantee is only satisfied when chunks are properly assigned to DA nodes in proportion to the amount of stake held by the DA nodes within the required quorums. See [Assignment](./assignment.md) for details and validation actions.

--- a/docs/spec/protocol-modules/storage/overview.md
+++ b/docs/spec/protocol-modules/storage/overview.md
@@ -7,7 +7,7 @@ Within the modular structure of the EigenDA protocol, when we consider "storage,
 >> When the minimal adversarial threshold assumptions of a blob are met for any quorum, then on-chain acceptance of a blob implies a full blob is held by honest DA nodes of that quorum for the designated period.
 
 We can further break this guarantee into two parts:
-1. Acceptance guarantee: When sufficient portion of stake is held by honest DA nodes of a given quorum, then off-chain acceptance implies that a full blob was transferred to the honest DA nodes of that quorum.
+1. Acceptance guarantee: When a sufficient portion of stake is held by honest DA nodes of a given quorum, then off-chain acceptance implies that a full blob was transferred to the honest DA nodes of that quorum.
 2. Storage guarantee: When honest nodes receive data that is accepted on-chain, they will store it for the designated period.
 
 ## Acceptance Guarantee
@@ -27,7 +27,7 @@ we need to be able to reconstruct from $U_q \setminus U_a$.
 The guarantee is upheld by two smaller modules of encoding and assignment.
 
 #### Encoding
-Encoding is used to take a data blob and transform it into an extended representation consisting of a collection of chunks, such that the original blob can be reconstructed from any sufficiently large group of chunks. This must be done in a verifiable manner so that the agent performing the encoding need not be a trusted actor. See [Encoding](./encoding.md) for details and validation actions.
+Encoding is used to take a data blob and transform it into an extended representation consisting of a collection of chunks, such that the original blob can be reconstructed from any sufficiently large group of chunks. This must be done in a verifiable manner so that the agent performing the encoding does need not to be a trusted actor. See [Encoding](./encoding.md) for details and validation actions.
 
 #### Assignment
 The acceptance guarantee is only satisfied when chunks are properly assigned to DA nodes in proportion to the amount of stake held by the DA nodes within the required quorums. See [Assignment](./assignment.md) for details and validation actions.


### PR DESCRIPTION
## Why are these changes needed?

For a better understanding and learning experience,
I fixed some typos in the docs.

Hope it helps.
Br,
Tudor.