### PR TITLE
Remove logging from G1 partial load

### DIFF
--- a/pkg/encoding/utils/pointsIO.go
+++ b/pkg/encoding/utils/pointsIO.go
@@ -121,7 +121,6 @@ func ReadG1PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 
 	n := to - from
 
-	startTimer := time.Now()
 	g1r := bufio.NewReaderSize(g1f, int(n*G1PointBytes))
 
 	_, err = g1f.Seek(int64(from)*G1PointBytes, 0)
@@ -137,12 +136,6 @@ func ReadG1PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 	if err != nil {
 		return nil, err
 	}
-
-	// measure reading time
-	t := time.Now()
-	elapsed := t.Sub(startTimer)
-	log.Printf("    Reading G1 points (%v bytes) takes %v\n", (n * G1PointBytes), elapsed)
-	startTimer = time.Now()
 
 	s1Outs := make([]bls.G1Point, n)
 
@@ -171,10 +164,6 @@ func ReadG1PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 		}
 	}
 
-	// measure parsing time
-	t = time.Now()
-	elapsed = t.Sub(startTimer)
-	log.Println("    Parsing takes", elapsed)
 	return s1Outs, nil
 }
 


### PR DESCRIPTION
## Why are these changes needed?
We're reading partial G1 points every time a blob is validated and log how long this read takes. This produces too much noise and the performance for loading such small set of points doesn't need to be measured and reported.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
