### PR TITLE
Make Churner work on v2 smart contracts

### DIFF
--- a/api/proto/churner/churner.proto
+++ b/api/proto/churner/churner.proto
@@ -33,7 +33,7 @@ message ChurnRequest {
 	//   - If any of the quorum fails to register, this entire request will fail.
 	// The IDs must be in range [0, 255].
 	repeated uint32 quorum_ids = 5;
-	// The Ethereum address of the operator.
+	// The Ethereum address (in hex like "0x123abcdef...") of the operator.
 	string operator_address = 6;
 }
 

--- a/api/proto/churner/churner.proto
+++ b/api/proto/churner/churner.proto
@@ -24,6 +24,8 @@ message ChurnRequest {
 	// The operator's BLS signature signed on the keccak256 hash of
 	// concat("ChurnRequest", g1, g2, salt).
 	bytes operator_request_signature = 3;
+	// The Ethereum address of the operator.
+	string operator_address = 6;
 	// The salt used as part of the message to sign on for operator_request_signature.
 	bytes salt = 4;
 	// The quorums to register for.

--- a/api/proto/churner/churner.proto
+++ b/api/proto/churner/churner.proto
@@ -24,8 +24,6 @@ message ChurnRequest {
 	// The operator's BLS signature signed on the keccak256 hash of
 	// concat("ChurnRequest", g1, g2, salt).
 	bytes operator_request_signature = 3;
-	// The Ethereum address of the operator.
-	string operator_address = 6;
 	// The salt used as part of the message to sign on for operator_request_signature.
 	bytes salt = 4;
 	// The quorums to register for.
@@ -35,6 +33,8 @@ message ChurnRequest {
 	//   - If any of the quorum fails to register, this entire request will fail.
 	// The IDs must be in range [0, 255].
 	repeated uint32 quorum_ids = 5;
+	// The Ethereum address of the operator.
+	string operator_address = 6;
 }
 
 message ChurnReply {

--- a/churner/churner.go
+++ b/churner/churner.go
@@ -284,9 +284,9 @@ func CalculateRequestHash(churnRequest *ChurnRequest) [32]byte {
 	var requestHash [32]byte
 	requestHashBytes := crypto.Keccak256(
 		[]byte("ChurnRequest"),
+		[]byte(churnRequest.OperatorAddress.Hex()),
 		churnRequest.OperatorToRegisterPubkeyG1.Serialize(),
 		churnRequest.OperatorToRegisterPubkeyG2.Serialize(),
-		[]byte(churnRequest.OperatorAddress.Hex()),
 		churnRequest.Salt[:],
 	)
 	copy(requestHash[:], requestHashBytes)

--- a/churner/churner.go
+++ b/churner/churner.go
@@ -78,14 +78,6 @@ func NewChurner(
 }
 
 func (c *churner) VerifyRequestSignature(ctx context.Context, churnRequest *ChurnRequest) (gethcommon.Address, error) {
-	operatorToRegisterAddress, err := c.Transactor.OperatorIDToAddress(ctx, churnRequest.OperatorToRegisterPubkeyG1.GetOperatorID())
-	if err != nil {
-		return gethcommon.Address{}, err
-	}
-	if operatorToRegisterAddress == gethcommon.HexToAddress(zeroAddressString) {
-		return gethcommon.Address{}, errors.New("operatorToRegisterPubkey is not registered with bls pubkey compendium")
-	}
-
 	isEqual, err := churnRequest.OperatorToRegisterPubkeyG1.VerifyEquivalence(churnRequest.OperatorToRegisterPubkeyG2)
 	if err != nil {
 		return gethcommon.Address{}, err

--- a/churner/churner.go
+++ b/churner/churner.go
@@ -286,6 +286,7 @@ func CalculateRequestHash(churnRequest *ChurnRequest) [32]byte {
 		[]byte("ChurnRequest"),
 		churnRequest.OperatorToRegisterPubkeyG1.Serialize(),
 		churnRequest.OperatorToRegisterPubkeyG2.Serialize(),
+		churnRequest.OperatorAddress.Hex(),
 		churnRequest.Salt[:],
 	)
 	copy(requestHash[:], requestHashBytes)

--- a/churner/churner.go
+++ b/churner/churner.go
@@ -28,6 +28,7 @@ type ChurnRequest struct {
 	OperatorToRegisterPubkeyG1 *core.G1Point
 	OperatorToRegisterPubkeyG2 *core.G2Point
 	OperatorRequestSignature   *core.Signature
+	OperatorAddress            gethcommon.Address
 	Salt                       [32]byte
 	QuorumIDs                  []core.QuorumID
 }
@@ -78,6 +79,7 @@ func NewChurner(
 }
 
 func (c *churner) VerifyRequestSignature(ctx context.Context, churnRequest *ChurnRequest) (gethcommon.Address, error) {
+	operatorToRegisterAddress := churnRequest.OperatorAddress
 	isEqual, err := churnRequest.OperatorToRegisterPubkeyG1.VerifyEquivalence(churnRequest.OperatorToRegisterPubkeyG2)
 	if err != nil {
 		return gethcommon.Address{}, err

--- a/churner/churner.go
+++ b/churner/churner.go
@@ -286,7 +286,7 @@ func CalculateRequestHash(churnRequest *ChurnRequest) [32]byte {
 		[]byte("ChurnRequest"),
 		churnRequest.OperatorToRegisterPubkeyG1.Serialize(),
 		churnRequest.OperatorToRegisterPubkeyG2.Serialize(),
-		churnRequest.OperatorAddress.Hex(),
+		[]byte(churnRequest.OperatorAddress.Hex()),
 		churnRequest.Salt[:],
 	)
 	copy(requestHash[:], requestHashBytes)

--- a/churner/server.go
+++ b/churner/server.go
@@ -8,6 +8,7 @@ import (
 	pb "github.com/Layr-Labs/eigenda/api/grpc/churner"
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -161,6 +162,8 @@ func (s *Server) validateChurnRequest(ctx context.Context, req *pb.ChurnRequest)
 func createChurnRequest(req *pb.ChurnRequest) *ChurnRequest {
 	signature := &core.Signature{G1Point: new(core.G1Point).Deserialize(req.GetOperatorRequestSignature())}
 
+	address := gethcommon.HexToAddress(req.GetOperatorAddress())
+
 	salt := [32]byte{}
 	copy(salt[:], req.GetSalt())
 
@@ -173,6 +176,7 @@ func createChurnRequest(req *pb.ChurnRequest) *ChurnRequest {
 		OperatorToRegisterPubkeyG1: new(core.G1Point).Deserialize(req.GetOperatorToRegisterPubkeyG1()),
 		OperatorToRegisterPubkeyG2: new(core.G2Point).Deserialize(req.GetOperatorToRegisterPubkeyG2()),
 		OperatorRequestSignature:   signature,
+		OperatorAddress:            address,
 		Salt:                       salt,
 		QuorumIDs:                  quorumIDs,
 	}

--- a/churner/server.go
+++ b/churner/server.go
@@ -173,10 +173,10 @@ func createChurnRequest(req *pb.ChurnRequest) *ChurnRequest {
 	}
 
 	return &ChurnRequest{
+		OperatorAddress:            address,
 		OperatorToRegisterPubkeyG1: new(core.G1Point).Deserialize(req.GetOperatorToRegisterPubkeyG1()),
 		OperatorToRegisterPubkeyG2: new(core.G2Point).Deserialize(req.GetOperatorToRegisterPubkeyG2()),
 		OperatorRequestSignature:   signature,
-		OperatorAddress:            address,
 		Salt:                       salt,
 		QuorumIDs:                  quorumIDs,
 	}

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -573,6 +573,7 @@ func (t *Transactor) WeightOfOperatorForQuorum(ctx context.Context, quorumID cor
 
 func (t *Transactor) CalculateOperatorChurnApprovalDigestHash(
 	ctx context.Context,
+	operatorAddress gethcommon.Address,
 	operatorId core.OperatorID,
 	operatorsToChurn []core.OperatorToChurn,
 	salt [32]byte,
@@ -588,7 +589,7 @@ func (t *Transactor) CalculateOperatorChurnApprovalDigestHash(
 	}
 	return t.Bindings.RegistryCoordinator.CalculateOperatorChurnApprovalDigestHash(&bind.CallOpts{
 		Context: ctx,
-	}, operatorId, opKickParams, salt, expiry)
+	}, operatorAddress, operatorId, opKickParams, salt, expiry)
 }
 
 func (t *Transactor) GetCurrentBlockNumber(ctx context.Context) (uint32, error) {

--- a/core/mock/tx.go
+++ b/core/mock/tx.go
@@ -136,6 +136,7 @@ func (t *MockTransactor) WeightOfOperatorForQuorum(ctx context.Context, quorumID
 
 func (t *MockTransactor) CalculateOperatorChurnApprovalDigestHash(
 	ctx context.Context,
+	operatorAddress gethcommon.Address,
 	operatorId core.OperatorID,
 	operatorsToChurn []core.OperatorToChurn,
 	salt [32]byte,

--- a/core/tx.go
+++ b/core/tx.go
@@ -110,6 +110,7 @@ type Transactor interface {
 	// CalculateOperatorChurnApprovalDigestHash returns calculated operator churn approval digest hash.
 	CalculateOperatorChurnApprovalDigestHash(
 		ctx context.Context,
+		operatorAddress gethcommon.Address,
 		operatorId OperatorID,
 		operatorsToChurn []OperatorToChurn,
 		salt [32]byte,

--- a/node/operator.go
+++ b/node/operator.go
@@ -20,6 +20,7 @@ import (
 )
 
 type Operator struct {
+	Address    string
 	Socket     string
 	Timeout    time.Duration
 	PrivKey    *ecdsa.PrivateKey
@@ -140,14 +141,15 @@ func requestChurnApproval(ctx context.Context, operator *Operator, churnerUrl st
 	ctx, cancel := context.WithTimeout(ctx, operator.Timeout)
 	defer cancel()
 
-	request := newChurnRequest(operator.KeyPair, operator.QuorumIDs)
+	request := newChurnRequest(operator.Address, operator.KeyPair, operator.QuorumIDs)
 	opt := grpc.MaxCallSendMsgSize(1024 * 1024 * 300)
 
 	return gc.Churn(ctx, request, opt)
 }
 
-func newChurnRequest(KeyPair *core.KeyPair, QuorumIDs []core.QuorumID) *grpcchurner.ChurnRequest {
+func newChurnRequest(address string, KeyPair *core.KeyPair, QuorumIDs []core.QuorumID) *grpcchurner.ChurnRequest {
 	churnRequest := &churner.ChurnRequest{
+		OperatorAddress:            address,
 		OperatorToRegisterPubkeyG1: KeyPair.PubKey,
 		OperatorToRegisterPubkeyG2: KeyPair.GetPubKeyG2(),
 		QuorumIDs:                  QuorumIDs,

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -116,6 +116,7 @@ func pluginOps(ctx *cli.Context) {
 	}
 
 	operator := &node.Operator{
+		Address:    config.Address,
 		Socket:     socket,
 		Timeout:    10 * time.Second,
 		PrivKey:    sk.PrivateKey,

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -57,6 +57,14 @@ var (
 		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "BLS_KEY_PASSWORD"),
 	}
 
+	// The address of the operator.
+	AddressFlag = cli.StringFlag{
+		Name:     "address",
+		Required: true,
+		Usage:    "The address of the operator to register in EigenDA",
+		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "ADDRESS"),
+	}
+
 	// The socket and the quorums to register.
 	SocketFlag = cli.StringFlag{
 		Name:     "socket",
@@ -112,6 +120,7 @@ type Config struct {
 	BlsKeyFile                    string
 	EcdsaKeyPassword              string
 	BlsKeyPassword                string
+	Address                       string
 	Socket                        string
 	QuorumIDList                  []core.QuorumID
 	ChainRpcUrl                   string
@@ -144,6 +153,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		BlsKeyPassword:                ctx.GlobalString(BlsKeyPasswordFlag.Name),
 		EcdsaKeyFile:                  ctx.GlobalString(EcdsaKeyFileFlag.Name),
 		BlsKeyFile:                    ctx.GlobalString(BlsKeyFileFlag.Name),
+		Address:                       ctx.GlobalString(AddressFlag.Name),
 		Socket:                        ctx.GlobalString(SocketFlag.Name),
 		QuorumIDList:                  ids,
 		ChainRpcUrl:                   ctx.GlobalString(ChainRpcUrlFlag.Name),


### PR DESCRIPTION
## Why are these changes needed?
In the v2 contracts, there is no pubkey compendium registration before registering the operator. As a result, we cannot convert operatorID to address.

The reason we did this was to avoid spams. However, since we set the rate limit to 5mins per request, it should be safe enough to counter the spams.

We may come up with stronger measures if this isn't the case (e.g. requiring a eth address with min balance).


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
