### PR TITLE
Compute the operator's time intervals during which the operator is live

### DIFF
--- a/disperser/dataapi/metrics_handlers.go
+++ b/disperser/dataapi/metrics_handlers.go
@@ -155,7 +155,7 @@ func (s *server) getOperatorNonsigningPercentage(ctx context.Context, intervalSe
 	}
 
 	pastBlockTimestamp := uint64(time.Now().Add(-time.Duration(intervalSeconds) * time.Second).Unix())
-	numBatchesByOperators, err := s.subgraphClient.QueryNumBatchesByOperatorsInThePastBlockTimestamp(ctx, pastBlockTimestamp)
+	numBatchesByOperators, err := s.subgraphClient.QueryNumBatchesByOperatorsInThePastBlockTimestamp(ctx, pastBlockTimestamp, nonSigners)
 	if err != nil {
 		return nil, err
 	}

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -286,7 +286,7 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 
 	operator := response.Operators["0xe1cdae12a0074f20b8fc96a0489376db34075e545ef60c4845d264a732568310"]
 	assert.Equal(t, http.StatusOK, res.StatusCode)
-	assert.Equal(t, 1, response.TotalNonSigners)
+	assert.Equal(t, 2, response.TotalNonSigners)
 	assert.Equal(t, 3, operator.TotalBatches)
 	assert.Equal(t, 1, operator.TotalUnsignedBatches)
 	assert.Equal(t, float64(33.33), operator.Percentage)

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -290,7 +290,7 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 	assert.Equal(t, 3, operator.TotalBatches)
 	assert.Equal(t, 1, operator.TotalUnsignedBatches)
 	assert.Equal(t, float64(33.33), operator.Percentage)
