### PR TITLE
set default number of confirmations to 0

### DIFF
--- a/common/geth/cli.go
+++ b/common/geth/cli.go
@@ -35,7 +35,7 @@ func EthClientFlags(envPrefix string) []cli.Flag {
 			Name:     numConfirmationsFlagName,
 			Usage:    "Number of confirmations to wait for",
 			Required: false,
-			Value:    3,
+			Value:    0,
 			EnvVar:   common.PrefixEnvVar(envPrefix, "NUM_CONFIRMATIONS"),
 		},
 	}

--- a/disperser/cmd/apiserver/main.go
+++ b/disperser/cmd/apiserver/main.go
@@ -60,7 +60,7 @@ func RunDisperserServer(ctx *cli.Context) error {
 
 	client, err := geth.NewClient(config.EthClientConfig, logger)
 	if err != nil {
-		logger.Error("Cannot create chain.Client", err)
+		logger.Error("Cannot create chain.Client", "err", err)
 		return err
 	}
 


### PR DESCRIPTION
## Why are these changes needed?
We recently added a flag to specify how many confirmations to wait for when a new transaction is submitted. 
This value should stay at 0 until we have transaction manager in place. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
