### PR TITLE
Fix disperser client

### DIFF
--- a/clients/disperser_client.go
+++ b/clients/disperser_client.go
@@ -9,8 +9,6 @@ import (
 	disperser_rpc "github.com/Layr-Labs/eigenda/api/grpc/disperser"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
-	"github.com/Layr-Labs/eigenda/retriever/flags"
-	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -23,11 +21,12 @@ type Config struct {
 	UseSecureGrpcFlag bool
 }
 
-func NewConfig(ctx *cli.Context) *Config {
+func NewConfig(hostname, port string, timeout time.Duration, useSecureGrpcFlag bool) *Config {
 	return &Config{
-		Hostname: ctx.GlobalString(flags.HostnameFlag.Name),
-		Port:     ctx.GlobalString(flags.GrpcPortFlag.Name),
-		Timeout:  ctx.Duration(flags.TimeoutFlag.Name),
+		Hostname:          hostname,
+		Port:              port,
+		Timeout:           timeout,
+		UseSecureGrpcFlag: useSecureGrpcFlag,
 	}
 }
 

--- a/tools/traffic/config.go
+++ b/tools/traffic/config.go
@@ -20,12 +20,16 @@ type Config struct {
 	LoggingConfig          logging.Config
 	RandomizeBlobs         bool
 	InstanceLaunchInterval time.Duration
-	UseSecureGrpcFlag      bool
 }
 
 func NewConfig(ctx *cli.Context) *Config {
 	return &Config{
-		Config:                 *clients.NewConfig(ctx),
+		Config: *clients.NewConfig(
+			ctx.GlobalString(flags.HostnameFlag.Name),
+			ctx.GlobalString(flags.GrpcPortFlag.Name),
+			ctx.Duration(flags.TimeoutFlag.Name),
+			ctx.GlobalBool(flags.UseSecureGrpcFlag.Name),
+		),
 		NumInstances:           ctx.GlobalUint(flags.NumInstancesFlag.Name),
 		RequestInterval:        ctx.Duration(flags.RequestIntervalFlag.Name),
 		DataSize:               ctx.GlobalUint64(flags.DataSizeFlag.Name),
@@ -34,6 +38,5 @@ func NewConfig(ctx *cli.Context) *Config {
 		LoggingConfig:          logging.ReadCLIConfig(ctx, flags.FlagPrefix),
 		RandomizeBlobs:         ctx.GlobalBool(flags.RandomizeBlobsFlag.Name),
 		InstanceLaunchInterval: ctx.Duration(flags.InstanceLaunchIntervalFlag.Name),
-		UseSecureGrpcFlag:      ctx.GlobalBool(flags.UseSecureGrpcFlag.Name),
 	}
 }


### PR DESCRIPTION
## Why are these changes needed?
Previously, disperser client was importing flags from `github.com/Layr-Labs/eigenda/retriever/flags` which may not be available from a host that's using the client.
It explicitly receives parameters to make the config.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
