### PR TITLE
Use logfmt instead of terminal format

### DIFF
--- a/common/logging/cli.go
+++ b/common/logging/cli.go
@@ -6,16 +6,20 @@ import (
 )
 
 const (
-	PathFlagName      = "log.path"
-	FileLevelFlagName = "log.level-file"
-	StdLevelFlagName  = "log.level-std"
+	PathFlagName       = "log.path"
+	FileFormatFlagName = "log.format-file"
+	FileLevelFlagName  = "log.level-file"
+	StdFormatFlagName  = "log.format-std"
+	StdLevelFlagName   = "log.level-std"
 )
 
 type Config struct {
-	Path      string
-	Prefix    string
-	FileLevel string
-	StdLevel  string
+	Path       string
+	Prefix     string
+	FileLevel  string
+	FileFormat string
+	StdLevel   string
+	StdFormat  string
 }
 
 func CLIFlags(envPrefix string, flagPrefix string) []cli.Flag {
@@ -38,21 +42,37 @@ func CLIFlags(envPrefix string, flagPrefix string) []cli.Flag {
 			Value:  "",
 			EnvVar: common.PrefixEnvVar(envPrefix, "LOG_PATH"),
 		},
+		cli.StringFlag{
+			Name:   common.PrefixFlag(flagPrefix, StdFormatFlagName),
+			Usage:  "Format of the log messages. Accepted options are 'terminal', 'json', and 'logfmt'",
+			Value:  "terminal",
+			EnvVar: common.PrefixEnvVar(envPrefix, "STD_LOG_FORMAT"),
+		},
+		cli.StringFlag{
+			Name:   common.PrefixFlag(flagPrefix, FileFormatFlagName),
+			Usage:  "Format of the log messages. Accepted options are 'terminal', 'json', and 'logfmt'",
+			Value:  "logfmt",
+			EnvVar: common.PrefixEnvVar(envPrefix, "FILE_LOG_FORMAT"),
+		},
 	}
 }
 
 func DefaultCLIConfig() Config {
 	return Config{
-		Path:      "",
-		FileLevel: "debug",
-		StdLevel:  "debug",
+		Path:       "",
+		FileFormat: "logfmt",
+		FileLevel:  "debug",
+		StdFormat:  "terminal",
+		StdLevel:   "debug",
 	}
 }
 
 func ReadCLIConfig(ctx *cli.Context, flagPrefix string) Config {
 	cfg := DefaultCLIConfig()
+	cfg.StdFormat = ctx.GlobalString(common.PrefixFlag(flagPrefix, StdFormatFlagName))
 	cfg.StdLevel = ctx.GlobalString(common.PrefixFlag(flagPrefix, StdLevelFlagName))
 	cfg.FileLevel = ctx.GlobalString(common.PrefixFlag(flagPrefix, FileLevelFlagName))
+	cfg.FileFormat = ctx.GlobalString(common.PrefixFlag(flagPrefix, FileFormatFlagName))
 	cfg.Path = ctx.GlobalString(common.PrefixFlag(flagPrefix, PathFlagName))
 	return cfg
 }

--- a/common/logging/logging.go
+++ b/common/logging/logging.go
@@ -20,6 +20,32 @@ func (l *Logger) SetHandler(h log.Handler) {
 	l.Logger.SetHandler(h)
 }
 
