### PR TITLE
Fix: add disperser as a dependency to retriever

### DIFF
--- a/retriever/cmd/Dockerfile
+++ b/retriever/cmd/Dockerfile
@@ -8,6 +8,7 @@ COPY common /app/common
 COPY core /app/core
 COPY api /app/api
 COPY contracts /app/contracts
+COPY disperser /app/disperser
 COPY clients /app/clients
 COPY node /app/node
 COPY churner /app/churner


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
