### PR TITLE
Pin foundry version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-293fad73670b7b59ca901c7f2105bf7a29165a90
 
       - name: Install graph cli
         run: |


### PR DESCRIPTION
## Why are these changes needed?
This is a temporary measure to fix the indexer integration test which started failing after foundry version [nightly-293fad73670b7b59ca901c7f2105bf7a29165a90](https://github.com/foundry-rs/foundry/releases/tag/nightly-293fad73670b7b59ca901c7f2105bf7a29165a90) release on (1/14). 
The calculated block hash from returned block header is different from the hash that is returned from the RPC endpoint, which makes indexer think that the headers are out of order (prevHash does not match the hash of the previous block). 
One suspicion is the `size` field of the RPC response is different between two versions (`0x318` vs `0x2fa`) while the sizes of the content are the same. 
We should pin the version as a temporary measure to unblock CI, and unpin when the issue is resolved.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
