### PR TITLE
Make node api work and add node version

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -23,7 +23,7 @@ const (
 	// Min number of seconds for the ExpirationPollIntervalSecFlag.
 	minExpirationPollIntervalSec = 3
 	AppName                      = "da-node"
-	SemVer                       = "0.0.1"
+	SemVer                       = "0.2.3"
 	GitCommit                    = ""
 	GitDate                      = ""
 )

--- a/node/node.go
+++ b/node/node.go
@@ -103,7 +103,7 @@ func NewNode(config *Config, pubIPProvider pubip.Provider, logger common.Logger)
 	cst := eth.NewChainState(tx, client)
 
 	// Setup Node Api
-	nodeApi := nodeapi.NewNodeApi(AppName, SemVer, "localhost:"+config.NodeApiPort, logger)
+	nodeApi := nodeapi.NewNodeApi(AppName, SemVer, ":"+config.NodeApiPort, logger)
 
 	// Make validator
 	enc, err := encoding.NewEncoder(config.EncoderConfig)


### PR DESCRIPTION
## Why are these changes needed?

`localhost` is loopback url so we should not provide it as address to http server when we want to access from docker container. We can just provide the `:port` and it will be accessible 


- Also added DA node version

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
