### PR TITLE
Update health check to use default implementation

### DIFF
--- a/churner/cmd/main.go
+++ b/churner/cmd/main.go
@@ -99,7 +99,8 @@ func run(ctx *cli.Context) error {
 	pb.RegisterChurnerServer(gs, churnerServer)
 
 	// Register Server for Health Checks
-	healthcheck.RegisterHealthServer(gs)
+	name := pb.Churner_ServiceDesc.ServiceName
+	healthcheck.RegisterHealthServer(name, gs)
 
 	log.Printf("churner server listening at %s", addr)
 	return gs.Serve(listener)

--- a/common/healthcheck/server.go
+++ b/common/healthcheck/server.go
@@ -6,10 +6,10 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-// RegisterHealthServer registers the generic gRPC health check server implementation
+// RegisterHealthServer registers the default gRPC health check server implementation
 // with the given gRPC server.
 func RegisterHealthServer(name string, server *grpc.Server) {
 	healthServer := health.NewServer()
-	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
 	healthServer.SetServingStatus(name, grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
 }

--- a/common/healthcheck/server.go
+++ b/common/healthcheck/server.go
@@ -1,28 +1,15 @@
 package healthcheck
 
 import (
-	"context"
-
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-type HealthServer struct{}
-
-// Watch implements grpc_health_v1.HealthServer.
-func (*HealthServer) Watch(*grpc_health_v1.HealthCheckRequest, grpc_health_v1.Health_WatchServer) error {
-	panic("unimplemented")
-}
-
-func (s *HealthServer) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	// If the server is healthy, return a response with status "SERVING".
-	return &grpc_health_v1.HealthCheckResponse{
-		Status: grpc_health_v1.HealthCheckResponse_SERVING,
-	}, nil
-}
-
-// RegisterHealthServer registers the HealthServer with the provided gRPC server.
-func RegisterHealthServer(server *grpc.Server) {
-	healthServer := &HealthServer{} // Initialize your health server implementation
-	grpc_health_v1.RegisterHealthServer(server, healthServer)
+// RegisterHealthServer registers the generic gRPC health check server implementation
+// with the given gRPC server.
+func RegisterHealthServer(name string, server *grpc.Server) {
+	healthServer := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
+	healthServer.SetServingStatus(name, grpc_health_v1.HealthCheckResponse_SERVING)
 }

--- a/common/healthcheck/server.go
+++ b/common/healthcheck/server.go
@@ -11,5 +11,5 @@ import (
 func RegisterHealthServer(name string, server *grpc.Server) {
 	healthServer := health.NewServer()
 	healthServer.SetServingStatus(name, grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
+	grpc_health_v1.RegisterHealthServer(server, healthServer)
 }

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -392,7 +392,8 @@ func (s *DispersalServer) Start(ctx context.Context) error {
 	pb.RegisterDisperserServer(gs, s)
 
 	// Register Server for Health Checks
-	healthcheck.RegisterHealthServer(gs)
+	name := pb.Disperser_ServiceDesc.ServiceName
+	healthcheck.RegisterHealthServer(name, gs)
 
 	s.logger.Info("port", s.config.GrpcPort, "address", listener.Addr().String(), "GRPC Listening")
 	if err := gs.Serve(listener); err != nil {

--- a/disperser/encoder/server.go
+++ b/disperser/encoder/server.go
@@ -140,7 +140,8 @@ func (s *Server) Start() error {
 	pb.RegisterEncoderServer(gs, s)
 
 	// Register Server for Health Checks
-	healthcheck.RegisterHealthServer(gs)
+	name := pb.Encoder_ServiceDesc.ServiceName
+	healthcheck.RegisterHealthServer(name, gs)
 
 	s.close = func() {
 		err := listener.Close()

--- a/retriever/cmd/main.go
+++ b/retriever/cmd/main.go
@@ -144,7 +144,8 @@ func RetrieverMain(ctx *cli.Context) error {
 	pb.RegisterRetrieverServer(gs, retrieverServiceServer)
 
 	// Register Server for Health Checks
-	healthcheck.RegisterHealthServer(gs)
+	name := pb.Retriever_ServiceDesc.ServiceName
+	healthcheck.RegisterHealthServer(name, gs)
 
 	log.Printf("server listening at %s", addr)
 	return gs.Serve(listener)


### PR DESCRIPTION
## Why are these changes needed?

Use default health check implementation https://pkg.go.dev/google.golang.org/grpc/health

Tested with https://github.com/grpc-ecosystem/grpc-health-probe
```
grpc-health-probe -tls -addr=disperser.eigenda-preprod.eigenops.xyz:443 -service="disperser.Disperser" 
status: SERVING

grpc-health-probe -tls -addr=disperser.eigenda-preprod.eigenops.xyz:443 -service="aaa"       
error: health rpc failed: rpc error: code = NotFound desc = unknown service

grpc-health-probe -tls -addr=disperser.eigenda-preprod.eigenops.xyz:443 -service="disperser.Disperser"
error: health rpc failed: rpc error: code = Unavailable desc = unexpected HTTP status code received from server: 503 (Service Unavailable)
```

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
