### PR TITLE
Handle the concurrency in the accounting of batch storing and validation

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -297,7 +297,6 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 			}
 			return
 		}
-		n.Logger.Debug("Store batch took", "duration:", time.Since(start))
 		storeChan <- storeResult{err: nil, keys: keys, latency: float64(time.Since(start).Milliseconds())}
 	}(n)
 
@@ -325,6 +324,7 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 		return nil, err
 	}
 	if result.keys != nil {
+		n.Logger.Debug("Store batch took", "duration:", time.Duration(result.latency))
 		n.Metrics.AcceptBatches("stored", batchSize)
 		n.Metrics.ObserveLatency("StoreChunks", "stored", result.latency)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -326,8 +326,7 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 	if result.keys != nil {
 		n.Metrics.AcceptBatches("stored", batchSize)
 		n.Metrics.ObserveLatency("StoreChunks", "stored", result.latency)
-		n.Logger.Debug("Store batch took", "duration:", time.Duration(result.latency*float64(time.Second)).Milliseconds())
-
+		n.Logger.Debug("Store batch took", "duration:", time.Duration(result.latency*float64(time.Millisecond)))
 	}
 
 	// Sign batch header hash if all validation checks pass and data items are written to database.

--- a/node/node.go
+++ b/node/node.go
@@ -324,9 +324,10 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 		return nil, err
 	}
 	if result.keys != nil {
-		n.Logger.Debug("Store batch took", "duration:", time.Duration(result.latency))
 		n.Metrics.AcceptBatches("stored", batchSize)
 		n.Metrics.ObserveLatency("StoreChunks", "stored", result.latency)
+		n.Logger.Debug("Store batch took", "duration:", time.Duration(result.latency*float64(time.Second)).Milliseconds())
+
 	}
 
 	// Sign batch header hash if all validation checks pass and data items are written to database.

--- a/node/node.go
+++ b/node/node.go
@@ -276,8 +276,12 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 		err error
 
 		// The keys that are stored to database for a single batch.
-		// Undefined if the err is not nil or err is ErrBatchAlreadyExist.
+		// Defined only if the batch not already exists and gets stored to database successfully.
 		keys *[][]byte
+
+		// Latency (in ms) to store the batch.
+		// Defined only if the batch not already exists and gets stored to database successfully.
+		latency float64
 	}
 	storeChan := make(chan storeResult)
 	go func(n *Node) {
@@ -287,16 +291,14 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 			// If batch already exists, we don't store it again, but we should not
 			// error out in such case.
 			if err == ErrBatchAlreadyExist {
-				storeChan <- storeResult{err: nil, keys: nil}
+				storeChan <- storeResult{err: nil, keys: nil, latency: 0}
 			} else {
-				storeChan <- storeResult{err: fmt.Errorf("failed to store batch: %w", err), keys: nil}
+				storeChan <- storeResult{err: fmt.Errorf("failed to store batch: %w", err), keys: nil, latency: 0}
 			}
 			return
 		}
-		n.Metrics.AcceptBatches("stored", batchSize)
-		n.Metrics.ObserveLatency("StoreChunks", "stored", float64(time.Since(start).Milliseconds()))
 		n.Logger.Debug("Store batch took", "duration:", time.Since(start))
-		storeChan <- storeResult{err: nil, keys: keys}
+		storeChan <- storeResult{err: nil, keys: keys, latency: float64(time.Since(start).Milliseconds())}
 	}(n)
 
 	// Validate batch.
@@ -321,6 +323,10 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 	result := <-storeChan
 	if result.err != nil {
 		return nil, err
+	}
+	if result.keys != nil {
+		n.Metrics.AcceptBatches("stored", batchSize)
+		n.Metrics.ObserveLatency("StoreChunks", "stored", result.latency)
 	}
 
 	// Sign batch header hash if all validation checks pass and data items are written to database.


### PR DESCRIPTION
## Why are these changes needed?
The batch storing and validation happen concurrently. We need to make sure we only store valid batches, so we may have to revert already stored batches (if they are actually invalid). As a result we have to account the metrics right when reversion happens.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
