### PR TITLE
[inabox] Update stake distribution for quorum 1

### DIFF
--- a/inabox/templates/testconfig-anvil.yaml
+++ b/inabox/templates/testconfig-anvil.yaml
@@ -29,7 +29,7 @@ services:
     - total: 100e18
       distribution: [1, 4, 6, 10]
     - total: 100e18
-      distribution: [2, 3, 5, 8]
+      distribution: [1, 3, 8, 9]
   basePort: 32000
   variables:
     globals:


### PR DESCRIPTION
## Why are these changes needed?
Update stake distribution for new quorum on inabox test to make sure the least staked operator is churned out
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
