### PR TITLE
Memoize and log operator addresses

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -233,7 +233,7 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	fmt.Println("quorumIDs", quorumIDs)
 
 	stageTimer = time.Now()
-	aggSig, err := b.Aggregator.AggregateSignatures(batch.State, quorumIDs, headerHash, update)
+	aggSig, err := b.Aggregator.AggregateSignatures(ctx, batch.State, quorumIDs, headerHash, update)
 	if err != nil {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailAggregateSignatures)
 		return fmt.Errorf("HandleSingleBatch: error aggregating signatures: %w", err)

--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -72,7 +72,10 @@ func makeBatcher(t *testing.T) (*batcherComponents, *bat.Batcher) {
 	assert.NoError(t, err)
 	cst.On("GetCurrentBlockNumber").Return(uint(10), nil)
 	asgn := &core.StdAssignmentCoordinator{}
-	agg := core.NewStdSignatureAggregator(logger)
+	transactor := &coremock.MockTransactor{}
+	transactor.On("OperatorIDToAddress").Return(gethcommon.Address{}, nil)
+	agg, err := core.NewStdSignatureAggregator(logger, transactor)
+	assert.NoError(t, err)
 	enc, err := makeTestEncoder()
 	assert.NoError(t, err)
 

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -75,7 +75,6 @@ func RunBatcher(ctx *cli.Context) error {
 	dispatcher := dispatcher.NewDispatcher(&dispatcher.Config{
 		Timeout: config.TimeoutConfig.AttestationTimeout,
 	}, logger)
-	agg := core.NewStdSignatureAggregator(logger)
 	asgn := &core.StdAssignmentCoordinator{}
 
 	client, err := geth.NewClient(config.EthClientConfig, logger)
@@ -88,6 +87,10 @@ func RunBatcher(ctx *cli.Context) error {
 		return err
 	}
 	tx, err := coreeth.NewTransactor(logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	if err != nil {
+		return err
+	}
+	agg, err := core.NewStdSignatureAggregator(logger, tx)
 	if err != nil {
 		return err
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -123,7 +123,10 @@ func mustMakeDisperser(t *testing.T, cst core.IndexedChainState, store disperser
 	}
 	dispatcher := dispatcher.NewDispatcher(dispatcherConfig, logger)
 
-	agg := core.NewStdSignatureAggregator(logger)
+	transactor := &coremock.MockTransactor{}
+	transactor.On("OperatorIDToAddress").Return(gethcommon.Address{}, nil)
+	agg, err := core.NewStdSignatureAggregator(logger, transactor)
+	assert.NoError(t, err)
 
 	confirmer := dispersermock.NewBatchConfirmer()
 	// should be encoding 3 and 0
@@ -309,10 +312,6 @@ func mustMakeOperators(t *testing.T, cst *coremock.ChainDataMock, logger common.
 			Transactor:              tx,
 			PubIPProvider:           pubIPProvider,
 			OperatorSocketsFilterer: mockOperatorSocketsFilterer,
-		}
-
-		if err != nil {
-			t.Fatal(err)
 		}
 
 		ratelimiter := &commonmock.NoopRatelimiter{}


### PR DESCRIPTION
## Why are these changes needed?
Looks up operator addresses from BLSPubkeyCompendium given the pub key, caches them, and logs them for better monitoring
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
