### PR TITLE
Add `TxnManager` metrics

### DIFF
--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -34,15 +34,21 @@ type EncodingStreamerMetrics struct {
 	EncodedBlobs *prometheus.GaugeVec
 }
 
+type TxnManagerMetrics struct {
+	Latency  prometheus.Summary
+	GasUsed  prometheus.Gauge
+	SpeedUps prometheus.Gauge
+}
+
 type Metrics struct {
 	*EncodingStreamerMetrics
+	*TxnManagerMetrics
 
 	registry *prometheus.Registry
 
 	Blob             *prometheus.CounterVec
 	Batch            *prometheus.CounterVec
 	BatchProcLatency *prometheus.SummaryVec
-	GasUsed          prometheus.Gauge
 	Attestation      *prometheus.GaugeVec
 	BatchError       *prometheus.CounterVec
 
@@ -67,8 +73,34 @@ func NewMetrics(httpPort string, logger common.Logger) *Metrics {
 		),
 	}
 
+	txnManagerMetrics := TxnManagerMetrics{
+		Latency: promauto.With(reg).NewSummary(
+			prometheus.SummaryOpts{
+				Namespace:  namespace,
+				Name:       "txn_manager_latency_ms",
+				Help:       "transaction confirmation latency summary in milliseconds",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
+			},
+		),
+		GasUsed: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "gas_used",
+				Help:      "gas used for onchain batch confirmation",
+			},
+		),
+		SpeedUps: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "speed_ups",
+				Help:      "number of times the gas price was increased",
+			},
+		),
+	}
+
 	metrics := &Metrics{
 		EncodingStreamerMetrics: &encodingStreamerMetrics,
+		TxnManagerMetrics:       &txnManagerMetrics,
 		Blob: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
@@ -93,13 +125,6 @@ func NewMetrics(httpPort string, logger common.Logger) *Metrics {
 				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			},
 			[]string{"stage"},
-		),
-		GasUsed: promauto.With(reg).NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: namespace,
-				Name:      "gas_used",
-				Help:      "gas used for onchain batch confirmation",
-			},
 		),
 		Attestation: promauto.With(reg).NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -180,4 +205,16 @@ func (g *Metrics) Start(ctx context.Context) {
 func (e *EncodingStreamerMetrics) UpdateEncodedBlobs(count int, size uint64) {
 	e.EncodedBlobs.WithLabelValues("size").Set(float64(size))
 	e.EncodedBlobs.WithLabelValues("number").Set(float64(count))
+}
+
+func (t *TxnManagerMetrics) ObserveLatency(latencyMs float64) {
+	t.Latency.Observe(latencyMs)
+}
+
+func (t *TxnManagerMetrics) UpdateGasUsed(gasUsed uint64) {
+	t.GasUsed.Set(float64(gasUsed))
+}
+
+func (t *TxnManagerMetrics) UpdateSpeedUps(speedUps int) {
+	t.SpeedUps.Set(float64(speedUps))
 }

--- a/disperser/batcher/txn_manager_test.go
+++ b/disperser/batcher/txn_manager_test.go
@@ -19,7 +19,8 @@ func TestProcessTransaction(t *testing.T) {
 	ethClient := &mock.MockEthClient{}
 	logger, err := logging.GetLogger(logging.DefaultCLIConfig())
 	assert.NoError(t, err)
-	txnManager := batcher.NewTxnManager(ethClient, 5, 48*time.Second, logger)
+	metrics := batcher.NewMetrics("9100", logger)
+	txnManager := batcher.NewTxnManager(ethClient, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	txnManager.Start(ctx)
@@ -68,7 +69,8 @@ func TestReplaceGasFee(t *testing.T) {
 	ethClient := &mock.MockEthClient{}
 	logger, err := logging.GetLogger(logging.DefaultCLIConfig())
 	assert.NoError(t, err)
-	txnManager := batcher.NewTxnManager(ethClient, 5, 48*time.Second, logger)
+	metrics := batcher.NewMetrics("9100", logger)
+	txnManager := batcher.NewTxnManager(ethClient, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	txnManager.Start(ctx)

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -141,7 +141,7 @@ func RunBatcher(ctx *cli.Context) error {
 		return err
 	}
 	finalizer := batcher.NewFinalizer(config.TimeoutConfig.ChainReadTimeout, config.BatcherConfig.FinalizerInterval, queue, client, rpcClient, config.BatcherConfig.MaxNumRetriesPerBlob, logger)
-	txnManager := batcher.NewTxnManager(client, 20, config.TimeoutConfig.ChainWriteTimeout, logger)
+	txnManager := batcher.NewTxnManager(client, 20, config.TimeoutConfig.ChainWriteTimeout, logger, metrics.TxnManagerMetrics)
 	batcher, err := batcher.NewBatcher(config.BatcherConfig, config.TimeoutConfig, queue, dispatcher, ics, asgn, encoderClient, agg, client, finalizer, tx, txnManager, logger, metrics)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Why are these changes needed?
Adding the following metrics to `TxnManager`:
- Latency measures how long a transaction takes to be confirmed onchain
- GasUsed measures how much gas is used for a transaction
- SpeedUps measures how many times gas was increased
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
