### PR TITLE
Stop indexer in inabox test cleanup to suppress logs

### DIFF
--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -47,6 +47,8 @@ var (
 	mockRollup        *rollupbindings.ContractMockRollup
 	retrievalClient   clients.RetrievalClient
 	numConfirmations  int = 3
+
+	cancel context.CancelFunc
 )
 
 func init() {
@@ -192,11 +194,16 @@ func setupRetrievalClient(testConfig *deploy.Config) error {
 		return err
 	}
 
-	return indexer.Index(context.Background())
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.Background())
+
+	return indexer.Index(ctx)
 }
 
 var _ = AfterSuite(func() {
 	if testConfig.Environment.IsLocal() {
+
+		cancel()
 
 		fmt.Println("Stopping binaries")
 		testConfig.StopBinaries()


### PR DESCRIPTION
## Why are these changes needed?

Stops indexer in inabox cleanup to avoid a large number of extraneous error logs from being printed to terminal. 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
