### PR TITLE
Relax encoding param check

### DIFF
--- a/core/encoding.go
+++ b/core/encoding.go
@@ -83,7 +83,7 @@ func GetEncodingParams(minChunkLength, minNumChunks uint) (EncodingParams, error
 // ValidateEncodingParams takes in the encoding parameters and returns an error if they are invalid.
 func ValidateEncodingParams(params EncodingParams, blobLength, SRSOrder int) error {
 
-	if int(params.ChunkLength*params.NumChunks) >= SRSOrder {
+	if int(params.ChunkLength*params.NumChunks) > SRSOrder {
 		return fmt.Errorf("the supplied encoding parameters are not valid with respect to the SRS. ChunkLength: %d, NumChunks: %d, SRSOrder: %d", params.ChunkLength, params.NumChunks, SRSOrder)
 	}
 

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -44,8 +44,8 @@ func makeTestEncoder() (core.Encoder, error) {
 		G1Path:          "../../inabox/resources/kzg/g1.point",
 		G2Path:          "../../inabox/resources/kzg/g2.point",
 		CacheDir:        "../../inabox/resources/kzg/SRSTables",
-		SRSOrder:        3000,
-		SRSNumberToLoad: 3000,
+		SRSOrder:        2048,
+		SRSNumberToLoad: 2048,
 		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
 	}
 
@@ -192,7 +192,7 @@ func checkBatchByUniversalVerifier(t *testing.T, cst core.IndexedChainState, enc
 func TestCoreLibrary(t *testing.T) {
 
 	numBlob := 1 // must be greater than 0
-	blobLengths := []int{1, 64, 1000}
+	blobLengths := []int{1, 64, 1000, 2000}
 	operatorCounts := []uint{1, 2, 4, 10, 30}
 
 	securityParams := []*core.SecurityParam{

--- a/pkg/encoding/kzgEncoder/encoder.go
+++ b/pkg/encoding/kzgEncoder/encoder.go
@@ -205,7 +205,7 @@ func (g *KzgEncoderGroup) NewKzgEncoder(params rs.EncodingParams) (*KzgEncoder, 
 func (g *KzgEncoderGroup) newKzgEncoder(params rs.EncodingParams) (*KzgEncoder, error) {
 
 	// Check that the parameters are valid with respect to the SRS.
-	if params.ChunkLen*params.NumChunks >= g.SRSOrder {
+	if params.ChunkLen*params.NumChunks > g.SRSOrder {
 		return nil, fmt.Errorf("the supplied encoding parameters are not valid with respect to the SRS. ChunkLength: %d, NumChunks: %d, SRSOrder: %d", params.ChunkLen, params.NumChunks, g.SRSOrder)
 	}
 


### PR DESCRIPTION
## Why are these changes needed?

Currently, we require that the SRS length be strictly greater than the encoded data length (chunkLength*numChunks). 

However, equality here should be acceptable; updated unit tests show that this case indeed works. 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
