### PR TITLE
CHORE:fix link jump

### DIFF
--- a/docs/design/encoding.md
+++ b/docs/design/encoding.md
@@ -37,7 +37,7 @@ As the encoding interface calls for the construction of `NumChunks` Chunks of le
 
 ## Amortized Multireveal Proof Generation with the FFT
 
-The construction of the multireveal proofs can also be performed using a DFT (as in [“Fast Amortized Kate Proofs”](./https://eprint.iacr.org/2023/033.pdf)). Leaving the full details of this process to the referenced document, we describe here only 1) the index-assignment the scheme used by the amortized multiproof generation approach and 2) the constraints that this creates for the overall encoder interface.
+The construction of the multireveal proofs can also be performed using a DFT (as in [“Fast Amortized Kate Proofs”](https://eprint.iacr.org/2023/033.pdf)). Leaving the full details of this process to the referenced document, we describe here only 1) the index-assignment the scheme used by the amortized multiproof generation approach and 2) the constraints that this creates for the overall encoder interface.
 
 Given the group $S$ corresponding to the indices of the polynomial evaluations and a cyclic group $C$ which is a subgroup of $S$, the cosets of $C$ in $S$ are given by
 


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`https://eprint.iacr.org/2023/033.pdf `is an link 
`./https://eprint.iacr.org/2023/033.pdf` will redirect to local file while can not find.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
