### PR TITLE
Allocate reader buffer more precisely

### DIFF
--- a/pkg/encoding/utils/pointsIO.go
+++ b/pkg/encoding/utils/pointsIO.go
@@ -122,7 +122,7 @@ func ReadG1PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 	n := to - from
 
 	startTimer := time.Now()
-	g1r := bufio.NewReaderSize(g1f, int(to*G1PointBytes))
+	g1r := bufio.NewReaderSize(g1f, int(n*G1PointBytes))
 
 	_, err = g1f.Seek(int64(from)*G1PointBytes, 0)
 	if err != nil {
@@ -303,7 +303,7 @@ func ReadG2PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 	n := to - from
 
 	startTimer := time.Now()
-	g2r := bufio.NewReaderSize(g2f, int(to*G2PointBytes))
+	g2r := bufio.NewReaderSize(g2f, int(n*G2PointBytes))
 
 	_, err = g2f.Seek(int64(from*G2PointBytes), 0)
 	if err != nil {


### PR DESCRIPTION
## Why are these changes needed?
When reading a slice of the points, and we know how many points to read, allocate the buffer precisely to that number so it could be more efficient at lower cost.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
