### PR TITLE
[encodingstreamer] Validate quorums

### DIFF
--- a/churner/churner.go
+++ b/churner/churner.go
@@ -173,7 +173,7 @@ func (c *churner) createChurnResponse(
 	}, nil
 }
 
-func (c *churner) getOperatorsToChurn(ctx context.Context, quorumIDs []uint8, operatorStakes [][]core.OperatorStake, operatorToRegisterAddress gethcommon.Address, currentBlockNumber uint32) ([]core.OperatorToChurn, error) {
+func (c *churner) getOperatorsToChurn(ctx context.Context, quorumIDs []uint8, operatorStakes core.OperatorStakes, operatorToRegisterAddress gethcommon.Address, currentBlockNumber uint32) ([]core.OperatorToChurn, error) {
 	operatorsToChurn := make([]core.OperatorToChurn, 0)
 	for i, quorumID := range quorumIDs {
 		operatorSetParams, err := c.Transactor.GetOperatorSetParams(ctx, quorumID)
@@ -185,7 +185,7 @@ func (c *churner) getOperatorsToChurn(ctx context.Context, quorumIDs []uint8, op
 			return nil, errors.New("maxOperatorCount is 0")
 		}
 
-		if uint32(len(operatorStakes[i])) < operatorSetParams.MaxOperatorCount {
+		if uint32(len(operatorStakes[quorumID])) < operatorSetParams.MaxOperatorCount {
 			// quorum is not full, so we can continue
 			continue
 		}
@@ -197,9 +197,9 @@ func (c *churner) getOperatorsToChurn(ctx context.Context, quorumIDs []uint8, op
 
 		// loop through operator stakes for the quorum and find the lowest one
 		totalStake := big.NewInt(0)
-		lowestStakeOperatorId := operatorStakes[i][0].OperatorID
-		lowestStake := operatorStakes[i][0].Stake
-		for _, operatorStake := range operatorStakes[i] {
+		lowestStakeOperatorId := operatorStakes[quorumID][0].OperatorID
+		lowestStake := operatorStakes[quorumID][0].Stake
+		for _, operatorStake := range operatorStakes[quorumID] {
 			if operatorStake.Stake.Cmp(lowestStake) < 0 {
 				lowestStake = operatorStake.Stake
 				lowestStakeOperatorId = operatorStake.OperatorID

--- a/churner/server_test.go
+++ b/churner/server_test.go
@@ -119,9 +119,9 @@ func setupMockTransactor() {
 	transactorMock.On("GetCurrentQuorumBitmapByOperatorId").Return(big.NewInt(2), nil)
 	transactorMock.On("GetCurrentBlockNumber").Return(uint32(2), nil)
 	transactorMock.On("GetQuorumCount").Return(uint16(1), nil)
-	transactorMock.On("GetOperatorStakesForQuorums").Return([][]dacore.OperatorStake{
-		{
-			{
+	transactorMock.On("GetOperatorStakesForQuorums").Return(dacore.OperatorStakes{
+		0: {
+			0: {
 				OperatorID: makeOperatorId(1),
 				Stake:      big.NewInt(2),
 			},

--- a/core/eth/state.go
+++ b/core/eth/state.go
@@ -39,11 +39,9 @@ func (cs *ChainState) GetOperatorState(ctx context.Context, blockNumber uint, qu
 	}
 
 	return getOperatorState(operatorsByQuorum, quorums, uint32(blockNumber))
-
 }
 
 func (cs *ChainState) GetCurrentBlockNumber() (uint, error) {
-
 	ctx := context.Background()
 	header, err := cs.Client.HeaderByNumber(ctx, nil)
 	if err != nil {
@@ -51,30 +49,25 @@ func (cs *ChainState) GetCurrentBlockNumber() (uint, error) {
 	}
 
 	return uint(header.Number.Uint64()), nil
-
 }
 
-func getOperatorState(operatorsByQuorum [][]core.OperatorStake, quorumIds []core.QuorumID, blockNumber uint32) (*core.OperatorState, error) {
+func getOperatorState(operatorsByQuorum core.OperatorStakes, quorumIds []core.QuorumID, blockNumber uint32) (*core.OperatorState, error) {
 	operators := make(map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo)
 	totals := make(map[core.QuorumID]*core.OperatorInfo)
 
-	for i, quorum := range operatorsByQuorum {
-
+	for quorumID, quorum := range operatorsByQuorum {
 		totalStake := big.NewInt(0)
-
-		operators[quorumIds[i]] = make(map[core.OperatorID]*core.OperatorInfo)
+		operators[quorumID] = make(map[core.OperatorID]*core.OperatorInfo)
 
 		for ind, op := range quorum {
-
-			operators[quorumIds[i]][op.OperatorID] = &core.OperatorInfo{
+			operators[quorumID][op.OperatorID] = &core.OperatorInfo{
 				Stake: op.Stake,
 				Index: core.OperatorIndex(ind),
 			}
 			totalStake.Add(totalStake, op.Stake)
-
 		}
 
-		totals[quorumIds[i]] = &core.OperatorInfo{
+		totals[quorumID] = &core.OperatorInfo{
 			Stake: totalStake,
 			Index: core.OperatorIndex(len(quorum)),
 		}
@@ -87,5 +80,4 @@ func getOperatorState(operatorsByQuorum [][]core.OperatorStake, quorumIds []core
 	}
 
 	return state, nil
-
 }

--- a/core/indexer/state.go
+++ b/core/indexer/state.go
@@ -62,7 +62,7 @@ func (ics *IndexedChainState) GetIndexedOperatorState(ctx context.Context, block
 	for _, quorum := range quorums {
 		key, ok := pubkeys.QuorumTotals[quorum]
 		if !ok {
-			return nil, errors.New("aggregate key for quorum not found")
+			continue
 		}
 		aggKeys[quorum] = &core.G1Point{G1Affine: key}
 	}

--- a/core/mock/tx.go
+++ b/core/mock/tx.go
@@ -58,17 +58,17 @@ func (t *MockTransactor) UpdateOperatorSocket(ctx context.Context, socket string
 	return args.Error(0)
 }
 
-func (t *MockTransactor) GetOperatorStakes(ctx context.Context, operatorId core.OperatorID, blockNumber uint32) ([][]core.OperatorStake, []core.QuorumID, error) {
+func (t *MockTransactor) GetOperatorStakes(ctx context.Context, operatorId core.OperatorID, blockNumber uint32) (core.OperatorStakes, []core.QuorumID, error) {
 	args := t.Called()
 	result0 := args.Get(0)
 	result1 := args.Get(1)
-	return result0.([][]core.OperatorStake), result1.([]core.QuorumID), args.Error(1)
+	return result0.(core.OperatorStakes), result1.([]core.QuorumID), args.Error(1)
 }
 
-func (t *MockTransactor) GetOperatorStakesForQuorums(ctx context.Context, quorums []core.QuorumID, blockNumber uint32) ([][]core.OperatorStake, error) {
+func (t *MockTransactor) GetOperatorStakesForQuorums(ctx context.Context, quorums []core.QuorumID, blockNumber uint32) (core.OperatorStakes, error) {
 	args := t.Called()
 	result := args.Get(0)
-	return result.([][]core.OperatorStake), args.Error(1)
+	return result.(core.OperatorStakes), args.Error(1)
 }
 
 func (t *MockTransactor) ConfirmBatch(ctx context.Context, batchHeader core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation core.SignatureAggregation) (*types.Receipt, error) {

--- a/core/state.go
+++ b/core/state.go
@@ -91,6 +91,8 @@ type ChainState interface {
 // ChainState is an interface for getting information about the current chain state.
 type IndexedChainState interface {
 	ChainState
+	// GetIndexedOperatorState returns the IndexedOperatorState for the given block number and quorums
+	// If the quorum is not found, the quorum will be ignored and the IndexedOperatorState will be returned for the remaining quorums
 	GetIndexedOperatorState(ctx context.Context, blockNumber uint, quorums []QuorumID) (*IndexedOperatorState, error)
 	Start(context context.Context) error
 }

--- a/core/thegraph/state.go
+++ b/core/thegraph/state.go
@@ -105,16 +105,25 @@ func (ics *indexedChainState) Start(ctx context.Context) error {
 	}
 }
 
-// GetIndexedOperatorState returns the IndexedOperatorState for the given block number and quorums
 func (ics *indexedChainState) GetIndexedOperatorState(ctx context.Context, blockNumber uint, quorums []core.QuorumID) (*core.IndexedOperatorState, error) {
 	operatorState, err := ics.ChainState.GetOperatorState(ctx, blockNumber, quorums)
 	if err != nil {
 		return nil, err
 	}
 
-	aggregatePublicKeys, err := ics.getQuorumAPKs(ctx, quorums, uint32(blockNumber))
-	if err != nil {
-		return nil, err
+	aggregatePublicKeys := ics.getQuorumAPKs(ctx, quorums, uint32(blockNumber))
+	aggKeys := make(map[uint8]*core.G1Point)
+	for _, apk := range aggregatePublicKeys {
+		if apk.Err != nil {
+			ics.logger.Warn("Error getting aggregate public key", "err", apk.Err)
+			continue
+		}
+		if apk.Err == nil && apk.AggregatePubk != nil {
+			aggKeys[apk.QuorumNumber] = apk.AggregatePubk
+		}
+	}
+	if len(aggKeys) == 0 {
+		return nil, errors.New("no aggregate public keys found for any of the specified quorums")
 	}
 
 	indexedOperators, err := ics.getRegisteredIndexedOperatorInfo(ctx, uint32(blockNumber))
@@ -125,7 +134,7 @@ func (ics *indexedChainState) GetIndexedOperatorState(ctx context.Context, block
 	state := &core.IndexedOperatorState{
 		OperatorState:    operatorState,
 		IndexedOperators: indexedOperators,
-		AggKeys:          aggregatePublicKeys,
+		AggKeys:          aggKeys,
 	}
 	return state, nil
 }
@@ -147,21 +156,41 @@ func (ics *indexedChainState) GetIndexedOperatorInfoByOperatorId(ctx context.Con
 	return convertIndexedOperatorInfoGqlToIndexedOperatorInfo(&query.Operator)
 }
 
+type quorumAPK struct {
+	QuorumNumber  uint8
+	AggregatePubk *core.G1Point
+	Err           error
+}
+
 // GetQuorumAPKs returns the Aggregate Public Keys for the given quorums at the given block number
-func (ics *indexedChainState) getQuorumAPKs(ctx context.Context, quorumIDs []core.QuorumID, blockNumber uint32) (map[uint8]*core.G1Point, error) {
-	quorumAPKs := make(map[uint8]*core.G1Point)
+func (ics *indexedChainState) getQuorumAPKs(ctx context.Context, quorumIDs []core.QuorumID, blockNumber uint32) map[uint8]*quorumAPK {
+	quorumAPKs := make(map[uint8]*quorumAPK)
 	for i := range quorumIDs {
 		id := quorumIDs[i]
-		quorumAPK, err := ics.getQuorumAPK(ctx, id, blockNumber)
+		apk, err := ics.getQuorumAPK(ctx, id, blockNumber)
 		if err != nil {
-			return nil, err
+			quorumAPKs[id] = &quorumAPK{
+				QuorumNumber:  uint8(id),
+				AggregatePubk: nil,
+				Err:           err,
+			}
+			continue
 		}
-		if quorumAPK == nil {
-			return nil, fmt.Errorf("quorum APK not found for quorum %d", id)
+		if apk == nil {
+			quorumAPKs[id] = &quorumAPK{
+				QuorumNumber:  uint8(id),
+				AggregatePubk: nil,
+				Err:           fmt.Errorf("quorum APK not found for quorum %d", id),
+			}
+			continue
 		}
-		quorumAPKs[id] = quorumAPK
+		quorumAPKs[id] = &quorumAPK{
+			QuorumNumber:  uint8(id),
+			AggregatePubk: apk,
+			Err:           nil,
+		}
 	}
-	return quorumAPKs, nil
+	return quorumAPKs
 }
 
 // GetQuorumAPK returns the Aggregate Public Key for the given quorum at the given block number

--- a/core/tx.go
+++ b/core/tx.go
@@ -26,6 +26,8 @@ type OperatorSetParam struct {
 	ChurnBIPsOfTotalStake    uint16
 }
 
+type OperatorStakes map[QuorumID]map[OperatorIndex]OperatorStake
+
 type Transactor interface {
 
 	// RegisterBLSPublicKey registers a new BLS public key with  the pubkey compendium smart contract.
@@ -54,11 +56,11 @@ type Transactor interface {
 	// GetOperatorStakes returns the stakes of all operators within the quorums that the operator represented by operatorId
 	//  is registered with. The returned stakes are for the block number supplied. The indices of the operators within each quorum
 	// are also returned.
-	GetOperatorStakes(ctx context.Context, operatorID OperatorID, blockNumber uint32) ([][]OperatorStake, []QuorumID, error)
+	GetOperatorStakes(ctx context.Context, operatorID OperatorID, blockNumber uint32) (OperatorStakes, []QuorumID, error)
 
 	// GetOperatorStakes returns the stakes of all operators within the supplied quorums. The returned stakes are for the block number supplied.
 	// The indices of the operators within each quorum are also returned.
-	GetOperatorStakesForQuorums(ctx context.Context, quorums []QuorumID, blockNumber uint32) ([][]OperatorStake, error)
+	GetOperatorStakesForQuorums(ctx context.Context, quorums []QuorumID, blockNumber uint32) (OperatorStakes, error)
 
 	// ConfirmBatch confirms a batch header and signature aggregation. The signature aggregation must satisfy the quorum thresholds
 	// specified in the batch header. If the signature aggregation does not satisfy the quorum thresholds, the transaction will fail.

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -226,10 +226,11 @@ func (e *EncodingStreamer) RequestEncoding(ctx context.Context, encoderChan chan
 	e.logger.Trace("[encodingstreamer] new metadatas to encode", "numMetadata", len(metadatas), "duration", time.Since(stageTimer))
 
 	// Get the operator state
-	state, err := e.getOperatorStateForBlobs(ctx, metadatas, referenceBlockNumber)
+	state, err := e.getOperatorState(ctx, metadatas, referenceBlockNumber)
 	if err != nil {
 		return fmt.Errorf("error getting operator state: %w", err)
 	}
+	metadatas = e.validateMetadataQuorums(metadatas, state)
 
 	metadataByKey := make(map[disperser.BlobKey]*disperser.BlobMetadata, 0)
 	for _, metadata := range metadatas {
@@ -510,7 +511,7 @@ func (e *EncodingStreamer) CreateBatch() (*batch, error) {
 		i++
 	}
 
-	state, err := e.getOperatorStateForBlobs(context.Background(), metadatas, e.ReferenceBlockNumber)
+	state, err := e.getOperatorState(context.Background(), metadatas, e.ReferenceBlockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +545,8 @@ func (e *EncodingStreamer) RemoveEncodedBlob(metadata *disperser.BlobMetadata) {
 	}
 }
 
-func (e *EncodingStreamer) getOperatorStateForBlobs(ctx context.Context, metadatas []*disperser.BlobMetadata, blockNumber uint) (*core.IndexedOperatorState, error) {
+// getOperatorState returns the operator state for the blobs that have valid quorums
+func (e *EncodingStreamer) getOperatorState(ctx context.Context, metadatas []*disperser.BlobMetadata, blockNumber uint) (*core.IndexedOperatorState, error) {
 
 	quorums := make(map[core.QuorumID]QuorumInfo, 0)
 	for _, metadata := range metadatas {
@@ -560,12 +562,33 @@ func (e *EncodingStreamer) getOperatorStateForBlobs(ctx context.Context, metadat
 		i++
 	}
 
-	// Get the operator state
+	// GetIndexedOperatorState should return state for valid quorums only
 	state, err := e.chainState.GetIndexedOperatorState(ctx, blockNumber, quorumIds)
 	if err != nil {
 		return nil, fmt.Errorf("error getting operator state at block number %d: %w", blockNumber, err)
 	}
-
 	return state, nil
+}
 
+// It also returns the list of valid blob metadatas (i.e. blobs that have valid quorums)
+func (e *EncodingStreamer) validateMetadataQuorums(metadatas []*disperser.BlobMetadata, state *core.IndexedOperatorState) []*disperser.BlobMetadata {
+	validMetadata := make([]*disperser.BlobMetadata, 0)
+	for _, metadata := range metadatas {
+		valid := true
+		for _, quorum := range metadata.RequestMetadata.SecurityParams {
+			if aggKey, ok := state.AggKeys[quorum.QuorumID]; !ok || aggKey == nil {
+				e.logger.Warn("got blob with a quorum without APK. Will skip.", "quorum", quorum.QuorumID)
+				valid = false
+			}
+		}
+		if valid {
+			validMetadata = append(validMetadata, metadata)
+		} else {
+			err := e.blobStore.HandleBlobFailure(context.Background(), metadata, 0)
+			if err != nil {
+				e.logger.Error("error handling blob failure", "err", err)
+			}
+		}
+	}
+	return validMetadata
 }

--- a/disperser/batcher/encoding_streamer_test.go
+++ b/disperser/batcher/encoding_streamer_test.go
@@ -513,6 +513,61 @@ func TestIncorrectParameters(t *testing.T) {
 
 }
 
+func TestInvalidQuorum(t *testing.T) {
+	encodingStreamer, c := createEncodingStreamer(t, 10, 1e12, streamerConfig)
+
+	c.chainDataMock.On("GetCurrentBlockNumber").Return(uint(10), nil)
+
+	out := make(chan batcher.EncodingResultOrStatus)
+
+	ctx := context.Background()
+
+	// this blob should not be encoded because the quorum does not exist
+	blob1 := makeTestBlob([]*core.SecurityParam{{
+		QuorumID:           0,
+		AdversaryThreshold: 75,
+		QuorumThreshold:    100,
+	}, {
+		QuorumID:           99, // this quorum does not exist
+		AdversaryThreshold: 75,
+		QuorumThreshold:    100,
+	}})
+
+	// this blob should be encoded
+	blob2 := makeTestBlob([]*core.SecurityParam{{
+		QuorumID:           0,
+		AdversaryThreshold: 75,
+		QuorumThreshold:    100,
+	}, {
+		QuorumID:           1,
+		AdversaryThreshold: 75,
+		QuorumThreshold:    100,
+	}})
+
+	metadataKey1, err := c.blobStore.StoreBlob(ctx, &blob1, uint64(time.Now().UnixNano()))
+	assert.Nil(t, err)
+	metadataKey2, err := c.blobStore.StoreBlob(ctx, &blob2, uint64(time.Now().UnixNano()))
+	assert.Nil(t, err)
+
+	// request encoding
+	err = encodingStreamer.RequestEncoding(context.Background(), out)
+	assert.Nil(t, err)
+
+	isRequested := encodingStreamer.EncodedBlobstore.HasEncodingRequested(metadataKey1, core.QuorumID(0), 10)
+	assert.False(t, isRequested)
+	isRequested = encodingStreamer.EncodedBlobstore.HasEncodingRequested(metadataKey1, core.QuorumID(99), 10)
+	assert.False(t, isRequested)
+
+	isRequested = encodingStreamer.EncodedBlobstore.HasEncodingRequested(metadataKey2, core.QuorumID(0), 10)
+	assert.True(t, isRequested)
+	isRequested = encodingStreamer.EncodedBlobstore.HasEncodingRequested(metadataKey2, core.QuorumID(1), 10)
+	assert.True(t, isRequested)
+
+	stats, err := c.blobStore.GetBlobMetadata(ctx, metadataKey1)
+	assert.NoError(t, err)
+	assert.Equal(t, disperser.Failed, stats.BlobStatus)
+}
+
 func TestGetBatch(t *testing.T) {
 	encodingStreamer, c := createEncodingStreamer(t, 10, 1e12, streamerConfig)
 	ctx := context.Background()


### PR DESCRIPTION
## Why are these changes needed?
Currently, quorum validation is delegated to the disperser server.
Encoding streamer does not handle invalid quorums, and if there's a request with invalid quorum, the entire iteration fails and encoding loop halts.
This PR addresses this by identifying invalid quorums and filtering out those blobs. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
