### PR TITLE
Make built-in indexer work for retrieval client

### DIFF
--- a/clients/mock/retrieval_client.go
+++ b/clients/mock/retrieval_client.go
@@ -18,6 +18,11 @@ func NewRetrievalClient() *MockRetrievalClient {
 	return &MockRetrievalClient{}
 }
 
+func (c *MockRetrievalClient) StartIndexingChainState(ctx context.Context) error {
+	args := c.Called()
+	return args.Error(0)
+}
+
 func (c *MockRetrievalClient) RetrieveBlob(
 	ctx context.Context,
 	batchHeaderHash [32]byte,

--- a/clients/retrieval_client.go
+++ b/clients/retrieval_client.go
@@ -45,11 +45,14 @@ func NewRetrievalClient(
 	encoder core.Encoder,
 	numConnections int,
 ) (*retrievalClient, error) {
-
 	indexedState, err := coreindexer.NewIndexedChainState(
 		chainState,
 		indexer,
 	)
+	if err != nil {
+		return nil, err
+	}
+	err = indexedState.Start(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/clients/retrieval_client.go
+++ b/clients/retrieval_client.go
@@ -10,6 +10,9 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/wealdtech/go-merkletree"
 	"github.com/wealdtech/go-merkletree/keccak256"
+
+	coreindexer "github.com/Layr-Labs/eigenda/core/indexer"
+	"github.com/Layr-Labs/eigenda/indexer"
 )
 
 type RetrievalClient interface {
@@ -35,20 +38,29 @@ var _ RetrievalClient = (*retrievalClient)(nil)
 
 func NewRetrievalClient(
 	logger common.Logger,
-	indexedChainState core.IndexedChainState,
+	chainState core.ChainState,
+	indexer indexer.Indexer,
 	assignmentCoordinator core.AssignmentCoordinator,
 	nodeClient NodeClient,
 	encoder core.Encoder,
 	numConnections int,
-) *retrievalClient {
+) (*retrievalClient, error) {
+
+	indexedState, err := coreindexer.NewIndexedChainState(
+		chainState,
+		indexer,
+	)
+	if err != nil {
+		return nil, err
+	}
 	return &retrievalClient{
 		logger:                logger,
-		indexedChainState:     indexedChainState,
+		indexedChainState:     indexedState,
 		assignmentCoordinator: assignmentCoordinator,
 		nodeClient:            nodeClient,
 		encoder:               encoder,
 		numConnections:        numConnections,
-	}
+	}, nil
 }
 
 func (r *retrievalClient) RetrieveBlob(

--- a/clients/retrieval_client.go
+++ b/clients/retrieval_client.go
@@ -52,10 +52,6 @@ func NewRetrievalClient(
 	if err != nil {
 		return nil, err
 	}
-	err = indexedState.Start(context.Background())
-	if err != nil {
-		return nil, err
-	}
 	return &retrievalClient{
 		logger:                logger,
 		indexedChainState:     indexedState,

--- a/clients/tests/retrieval_client_test.go
+++ b/clients/tests/retrieval_client_test.go
@@ -88,6 +88,10 @@ func setup(t *testing.T) {
 	if err != nil {
 		panic("failed to create a new retrieval client")
 	}
+	err = indexer.Index(context.Background())
+	if err != nil {
+		panic("failed to start indexing")
+	}
 
 	var (
 		quorumID           core.QuorumID = 0

--- a/clients/tests/retrieval_client_test.go
+++ b/clients/tests/retrieval_client_test.go
@@ -83,6 +83,7 @@ func setup(t *testing.T) {
 	}
 
 	indexer = &indexermock.MockIndexer{}
+	indexer.On("Index").Return(nil).Once()
 	retrievalClient, err = clients.NewRetrievalClient(logger, chainState, indexer, coordinator, nodeClient, encoder, 2)
 	if err != nil {
 		panic("failed to create a new retrieval client")

--- a/clients/tests/retrieval_client_test.go
+++ b/clients/tests/retrieval_client_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/Layr-Labs/eigenda/common/logging"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/encoding"
+	coreindexer "github.com/Layr-Labs/eigenda/core/indexer"
 	coremock "github.com/Layr-Labs/eigenda/core/mock"
+	indexermock "github.com/Layr-Labs/eigenda/indexer/mock"
 	"github.com/Layr-Labs/eigenda/pkg/encoding/kzgEncoder"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/wealdtech/go-merkletree"
@@ -42,6 +45,9 @@ func makeTestEncoder() (core.Encoder, error) {
 
 var (
 	indexedChainState      core.IndexedChainState
+	chainState             core.ChainState
+	indexer                *indexermock.MockIndexer
+	operatorState          *core.OperatorState
 	nodeClient             *clientsmock.MockNodeClient
 	coordinator            *core.StdAssignmentCoordinator
 	retrievalClient        clients.RetrievalClient
@@ -55,9 +61,14 @@ var (
 func setup(t *testing.T) {
 
 	var err error
-	indexedChainState, err = coremock.NewChainDataMock(core.OperatorIndex(numOperators))
+	chainState, err = coremock.NewChainDataMock(core.OperatorIndex(numOperators))
 	if err != nil {
 		t.Fatalf("failed to create new mocked chain data: %s", err)
+	}
+
+	indexedChainState, err = coremock.NewChainDataMock(core.OperatorIndex(numOperators))
+	if err != nil {
+		t.Fatalf("failed to create new mocked indexed chain data: %s", err)
 	}
 
 	nodeClient = clientsmock.NewNodeClient()
@@ -70,7 +81,12 @@ func setup(t *testing.T) {
 	if err != nil {
 		panic("failed to create a new logger")
 	}
-	retrievalClient = clients.NewRetrievalClient(logger, indexedChainState, coordinator, nodeClient, encoder, 2)
+
+	indexer = &indexermock.MockIndexer{}
+	retrievalClient, err = clients.NewRetrievalClient(logger, chainState, indexer, coordinator, nodeClient, encoder, 2)
+	if err != nil {
+		panic("failed to create a new retrieval client")
+	}
 
 	var (
 		quorumID           core.QuorumID = 0
@@ -90,7 +106,7 @@ func setup(t *testing.T) {
 		},
 		Data: gettysburgAddressBytes,
 	}
-	operatorState, err := indexedChainState.GetOperatorState(context.Background(), (0), []core.QuorumID{quorumID})
+	operatorState, err = indexedChainState.GetOperatorState(context.Background(), (0), []core.QuorumID{quorumID})
 	if err != nil {
 		t.Fatalf("failed to get operator state: %s", err)
 	}
@@ -166,6 +182,38 @@ func setup(t *testing.T) {
 
 }
 
+func mustMakeOpertatorPubKeysPair(t *testing.T) *coreindexer.OperatorPubKeys {
+	operators := make(map[[32]byte]coreindexer.OperatorPubKeysPair, len(operatorState.Operators))
+	for operatorId := range operatorState.Operators[0] {
+		keyPair, err := core.GenRandomBlsKeys()
+		if err != nil {
+			t.Fatalf("Generating random BLS keys Error: %s", err.Error())
+		}
+		operators[operatorId] = coreindexer.OperatorPubKeysPair{
+			PubKeyG1: keyPair.PubKey.G1Affine,
+			PubKeyG2: keyPair.GetPubKeyG2().G2Affine,
+		}
+	}
+	keyPair, err := core.GenRandomBlsKeys()
+	if err != nil {
+		t.Fatalf("Generating random BLS keys Error: %s", err.Error())
+	}
+	return &coreindexer.OperatorPubKeys{
+		Operators: operators,
+		QuorumTotals: map[core.QuorumID]*bn254.G1Affine{
+			0: keyPair.PubKey.G1Affine,
+		},
+	}
+}
+
+func musMakeOperatorSocket(t *testing.T) coreindexer.OperatorSockets {
+	operatorSocket := make(coreindexer.OperatorSockets, len(operatorState.Operators))
+	for operatorId := range operatorState.Operators[0] {
+		operatorSocket[operatorId] = "test"
+	}
+	return operatorSocket
+}
+
 func TestInvalidBlobHeader(t *testing.T) {
 
 	setup(t)
@@ -175,6 +223,12 @@ func TestInvalidBlobHeader(t *testing.T) {
 	nodeClient.
 		On("GetChunks", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(encodedBlob)
+
+	operatorPubKeys := mustMakeOpertatorPubKeysPair(t)
+	operatorSocket := musMakeOperatorSocket(t)
+
+	indexer.On("GetObject", mock.Anything, 0).Return(operatorPubKeys, nil).Once()
+	indexer.On("GetObject", mock.Anything, 1).Return(operatorSocket, nil).Once()
 
 	_, err := retrievalClient.RetrieveBlob(context.Background(), batchHeaderHash, 0, 0, batchRoot, 0)
 	assert.ErrorContains(t, err, "failed to get blob header from all operators")
@@ -190,6 +244,12 @@ func TestValidBlobHeader(t *testing.T) {
 	nodeClient.
 		On("GetChunks", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(encodedBlob)
+
+	operatorPubKeys := mustMakeOpertatorPubKeysPair(t)
+	operatorSocket := musMakeOperatorSocket(t)
+
+	indexer.On("GetObject", mock.Anything, 0).Return(operatorPubKeys, nil).Once()
+	indexer.On("GetObject", mock.Anything, 1).Return(operatorSocket, nil).Once()
 
 	data, err := retrievalClient.RetrieveBlob(context.Background(), batchHeaderHash, 0, 0, batchRoot, 0)
 	assert.NoError(t, err)

--- a/core/indexer/indexer.go
+++ b/core/indexer/indexer.go
@@ -1,0 +1,59 @@
+package indexer
+
+import (
+	"fmt"
+
+	dacommon "github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/indexer"
+	indexereth "github.com/Layr-Labs/eigenda/indexer/eth"
+	inmemstore "github.com/Layr-Labs/eigenda/indexer/inmem"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func SetupNewIndexer(
+	config *indexer.Config,
+	gethClient dacommon.EthClient,
+	rpcClient dacommon.RPCEthClient,
+	eigenDAServiceManagerAddr string,
+	logger dacommon.Logger,
+) (indexer.Indexer, error) {
+
+	eigenDAServiceManager := common.HexToAddress(eigenDAServiceManagerAddr)
+
+	pubKeyFilterer, err := NewOperatorPubKeysFilterer(eigenDAServiceManager, gethClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new operator pubkeys filter: %w", err)
+	}
+
+	socketsFilterer, err := NewOperatorSocketsFilterer(eigenDAServiceManager, gethClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new operator sockets filter: %w", err)
+	}
+
+	handlers := []indexer.AccumulatorHandler{
+		{
+			Acc:      NewOperatorPubKeysAccumulator(logger),
+			Filterer: pubKeyFilterer,
+			Status:   indexer.Good,
+		},
+		{
+			Acc:      NewOperatorSocketsAccumulator(logger),
+			Filterer: socketsFilterer,
+			Status:   indexer.Good,
+		},
+	}
+
+	var (
+		upgrader    = &Upgrader{}
+		headerStore = inmemstore.NewHeaderStore()
+		headerSrvc  = indexereth.NewHeaderService(logger, rpcClient)
+	)
+	return indexer.New(
+		config,
+		handlers,
+		headerSrvc,
+		headerStore,
+		upgrader,
+		logger,
+	), nil
+}

--- a/core/indexer/indexer.go
+++ b/core/indexer/indexer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func SetupNewIndexer(
+func CreateNewIndexer(
 	config *indexer.Config,
 	gethClient dacommon.EthClient,
 	rpcClient dacommon.RPCEthClient,

--- a/core/indexer/state_test.go
+++ b/core/indexer/state_test.go
@@ -8,9 +8,13 @@ import (
 	"path/filepath"
 	"time"
 
+	coreindexer "github.com/Layr-Labs/eigenda/core/indexer"
 	"github.com/Layr-Labs/eigenda/indexer"
+	indexereth "github.com/Layr-Labs/eigenda/indexer/eth"
 	"github.com/Layr-Labs/eigenda/indexer/inmem"
+	inmemstore "github.com/Layr-Labs/eigenda/indexer/inmem"
 	"github.com/Layr-Labs/eigenda/indexer/leveldb"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/geth"
@@ -23,7 +27,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -107,14 +110,46 @@ func mustMakeChainState(env *deploy.Config, store indexer.HeaderStore, logger co
 
 	tx, err := eth.NewTransactor(logger, client, env.EigenDA.OperatorStateRetreiver, env.EigenDA.ServiceManager)
 	Expect(err).ToNot(HaveOccurred())
-	cs := eth.NewChainState(tx, client)
 
-	addr := gethcommon.HexToAddress(env.EigenDA.ServiceManager)
+	eigenDAServiceManagerAddr := gethcommon.HexToAddress(env.EigenDA.ServiceManager)
 
-	indexerConfig := &indexer.Config{
-		PullInterval: 1 * time.Second,
+	pubKeyFilterer, err := coreindexer.NewOperatorPubKeysFilterer(eigenDAServiceManagerAddr, client)
+	Expect(err).ToNot(HaveOccurred())
+
+	socketsFilterer, err := coreindexer.NewOperatorSocketsFilterer(eigenDAServiceManagerAddr, client)
+	Expect(err).ToNot(HaveOccurred())
+
+	handlers := []indexer.AccumulatorHandler{
+		{
+			Acc:      coreindexer.NewOperatorPubKeysAccumulator(logger),
+			Filterer: pubKeyFilterer,
+			Status:   indexer.Good,
+		},
+		{
+			Acc:      coreindexer.NewOperatorSocketsAccumulator(logger),
+			Filterer: socketsFilterer,
+			Status:   indexer.Good,
+		},
 	}
-	chainState, err := indexedstate.NewIndexedChainState(indexerConfig, addr, cs, store, client, rpcClient, logger)
+
+	var (
+		upgrader      = &coreindexer.Upgrader{}
+		headerStore   = inmemstore.NewHeaderStore()
+		cs            = eth.NewChainState(tx, client)
+		headerSrvc    = indexereth.NewHeaderService(logger, rpcClient)
+		indexerConfig = indexer.Config{
+			PullInterval: 1 * time.Second,
+		}
+		indexer = indexer.New(
+			&indexerConfig,
+			handlers,
+			headerSrvc,
+			headerStore,
+			upgrader,
+			logger,
+		)
+	)
+	chainState, err := indexedstate.NewIndexedChainState(cs, indexer)
 	if err != nil {
 		panic(err)
 	}
@@ -166,8 +201,9 @@ var _ = Describe("Indexer", func() {
 			mustRegisterOperators(testConfig, logger)
 
 			time.Sleep(1 * time.Second)
-
-			obj, _, err := chainState.Indexer.HeaderStore.GetLatestObject(chainState.Indexer.Handlers[0].Acc, false)
+			lastHeader, err := chainState.Indexer.GetLatestHeader(false)
+			Expect(err).ToNot(HaveOccurred())
+			obj, err := chainState.Indexer.GetObject(lastHeader, 0)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj).NotTo(BeNil())
 
@@ -175,7 +211,7 @@ var _ = Describe("Indexer", func() {
 			Expect(ok).To(BeTrue())
 			Expect(pubKeys.Operators).To(HaveLen(len(testConfig.Operators)))
 
-			obj, header, err := chainState.Indexer.HeaderStore.GetLatestObject(chainState.Indexer.Handlers[1].Acc, false)
+			obj, err = chainState.Indexer.GetObject(lastHeader, 1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj).NotTo(BeNil())
 
@@ -183,6 +219,8 @@ var _ = Describe("Indexer", func() {
 			Expect(ok).To(BeTrue())
 			Expect(sockets).To(HaveLen(len(testConfig.Operators)))
 
+			header, err := chainState.Indexer.GetLatestHeader(false)
+			Expect(err).ToNot(HaveOccurred())
 			state, err := chainState.GetIndexedOperatorState(ctx, uint(header.Number), quorums)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/core/indexer/state_test.go
+++ b/core/indexer/state_test.go
@@ -115,7 +115,7 @@ func mustMakeChainState(env *deploy.Config, store indexer.HeaderStore, logger co
 		}
 	)
 
-	indexer, err := coreindexer.SetupNewIndexer(
+	indexer, err := coreindexer.CreateNewIndexer(
 		&indexerConfig,
 		client,
 		rpcClient,

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -11,11 +11,6 @@ import (
 
 	coreindexer "github.com/Layr-Labs/eigenda/core/indexer"
 	"github.com/Layr-Labs/eigenda/core/thegraph"
-	"github.com/Layr-Labs/eigenda/indexer"
-	indexereth "github.com/Layr-Labs/eigenda/indexer/eth"
-
-	inmemstore "github.com/Layr-Labs/eigenda/indexer/inmem"
-	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/Layr-Labs/eigenda/common/aws/dynamodb"
 	"github.com/Layr-Labs/eigenda/common/aws/s3"
@@ -123,45 +118,16 @@ func RunBatcher(ctx *cli.Context) error {
 	} else {
 		logger.Info("Using built-in indexer")
 
-		eigenDAServiceManagerAddr := gethcommon.HexToAddress(config.EigenDAServiceManagerAddr)
-
-		pubKeyFilterer, err := coreindexer.NewOperatorPubKeysFilterer(eigenDAServiceManagerAddr, client)
-		if err != nil {
-			return fmt.Errorf("failed to create new operator pubkeys filter: %w", err)
-		}
-
-		socketsFilterer, err := coreindexer.NewOperatorSocketsFilterer(eigenDAServiceManagerAddr, client)
-		if err != nil {
-			return fmt.Errorf("failed to create new operator sockets filter: %w", err)
-		}
-
-		handlers := []indexer.AccumulatorHandler{
-			{
-				Acc:      coreindexer.NewOperatorPubKeysAccumulator(logger),
-				Filterer: pubKeyFilterer,
-				Status:   indexer.Good,
-			},
-			{
-				Acc:      coreindexer.NewOperatorSocketsAccumulator(logger),
-				Filterer: socketsFilterer,
-				Status:   indexer.Good,
-			},
-		}
-
-		var (
-			upgrader    = &coreindexer.Upgrader{}
-			headerStore = inmemstore.NewHeaderStore()
-			headerSrvc  = indexereth.NewHeaderService(logger, rpcClient)
-			indexer     = indexer.New(
-				&config.IndexerConfig,
-				handlers,
-				headerSrvc,
-				headerStore,
-				upgrader,
-				logger,
-			)
+		indexer, err := coreindexer.SetupNewIndexer(
+			&config.IndexerConfig,
+			client,
+			rpcClient,
+			config.EigenDAServiceManagerAddr,
+			logger,
 		)
-
+		if err != nil {
+			return err
+		}
 		ics, err = coreindexer.NewIndexedChainState(cs, indexer)
 		if err != nil {
 			return err

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -118,7 +118,7 @@ func RunBatcher(ctx *cli.Context) error {
 	} else {
 		logger.Info("Using built-in indexer")
 
-		indexer, err := coreindexer.SetupNewIndexer(
+		indexer, err := coreindexer.CreateNewIndexer(
 			&config.IndexerConfig,
 			client,
 			rpcClient,

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -163,7 +163,7 @@ func setupRetrievalClient(testConfig *deploy.Config) error {
 		return err
 	}
 
-	indexer, err := coreindexer.SetupNewIndexer(
+	indexer, err := coreindexer.CreateNewIndexer(
 		&indexer.Config{
 			PullInterval: 100 * time.Millisecond,
 		},

--- a/indexer/eth/header_service.go
+++ b/indexer/eth/header_service.go
@@ -28,7 +28,7 @@ func (h *HeaderService) PullNewHeaders(lastHeader *head.Header) (head.Headers, b
 	ctx := context.Background()
 	latestHeader, err := h.getHeaderByNumber(ctx, nil)
 	if err != nil {
-		h.logger.Error("Error. Cannot get latest header:", err)
+		h.logger.Error("Error. Cannot get latest header:", "err", err)
 		return nil, false, err
 	}
 
@@ -44,7 +44,7 @@ func (h *HeaderService) PullNewHeaders(lastHeader *head.Header) (head.Headers, b
 
 	newHeaders, err := h.headersByRange(ctx, starting, int(count))
 	if err != nil {
-		h.logger.Error("Error. Cannot get latest header: ", err)
+		h.logger.Error("Error. Cannot get latest header: ", "err", err)
 		return nil, false, err
 	}
 
@@ -71,7 +71,7 @@ func (h *HeaderService) PullLatestHeader(finalized bool) (*head.Header, error) {
 
 	header, err := h.getHeaderByNumber(ctx, nil)
 	if err != nil {
-		h.logger.Error("Error. Cannot get latest header", err)
+		h.logger.Error("Error. Cannot get latest header", "err", err)
 		return nil, err
 	}
 
@@ -79,7 +79,7 @@ func (h *HeaderService) PullLatestHeader(finalized bool) (*head.Header, error) {
 	if finalized && diff >= DistanceFromHead {
 		latestFinalized, err := h.getHeaderByNumber(ctx, big.NewInt(diff))
 		if err != nil {
-			h.logger.Error("Error. Cannot get finalized header", err)
+			h.logger.Error("Error. Cannot get finalized header", "err", err)
 			return nil, err
 		}
 		return &head.Header{

--- a/indexer/mock/indexer.go
+++ b/indexer/mock/indexer.go
@@ -1,0 +1,34 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/Layr-Labs/eigenda/indexer"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockIndexer struct {
+	mock.Mock
+}
+
+var _ indexer.Indexer = (*MockIndexer)(nil)
+
+func (m *MockIndexer) Index(ctx context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockIndexer) HandleAccumulator(acc indexer.Accumulator, f indexer.Filterer, headers indexer.Headers) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockIndexer) GetLatestHeader(finalized bool) (*indexer.Header, error) {
+	args := m.Called(finalized)
+	return args.Get(0).(*indexer.Header), args.Error(1)
+}
+
+func (m *MockIndexer) GetObject(header *indexer.Header, handlerIndex int) (indexer.AccumulatorObject, error) {
+	args := m.Called(header, handlerIndex)
+	return args.Get(0).(indexer.AccumulatorObject), args.Error(1)
+}

--- a/indexer/test/indexer_test.go
+++ b/indexer/test/indexer_test.go
@@ -51,7 +51,7 @@ func TestIndex(t *testing.T) {
 	config := indexer.Config{
 		PullInterval: 100 * time.Millisecond,
 	}
-	indexer := indexer.NewIndexer(
+	indexer := indexer.New(
 		&config,
 		handlers,
 		headerSrvc,

--- a/pkg/kzg/bn254/globals_test.go
+++ b/pkg/kzg/bn254/globals_test.go
@@ -1,4 +1,3 @@
-
 package bn254
 
 import (

--- a/retriever/cmd/main.go
+++ b/retriever/cmd/main.go
@@ -98,7 +98,7 @@ func RetrieverMain(ctx *cli.Context) error {
 		log.Fatalln("could not start tcp listener", err)
 	}
 
-	indexer, err := coreindexer.SetupNewIndexer(
+	indexer, err := coreindexer.CreateNewIndexer(
 		&config.IndexerConfig,
 		gethClient,
 		rpcClient,

--- a/test/synthetic-test/synthetic_client_test.go
+++ b/test/synthetic-test/synthetic_client_test.go
@@ -236,7 +236,7 @@ func setupRetrievalClient(ethClient common.EthClient, retrievalClientConfig *Ret
 	}
 
 	retrievalClient = clients.NewRetrievalClient(logger, indexedChainStateClient, agn, nodeClient, encoder, 10)
-	return nil
+	return indexer.Index(context.Background())
 }
 
 // TODO: This file contains some code that can be refactored and shared across some other tests ex:Integration Test.


### PR DESCRIPTION
## Why are these changes needed?

Context issue:
- Users previously only required a retrieval client with a built-in indexer.
- Current changes necessitate the addition of a graph node, adding complexity for users.

Solution in this PR: 
- Prioritize making the built-in indexer effective instead of relying on the graph node.

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(
