### PR TITLE
Use `TxnManager` for onchain transactions

### DIFF
--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -417,7 +417,7 @@ func (t *Transactor) GetOperatorStakesForQuorums(ctx context.Context, quorums []
 // BuildConfirmBatchTxn builds a transaction to confirm a batch header and signature aggregation. The signature aggregation must satisfy the quorum thresholds
 // specified in the batch header. If the signature aggregation does not satisfy the quorum thresholds, the transaction will fail.
 // Note that this function returns a transaction without publishing it to the blockchain. The caller is responsible for publishing the transaction.
-func (t *Transactor) BuildConfirmBatchTxn(ctx context.Context, batchHeader core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation core.SignatureAggregation) (*types.Transaction, error) {
+func (t *Transactor) BuildConfirmBatchTxn(ctx context.Context, batchHeader *core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation *core.SignatureAggregation) (*types.Transaction, error) {
 	quorumNumbers := quorumParamsToQuorumNumbers(quorums)
 	nonSignerOperatorIds := make([][32]byte, len(signatureAggregation.NonSigners))
 	for i := range signatureAggregation.NonSigners {
@@ -496,7 +496,7 @@ func (t *Transactor) BuildConfirmBatchTxn(ctx context.Context, batchHeader core.
 
 // ConfirmBatch confirms a batch header and signature aggregation. The signature aggregation must satisfy the quorum thresholds
 // specified in the batch header. If the signature aggregation does not satisfy the quorum thresholds, the transaction will fail.
-func (t *Transactor) ConfirmBatch(ctx context.Context, batchHeader core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation core.SignatureAggregation) (*types.Receipt, error) {
+func (t *Transactor) ConfirmBatch(ctx context.Context, batchHeader *core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation *core.SignatureAggregation) (*types.Receipt, error) {
 	tx, err := t.BuildConfirmBatchTxn(ctx, batchHeader, quorums, signatureAggregation)
 	if err != nil {
 		t.Logger.Error("Failed to build a ConfirmBatch txn", "err", err)

--- a/core/mock/tx.go
+++ b/core/mock/tx.go
@@ -71,7 +71,13 @@ func (t *MockTransactor) GetOperatorStakesForQuorums(ctx context.Context, quorum
 	return result.(core.OperatorStakes), args.Error(1)
 }
 
-func (t *MockTransactor) ConfirmBatch(ctx context.Context, batchHeader core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation core.SignatureAggregation) (*types.Receipt, error) {
+func (t *MockTransactor) BuildConfirmBatchTxn(ctx context.Context, batchHeader *core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation *core.SignatureAggregation) (*types.Transaction, error) {
+	args := t.Called()
+	result := args.Get(0)
+	return result.(*types.Transaction), args.Error(1)
+}
+
+func (t *MockTransactor) ConfirmBatch(ctx context.Context, batchHeader *core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation *core.SignatureAggregation) (*types.Receipt, error) {
 	args := t.Called()
 	var receipt *types.Receipt
 	if args.Get(0) != nil {

--- a/core/tx.go
+++ b/core/tx.go
@@ -62,9 +62,12 @@ type Transactor interface {
 	// The indices of the operators within each quorum are also returned.
 	GetOperatorStakesForQuorums(ctx context.Context, quorums []QuorumID, blockNumber uint32) (OperatorStakes, error)
 
+	// BuildConfirmBatchTxn builds a transaction to confirm a batch header and signature aggregation.
+	BuildConfirmBatchTxn(ctx context.Context, batchHeader *BatchHeader, quorums map[QuorumID]*QuorumResult, signatureAggregation *SignatureAggregation) (*types.Transaction, error)
+
 	// ConfirmBatch confirms a batch header and signature aggregation. The signature aggregation must satisfy the quorum thresholds
 	// specified in the batch header. If the signature aggregation does not satisfy the quorum thresholds, the transaction will fail.
-	ConfirmBatch(ctx context.Context, batchHeader BatchHeader, quorums map[QuorumID]*QuorumResult, signatureAggregation SignatureAggregation) (*types.Receipt, error)
+	ConfirmBatch(ctx context.Context, batchHeader *BatchHeader, quorums map[QuorumID]*QuorumResult, signatureAggregation *SignatureAggregation) (*types.Receipt, error)
 
 	// GetBlockStaleMeasure returns the BLOCK_STALE_MEASURE defined onchain.
 	GetBlockStaleMeasure(ctx context.Context) (uint32, error)

--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
@@ -63,13 +64,14 @@ type Batcher struct {
 
 	Queue         disperser.BlobStore
 	Dispatcher    disperser.Dispatcher
-	Confirmer     disperser.BatchConfirmer
 	EncoderClient disperser.EncoderClient
 
 	ChainState            core.IndexedChainState
 	AssignmentCoordinator core.AssignmentCoordinator
 	Aggregator            core.SignatureAggregator
 	EncodingStreamer      *EncodingStreamer
+	Transactor            core.Transactor
+	TransactionManager    TxnManager
 	Metrics               *Metrics
 
 	ethClient common.EthClient
@@ -82,13 +84,14 @@ func NewBatcher(
 	timeoutConfig TimeoutConfig,
 	queue disperser.BlobStore,
 	dispatcher disperser.Dispatcher,
-	confirmer disperser.BatchConfirmer,
 	chainState core.IndexedChainState,
 	assignmentCoordinator core.AssignmentCoordinator,
 	encoderClient disperser.EncoderClient,
 	aggregator core.SignatureAggregator,
 	ethClient common.EthClient,
 	finalizer Finalizer,
+	transactor core.Transactor,
+	txnManager TxnManager,
 	logger common.Logger,
 	metrics *Metrics,
 ) (*Batcher, error) {
@@ -114,13 +117,14 @@ func NewBatcher(
 
 		Queue:         queue,
 		Dispatcher:    dispatcher,
-		Confirmer:     confirmer,
 		EncoderClient: encoderClient,
 
 		ChainState:            chainState,
 		AssignmentCoordinator: assignmentCoordinator,
 		Aggregator:            aggregator,
 		EncodingStreamer:      encodingStreamer,
+		Transactor:            transactor,
+		TransactionManager:    txnManager,
 		Metrics:               metrics,
 
 		ethClient: ethClient,
@@ -142,6 +146,24 @@ func (b *Batcher) Start(ctx context.Context) error {
 		return err
 	}
 	batchTrigger := b.EncodingStreamer.EncodedSizeNotifier
+
+	go func() {
+		receiptChan := b.TransactionManager.ReceiptChan()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case receiptOrErr := <-receiptChan:
+				b.logger.Info("received response from transaction manager", "receipt", receiptOrErr.Receipt, "err", receiptOrErr.Err)
+				err := b.ProcessConfirmedBatch(ctx, receiptOrErr)
+				if err != nil {
+					b.logger.Error("failed to process confirmed batch", "err", err)
+				}
+			}
+		}
+	}()
+	b.TransactionManager.Start(ctx)
+
 	b.finalizer.Start(ctx)
 
 	go func() {
@@ -177,6 +199,155 @@ func (b *Batcher) Start(ctx context.Context) error {
 	return nil
 }
 
+// updateConfirmationInfo updates the confirmation info for each blob in the batch and returns failed blobs to retry.
+func (b *Batcher) updateConfirmationInfo(
+	ctx context.Context,
+	batchData confirmationMetadata,
+	txnReceipt *types.Receipt,
+) ([]*disperser.BlobMetadata, error) {
+	if txnReceipt.BlockNumber == nil {
+		return nil, fmt.Errorf("HandleSingleBatch: error getting transaction receipt block number")
+	}
+	if len(batchData.blobs) == 0 {
+		return nil, fmt.Errorf("failed to process confirmed batch: no blobs from transaction manager metadata")
+	}
+	if batchData.batchHeader == nil {
+		return nil, fmt.Errorf("failed to process confirmed batch: batch header from transaction manager metadata is nil")
+	}
+	if len(batchData.blobHeaders) == 0 {
+		return nil, fmt.Errorf("failed to process confirmed batch: no blob headers from transaction manager metadata")
+	}
+	if batchData.merkleTree == nil {
+		return nil, fmt.Errorf("failed to process confirmed batch: merkle tree from transaction manager metadata is nil")
+	}
+	if batchData.aggSig == nil {
+		return nil, fmt.Errorf("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
+	}
+	headerHash, err := batchData.batchHeader.GetBatchHeaderHash()
+	if err != nil {
+		return nil, fmt.Errorf("HandleSingleBatch: error getting batch header hash: %w", err)
+	}
+	batchID, err := b.getBatchID(ctx, txnReceipt)
+	if err != nil {
+		return nil, fmt.Errorf("HandleSingleBatch: error fetching batch ID: %w", err)
+	}
+
+	blobsToRetry := make([]*disperser.BlobMetadata, 0)
+	var updateConfirmationInfoErr error
+
+	for blobIndex, metadata := range batchData.blobs {
+		// Mark the blob failed if it didn't get enough signatures.
+		status := disperser.InsufficientSignatures
+
+		var proof []byte
+		if isBlobAttested(batchData.aggSig.QuorumResults, batchData.blobHeaders[blobIndex]) {
+			status = disperser.Confirmed
+			// generate inclusion proof
+			if blobIndex >= len(batchData.blobHeaders) {
+				b.logger.Error("HandleSingleBatch: error confirming blobs: blob header not found in batch", "index", blobIndex)
+				blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
+				continue
+			}
+			blobHeader := batchData.blobHeaders[blobIndex]
+
+			blobHeaderHash, err := blobHeader.GetBlobHeaderHash()
+			if err != nil {
+				b.logger.Error("HandleSingleBatch: failed to get blob header hash", "err", err)
+				blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
+				continue
+			}
+			merkleProof, err := batchData.merkleTree.GenerateProof(blobHeaderHash[:], 0)
+			if err != nil {
+				b.logger.Error("HandleSingleBatch: failed to generate blob header inclusion proof", "err", err)
+				blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
+				continue
+			}
+			proof = serializeProof(merkleProof)
+		}
+
+		confirmationInfo := &disperser.ConfirmationInfo{
+			BatchHeaderHash:         headerHash,
+			BlobIndex:               uint32(blobIndex),
+			SignatoryRecordHash:     core.ComputeSignatoryRecordHash(uint32(batchData.batchHeader.ReferenceBlockNumber), batchData.aggSig.NonSigners),
+			ReferenceBlockNumber:    uint32(batchData.batchHeader.ReferenceBlockNumber),
+			BatchRoot:               batchData.batchHeader.BatchRoot[:],
+			BlobInclusionProof:      proof,
+			BlobCommitment:          &batchData.blobHeaders[blobIndex].BlobCommitments,
+			BatchID:                 uint32(batchID),
+			ConfirmationTxnHash:     txnReceipt.TxHash,
+			ConfirmationBlockNumber: uint32(txnReceipt.BlockNumber.Uint64()),
+			Fee:                     []byte{0}, // No fee
+			QuorumResults:           batchData.aggSig.QuorumResults,
+			BlobQuorumInfos:         batchData.blobHeaders[blobIndex].QuorumInfos,
+		}
+
+		if status == disperser.Confirmed {
+			if _, updateConfirmationInfoErr = b.Queue.MarkBlobConfirmed(ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
+				b.Metrics.UpdateCompletedBlob(int(metadata.RequestMetadata.BlobSize), disperser.Confirmed)
+				// remove encoded blob from storage so we don't disperse it again
+				b.EncodingStreamer.RemoveEncodedBlob(metadata)
+			}
+		} else if status == disperser.InsufficientSignatures {
+			if _, updateConfirmationInfoErr = b.Queue.MarkBlobInsufficientSignatures(ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
+				b.Metrics.UpdateCompletedBlob(int(metadata.RequestMetadata.BlobSize), disperser.InsufficientSignatures)
+				// remove encoded blob from storage so we don't disperse it again
+				b.EncodingStreamer.RemoveEncodedBlob(metadata)
+			}
+		} else {
+			updateConfirmationInfoErr = fmt.Errorf("HandleSingleBatch: trying to update confirmation info for blob in status other than confirmed or insufficient signatures: %s", status.String())
+		}
+		if updateConfirmationInfoErr != nil {
+			b.logger.Error("HandleSingleBatch: error updating blob confirmed metadata", "err", updateConfirmationInfoErr)
+			blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
+		}
+		requestTime := time.Unix(0, int64(metadata.RequestMetadata.RequestedAt))
+		b.Metrics.ObserveLatency("E2E", float64(time.Since(requestTime).Milliseconds()))
+	}
+
+	return blobsToRetry, nil
+}
+
+func (b *Batcher) ProcessConfirmedBatch(ctx context.Context, receiptOrErr *ReceiptOrErr) error {
+	if receiptOrErr.Metadata == nil {
+		return fmt.Errorf("failed to process confirmed batch: no metadata from transaction manager response")
+	}
+	confirmationMetadata := receiptOrErr.Metadata.(confirmationMetadata)
+	blobs := confirmationMetadata.blobs
+	if len(blobs) == 0 {
+		return fmt.Errorf("failed to process confirmed batch: no blobs from transaction manager metadata")
+	}
+	if receiptOrErr.Err != nil {
+		_ = b.handleFailure(ctx, blobs, FailConfirmBatch)
+		return fmt.Errorf("failed to confirm batch onchain: %w", receiptOrErr.Err)
+	}
+	if confirmationMetadata.aggSig == nil {
+		_ = b.handleFailure(ctx, blobs, FailNoAggregatedSignature)
+		return fmt.Errorf("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
+	}
+	b.logger.Info("received ConfirmBatch transaction receipt", "blockNumber", receiptOrErr.Receipt.BlockNumber, "txnHash", receiptOrErr.Receipt.TxHash.Hex())
+
+	// Mark the blobs as complete
+	stageTimer := time.Now()
+	blobsToRetry, err := b.updateConfirmationInfo(ctx, confirmationMetadata, receiptOrErr.Receipt)
+	if err != nil {
+		_ = b.handleFailure(ctx, blobs, FailUpdateConfirmationInfo)
+		return fmt.Errorf("failed to update confirmation info: %w", err)
+	}
+	if len(blobsToRetry) > 0 {
+		b.logger.Error("failed to update confirmation info", "failed", len(blobsToRetry), "total", len(blobs))
+		_ = b.handleFailure(ctx, blobsToRetry, FailUpdateConfirmationInfo)
+	}
+	b.logger.Trace("[batcher] Update confirmation info took", "duration", time.Since(stageTimer))
+	b.Metrics.ObserveLatency("UpdateConfirmationInfo", float64(time.Since(stageTimer).Milliseconds()))
+	batchSize := int64(0)
+	for _, blobMeta := range blobs {
+		batchSize += int64(blobMeta.RequestMetadata.BlobSize)
+	}
+	b.Metrics.IncrementBatchCount(batchSize)
+
+	return nil
+}
+
 func (b *Batcher) handleFailure(ctx context.Context, blobMetadatas []*disperser.BlobMetadata, reason FailReason) error {
 	var result *multierror.Error
 	for _, metadata := range blobMetadatas {
@@ -193,6 +364,15 @@ func (b *Batcher) handleFailure(ctx context.Context, blobMetadatas []*disperser.
 	// Return the error(s)
 	return result.ErrorOrNil()
 }
+
+type confirmationMetadata struct {
+	batchHeader *core.BatchHeader
+	blobs       []*disperser.BlobMetadata
+	blobHeaders []*core.BlobHeader
+	merkleTree  *merkletree.MerkleTree
+	aggSig      *core.SignatureAggregation
+}
+
 func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	log := b.logger
 	// start a timer
@@ -230,7 +410,6 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	for quorumID := range batch.State.Operators {
 		quorumIDs = append(quorumIDs, quorumID)
 	}
-	fmt.Println("quorumIDs", quorumIDs)
 
 	stageTimer = time.Now()
 	aggSig, err := b.Aggregator.AggregateSignatures(ctx, batch.State, quorumIDs, headerHash, update)
@@ -242,7 +421,7 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	b.Metrics.ObserveLatency("AggregateSignatures", float64(time.Since(stageTimer).Milliseconds()))
 	b.Metrics.UpdateAttestation(len(batch.State.IndexedOperators), len(aggSig.NonSigners))
 
-	passed, numPassed := getBlobQuorumPassStatus(aggSig.QuorumResults, batch.BlobHeaders)
+	numPassed := numBlobsAttested(aggSig.QuorumResults, batch.BlobHeaders)
 	// TODO(mooselumph): Determine whether to confirm the batch based on the number of successes
 	if numPassed == 0 {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailNoSignatures)
@@ -251,108 +430,24 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 
 	// Confirm the batch
 	log.Trace("[batcher] Confirming batch...")
-	stageTimer = time.Now()
-	txnReceipt, err := b.Confirmer.ConfirmBatch(ctx, batch.BatchHeader, aggSig.QuorumResults, aggSig)
+
+	txn, err := b.Transactor.BuildConfirmBatchTxn(ctx, batch.BatchHeader, aggSig.QuorumResults, aggSig)
 	if err != nil {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailConfirmBatch)
-		return fmt.Errorf("HandleSingleBatch: error confirming batch: %w", err)
+		return fmt.Errorf("HandleSingleBatch: error building confirmBatch transaction: %w", err)
 	}
-	log.Trace("[batcher] ConfirmBatch took", "duration", time.Since(stageTimer))
-	log.Info("[batcher] Batch confirmed at block", "blockNumber", txnReceipt.BlockNumber, "txnHash", txnReceipt.TxHash.Hex())
-	b.Metrics.ObserveLatency("ConfirmBatch", float64(time.Since(stageTimer).Milliseconds()))
-	b.Metrics.GasUsed.Set(float64(txnReceipt.GasUsed))
-
-	batchID, err := b.getBatchID(ctx, txnReceipt)
+	err = b.TransactionManager.ProcessTransaction(ctx, NewTxnRequest(txn, "confirmBatch", big.NewInt(0), confirmationMetadata{
+		batchHeader: batch.BatchHeader,
+		blobs:       batch.BlobMetadata,
+		blobHeaders: batch.BlobHeaders,
+		merkleTree:  batch.MerkleTree,
+		aggSig:      aggSig,
+	}))
 	if err != nil {
-		_ = b.handleFailure(ctx, batch.BlobMetadata, FailGetBatchID)
-		return fmt.Errorf("HandleSingleBatch: error fetching batch ID: %w", err)
+		_ = b.handleFailure(ctx, batch.BlobMetadata, FailConfirmBatch)
+		return fmt.Errorf("HandleSingleBatch: error sending confirmBatch transaction: %w", err)
 	}
 
-	// Mark the blobs as complete
-	log.Trace("[batcher] Marking blobs as complete...")
-	stageTimer = time.Now()
-	blobsToRetry := make([]*disperser.BlobMetadata, 0)
-	var updateConfirmationInfoErr error
-	for blobIndex, metadata := range batch.BlobMetadata {
-		// Mark the blob failed if it didn't get enough signatures.
-		status := disperser.Confirmed
-		if !passed[blobIndex] {
-			status = disperser.InsufficientSignatures
-		}
-
-		var blobHeader *core.BlobHeader
-		var proof []byte
-		if status == disperser.Confirmed {
-			// generate inclusion proof
-			if blobIndex >= len(batch.BlobHeaders) {
-				return fmt.Errorf("HandleSingleBatch: error confirming blobs: blob header at index %d not found in batch", blobIndex)
-			}
-			blobHeader = batch.BlobHeaders[blobIndex]
-
-			blobHeaderHash, err := blobHeader.GetBlobHeaderHash()
-			if err != nil {
-				return fmt.Errorf("HandleSingleBatch: failed to get blob header hash: %w", err)
-			}
-			merkleProof, err := batch.MerkleTree.GenerateProof(blobHeaderHash[:], 0)
-			if err != nil {
-				return fmt.Errorf("HandleSingleBatch: failed to generate blob header inclusion proof: %w", err)
-			}
-			proof = serializeProof(merkleProof)
-		}
-
-		confirmationInfo := &disperser.ConfirmationInfo{
-			BatchHeaderHash:         headerHash,
-			BlobIndex:               uint32(blobIndex),
-			SignatoryRecordHash:     core.ComputeSignatoryRecordHash(uint32(batch.BatchHeader.ReferenceBlockNumber), aggSig.NonSigners),
-			ReferenceBlockNumber:    uint32(batch.BatchHeader.ReferenceBlockNumber),
-			BatchRoot:               batch.BatchHeader.BatchRoot[:],
-			BlobInclusionProof:      proof,
-			BlobCommitment:          &batch.BlobHeaders[blobIndex].BlobCommitments,
-			BatchID:                 uint32(batchID),
-			ConfirmationTxnHash:     txnReceipt.TxHash,
-			ConfirmationBlockNumber: uint32(txnReceipt.BlockNumber.Uint64()),
-			Fee:                     []byte{0}, // No fee
-			QuorumResults:           aggSig.QuorumResults,
-			BlobQuorumInfos:         batch.BlobHeaders[blobIndex].QuorumInfos,
-		}
-
-		if status == disperser.Confirmed {
-			if _, updateConfirmationInfoErr = b.Queue.MarkBlobConfirmed(ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
-				b.Metrics.UpdateCompletedBlob(int(metadata.RequestMetadata.BlobSize), disperser.Confirmed)
-				// remove encoded blob from storage so we don't disperse it again
-				b.EncodingStreamer.RemoveEncodedBlob(metadata)
-			}
-		} else if status == disperser.InsufficientSignatures {
-			if _, updateConfirmationInfoErr = b.Queue.MarkBlobInsufficientSignatures(ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
-				b.Metrics.UpdateCompletedBlob(int(metadata.RequestMetadata.BlobSize), disperser.InsufficientSignatures)
-				// remove encoded blob from storage so we don't disperse it again
-				b.EncodingStreamer.RemoveEncodedBlob(metadata)
-			}
-		} else {
-			updateConfirmationInfoErr = fmt.Errorf("HandleSingleBatch: trying to update confirmation info for blob in status other than confirmed or insufficient signatures: %s", status.String())
-		}
-		if updateConfirmationInfoErr != nil {
-			log.Error("HandleSingleBatch: error updating blob confirmed metadata", "err", updateConfirmationInfoErr)
-			blobsToRetry = append(blobsToRetry, batch.BlobMetadata[blobIndex])
-		}
-		requestTime := time.Unix(0, int64(metadata.RequestMetadata.RequestedAt))
-		b.Metrics.ObserveLatency("E2E", float64(time.Since(requestTime).Milliseconds()))
-	}
-
-	if len(blobsToRetry) > 0 {
-		_ = b.handleFailure(ctx, blobsToRetry, FailUpdateConfirmationInfo)
-		if len(blobsToRetry) == len(batch.BlobMetadata) {
-			return fmt.Errorf("HandleSingleBatch: failed to update blob confirmed metadata for all blobs in batch: %w", updateConfirmationInfoErr)
-		}
-	}
-
-	log.Trace("[batcher] Update confirmation info took", "duration", time.Since(stageTimer))
-	b.Metrics.ObserveLatency("UpdateConfirmationInfo", float64(time.Since(stageTimer).Milliseconds()))
-	batchSize := int64(0)
-	for _, blobMeta := range batch.BlobMetadata {
-		batchSize += int64(blobMeta.RequestMetadata.BlobSize)
-	}
-	b.Metrics.IncrementBatchCount(batchSize)
 	return nil
 }
 
@@ -440,12 +535,10 @@ func (b *Batcher) getBatchID(ctx context.Context, txReceipt *types.Receipt) (uin
 	return batchID, nil
 }
 
-// Determine failure status for each blob based on stake signed per quorum. We fail a blob if it received
-// insufficient signatures for any quorum
-func getBlobQuorumPassStatus(signedQuorums map[core.QuorumID]*core.QuorumResult, headers []*core.BlobHeader) ([]bool, int) {
+// numBlobsAttested returns the number of blobs that have been successfully attested by the given quorums
+func numBlobsAttested(signedQuorums map[core.QuorumID]*core.QuorumResult, headers []*core.BlobHeader) int {
 	numPassed := 0
-	passed := make([]bool, len(headers))
-	for ind, blob := range headers {
+	for _, blob := range headers {
 		thisPassed := true
 		for _, quorum := range blob.QuorumInfos {
 			if signedQuorums[quorum.QuorumID].PercentSigned < quorum.QuorumThreshold {
@@ -453,11 +546,19 @@ func getBlobQuorumPassStatus(signedQuorums map[core.QuorumID]*core.QuorumResult,
 				break
 			}
 		}
-		passed[ind] = thisPassed
 		if thisPassed {
 			numPassed++
 		}
 	}
 
-	return passed, numPassed
+	return numPassed
+}
+
+func isBlobAttested(signedQuorums map[core.QuorumID]*core.QuorumResult, header *core.BlobHeader) bool {
+	for _, quorum := range header.QuorumInfos {
+		if signedQuorums[quorum.QuorumID].PercentSigned < quorum.QuorumThreshold {
+			return false
+		}
+	}
+	return true
 }

--- a/disperser/batcher/eth/confirmer.go
+++ b/disperser/batcher/eth/confirmer.go
@@ -44,7 +44,7 @@ func (c *BatchConfirmer) ConfirmBatch(ctx context.Context, header *core.BatchHea
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	for i := 0; i < maxRetries; i++ {
-		txReceipt, err = c.Transactor.ConfirmBatch(ctxWithTimeout, *header, quorums, *sigAgg)
+		txReceipt, err = c.Transactor.ConfirmBatch(ctxWithTimeout, header, quorums, sigAgg)
 		if err == nil {
 			break
 		}

--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -22,6 +22,7 @@ const (
 	FailConfirmBatch           FailReason = "confirm_batch"
 	FailGetBatchID             FailReason = "get_batch_id"
 	FailUpdateConfirmationInfo FailReason = "update_confirmation_info"
+	FailNoAggregatedSignature  FailReason = "no_aggregated_signature"
 )
 
 type MetricsConfig struct {

--- a/disperser/batcher/mock/txn_manager.go
+++ b/disperser/batcher/mock/txn_manager.go
@@ -1,0 +1,33 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/Layr-Labs/eigenda/disperser/batcher"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockTxnManager struct {
+	mock.Mock
+
+	Requests []*batcher.TxnRequest
+}
+
+var _ batcher.TxnManager = (*MockTxnManager)(nil)
+
+func NewTxnManager() *MockTxnManager {
+	return &MockTxnManager{}
+}
+
+func (b *MockTxnManager) Start(ctx context.Context) {}
+
+func (b *MockTxnManager) ProcessTransaction(ctx context.Context, req *batcher.TxnRequest) error {
+	args := b.Called()
+	b.Requests = append(b.Requests, req)
+	return args.Error(0)
+}
+
+func (b *MockTxnManager) ReceiptChan() chan *batcher.ReceiptOrErr {
+	args := b.Called()
+	return args.Get(0).(chan *batcher.ReceiptOrErr)
+}

--- a/disperser/batcher/txn_manager_test.go
+++ b/disperser/batcher/txn_manager_test.go
@@ -37,7 +37,7 @@ func TestProcessTransaction(t *testing.T) {
 		Value: nil,
 	})
 	assert.NoError(t, err)
-	receiptOrErr := <-txnManager.ReceiptChan
+	receiptOrErr := <-txnManager.ReceiptChan()
 	assert.NoError(t, receiptOrErr.Err)
 	assert.Equal(t, uint64(1), receiptOrErr.Receipt.BlockNumber.Uint64())
 	ethClient.AssertNumberOfCalls(t, "GetLatestGasCaps", 1)
@@ -55,7 +55,7 @@ func TestProcessTransaction(t *testing.T) {
 	})
 	<-ctx.Done()
 	assert.NoError(t, err)
-	receiptOrErr = <-txnManager.ReceiptChan
+	receiptOrErr = <-txnManager.ReceiptChan()
 	assert.Error(t, receiptOrErr.Err, randomErr)
 	assert.Nil(t, receiptOrErr.Receipt)
 	ethClient.AssertNumberOfCalls(t, "GetLatestGasCaps", 2)

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	coreeth "github.com/Layr-Labs/eigenda/core/eth"
 	"github.com/Layr-Labs/eigenda/disperser/batcher"
-	"github.com/Layr-Labs/eigenda/disperser/batcher/eth"
 	dispatcher "github.com/Layr-Labs/eigenda/disperser/batcher/grpc"
 	"github.com/Layr-Labs/eigenda/disperser/cmd/batcher/flags"
 	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
@@ -94,11 +93,6 @@ func RunBatcher(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	confirmer, err := eth.NewBatchConfirmer(tx, config.TimeoutConfig.ChainWriteTimeout)
-	if err != nil {
-		return err
-	}
-
 	blockStaleMeasure, err := tx.GetBlockStaleMeasure(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get BLOCK_STALE_MEASURE: %w", err)
@@ -147,7 +141,8 @@ func RunBatcher(ctx *cli.Context) error {
 		return err
 	}
 	finalizer := batcher.NewFinalizer(config.TimeoutConfig.ChainReadTimeout, config.BatcherConfig.FinalizerInterval, queue, client, rpcClient, config.BatcherConfig.MaxNumRetriesPerBlob, logger)
-	batcher, err := batcher.NewBatcher(config.BatcherConfig, config.TimeoutConfig, queue, dispatcher, confirmer, ics, asgn, encoderClient, agg, client, finalizer, logger, metrics)
+	txnManager := batcher.NewTxnManager(client, 20, config.TimeoutConfig.ChainWriteTimeout, logger)
+	batcher, err := batcher.NewBatcher(config.BatcherConfig, config.TimeoutConfig, queue, dispatcher, ics, asgn, encoderClient, agg, client, finalizer, tx, txnManager, logger, metrics)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why are these changes needed?
- make use of `TxnManager` to wait for transactions in a separate goroutines
- `confirmationInfo` is updated in a separate goroutine as transaction receipt is now received asynchronously
<!-- Please give a short summary of the change and the problem this solves. -->

TODOs In following PRs:
- update retry logic 
- add metrics to `TxnManager`

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