+func getStreamHandlerFromFormat(format string) (log.Handler, error) {
+	switch format {
+	case "terminal":
+		return log.StreamHandler(os.Stdout, log.TerminalFormat(false)), nil
+	case "json":
+		return log.StreamHandler(os.Stdout, log.JSONFormat()), nil
+	case "logfmt":
+		return log.StreamHandler(os.Stdout, log.LogfmtFormat()), nil
+	default:
+		return nil, fmt.Errorf("invalid log format: %s", format)
+	}
+}
+
+func getFileHandlerFromFormat(path string, format string) (log.Handler, error) {
+	switch format {
+	case "terminal":
+		return log.FileHandler(path, log.TerminalFormat(false))
+	case "json":
+		return log.FileHandler(path, log.JSONFormat())
+	case "logfmt":
+		return log.FileHandler(path, log.LogfmtFormat())
+	default:
+		return nil, fmt.Errorf("invalid log format: %s", format)
+	}
+}
+
 // GetLogger returns a logger with the specified configuration.
 func GetLogger(cfg Config) (common.Logger, error) {
 	fileLevel, err := log.LvlFromString(cfg.FileLevel)
@@ -32,10 +58,19 @@ func GetLogger(cfg Config) (common.Logger, error) {
 	}
 
 	logger := &Logger{Logger: log.New()}
-	stdh := log.StreamHandler(os.Stdout, log.LogfmtFormat())
+	// This is required to print locations of log calls
+	// This was recently added in this PR: https://github.com/ethereum/go-ethereum/pull/28069/files
+	// where the default behavior was changed to not print origins
+	// This was due to it being very expensive to compute origins
+	// We should evaluate enabling/disabling this based on the flag
+	log.PrintOrigins(true)
+	stdh, err := getStreamHandlerFromFormat(cfg.StdFormat)
+	if err != nil {
+		return nil, err
+	}
 	stdHandler := log.CallerFileHandler(log.LvlFilterHandler(stdLevel, stdh))
 	if cfg.Path != "" {
-		fh, err := log.FileHandler(cfg.Path, log.LogfmtFormat())
+		fh, err := getFileHandlerFromFormat(cfg.Path, cfg.FileFormat)
 		if err != nil {
 			return nil, err
 		}

--- a/common/logging/logging.go
+++ b/common/logging/logging.go
@@ -32,13 +32,7 @@ func GetLogger(cfg Config) (common.Logger, error) {
 	}
 
 	logger := &Logger{Logger: log.New()}
-	// This is required to print locations of log calls
-	// This was recently added in this PR: https://github.com/ethereum/go-ethereum/pull/28069/files
-	// where the default behavior was changed to not print origins
-	// This was due to it being very expensive to compute origins
-	// We should evaluate enabling/disabling this based on the flag
-	log.PrintOrigins(true)
-	stdh := log.StreamHandler(os.Stdout, log.TerminalFormat(false))
+	stdh := log.StreamHandler(os.Stdout, log.LogfmtFormat())
 	stdHandler := log.CallerFileHandler(log.LvlFilterHandler(stdLevel, stdh))
 	if cfg.Path != "" {
 		fh, err := log.FileHandler(cfg.Path, log.LogfmtFormat())

--- a/core/indexer/state_test.go
+++ b/core/indexer/state_test.go
@@ -144,8 +144,10 @@ var _ = Describe("Indexer", func() {
 			}
 
 			logger, err := logging.GetLogger(logging.Config{
-				StdLevel:  "debug",
-				FileLevel: "debug",
+				StdFormat:  "terminal",
+				StdLevel:   "debug",
+				FileFormat: "logfmt",
+				FileLevel:  "debug",
 			})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/core/thegraph/state_integration_test.go
+++ b/core/thegraph/state_integration_test.go
@@ -81,8 +81,10 @@ func TestIndexerIntegration(t *testing.T) {
 	defer teardown()
 
 	logger, err := logging.GetLogger(logging.Config{
-		StdLevel:  "debug",
-		FileLevel: "debug",
+		StdFormat:  "terminal",
+		StdLevel:   "debug",
+		FileFormat: "logfmt",
+		FileLevel:  "debug",
 	})
 	assert.NoError(t, err)
 

--- a/core/thegraph/state_test.go
+++ b/core/thegraph/state_test.go
@@ -42,8 +42,10 @@ func (m *mockChainState) GetOperatorStateByOperator(ctx context.Context, blockNu
 
 func TestIndexedChainState_GetIndexedOperatorState(t *testing.T) {
 	logger, err := logging.GetLogger(logging.Config{
-		StdLevel:  "debug",
-		FileLevel: "debug",
+		StdFormat:  "terminal",
+		StdLevel:   "debug",
+		FileFormat: "logfmt",
+		FileLevel:  "debug",
 	})
 	assert.NoError(t, err)
 
@@ -104,8 +106,10 @@ func TestIndexedChainState_GetIndexedOperatorState(t *testing.T) {
 
 func TestIndexedChainState_GetIndexedOperatorInfoByOperatorId(t *testing.T) {
 	logger, err := logging.GetLogger(logging.Config{
-		StdLevel:  "debug",
-		FileLevel: "debug",
+		StdFormat:  "terminal",
+		StdLevel:   "debug",
+		FileFormat: "logfmt",
+		FileLevel:  "debug",
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
## Why are these changes needed?

Right now our logs look like this:
```
INFO [01-30|15:23:34.705|github.com/Layr-Labs/eigenda/disperser/dataapi/server.go:514] server running                           addr=:8080 caller=server.go:514
```
This is because we use "Terminal Format" which should really only be used in development.

Grafana will have an easier time parsing the log if we use [logfmt (brandur.org)](https://www.brandur.org/logfmt):
```
t=2024-01-30T15:25:39-0800 lvl=dbug msg="Getting blob metadata"               batchHeaderHash="[48 120 51 50 54 54 101 54 57 50 102 97 98 101 97 57 102 57 102 55 51 52 51 99 98 101 49 97 97 57 53 100 97 52 56 57 98 54 52 99 101 53 53 49 97 53 56 54 55 52 102 51 48 101 55 48 54 98 100 102 48 99 48 57 98 99]" caller=server.go:425
```

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
