### PR TITLE
Cap the max quorumID to 254

### DIFF
--- a/api/proto/churner/churner.proto
+++ b/api/proto/churner/churner.proto
@@ -31,7 +31,7 @@ message ChurnRequest {
 	//   - If any of the quorum here has already been registered, this entire request
 	//     will fail to proceed.
 	//   - If any of the quorum fails to register, this entire request will fail.
-	// The IDs must be in range [0, 255].
+	// The IDs must be in range [0, 254].
 	repeated uint32 quorum_ids = 5;
 	// The Ethereum address (in hex like "0x123abcdef...") of the operator.
 	string operator_address = 6;

--- a/api/proto/disperser/disperser.proto
+++ b/api/proto/disperser/disperser.proto
@@ -16,8 +16,8 @@ service Disperser {
 	// client to authenticate itself via the AuthenticationData message. The protoco is as follows:
 	// 1. The client sends a DisperseBlobAuthenticated request with the DisperseBlobRequest message
 	// 2. The Disperser sends back a BlobAuthHeader message containing information for the client to
-	//    verify and sign. 
-	// 3. The client verifies the BlobAuthHeader and sends back the signed BlobAuthHeader in an 
+	//    verify and sign.
+	// 3. The client verifies the BlobAuthHeader and sends back the signed BlobAuthHeader in an
 	//	  AuthenticationData message.
 	// 4. The Disperser verifies the signature and returns a DisperseBlobReply message.
 	rpc DisperseBlobAuthenticated(stream AuthenticatedRequest) returns (stream AuthenticatedReply);
@@ -53,13 +53,13 @@ message AuthenticatedReply {
 }
 
 // BlobAuthHeader contains information about the blob for the client to verify and sign.
-// - Once payments are enabled, the BlobAuthHeader the KZG commitment to the blob, which the client 
+// - Once payments are enabled, the BlobAuthHeader the KZG commitment to the blob, which the client
  // will verify and sign. Having the client verify the KZG commitment instead of calculating it avoids
-// the need for the client to have the KZG structured reference string (SRS), which can be large. 
+// the need for the client to have the KZG structured reference string (SRS), which can be large.
 // The signed KZG commitment prevents the disperser from sending a different blob to the DA Nodes
 // than the one the client sent.
 // - In the meantime, the BlobAuthHeader contains a simple challenge parameter is used to prevent
-// replay attacks in the event that a signature is leaked. 
+// replay attacks in the event that a signature is leaked.
 message BlobAuthHeader {
 	uint32 challenge_parameter = 1;
 }
@@ -128,7 +128,7 @@ message RetrieveBlobReply {
 message SecurityParams {
 	// The ID of the quorum.
 	// The quorum must be already registered on EigenLayer. The ID must be
-	// in range [0, 255].
+	// in range [0, 254].
 	uint32 quorum_id = 1;
 	// The max percentage of stake within the quorum that can be held by or delegated
 	// to adversarial operators.

--- a/api/proto/node/node.proto
+++ b/api/proto/node/node.proto
@@ -47,7 +47,7 @@ message RetrieveChunksRequest {
 	uint32 blob_index = 2;
 	// Which quorum of the blob to retrieve for (note: a blob can have multiple
 	// quorums and the chunks for different quorums at a Node can be different).
-	// The ID must be in range [0, 255].
+	// The ID must be in range [0, 254].
 	uint32 quorum_id = 3;
 }
 
@@ -108,7 +108,7 @@ message Bundle {
 message BlobHeader {
 	// The KZG commitment to the polynomial representing the blob.
 	bytes commitment = 1;
-  // The KZG commitment to the polynomial representing the blob on G2, it is uesd 
+  // The KZG commitment to the polynomial representing the blob on G2, it is uesd
   // for proving the degree of the polynomial
   bytes length_commitment = 2;
 	// The low degree proof. It's the KZG commitment to the polynomial shifted to

--- a/core/data.go
+++ b/core/data.go
@@ -28,6 +28,13 @@ type SecurityParam struct {
 	QuorumRate common.RateParam `json:"quorum_rate"`
 }
 
+const (
+	// We use uint8 to count the number of quorums, so we can have at most 255 quorums,
+	// which means the max ID can not be larger than 254 (from 0 to 254, there are 255
+	// different IDs).
+	MaxQuorumID = 254
+)
+
 func (s *SecurityParam) String() string {
 	return fmt.Sprintf("QuorumID: %d, AdversaryThreshold: %d, QuorumThreshold: %d", s.QuorumID, s.AdversaryThreshold, s.QuorumThreshold)
 }

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -191,8 +191,8 @@ func (s *DispersalServer) disperseBlob(ctx context.Context, blob *core.Blob, aut
 	}
 
 	seenQuorums := make(map[uint8]struct{})
-	// The quorum ID must be in range [0, 255]. It'll actually be converted
-	// to uint8, so it cannot be greater than 255.
+	// The quorum ID must be in range [0, 254]. It'll actually be converted
+	// to uint8, so it cannot be greater than 254.
 	for _, param := range securityParams {
 		if _, ok := seenQuorums[param.QuorumID]; ok {
 			return nil, fmt.Errorf("invalid request: security_params must not contain duplicate quorum_id")

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -173,8 +173,8 @@ func (s *Server) RetrieveChunks(ctx context.Context, in *pb.RetrieveChunksReques
 	}))
 	defer timer.ObserveDuration()
 
-	if in.GetQuorumId() > 255 {
-		return nil, fmt.Errorf("invalid request: quorum ID must be in range [0, 255], but found %d", in.GetQuorumId())
+	if in.GetQuorumId() > core.MaxQuorumID {
+		return nil, fmt.Errorf("invalid request: quorum ID must be in range [0, %d], but found %d", core.MaxQuorumID, in.GetQuorumId())
 	}
 
 	var batchHeaderHash [32]byte


### PR DESCRIPTION
## Why are these changes needed?
We use uint8 to count the number of quorums, which means we can have at most 255 quorums, meaning that we can not use an ID larger than 254.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
