### PR TITLE
fix(breaking): add storage gap to da service manager storage

### DIFF
--- a/contracts/src/core/EigenDAServiceManagerStorage.sol
+++ b/contracts/src/core/EigenDAServiceManagerStorage.sol
@@ -39,4 +39,8 @@ abstract contract EigenDAServiceManagerStorage is IEigenDAServiceManager {
     /// @notice address that is permissioned to confirm batches
     address public batchConfirmer;
 
+     // storage gap for upgradeability
+     // slither-disable-next-line shadowing-state
+     uint256[47] private __GAP;
+
 }


### PR DESCRIPTION
## Why are these changes needed?

EigenDAServiceManager storage needs a gap to prevent changes in its layout from pushing into the storage layout of contracts it inherits.  This change adds the standard 50 storage slot buffer between each contract in the inheritance chain. Three are currently used, and 47 are appended to the end to account for future changes.

The attached screen shows the storage layout before and after to illustrate that the `__GAP` was needed after the three storage slots currently used by EigenDA to prevent shifting the entire storage layout if a new variable or mapping was added.

<img width="1001" alt="Screenshot 2024-01-26 at 1 55 17 PM" src="https://github.com/Layr-Labs/eigenda/assets/12021290/6b623f96-3dcd-4387-acab-3ae3a61802ce">
