### PR TITLE
Read MaxBlobsToFetchFromStoreFlag

### DIFF
--- a/disperser/cmd/batcher/flags/flags.go
+++ b/disperser/cmd/batcher/flags/flags.go
@@ -164,7 +164,6 @@ var (
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "TARGET_NUM_CHUNKS"),
 		Value:    0,
 	}
-
 	MaxBlobsToFetchFromStoreFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "max-blobs-to-fetch-from-store"),
 		Usage:    "Limit used to specify how many blobs to fetch from store at time when used with dynamodb pagination",
@@ -200,6 +199,7 @@ var optionalFlags = []cli.Flag{
 	EncodingRequestQueueSizeFlag,
 	MaxNumRetriesPerBlobFlag,
 	TargetNumChunksFlag,
+	MaxBlobsToFetchFromStoreFlag,
 }
 
 // Flags contains the list of configuration options available to the binary.


### PR DESCRIPTION
## Why are these changes needed?
This flag was added in https://github.com/Layr-Labs/eigenda/pull/157 to limit the number of blobs to process per encoding streamer loop, but hasn't been configured to be read from CLI
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
