### PR TITLE
PubIP flag

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	BLSOperatorStateRetrieverAddr string
 	EigenDAServiceManagerAddr     string
 	PubIPProvider                 string
+	PubIP                         string
 	PubIPCheckInterval            time.Duration
 	ChurnerUrl                    string
 	NumBatchValidators            int
@@ -160,6 +161,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		LoggingConfig:                 logging.ReadCLIConfig(ctx, flags.FlagPrefix),
 		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
 		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
+		PubIP:                         ctx.GlobalString(flags.PubIPFlag.Name),
 		PubIPProvider:                 ctx.GlobalString(flags.PubIPProviderFlag.Name),
 		PubIPCheckInterval:            ctx.GlobalDuration(flags.PubIPCheckIntervalFlag.Name),
 		ChurnerUrl:                    ctx.GlobalString(flags.ChurnerUrlFlag.Name),

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -142,6 +142,12 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "CHURNER_USE_SECURE_GRPC"),
 	}
+	PubIPFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "public-ip"),
+		Usage:    "The public IP to register on-chain (disable IP Provider)",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "PUBLIC_IP"),
+	}
 	PubIPProviderFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "public-ip-provider"),
 		Usage:    "The ip provider service used to obtain a node's public IP [seeip (default), ipify)",

--- a/node/node.go
+++ b/node/node.go
@@ -396,10 +396,16 @@ func (n *Node) checkCurrentNodeIp(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			newSocketAddr, err := SocketAddress(ctx, n.PubIPProvider, n.Config.DispersalPort, n.Config.RetrievalPort)
-			if err != nil {
-				n.Logger.Error("failed to get socket address", "err", err)
-				continue
+			var newSocketAddr string
+			var err error
+			if n.Config.PubIP != "" {
+				newSocketAddr = string(core.MakeOperatorSocket(n.Config.PubIP, n.Config.DispersalPort, n.Config.RetrievalPort))
+			} else {
+				newSocketAddr, err = SocketAddress(ctx, n.PubIPProvider, n.Config.DispersalPort, n.Config.RetrievalPort)
+				if err != nil {
+					n.Logger.Error("failed to get socket address", "err", err)
+					continue
+				}
 			}
 			n.updateSocketAddress(ctx, newSocketAddr)
 		}


### PR DESCRIPTION
## Why are these changes needed?

In a dynamic IP context, this flag should allow using an external IP and holder (Load Balancer) as entry point to join the node.

## Checks

 - Lint and build
 - To check: working

