### PR TITLE
Auto correct the IP if the operator set their IP to localhost when opt-in

### DIFF
--- a/core/state.go
+++ b/core/state.go
@@ -19,17 +19,17 @@ func MakeOperatorSocket(nodeIP, dispersalPort, retrievalPort string) OperatorSoc
 	return OperatorSocket(fmt.Sprintf("%s:%s;%s", nodeIP, dispersalPort, retrievalPort))
 }
 
-func ParseOperatorSocket(operatorSocket string) (host string, dispersalPort string, retrievalPort string, err error) {
-	s := strings.Split(operatorSocket, ";")
+func ParseOperatorSocket(socket string) (host string, dispersalPort string, retrievalPort string, err error) {
+	s := strings.Split(socket, ";")
 	if len(s) != 2 {
-		err = fmt.Errorf("invalid socket address format, missing retrieval port: %s", operatorSocket)
+		err = fmt.Errorf("invalid socket address format, missing retrieval port: %s", socket)
 		return
 	}
 	retrievalPort = s[1]
 
 	s = strings.Split(s[0], ":")
 	if len(s) != 2 {
-		err = fmt.Errorf("invalid socket address format: %s", operatorSocket)
+		err = fmt.Errorf("invalid socket address format: %s", socket)
 		return
 	}
 	host = s[0]

--- a/core/state.go
+++ b/core/state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 )
 
 // Operators
@@ -16,6 +17,26 @@ func (s OperatorSocket) String() string {
 
 func MakeOperatorSocket(nodeIP, dispersalPort, retrievalPort string) OperatorSocket {
 	return OperatorSocket(fmt.Sprintf("%s:%s;%s", nodeIP, dispersalPort, retrievalPort))
+}
+
+func ParseOperatorSocket(operatorSocket string) (socket string, dispersalPort string, retrievalPort string, err error) {
+	s := strings.Split(operatorSocket, ":")
+	if len(s) != 2 {
+		err = fmt.Errorf("invalid socket address format: %s", operatorSocket)
+		return
+	}
+	hostname := s[0]
+	dispersalPort = s[1]
+
+	s = strings.Split(operatorSocket, ";")
+	if len(s) != 2 {
+		err = fmt.Errorf("invalid socket address format, missing retrieval port: %s", operatorSocket)
+		return
+	}
+	retrievalPort = s[1]
+
+	socket = string(MakeOperatorSocket(hostname, dispersalPort, retrievalPort))
+	return
 }
 
 type StakeAmount *big.Int

--- a/core/state.go
+++ b/core/state.go
@@ -20,20 +20,20 @@ func MakeOperatorSocket(nodeIP, dispersalPort, retrievalPort string) OperatorSoc
 }
 
 func ParseOperatorSocket(operatorSocket string) (host string, dispersalPort string, retrievalPort string, err error) {
-	s := strings.Split(operatorSocket, ":")
+	s := strings.Split(operatorSocket, ";")
+	if len(s) != 2 {
+		err = fmt.Errorf("invalid socket address format, missing retrieval port: %s", operatorSocket)
+		return
+	}
+	retrievalPort = s[1]
+
+	s = strings.Split(s[0], ":")
 	if len(s) != 2 {
 		err = fmt.Errorf("invalid socket address format: %s", operatorSocket)
 		return
 	}
 	host = s[0]
 	dispersalPort = s[1]
-
-	s = strings.Split(operatorSocket, ";")
-	if len(s) != 2 {
-		err = fmt.Errorf("invalid socket address format, missing retrieval port: %s", operatorSocket)
-		return
-	}
-	retrievalPort = s[1]
 
 	return
 }

--- a/core/state.go
+++ b/core/state.go
@@ -19,13 +19,13 @@ func MakeOperatorSocket(nodeIP, dispersalPort, retrievalPort string) OperatorSoc
 	return OperatorSocket(fmt.Sprintf("%s:%s;%s", nodeIP, dispersalPort, retrievalPort))
 }
 
