### PR TITLE
Track num deleted batches with counter rather than num active batches

### DIFF
--- a/node/store.go
+++ b/node/store.go
@@ -267,7 +267,6 @@ func (s *Store) StoreBatch(ctx context.Context, header *core.BatchHeader, blobs 
 		log.Error("Failed to write the batch into local database:", "err", err)
 		return nil, err
 	}
-	s.metrics.AddCurrentBatch(size)
 
 	return &keys, nil
 }


### PR DESCRIPTION

## Why are these changes needed?
The num of active batches can go up and down, so it has to be a Gauge.

However, Gauge isn't really a good fit for tracking active batches, because it will get set to 0 at Node start, which is wrong for accounting.

Here we track two things:
- Accumulated batches added
- Accumulated batches deleted

Both of them are counters (avoid using Gauge)

On the dashboard, the diff between the two is the num of active batches.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
