### PR TITLE
[TxnManager] Check if replaced txns are confirmed

### DIFF
--- a/common/ethclient.go
+++ b/common/ethclient.go
@@ -42,4 +42,5 @@ type EthClient interface {
 	EstimateGasPriceAndLimitAndSendTx(ctx context.Context, tx *types.Transaction, tag string, value *big.Int) (*types.Receipt, error)
 	UpdateGas(ctx context.Context, tx *types.Transaction, value, gasTipCap, gasFeeCap *big.Int) (*types.Transaction, error)
 	EnsureTransactionEvaled(ctx context.Context, tx *types.Transaction, tag string) (*types.Receipt, error)
+	EnsureAnyTransactionEvaled(ctx context.Context, txs []*types.Transaction, tag string) (*types.Receipt, error)
 }

--- a/common/mock/ethclient.go
+++ b/common/mock/ethclient.go
@@ -220,3 +220,13 @@ func (mock *MockEthClient) EnsureTransactionEvaled(ctx context.Context, tx *type
 
 	return result, args.Error(1)
 }
+
+func (mock *MockEthClient) EnsureAnyTransactionEvaled(ctx context.Context, txs []*types.Transaction, tag string) (*types.Receipt, error) {
+	args := mock.Called()
+	var result *types.Receipt
+	if args.Get(0) != nil {
+		result = args.Get(0).(*types.Receipt)
+	}
+
+	return result, args.Error(1)
+}