-func ParseOperatorSocket(operatorSocket string) (socket string, dispersalPort string, retrievalPort string, err error) {
+func ParseOperatorSocket(operatorSocket string) (host string, dispersalPort string, retrievalPort string, err error) {
 	s := strings.Split(operatorSocket, ":")
 	if len(s) != 2 {
 		err = fmt.Errorf("invalid socket address format: %s", operatorSocket)
 		return
 	}
-	hostname := s[0]
+	host = s[0]
 	dispersalPort = s[1]
 
 	s = strings.Split(operatorSocket, ";")
@@ -35,7 +35,6 @@ func ParseOperatorSocket(operatorSocket string) (socket string, dispersalPort st
 	}
 	retrievalPort = s[1]
 
-	socket = string(MakeOperatorSocket(hostname, dispersalPort, retrievalPort))
 	return
 }
 

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -264,4 +264,12 @@ func TestParseOperatorSocket(t *testing.T) {
 	assert.Equal(t, "localhost", host)
 	assert.Equal(t, "1234", dispersalPort)
 	assert.Equal(t, "5678", retrievalPort)
+
+	_, _, _, err = core.ParseOperatorSocket("localhost:12345678")
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid socket address format, missing retrieval port: localhost:12345678", err.Error())
+
+	_, _, _, err = core.ParseOperatorSocket("localhost1234;5678")
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid socket address format: localhost1234;5678", err.Error())
 }

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -256,3 +256,12 @@ func TestCoreLibrary(t *testing.T) {
 	}
 
 }
