### PR TITLE
Add a new metric so total batches and removed batches are aligned

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -25,6 +25,7 @@ type Metrics struct {
 	// The latency (in ms) to process the request.
 	RequestLatency *prometheus.SummaryVec
 	// Accumulated number and size of batches processed by their statuses.
+	// TODO: this metrics should be removed in future release.
 	AccuBatchesDeprecated *prometheus.CounterVec
 	// Accumulated number and size of batches processed by their statuses.
 	AccuBatches *prometheus.CounterVec
@@ -60,7 +61,7 @@ func NewMetrics(eigenMetrics eigenmetrics.Metrics, reg *prometheus.Registry, log
 			prometheus.CounterOpts{
 				Namespace: Namespace,
 				Name:      "eigenda_rpc_requests_total",
-				Help:      "the total number of requests handled by the DA node",
+				Help:      "the total number of requests processed by the DA node",
 			},
 			[]string{"method", "status"},
 		),
@@ -77,7 +78,7 @@ func NewMetrics(eigenMetrics eigenmetrics.Metrics, reg *prometheus.Registry, log
 			prometheus.CounterOpts{
 				Namespace: Namespace,
 				Name:      "eigenda_batches_total",
-				Help:      "the total number and size of batches handled by the DA node",
+				Help:      "the total number and size of batches processed by the DA node",
 			},
 			[]string{"type", "status"},
 		),
@@ -86,8 +87,8 @@ func NewMetrics(eigenMetrics eigenmetrics.Metrics, reg *prometheus.Registry, log
 		AccuBatches: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: Namespace,
-				Name:      "eigenda_accumulated_batches_total",
-				Help:      "the total number and size of batches handled by the DA node",
+				Name:      "eigenda_processed_batches_total",
+				Help:      "the total number and size of batches processed by the DA node",
 			},
 			[]string{"type", "status"},
 		),


### PR DESCRIPTION
## Why are these changes needed?
The current `eigenda_batches_total` is not aligned with the newly added `eigenda_removed_batches_total` (in https://github.com/Layr-Labs/eigenda/pull/115), that is, the diff between the two will not be the current live batches, because `eigenda_removed_batches_total` will start counting later.

This PR adds a new metric `eigenda_processed_batches_total` to pair with `eigenda_removed_batches_total`. We will hard remove the `eigenda_batches_total` in future release.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