--- a/disperser/batcher/txn_manager_test.go
+++ b/disperser/batcher/txn_manager_test.go
@@ -28,7 +28,7 @@ func TestProcessTransaction(t *testing.T) {
 	ethClient.On("GetLatestGasCaps").Return(big.NewInt(1e9), big.NewInt(1e9), nil)
 	ethClient.On("UpdateGas").Return(txn, nil)
 	ethClient.On("SendTransaction").Return(nil)
-	ethClient.On("EnsureTransactionEvaled").Return(&types.Receipt{
+	ethClient.On("EnsureAnyTransactionEvaled").Return(&types.Receipt{
 		BlockNumber: new(big.Int).SetUint64(1),
 	}, nil).Once()
 
@@ -44,11 +44,11 @@ func TestProcessTransaction(t *testing.T) {
 	ethClient.AssertNumberOfCalls(t, "GetLatestGasCaps", 1)
 	ethClient.AssertNumberOfCalls(t, "UpdateGas", 1)
 	ethClient.AssertNumberOfCalls(t, "SendTransaction", 1)
-	ethClient.AssertNumberOfCalls(t, "EnsureTransactionEvaled", 1)
+	ethClient.AssertNumberOfCalls(t, "EnsureAnyTransactionEvaled", 1)
 
 	// now test the case where the transaction fails
 	randomErr := fmt.Errorf("random error")
-	ethClient.On("EnsureTransactionEvaled").Return(nil, randomErr)
+	ethClient.On("EnsureAnyTransactionEvaled").Return(nil, randomErr)
 	err = txnManager.ProcessTransaction(ctx, &batcher.TxnRequest{
 		Tx:    txn,
 		Tag:   "test transaction",
@@ -62,7 +62,7 @@ func TestProcessTransaction(t *testing.T) {
 	ethClient.AssertNumberOfCalls(t, "GetLatestGasCaps", 2)
 	ethClient.AssertNumberOfCalls(t, "UpdateGas", 2)
 	ethClient.AssertNumberOfCalls(t, "SendTransaction", 2)
-	ethClient.AssertNumberOfCalls(t, "EnsureTransactionEvaled", 2)
+	ethClient.AssertNumberOfCalls(t, "EnsureAnyTransactionEvaled", 2)
 }
 
 func TestReplaceGasFee(t *testing.T) {
@@ -79,8 +79,8 @@ func TestReplaceGasFee(t *testing.T) {
 	ethClient.On("UpdateGas").Return(txn, nil)
 	ethClient.On("SendTransaction").Return(nil)
 	// assume that the transaction is not mined within the timeout
-	ethClient.On("EnsureTransactionEvaled").Return(nil, context.DeadlineExceeded).Once()
-	ethClient.On("EnsureTransactionEvaled").Return(&types.Receipt{
+	ethClient.On("EnsureAnyTransactionEvaled").Return(nil, context.DeadlineExceeded).Once()
+	ethClient.On("EnsureAnyTransactionEvaled").Return(&types.Receipt{
 		BlockNumber: new(big.Int).SetUint64(1),
 	}, nil)
 
@@ -94,7 +94,7 @@ func TestReplaceGasFee(t *testing.T) {
 	ethClient.AssertNumberOfCalls(t, "GetLatestGasCaps", 2)
 	ethClient.AssertNumberOfCalls(t, "UpdateGas", 2)
 	ethClient.AssertNumberOfCalls(t, "SendTransaction", 2)
-	ethClient.AssertNumberOfCalls(t, "EnsureTransactionEvaled", 2)
+	ethClient.AssertNumberOfCalls(t, "EnsureAnyTransactionEvaled", 2)
 }
 
 func TestTransactionFailure(t *testing.T) {
@@ -114,8 +114,8 @@ func TestTransactionFailure(t *testing.T) {
 	ethClient.On("UpdateGas").Return(nil, speedUpFailure).Once()
 	ethClient.On("SendTransaction").Return(nil)
 	// assume that the transaction is not mined within the timeout
-	ethClient.On("EnsureTransactionEvaled").Return(nil, context.DeadlineExceeded).Once()
-	ethClient.On("EnsureTransactionEvaled").Return(&types.Receipt{
+	ethClient.On("EnsureAnyTransactionEvaled").Return(nil, context.DeadlineExceeded).Once()
+	ethClient.On("EnsureAnyTransactionEvaled").Return(&types.Receipt{
 		BlockNumber: new(big.Int).SetUint64(1),
 	}, nil)
 
@@ -128,4 +128,76 @@ func TestTransactionFailure(t *testing.T) {
 	assert.NoError(t, err)
 	res := <-txnManager.ReceiptChan()
 	assert.Error(t, res.Err, speedUpFailure)
+}
+
+func TestSendTransactionRetry(t *testing.T) {
+	ethClient := &mock.MockEthClient{}
+	logger, err := logging.GetLogger(logging.DefaultCLIConfig())
+	assert.NoError(t, err)
+	metrics := batcher.NewMetrics("9100", logger)
+	txnManager := batcher.NewTxnManager(ethClient, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	defer cancel()
+	txnManager.Start(ctx)
+	txn := types.NewTransaction(0, common.HexToAddress("0x1"), big.NewInt(1e18), 100000, big.NewInt(1e9), []byte{})
+	ethClient.On("GetLatestGasCaps").Return(big.NewInt(1e9), big.NewInt(1e9), nil)
+	ethClient.On("UpdateGas").Return(txn, nil)
+	ethClient.On("SendTransaction").Return(nil).Once()
+	// assume that it fails to send the replacement transaction once
+	ethClient.On("SendTransaction").Return(fmt.Errorf("send txn failure")).Once()
+	// assume that the transaction is not mined within the timeout
+	ethClient.On("EnsureAnyTransactionEvaled").Return(nil, context.DeadlineExceeded).Once()
+	ethClient.On("EnsureAnyTransactionEvaled").Return(&types.Receipt{
+		BlockNumber: new(big.Int).SetUint64(1),
+	}, nil)
+
+	err = txnManager.ProcessTransaction(ctx, &batcher.TxnRequest{
+		Tx:    txn,
+		Tag:   "test transaction",
+		Value: nil,
+	})
+	<-ctx.Done()
+	assert.NoError(t, err)
+	res := <-txnManager.ReceiptChan()
+	assert.NoError(t, res.Err)
+	assert.Equal(t, uint64(1), res.Receipt.BlockNumber.Uint64())
+	ethClient.AssertNumberOfCalls(t, "GetLatestGasCaps", 2)
+	ethClient.AssertNumberOfCalls(t, "UpdateGas", 2)
+	ethClient.AssertNumberOfCalls(t, "SendTransaction", 2)
+	ethClient.AssertNumberOfCalls(t, "EnsureAnyTransactionEvaled", 2)
+}
+
+func TestSendTransactionRetryFailure(t *testing.T) {
+	ethClient := &mock.MockEthClient{}
+	logger, err := logging.GetLogger(logging.DefaultCLIConfig())
+	assert.NoError(t, err)
+	metrics := batcher.NewMetrics("9100", logger)
+	txnManager := batcher.NewTxnManager(ethClient, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	defer cancel()
+	txnManager.Start(ctx)
+	txn := types.NewTransaction(0, common.HexToAddress("0x1"), big.NewInt(1e18), 100000, big.NewInt(1e9), []byte{})
+	ethClient.On("GetLatestGasCaps").Return(big.NewInt(1e9), big.NewInt(1e9), nil)
+	ethClient.On("UpdateGas").Return(txn, nil)
+	ethClient.On("SendTransaction").Return(nil).Once()
+	// assume that it keeps failing to send the replacement transaction
+	sendErr := fmt.Errorf("send txn failure")
+	ethClient.On("SendTransaction").Return(sendErr)
+	// assume that the transaction is not mined within the timeout
+	ethClient.On("EnsureAnyTransactionEvaled").Return(nil, context.DeadlineExceeded)
+
+	err = txnManager.ProcessTransaction(ctx, &batcher.TxnRequest{
+		Tx:    txn,
+		Tag:   "test transaction",
+		Value: nil,
+	})
+	<-ctx.Done()
+	assert.NoError(t, err)
+	res := <-txnManager.ReceiptChan()
+	assert.Error(t, res.Err, sendErr)
+	assert.Nil(t, res.Receipt)
+	ethClient.AssertNumberOfCalls(t, "GetLatestGasCaps", 5)
+	ethClient.AssertNumberOfCalls(t, "UpdateGas", 5)
+	ethClient.AssertNumberOfCalls(t, "SendTransaction", 5)
+	ethClient.AssertNumberOfCalls(t, "EnsureAnyTransactionEvaled", 4)
 }


### PR DESCRIPTION
## Why are these changes needed?
Consider a scenario where transaction A is sent, and it's replaced by transaction B because it hasn't been confirmed within the timeout.
There is a possibility that transaction A gets confirmed instead, even though it's been replaced by B. In this case, transaction B is dropped from the mempool. 
TxnManager needs to detect this case (the "replaced" transactions are getting confirmed) and return the receipt for the confirmed transaction.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
