### PR TITLE
Fix: Check total stake before calculating chunk length

### DIFF
--- a/core/assignment.go
+++ b/core/assignment.go
@@ -174,7 +174,9 @@ func (c *StdAssignmentCoordinator) ValidateChunkLength(state *OperatorState, blo
 
 	totalStake := state.Totals[info.QuorumID].Stake
 	if info.ChunkLength != MinChunkLength {
-
+		if totalStake.Cmp(big.NewInt(0)) == 0 {
+			return false, fmt.Errorf("total stake in quorum %d must be greater than 0", info.QuorumID)
+		}
 		num := new(big.Int).Mul(big.NewInt(2*int64(blobLength*percentMultiplier)), minStake)
 		denom := new(big.Int).Mul(big.NewInt(int64(info.QuorumThreshold-info.AdversaryThreshold)), totalStake)
 		maxChunkLength := uint(roundUpDivideBig(num, denom).Uint64())


### PR DESCRIPTION
## Why are these changes needed?
If `totalStake` is 0, `ValidateChunkLength` will panic with division by 0 exception
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