+
+func TestParseOperatorSocket(t *testing.T) {
+	operatorSocket := "localhost:1234;5678"
+	host, dispersalPort, retrievalPort, err := core.ParseOperatorSocket(operatorSocket)
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost", host)
+	assert.Equal(t, "1234", dispersalPort)
+	assert.Equal(t, "5678", retrievalPort)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -375,7 +375,7 @@ func (n *Node) checkCurrentNodeIp(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			newSocketAddr, err := n.socketAddress(ctx)
+			newSocketAddr, err := SocketAddress(ctx, n.PubIPProvider, n.Config.DispersalPort, n.Config.RetrievalPort)
 			if err != nil {
 				n.Logger.Error("failed to get socket address", "err", err)
 				continue
@@ -383,15 +383,6 @@ func (n *Node) checkCurrentNodeIp(ctx context.Context) {
 			n.updateSocketAddress(ctx, newSocketAddr)
 		}
 	}
-}
-
-func (n *Node) socketAddress(ctx context.Context) (string, error) {
-	ip, err := n.PubIPProvider.PublicIPAddress(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get public ip address from IP provider: %w", err)
-	}
-	socket := core.MakeOperatorSocket(ip, n.Config.DispersalPort, n.Config.RetrievalPort)
-	return socket.String(), nil
 }
 
 // we only need to build the sdk clients for eigenmetrics right now,

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -99,13 +99,13 @@ func pluginOps(ctx *cli.Context) {
 		return
 	}
 
-	host, dispersalPort, retrievalPort, err := core.ParseOperatorSocket(config.Socket)
+	_, dispersalPort, retrievalPort, err := core.ParseOperatorSocket(config.Socket)
 	if err != nil {
 		log.Printf("Error: failed to parse operator socket: %v", err)
 		return
 	}
 
-	socket := string(core.MakeOperatorSocket(host, dispersalPort, retrievalPort))
+	socket := config.Socket
 	if isLocalhost(socket) {
 		pubIPProvider := pubip.ProviderOrDefault(config.PubIPProvider)
 		socket, err = node.SocketAddress(context.Background(), pubIPProvider, dispersalPort, retrievalPort)

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -136,7 +136,7 @@ func pluginOps(ctx *cli.Context) {
 		pubIPProvider := pubip.ProviderOrDefault(config.PubIPProvider)
 		socket, err = node.SocketAddress(context.Background(), pubIPProvider, dispersalPort, retrievalPort)
 		if err != nil {
-			log.Printf("Error: failed to create EigenDA transactor: %v", err)
+			log.Printf("Error: failed to get socket address from ip provider: %v", err)
 			return
 		}
 	}

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -116,11 +116,25 @@ func pluginOps(ctx *cli.Context) {
 		return
 	}
 
-	pubIPProvider := pubip.ProviderOrDefault(config.PubIPProvider)
+	s := strings.Split(config.Socket, ":")
+	if len(s) != 2 {
+		log.Printf("Error: invalid socket address format: %s", config.Socket)
+		return
+	}
+	hostname := s[0]
+	dispersalPort := s[1]
 
-	socket := string(core.MakeOperatorSocket(config.Hostname, config.DispersalPort, config.RetrievalPort))
+	s = strings.Split(config.Socket, ";")
+	if len(s) != 2 {
+		log.Printf("Error: invalid socket address format, missing retrieval port: %s", config.Socket)
+		return
+	}
+	retrievalPort := s[1]
+
+	socket := string(core.MakeOperatorSocket(hostname, dispersalPort, retrievalPort))
 	if isLocalhost(socket) {
-		socket, err = node.SocketAddress(context.Background(), pubIPProvider, config.DispersalPort, config.RetrievalPort)
+		pubIPProvider := pubip.ProviderOrDefault(config.PubIPProvider)
+		socket, err = node.SocketAddress(context.Background(), pubIPProvider, dispersalPort, retrievalPort)
 		if err != nil {
 			log.Printf("Error: failed to create EigenDA transactor: %v", err)
 			return

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -116,22 +116,12 @@ func pluginOps(ctx *cli.Context) {
 		return
 	}
 
-	s := strings.Split(config.Socket, ":")
-	if len(s) != 2 {
-		log.Printf("Error: invalid socket address format: %s", config.Socket)
+	socket, dispersalPort, retrievalPort, err := core.ParseOperatorSocket(config.Socket)
+	if err != nil {
+		log.Printf("Error: failed to parse operator socket: %v", err)
 		return
 	}
-	hostname := s[0]
-	dispersalPort := s[1]
 
-	s = strings.Split(config.Socket, ";")
-	if len(s) != 2 {
-		log.Printf("Error: invalid socket address format, missing retrieval port: %s", config.Socket)
-		return
-	}
-	retrievalPort := s[1]
-
-	socket := string(core.MakeOperatorSocket(hostname, dispersalPort, retrievalPort))
 	if isLocalhost(socket) {
 		pubIPProvider := pubip.ProviderOrDefault(config.PubIPProvider)
 		socket, err = node.SocketAddress(context.Background(), pubIPProvider, dispersalPort, retrievalPort)

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -116,12 +116,13 @@ func pluginOps(ctx *cli.Context) {
 		return
 	}
 
-	socket, dispersalPort, retrievalPort, err := core.ParseOperatorSocket(config.Socket)
+	host, dispersalPort, retrievalPort, err := core.ParseOperatorSocket(config.Socket)
 	if err != nil {
 		log.Printf("Error: failed to parse operator socket: %v", err)
 		return
 	}
 
+	socket := string(core.MakeOperatorSocket(host, dispersalPort, retrievalPort))
 	if isLocalhost(socket) {
 		pubIPProvider := pubip.ProviderOrDefault(config.PubIPProvider)
 		socket, err = node.SocketAddress(context.Background(), pubIPProvider, dispersalPort, retrievalPort)

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -14,6 +14,31 @@ import (
 var (
 	/* Required Flags */
 
+	HostnameFlag = cli.StringFlag{
+		Name:     "hostname",
+		Usage:    "Hostname at which node is available",
+		Required: true,
+		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "HOSTNAME"),
+	}
+	DispersalPortFlag = cli.StringFlag{
+		Name:     "dispersal-port",
+		Usage:    "Port at which node registers to listen for dispersal calls",
+		Required: true,
+		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "DISPERSAL_PORT"),
+	}
+	RetrievalPortFlag = cli.StringFlag{
+		Name:     "retrieval-port",
+		Usage:    "Port at which node registers to listen for retrieval calls",
+		Required: true,
+		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "RETRIEVAL_PORT"),
+	}
+	PubIPProviderFlag = cli.StringFlag{
+		Name:     "public-ip-provider",
+		Usage:    "The ip provider service used to obtain a operator's public IP [seeip (default), ipify)",
+		Required: true,
+		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "PUBLIC_IP_PROVIDER"),
+	}
+
 	// The operation to run.
 	OperationFlag = cli.StringFlag{
 		Name:     "operation",
@@ -99,6 +124,10 @@ var (
 )
 
 type Config struct {
+	Hostname                      string
+	RetrievalPort                 string
+	DispersalPort                 string
+	PubIPProvider                 string
 	Operation                     string
 	EcdsaKeyFile                  string
 	BlsKeyFile                    string
@@ -130,6 +159,10 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	}
 
 	return &Config{
+		Hostname:                      ctx.GlobalString(HostnameFlag.Name),
+		DispersalPort:                 ctx.GlobalString(DispersalPortFlag.Name),
+		RetrievalPort:                 ctx.GlobalString(RetrievalPortFlag.Name),
+		PubIPProvider:                 ctx.GlobalString(PubIPProviderFlag.Name),
 		Operation:                     op,
 		EcdsaKeyPassword:              ctx.GlobalString(EcdsaKeyPasswordFlag.Name),
 		BlsKeyPassword:                ctx.GlobalString(BlsKeyPasswordFlag.Name),

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -14,24 +14,6 @@ import (
 var (
 	/* Required Flags */
 
-	HostnameFlag = cli.StringFlag{
-		Name:     "hostname",
-		Usage:    "Hostname at which node is available",
-		Required: true,
-		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "HOSTNAME"),
-	}
-	DispersalPortFlag = cli.StringFlag{
-		Name:     "dispersal-port",
-		Usage:    "Port at which node registers to listen for dispersal calls",
-		Required: true,
-		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "DISPERSAL_PORT"),
-	}
-	RetrievalPortFlag = cli.StringFlag{
-		Name:     "retrieval-port",
-		Usage:    "Port at which node registers to listen for retrieval calls",
-		Required: true,
-		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "RETRIEVAL_PORT"),
-	}
 	PubIPProviderFlag = cli.StringFlag{
 		Name:     "public-ip-provider",
 		Usage:    "The ip provider service used to obtain a operator's public IP [seeip (default), ipify)",
@@ -124,9 +106,6 @@ var (
 )
 
 type Config struct {
-	Hostname                      string
-	RetrievalPort                 string
-	DispersalPort                 string
 	PubIPProvider                 string
 	Operation                     string
 	EcdsaKeyFile                  string
@@ -159,9 +138,6 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	}
 
 	return &Config{
-		Hostname:                      ctx.GlobalString(HostnameFlag.Name),
-		DispersalPort:                 ctx.GlobalString(DispersalPortFlag.Name),
-		RetrievalPort:                 ctx.GlobalString(RetrievalPortFlag.Name),
 		PubIPProvider:                 ctx.GlobalString(PubIPProviderFlag.Name),
 		Operation:                     op,
 		EcdsaKeyPassword:              ctx.GlobalString(EcdsaKeyPasswordFlag.Name),

--- a/node/utils.go
+++ b/node/utils.go
@@ -2,9 +2,12 @@ package node
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 
+	"github.com/Layr-Labs/eigenda/common/pubip"
 	"github.com/Layr-Labs/eigenda/core"
 )
 
@@ -79,4 +82,13 @@ func DecodeBatchExpirationKey(key []byte) (int64, error) {
 	}
 	ts := int64(binary.BigEndian.Uint64(key[len(key)-8:]))
 	return ts, nil
+}
+
+func SocketAddress(ctx context.Context, provider pubip.Provider, dispersalPort string, retrievalPort string) (string, error) {
+	ip, err := provider.PublicIPAddress(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get public ip address from IP provider: %w", err)
+	}
+	socket := core.MakeOperatorSocket(ip, dispersalPort, retrievalPort)
+	return socket.String(), nil
 }


### PR DESCRIPTION
## Why are these changes needed?

We are seeing more operators setting their Node IP to localhost.
Such Nodes won't be reachable from public. We should auto correct the IP (from localhost to current IP with IP checker) when the operator registers.

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
