### PR TITLE
[encodingstreamer] Consider blobs pending confirmation

### DIFF
--- a/disperser/batcher/encoded_blob_store.go
+++ b/disperser/batcher/encoded_blob_store.go
@@ -10,6 +10,12 @@ import (
 )
 
 type requestID string
+type status uint
+
+const (
+	PendingDispersal status = iota
+	PendingConfirmation
+)
 
 type encodedBlobStore struct {
 	mu sync.RWMutex
@@ -30,6 +36,7 @@ type EncodingResult struct {
 	Commitment           *core.BlobCommitments
 	Chunks               []*core.Chunk
 	Assignments          map[core.OperatorID]core.Assignment
+	Status               status
 }
 
 // EncodingResultOrStatus is a wrapper for EncodingResult that also contains an error
@@ -66,7 +73,7 @@ func (e *encodedBlobStore) HasEncodingRequested(blobKey disperser.BlobKey, quoru
 	}
 
 	res, ok := e.encoded[requestID]
-	if ok && res.ReferenceBlockNumber == referenceBlockNumber {
+	if ok && (res.Status == PendingConfirmation || res.ReferenceBlockNumber == referenceBlockNumber) {
 		return true
 	}
 	return false
@@ -132,23 +139,28 @@ func (e *encodedBlobStore) DeleteEncodingResult(blobKey disperser.BlobKey, quoru
 	e.encodedResultSize -= getChunksSize(encodedResult)
 }
 
-// GetNewAndDeleteStaleEncodingResults returns all the fresh encoded results and deletes all the stale results
+// GetNewAndDeleteStaleEncodingResults returns all the fresh encoded results that are pending dispersal, and deletes all the stale results that are older than the given block number
 func (e *encodedBlobStore) GetNewAndDeleteStaleEncodingResults(blockNumber uint) []*EncodingResult {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	fetched := make([]*EncodingResult, 0)
 	staleCount := 0
+	pendingConfirmation := 0
 	for k, encodedResult := range e.encoded {
-		if encodedResult.ReferenceBlockNumber < blockNumber {
+		if encodedResult.Status == PendingConfirmation {
+			pendingConfirmation++
+		} else if encodedResult.ReferenceBlockNumber == blockNumber {
+			fetched = append(fetched, encodedResult)
+		} else if encodedResult.ReferenceBlockNumber < blockNumber {
 			// this is safe: https://go.dev/doc/effective_go#for
 			delete(e.encoded, k)
 			staleCount++
 			e.encodedResultSize -= getChunksSize(encodedResult)
 		} else {
-			fetched = append(fetched, encodedResult)
+			e.logger.Error("GetNewAndDeleteStaleEncodingResults: unexpected case", "refBlockNumber", encodedResult.ReferenceBlockNumber, "blockNumber", blockNumber, "status", encodedResult.Status)
 		}
 	}
-	e.logger.Trace("consumed encoded results", "fetched", len(fetched), "stale", staleCount, "blockNumber", blockNumber, "encodedSize", e.encodedResultSize)
+	e.logger.Trace("consumed encoded results", "fetched", len(fetched), "stale", staleCount, "pendingConfirmation", pendingConfirmation, "blockNumber", blockNumber, "encodedSize", e.encodedResultSize)
 
 	return fetched
 }
@@ -159,6 +171,19 @@ func (e *encodedBlobStore) GetEncodedResultSize() (int, uint64) {
 	defer e.mu.RUnlock()
 
 	return len(e.encoded), e.encodedResultSize
+}
+
+func (e *encodedBlobStore) MarkEncodedResultPendingConfirmation(blobKey disperser.BlobKey, quorumID core.QuorumID) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	requestID := getRequestID(blobKey, quorumID)
+	if _, ok := e.encoded[requestID]; !ok {
+		return fmt.Errorf("MarkEncodedBlobPendingConfirmation: no such key (%s) in encoded set", requestID)
+	}
+
+	e.encoded[requestID].Status = PendingConfirmation
+	return nil
 }
 
 func getRequestID(key disperser.BlobKey, quorumID core.QuorumID) requestID {

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -359,6 +359,7 @@ func (e *EncodingStreamer) RequestEncodingForBlob(ctx context.Context, metadata 
 					Commitment:           commits,
 					Chunks:               chunks,
 					Assignments:          res.Assignments,
+					Status:               PendingDispersal,
 				},
 				Err: nil,
 			}
@@ -543,6 +544,16 @@ func (e *EncodingStreamer) RemoveEncodedBlob(metadata *disperser.BlobMetadata) {
 	for _, sp := range metadata.RequestMetadata.SecurityParams {
 		e.EncodedBlobstore.DeleteEncodingResult(metadata.GetBlobKey(), sp.QuorumID)
 	}
+}
+
+func (e *EncodingStreamer) MarkBlobPendingConfirmation(metadata *disperser.BlobMetadata) error {
+	for _, sp := range metadata.RequestMetadata.SecurityParams {
+		err := e.EncodedBlobstore.MarkEncodedResultPendingConfirmation(metadata.GetBlobKey(), sp.QuorumID)
+		if err != nil {
+			return fmt.Errorf("error marking blob pending confirmation: %w", err)
+		}
+	}
+	return nil
 }
 
 // getOperatorState returns the operator state for the blobs that have valid quorums


### PR DESCRIPTION
## Why are these changes needed?
Now that onchain confirmation is handled asynchronously, few things need to change in encoding streamer.
At encoding time, it should not encode blobs that are already pending confirmation.
At batch creation time, it shouldn't delete blobs pending confirmation even if they're stale.
At batcher, 1) blobs should be marked as pending confirmation once it's dispersed to DA nodes, and 2) removed from encoded blob store when batching finishes even when they fail
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
