### PR TITLE
Handle unconfirmed blobs in blob feed fetch

### DIFF
--- a/disperser/dataapi/blobs_handlers.go
+++ b/disperser/dataapi/blobs_handlers.go
@@ -42,6 +42,11 @@ func (s *server) convertBlobMetadatasToBlobMetadataResponse(ctx context.Context,
 	)
 
 	sort.SliceStable(metadatas, func(i, j int) bool {
+		// We may have unconfirmed blobs to fetch, which will not have the ConfirmationInfo.
+		// In such case, we order them by request timestamp.
+		if metadatas[i].ConfirmationInfo == nil || metadatas[j].ConfirmationInfo == nil {
+			return metadatas[i].RequestMetadata.RequestedAt < metadatas[j].RequestMetadata.RequestedAt
+		}
 		if metadatas[i].ConfirmationInfo.BatchID != metadatas[j].ConfirmationInfo.BatchID {
 			return metadatas[i].ConfirmationInfo.BatchID < metadatas[j].ConfirmationInfo.BatchID
 		}

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -407,15 +407,6 @@ func (s *server) getBlobMetadataByBatchesWithLimit(ctx context.Context, limit in
 			for _, bm := range metadatas {
 				blobKey := bm.GetBlobKey().String()
 				if _, found := blobKeyPresence[blobKey]; !found {
-					// We only interest in confirmed blobs.
-					isConfirmed, confirmErr := bm.IsConfirmed()
-					if confirmErr != nil {
-						return nil, nil, err
-					}
-					if !isConfirmed {
-						s.logger.Info("Skipping unconfirmed blob", "blobkey", blobKey)
-						continue
-					}
 					blobKeyPresence[blobKey] = struct{}{}
 					blobMetadatas = append(blobMetadatas, bm)
 				} else {

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -407,6 +407,15 @@ func (s *server) getBlobMetadataByBatchesWithLimit(ctx context.Context, limit in
 			for _, bm := range metadatas {
 				blobKey := bm.GetBlobKey().String()
 				if _, found := blobKeyPresence[blobKey]; !found {
+					// We only interest in confirmed blobs.
+					isConfirmed, confirmErr := bm.IsConfirmed()
+					if confirmErr != nil {
+						return nil, nil, err
+					}
+					if !isConfirmed {
+						s.logger.Info("Skipping unconfirmed blob", "blobkey", blobKey)
+						continue
+					}
 					blobKeyPresence[blobKey] = struct{}{}
 					blobMetadatas = append(blobMetadatas, bm)
 				} else {


### PR DESCRIPTION
## Why are these changes needed?
There is a bug in blob feed fetch API at the dataapi server.

The bug happens because:
1) the blob feed is fetched by batchHeaderHash (i.e. not by blob status)
2) getting by batch will return unconfirmed blobs
3) the unconfirmed blobs will have nil confirmation info, which is accessed by blob sorting (we want to order blobs before return)

This will fail then the entire request, so there will be no blobs returned.

This case will happen as long as there is partial failure for a batch (i.e. some blobs in a batch failed). It's a little surprising that this is the first time we hit partial failure; we need to verify this in follow up.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
