### PR TITLE
Don't memoize eth client TransactOpts

### DIFF
--- a/common/ethclient.go
+++ b/common/ethclient.go
@@ -12,7 +12,7 @@ import (
 
 type EthClient interface {
 	GetAccountAddress() common.Address
-	GetNoSendTransactOpts() *bind.TransactOpts
+	GetNoSendTransactOpts() (*bind.TransactOpts, error)
 	ChainID(ctx context.Context) (*big.Int, error)
 	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)

--- a/common/mock/ethclient.go
+++ b/common/mock/ethclient.go
@@ -31,10 +31,10 @@ func (mock *MockEthClient) GetAccountAddress() common.Address {
 	return result.(common.Address)
 }
 
-func (mock *MockEthClient) GetNoSendTransactOpts() *bind.TransactOpts {
+func (mock *MockEthClient) GetNoSendTransactOpts() (*bind.TransactOpts, error) {
 	args := mock.Called()
 	result := args.Get(0)
-	return result.(*bind.TransactOpts)
+	return result.(*bind.TransactOpts), args.Error(1)
 }
 
 func (mock *MockEthClient) ChainID(ctx context.Context) (*big.Int, error) {

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -123,7 +123,12 @@ func (t *Transactor) RegisterBLSPublicKey(ctx context.Context, keypair *core.Key
 		}
 
 		// assemble tx
-		tx, err := t.Bindings.PubkeyCompendium.RegisterBLSPublicKey(t.EthClient.GetNoSendTransactOpts(), signedMessageHashParam, pubkeyG1Param, pubkeyG2Param)
+		opts, err := t.EthClient.GetNoSendTransactOpts()
+		if err != nil {
+			t.Logger.Error("Failed to generate transact opts", "err", err)
+			return err
+		}
+		tx, err := t.Bindings.PubkeyCompendium.RegisterBLSPublicKey(opts, signedMessageHashParam, pubkeyG1Param, pubkeyG2Param)
 		if err != nil {
 			t.Logger.Error("Error assembling RegisterBLSPublicKey tx")
 			return err
@@ -173,8 +178,12 @@ func (t *Transactor) RegisterOperator(ctx context.Context, pubkeyG1 *core.G1Poin
 		Y: pubkey.Y,
 	}
 	quorumNumbers := quorumIDsToQuorumNumbers(quorumIds)
-
-	tx, err := t.Bindings.BLSRegCoordWithIndices.RegisterOperatorWithCoordinator1(t.EthClient.GetNoSendTransactOpts(), quorumNumbers, g1Point, socket)
+	opts, err := t.EthClient.GetNoSendTransactOpts()
+	if err != nil {
+		t.Logger.Error("Failed to generate transact opts", "err", err)
+		return err
+	}
+	tx, err := t.Bindings.BLSRegCoordWithIndices.RegisterOperatorWithCoordinator1(opts, quorumNumbers, g1Point, socket)
 
 	if err != nil {
 		t.Logger.Error("Failed to register operator", "err", err)
@@ -221,8 +230,13 @@ func (t *Transactor) RegisterOperatorWithChurn(ctx context.Context, pubkeyG1 *co
 		Expiry:    new(big.Int).SetInt64(churnReply.SignatureWithSaltAndExpiry.Expiry),
 	}
 
+	opts, err := t.EthClient.GetNoSendTransactOpts()
+	if err != nil {
+		t.Logger.Error("Failed to generate transact opts", "err", err)
+		return err
+	}
 	tx, err := t.Bindings.BLSRegCoordWithIndices.RegisterOperatorWithCoordinator(
-		t.EthClient.GetNoSendTransactOpts(),
+		opts,
 		quorumNumbers,
 		operatorToRegisterPubkey,
 		socket,
@@ -270,8 +284,13 @@ func (t *Transactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Po
 		Y: pubkey.Y,
 	}
 
+	opts, err := t.EthClient.GetNoSendTransactOpts()
+	if err != nil {
+		t.Logger.Error("Failed to generate transact opts", "err", err)
+		return err
+	}
 	tx, err := t.Bindings.BLSRegCoordWithIndices.DeregisterOperatorWithCoordinator(
-		t.EthClient.GetNoSendTransactOpts(),
+		opts,
 		quorumNumbers,
 		g1Point,
 	)
@@ -290,7 +309,12 @@ func (t *Transactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Po
 
 // UpdateOperatorSocket updates the socket of the operator in all the quorums that it is
 func (t *Transactor) UpdateOperatorSocket(ctx context.Context, socket string) error {
-	tx, err := t.Bindings.BLSRegCoordWithIndices.UpdateSocket(t.EthClient.GetNoSendTransactOpts(), socket)
+	opts, err := t.EthClient.GetNoSendTransactOpts()
+	if err != nil {
+		t.Logger.Error("Failed to generate transact opts", "err", err)
+		return err
+	}
+	tx, err := t.Bindings.BLSRegCoordWithIndices.UpdateSocket(opts, socket)
 	if err != nil {
 		t.Logger.Error("Failed to update operator socket", "err", err)
 		return err
@@ -441,7 +465,12 @@ func (t *Transactor) ConfirmBatch(ctx context.Context, batchHeader core.BatchHea
 		NonSignerStakeIndices:        checkSignaturesIndices.NonSignerStakeIndices,
 	}
 
-	tx, err := t.Bindings.EigenDAServiceManager.ConfirmBatch(t.EthClient.GetNoSendTransactOpts(), batchH, signatureChecker)
+	opts, err := t.EthClient.GetNoSendTransactOpts()
+	if err != nil {
+		t.Logger.Error("Failed to generate transact opts", "err", err)
+		return nil, err
+	}
+	tx, err := t.Bindings.EigenDAServiceManager.ConfirmBatch(opts, batchH, signatureChecker)
 	if err != nil {
 		t.Logger.Error("Failed to confirm batch", "err", err)
 		return nil, err

--- a/inabox/tests/integration_test.go
+++ b/inabox/tests/integration_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/tools/traffic"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,8 +22,8 @@ var _ = Describe("Inabox Integration", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 		defer cancel()
 
-		optsWithValue := new(bind.TransactOpts)
-		*optsWithValue = *ethClient.GetNoSendTransactOpts()
+		optsWithValue, err := ethClient.GetNoSendTransactOpts()
+		Expect(err).To(BeNil())
 		optsWithValue.Value = big.NewInt(1e18)
 		tx, err := mockRollup.RegisterValidator(optsWithValue)
 		Expect(err).To(BeNil())
@@ -76,7 +75,9 @@ var _ = Describe("Inabox Integration", func() {
 				if *blobStatus == disperser.Confirmed {
 					blobHeader := blobHeaderFromProto(reply.GetInfo().GetBlobHeader())
 					verificationProof := blobVerificationProofFromProto(reply.GetInfo().GetBlobVerificationProof())
-					tx, err := mockRollup.PostCommitment(ethClient.GetNoSendTransactOpts(), blobHeader, verificationProof)
+					opts, err := ethClient.GetNoSendTransactOpts()
+					Expect(err).To(BeNil())
+					tx, err := mockRollup.PostCommitment(opts, blobHeader, verificationProof)
 					Expect(err).To(BeNil())
 					_, err = ethClient.EstimateGasPriceAndLimitAndSendTx(ctx, tx, "PostCommitment", nil)
 					Expect(err).To(BeNil())

--- a/test/synthetic-test/synthetic_client_test.go
+++ b/test/synthetic-test/synthetic_client_test.go
@@ -328,7 +328,9 @@ loop:
 					ethClientCtx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 					defer cancel()
 
-					tx, err := mockRollup.PostCommitment(ethClient.GetNoSendTransactOpts(), blobHeader, verificationProof)
+					opts, err := ethClient.GetNoSendTransactOpts()
+					assert.Nil(t, err)
+					tx, err := mockRollup.PostCommitment(opts, blobHeader, verificationProof)
 					assert.Nil(t, err)
 					assert.NotNil(t, tx)
 					logger.Printf("PostCommitment Tx %v", tx)


### PR DESCRIPTION
## Why are these changes needed?
I think memoizing `TransactOpts` is potentially dangerous pattern as it's trivial to update the memoized `TransactOpts` and the caller needs to remember not to. 
Since generating `TransactOpts` isn't too expensive, generating new `TransactOpts` each time can prevent such scenario. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