-	assert.Equal(t, 1, len(response.Operators))
+	assert.Equal(t, 2, len(response.Operators))
 }
 
 func setUpRouter() *gin.Engine {

--- a/disperser/dataapi/subgraph_client.go
+++ b/disperser/dataapi/subgraph_client.go
@@ -281,14 +281,14 @@ func getOperatorsWithRegisteredDeregisteredIntervalEvents(
 			dereg := operators[operatorId][1]
 			if len(reg) == 0 && len(dereg) == 0 {
 				// The operator has no registration/deregistration events: it's live
-				// during the entire time window.
+				// for the entire time window.
 				operatorEventsChan <- OperatorEvents{
 					OperatorId: operatorId,
 					Events:     []uint64{blockTimestamp, currentTs},
 				}
 			} else if len(reg) == 0 {
 				// The operator has only deregistration event: it's live from the beginning
-				// until the deregistration.
+				// of the time window until the deregistration.
 				operatorEventsChan <- OperatorEvents{
 					OperatorId: operatorId,
 					Events:     []uint64{blockTimestamp, dereg[0]},
@@ -302,9 +302,10 @@ func getOperatorsWithRegisteredDeregisteredIntervalEvents(
 				}
 			} else {
 				// The operator has both registration and deregistration events in the time
-				// window of interest.
+				// window.
 				if reg[0] < dereg[0] {
-					// The first event in the time window is registration.
+					// The first event in the time window is registration. This means at
+					// the beginning (i.e. blockTimestamp) it's not live.
 					for i := 0; i < len(reg); i++ {
 						if i < len(dereg) {
 							operatorEventsChan <- OperatorEvents{
@@ -319,7 +320,8 @@ func getOperatorsWithRegisteredDeregisteredIntervalEvents(
 						}
 					}
 				} else {
-					// The first event in the time window is deregistration.
+					// The first event in the time window is deregistration. This means at
+					// the beginning (i.e. blockTimestamp) it's live already.
 					operatorEventsChan <- OperatorEvents{
 						OperatorId: operatorId,
 						Events:     []uint64{blockTimestamp, dereg[0]},

--- a/disperser/dataapi/subgraph_client_test.go
+++ b/disperser/dataapi/subgraph_client_test.go
@@ -43,7 +43,7 @@ var (
 		},
 	}
 
-	nonsigners = map[string]int{
+	nonSigners = map[string]int{
 		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f211": 1,
 		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f212": 1,
 		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f222": 1,
@@ -198,7 +198,7 @@ func TestQueryNumBatchesByOperatorsInThePastBlockTimestamp(t *testing.T) {
 	mockSubgraphApi.On("QueryDeregisteredOperatorsGreaterThanBlockTimestamp").Return(subgraphOperatorDeregistereds, nil)
 	mockSubgraphApi.On("QueryBatchesByBlockTimestampRange").Return(subgraphBatches, nil)
 	subgraphClient := dataapi.NewSubgraphClient(mockSubgraphApi, &commock.Logger{})
-	numBatchesByOperators, err := subgraphClient.QueryNumBatchesByOperatorsInThePastBlockTimestamp(context.Background(), uint64(1), nonsigners)
+	numBatchesByOperators, err := subgraphClient.QueryNumBatchesByOperatorsInThePastBlockTimestamp(context.Background(), uint64(1), nonSigners)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 2, len(numBatchesByOperators))

--- a/disperser/dataapi/subgraph_client_test.go
+++ b/disperser/dataapi/subgraph_client_test.go
@@ -43,6 +43,12 @@ var (
 		},
 	}
 
+	nonsigners = map[string]int{
+		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f211": 1,
+		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f212": 1,
+		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f222": 1,
+	}
+
 	subgraphBatches = []*subgraph.Batches{
 		{
 			Id:              "0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f207",
@@ -192,7 +198,7 @@ func TestQueryNumBatchesByOperatorsInThePastBlockTimestamp(t *testing.T) {
 	mockSubgraphApi.On("QueryDeregisteredOperatorsGreaterThanBlockTimestamp").Return(subgraphOperatorDeregistereds, nil)
 	mockSubgraphApi.On("QueryBatchesByBlockTimestampRange").Return(subgraphBatches, nil)
 	subgraphClient := dataapi.NewSubgraphClient(mockSubgraphApi, &commock.Logger{})
-	numBatchesByOperators, err := subgraphClient.QueryNumBatchesByOperatorsInThePastBlockTimestamp(context.Background(), uint64(1))
+	numBatchesByOperators, err := subgraphClient.QueryNumBatchesByOperatorsInThePastBlockTimestamp(context.Background(), uint64(1), nonsigners)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 2, len(numBatchesByOperators))

--- a/disperser/dataapi/subgraph_client_test.go
+++ b/disperser/dataapi/subgraph_client_test.go
@@ -44,9 +44,9 @@ var (
 	}
 
 	nonSigners = map[string]int{
-		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f211": 1,
-		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f212": 1,
-		"0x000763fb86a79eda47c891d8826474d80b6a935ad2a2b5de921933e05c67f320f222": 1,
+		"0xe1cdae12a0074f20b8fc96a0489376db34075e545ef60c4845d264a732568311": 1,
+		"0xe1cdae12a0074f20b8fc96a0489376db34075e545ef60c4845d264a732568310": 1,
+		"0xe22dae12a0074f20b8fc96a0489376db34075e545ef60c4845d264a732568311": 1,
 	}
 
 	subgraphBatches = []*subgraph.Batches{
@@ -201,7 +201,8 @@ func TestQueryNumBatchesByOperatorsInThePastBlockTimestamp(t *testing.T) {
 	numBatchesByOperators, err := subgraphClient.QueryNumBatchesByOperatorsInThePastBlockTimestamp(context.Background(), uint64(1), nonSigners)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 2, len(numBatchesByOperators))
+	// We compute the num batches for each nonsigning operator.
+	assert.Equal(t, 3, len(numBatchesByOperators))
 
 	numBatches := numBatchesByOperators["0xe1cdae12a0074f20b8fc96a0489376db34075e545ef60c4845d264a732568310"]
 	assert.Equal(t, 3, numBatches)


### PR DESCRIPTION
## Why are these changes needed?
This makes a fix to https://github.com/Layr-Labs/eigenda/pull/137. The current code is not right in computing the time intervals when the operator is live. The dataapi server doesn't return anything due to the issue.

It works as expected with this PR:

```
curl http://localhost:9000/api/v1/metrics/operator_nonsigning_percentage
{"total_non_signers":30,"operators":{"0x0e563c9be4ce991aec3e2a5ea2df841e7d55c731570e8081b23e1220c62e2ec3":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x174b33b8d2292ae95e3f89213963daf206fc120746e1da7b6d60ede7f54cecea":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x201dbd9e960df4fafe854c775c0bba320ffcf1c6dd0b05b81cdff50ada9a7ff2":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x228275bb077d0b961e851b7e6688ee9c7f196ba5230f0c401c3669073fb514de":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x2327030d23b8a1c4d15998fcede5f4f629a708474e6a5fdfbc9528364bac44b5":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x3bb3f206227d6da7e37ac71cba47a501a6c970f384ec23df95fcea1c2cfcf036":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x405e46429bbb6b185aefc3533c645acde53908cb74df509d92bb188339fc4fd1":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x40975e69514a01102a84df9841642a542f3db5a3d4cf2100e7d5e5b305795ca8":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x426d1a0363fbdcd0c8d33b643252164057193ca022958fa0da99d9e70c980dd7":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x449eaed88c372d1680f7f3e858f21125fd957aa09e3ca75d2ae6d21ecb4ad47a":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x48a1784ea77ba50e2d6973e9b690758aaa2a6cdd284b079a22f97992be9047ad":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x4df821c56e69dcae3b85c2321eb8f7b0f1016b3514c81308b5fdbb28fbe182ce":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x4ebc68033d08a1af434c0faa1c22501febb52247e1cfd047b91dacfdb82cabfd":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x587a9ad4dc756ca0dd449830c3901dd9de00c09c81f9d618f9b3ece86348f049":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x5cba09edb487ff0398e56aa7add0675724b755d5ef0feb06ef03f26ace53745a":{"total_unsigned_batches":1,"total_batches":73,"percentage":1.37},"0x690eb1626395c9e32975a7a6ffd75acf7cfbbc0aceb09b78bda65574902173c9":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x71935c893cb205076b3f532e54d08c5989401899e26c2005aca17a3622fd369c":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x7f536316dc1b4de728c4d2f5cd8f7db2ac6f8e2b7af25421dcdf3c68f969d464":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x817c119843de860391090aa01bb39731066838977745be7467f549f8c28a79b5":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x91f9c3a43cd54c92a6f3253398e8f592d1b6ad8d376fe189a81786a6a1a84dde":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0x98478a8aeba89118cf99efc813aa7b8910869ebfd339319519ac4f2af65f5a79":{"total_unsigned_batches":9,"total_batches":73,"percentage":12.33},"0xa0f574fa4c955be55b2494deed3ae7e2e86c643e40167aff63e9aa7248fab500":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0xa38a890da2ade3555ad9184c5f3f87b969e13d073e8c16dc8e69ed89cdf9f5d9":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0xa4446f2e77748e81e3228a536f125cb6584da8015e253f5443d7ec7ef639fc4a":{"total_unsigned_batches":5,"total_batches":73,"percentage":6.85},"0xb8022610b472ef49847326f186fca90a480fc8c661e45ae744e79e46f5f31a04":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0xbcb74c03db09fd0f681e6eb1b7d2aa252911a68397b6b0b48c3a259aa858fc36":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0xcb3206c8cde3805ff8af3956c0e9ee0c527fa06b28dfed0c33e4c41e43313bc0":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0xeadd14807b8185b808b95a5623f8b251d62bc8ee6549c926ddec047f11fb368f":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0xee891a0004503bf9eeeb127f73beee69bba837b27e16c4b57415d987fd9f608e":{"total_unsigned_batches":73,"total_batches":73,"percentage":100},"0xf974b97ea6cde03986234e55ed476a7b6a2d648f66b4726a450c5d658861056f":{"total_unsigned_batches":10,"total_batches":73,"percentage":13.7}}}
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
