### PR TITLE
Raise blob size limit

### DIFF
--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -23,7 +23,7 @@ var errAccountRateLimit = fmt.Errorf("request ratelimited: account limit")
 
 const systemAccountKey = "system"
 
-const maxBlobSize = 1024 * 512 // 512 KiB
+const maxBlobSize = 2 * 1024 * 1024 // 2 MiB
 
 type DispersalServer struct {
 	pb.UnimplementedDisperserServer
@@ -106,7 +106,7 @@ func (s *DispersalServer) DisperseBlob(ctx context.Context, req *pb.DisperseBlob
 	blobSize := len(req.GetData())
 	// The blob size in bytes must be in range [1, maxBlobSize].
 	if blobSize > maxBlobSize {
-		return nil, fmt.Errorf("blob size cannot exceed 512 KiB")
+		return nil, fmt.Errorf("blob size cannot exceed 2 MiB")
 	}
 	if blobSize == 0 {
 		return nil, fmt.Errorf("blob size must be greater than 0")

--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -52,7 +52,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestDisperseBlob(t *testing.T) {
-	data := make([]byte, 1024)
+	data := make([]byte, 1024*1024)
 	_, err := rand.Read(data)
 	assert.NoError(t, err)
 
@@ -247,7 +247,7 @@ func TestRetrieveBlobFailsWhenBlobNotConfirmed(t *testing.T) {
 }
 
 func TestDisperseBlobWithExceedSizeLimit(t *testing.T) {
-	data := make([]byte, 1024*512+10)
+	data := make([]byte, 2*1024*1024+10)
 	_, err := rand.Read(data)
 	assert.NoError(t, err)
 
@@ -274,7 +274,7 @@ func TestDisperseBlobWithExceedSizeLimit(t *testing.T) {
 		},
 	})
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "blob size cannot exceed 512 KiB")
+	assert.Equal(t, err.Error(), "blob size cannot exceed 2 MiB")
 }
 
 func setup(m *testing.M) {


### PR DESCRIPTION
## Why are these changes needed?
To support the users's throughput need when we have blob rate limiting, and to align with Ethereum.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
