### PR TITLE
[TxnManager] Halt when speed up fails

### DIFF
--- a/common/mock/ethclient.go
+++ b/common/mock/ethclient.go
@@ -194,8 +194,11 @@ func (mock *MockEthClient) GetLatestGasCaps(ctx context.Context) (gasTipCap, gas
 
 func (mock *MockEthClient) UpdateGas(ctx context.Context, tx *types.Transaction, value, gasTipCap, gasFeeCap *big.Int) (*types.Transaction, error) {
 	args := mock.Called()
-	result := args.Get(0)
-	return result.(*types.Transaction), args.Error(1)
+	var newTx *types.Transaction
+	if args.Get(0) != nil {
+		newTx = args.Get(0).(*types.Transaction)
+	}
+	return newTx, args.Error(1)
 }
 
 func (mock *MockEthClient) EstimateGasPriceAndLimitAndSendTx(ctx context.Context, tx *types.Transaction, tag string, value *big.Int) (*types.Receipt, error) {

--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -39,6 +39,8 @@ type TxnManagerMetrics struct {
 	Latency  prometheus.Summary
 	GasUsed  prometheus.Gauge
 	SpeedUps prometheus.Gauge
+	TxQueue  prometheus.Gauge
+	NumTx    *prometheus.CounterVec
 }
 
 type Metrics struct {
@@ -96,6 +98,21 @@ func NewMetrics(httpPort string, logger common.Logger) *Metrics {
 				Name:      "speed_ups",
 				Help:      "number of times the gas price was increased",
 			},
+		),
+		TxQueue: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "tx_queue",
+				Help:      "number of transactions in transaction queue",
+			},
+		),
+		NumTx: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "tx_total",
+				Help:      "number of transactions processed",
+			},
+			[]string{"state"},
 		),
 	}
 
@@ -223,4 +240,12 @@ func (t *TxnManagerMetrics) UpdateGasUsed(gasUsed uint64) {
 
 func (t *TxnManagerMetrics) UpdateSpeedUps(speedUps int) {
 	t.SpeedUps.Set(float64(speedUps))
+}
+
+func (t *TxnManagerMetrics) UpdateTxQueue(txQueue int) {
+	t.TxQueue.Set(float64(txQueue))
+}
+
+func (t *TxnManagerMetrics) IncrementTxnCount(state string) {
+	t.NumTx.WithLabelValues(state).Inc()
 }

--- a/disperser/batcher/txn_manager_test.go
+++ b/disperser/batcher/txn_manager_test.go
@@ -96,3 +96,36 @@ func TestReplaceGasFee(t *testing.T) {
 	ethClient.AssertNumberOfCalls(t, "SendTransaction", 2)
 	ethClient.AssertNumberOfCalls(t, "EnsureTransactionEvaled", 2)
 }
+
+func TestTransactionFailure(t *testing.T) {
+	ethClient := &mock.MockEthClient{}
+	logger, err := logging.GetLogger(logging.DefaultCLIConfig())
+	assert.NoError(t, err)
+	metrics := batcher.NewMetrics("9100", logger)
+	txnManager := batcher.NewTxnManager(ethClient, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	defer cancel()
+	txnManager.Start(ctx)
+	txn := types.NewTransaction(0, common.HexToAddress("0x1"), big.NewInt(1e18), 100000, big.NewInt(1e9), []byte{})
+	ethClient.On("GetLatestGasCaps").Return(big.NewInt(1e9), big.NewInt(1e9), nil)
+	ethClient.On("UpdateGas").Return(txn, nil).Once()
+	// now assume that the transaction fails on retry
+	speedUpFailure := fmt.Errorf("speed up failure")
+	ethClient.On("UpdateGas").Return(nil, speedUpFailure).Once()
+	ethClient.On("SendTransaction").Return(nil)
+	// assume that the transaction is not mined within the timeout
+	ethClient.On("EnsureTransactionEvaled").Return(nil, context.DeadlineExceeded).Once()
+	ethClient.On("EnsureTransactionEvaled").Return(&types.Receipt{
+		BlockNumber: new(big.Int).SetUint64(1),
+	}, nil)
+
+	err = txnManager.ProcessTransaction(ctx, &batcher.TxnRequest{
+		Tx:    txn,
+		Tag:   "test transaction",
+		Value: nil,
+	})
+	<-ctx.Done()
+	assert.NoError(t, err)
+	res := <-txnManager.ReceiptChan()
+	assert.Error(t, res.Err, speedUpFailure)
+}


### PR DESCRIPTION
## Why are these changes needed?
When speed up fails, it should return the error instead of keep retrying
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
