### PR TITLE
[DynamodB] Fix Flaky Pagination UT

### DIFF
--- a/common/aws/dynamodb/client_test.go
+++ b/common/aws/dynamodb/client_test.go
@@ -349,7 +349,7 @@ func TestQueryIndexPaginationItemNoLimit(t *testing.T) {
 	ctx := context.Background()
 	numItems := 30
 	for i := 0; i < numItems; i += 1 {
-		requestedAt := time.Now().Add(-time.Duration(i) * time.Second).Unix()
+		requestedAt := time.Now().Add(-time.Duration(3*i) * time.Second).Unix()
 
 		// Create new item
 		item := commondynamodb.Item{
@@ -409,7 +409,16 @@ func TestQueryIndexPagination(t *testing.T) {
 	ctx := context.Background()
 	numItems := 30
 	for i := 0; i < numItems; i += 1 {
-		requestedAt := time.Now().Add(-time.Duration(i) * time.Second).Unix()
+		// Noticed same timestamp for multiple items which resulted in key28
+		// being returned when 10 items were queried as first item,hence multiplying
+		// by random number 3 here to avoid such a situation
+		// requestedAt: 1705040877
+		// metadataKey: key28
+		// BlobKey: blob28
+		// requestedAt: 1705040877
+		// metadataKey: key29
+		// BlobKey: blob29
+		requestedAt := time.Now().Add(-time.Duration(3*i) * time.Second).Unix()
 
 		// Create new item
 		item := commondynamodb.Item{


### PR DESCRIPTION
## Why are these changes needed?
Noticed when adding items to dB following values for requestedAt resulting in key28 being returned as the first key on a query.

// requestedAt: 1705040877
// metadataKey: key28
// BlobKey: blob28
// requestedAt: 1705040877
// metadataKey: key29
// BlobKey: blob29

Fixed it by increasing time duration for requestedAt between adding each item

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
