### PR TITLE
add utility to update socket

### DIFF
--- a/core/tx.go
+++ b/core/tx.go
@@ -58,7 +58,7 @@ type Transactor interface {
 	// are also returned.
 	GetOperatorStakes(ctx context.Context, operatorID OperatorID, blockNumber uint32) (OperatorStakes, []QuorumID, error)
 
-	// GetOperatorStakes returns the stakes of all operators within the supplied quorums. The returned stakes are for the block number supplied.
+	// GetOperatorStakesForQuorums returns the stakes of all operators within the supplied quorums. The returned stakes are for the block number supplied.
 	// The indices of the operators within each quorum are also returned.
 	GetOperatorStakesForQuorums(ctx context.Context, quorums []QuorumID, blockNumber uint32) (OperatorStakes, error)
 

--- a/node/operator.go
+++ b/node/operator.go
@@ -25,7 +25,7 @@ type Operator struct {
 	QuorumIDs  []core.QuorumID
 }
 
-// Register operator registers the operator with the given public key for the given quorum IDs.
+// RegisterOperator operator registers the operator with the given public key for the given quorum IDs.
 func RegisterOperator(ctx context.Context, operator *Operator, transactor core.Transactor, churnerUrl string, useSecureGrpc bool, logger common.Logger) error {
 	registeredQuorumIds, err := transactor.GetRegisteredQuorumIdsForOperator(ctx, operator.OperatorId)
 	if err != nil {
@@ -109,6 +109,11 @@ func UpdateOperatorQuorums(
 		return fmt.Errorf("failed to deregister operator: %w", err)
 	}
 	return RegisterOperator(ctx, operator, transactor, churnerUrl, useSecureGrpc, logger)
+}
+
+// UpdateOperatorSocket updates the socket for the given operator
+func UpdateOperatorSocket(ctx context.Context, transactor core.Transactor, socket string) error {
+	return transactor.UpdateOperatorSocket(ctx, socket)
 }
 
 func requestChurnApproval(ctx context.Context, operator *Operator, churnerUrl string, useSecureGrpc bool, logger common.Logger) (*grpcchurner.ChurnReply, error) {

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -146,6 +146,14 @@ func pluginOps(ctx *cli.Context) {
 			return
 		}
 		log.Printf("Info: successfully updated quorums, for operator ID: %x, operator address: %x, socket: %s, and quorums: %v", operatorID, sk.Address, config.Socket, config.QuorumIDList)
+	} else if config.Operation == "update-socket" {
+		log.Printf("Info: Operator with Operator Address: %x is updating its socket: %s", sk.Address, config.Socket)
+		err = node.UpdateOperatorSocket(context.Background(), tx, config.Socket)
+		if err != nil {
+			log.Printf("Error: failed to update socket for operator ID: %x, operator address: %x, socket: %s, error: %v", operatorID, sk.Address, config.Socket, err)
+			return
+		}
+		log.Printf("Info: successfully updated socket, for operator ID: %x, operator address: %x, socket: %s", operatorID, sk.Address, config.Socket)
 	} else {
 		log.Fatalf("Fatal: unsupported operation: %s", config.Operation)
 	}


### PR DESCRIPTION
## Why are these changes needed?

Operators sometimes disabled the auto update of IP due to their requirement of static IP (node behind Load balancer or k8s)
But when they change the IP sometime, they need to update socket. Node registration doesn't update it if node is already registered to EigenDA. SO we want to provide a utility just to update the socket for operators.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
