### PR TITLE
[finalizer] Go through all confirmed blobs

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -47,6 +47,7 @@ type TimeoutConfig struct {
 type Config struct {
 	PullInterval             time.Duration
 	FinalizerInterval        time.Duration
+	FinalizerPoolSize        int
 	EncoderSocket            string
 	SRSOrder                 int
 	NumConnections           int

--- a/disperser/cmd/batcher/config.go
+++ b/disperser/cmd/batcher/config.go
@@ -45,6 +45,7 @@ func NewConfig(ctx *cli.Context) Config {
 		BatcherConfig: batcher.Config{
 			PullInterval:             ctx.GlobalDuration(flags.PullIntervalFlag.Name),
 			FinalizerInterval:        ctx.GlobalDuration(flags.FinalizerIntervalFlag.Name),
+			FinalizerPoolSize:        ctx.GlobalInt(flags.FinalizerPoolSizeFlag.Name),
 			EncoderSocket:            ctx.GlobalString(flags.EncoderSocket.Name),
 			NumConnections:           ctx.GlobalInt(flags.NumConnectionsFlag.Name),
 			EncodingRequestQueueSize: ctx.GlobalInt(flags.EncodingRequestQueueSizeFlag.Name),

--- a/disperser/cmd/batcher/flags/flags.go
+++ b/disperser/cmd/batcher/flags/flags.go
@@ -134,6 +134,13 @@ var (
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "FINALIZER_INTERVAL"),
 		Value:    6 * time.Minute,
 	}
+	FinalizerPoolSizeFlag = cli.IntFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "finalizer-pool-size"),
+		Usage:    "Size of the finalizer workerpool",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "FINALIZER_POOL_SIZE"),
+		Value:    4,
+	}
 	EncodingRequestQueueSizeFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "encoding-request-queue-size"),
 		Usage:    "Size of the encoding request queue",
@@ -196,6 +203,7 @@ var optionalFlags = []cli.Flag{
 	ChainWriteTimeoutFlag,
 	NumConnectionsFlag,
 	FinalizerIntervalFlag,
+	FinalizerPoolSizeFlag,
 	EncodingRequestQueueSizeFlag,
 	MaxNumRetriesPerBlobFlag,
 	TargetNumChunksFlag,

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -140,7 +140,7 @@ func RunBatcher(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	finalizer := batcher.NewFinalizer(config.TimeoutConfig.ChainReadTimeout, config.BatcherConfig.FinalizerInterval, queue, client, rpcClient, config.BatcherConfig.MaxNumRetriesPerBlob, logger)
+	finalizer := batcher.NewFinalizer(config.TimeoutConfig.ChainReadTimeout, config.BatcherConfig.FinalizerInterval, queue, client, rpcClient, config.BatcherConfig.MaxNumRetriesPerBlob, 1000, config.BatcherConfig.FinalizerPoolSize, logger, metrics.FinalizerMetrics)
 	txnManager := batcher.NewTxnManager(client, 20, config.TimeoutConfig.ChainWriteTimeout, logger, metrics.TxnManagerMetrics)
 	batcher, err := batcher.NewBatcher(config.BatcherConfig, config.TimeoutConfig, queue, dispatcher, ics, asgn, encoderClient, agg, client, finalizer, tx, txnManager, logger, metrics)
 	if err != nil {


### PR DESCRIPTION
## Why are these changes needed?
Previously, finalizer was only fetching 1MB worth of confirmed blob metadata to mark them as finalized. 
It needs to go through all confirmed blob metadata to consider whether to mark them as finalized. 

This PR also adds metrics for finalizer. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
