### PR TITLE
rm wrong validationa and expose log

### DIFF
--- a/pkg/encoding/encoder/encode.go
+++ b/pkg/encoding/encoder/encode.go
@@ -54,10 +54,8 @@ func (g *Encoder) Encode(inputFr []bls.Fr) (*GlobalPoly, []Frame, []uint32, erro
 		return nil, nil, nil, err
 	}
 
-	if g.verbose {
-		log.Printf("  SUMMARY: Encode %v byte among %v numNode takes %v\n",
-			len(inputFr)*bls.BYTES_PER_COEFFICIENT, g.NumChunks, time.Since(start))
-	}
+	log.Printf("  SUMMARY: Encode %v byte among %v numNode takes %v\n",
+		len(inputFr)*bls.BYTES_PER_COEFFICIENT, g.NumChunks, time.Since(start))
 
 	return poly, frames, indices, nil
 }

--- a/pkg/encoding/kzgEncoder/multiframe.go
+++ b/pkg/encoding/kzgEncoder/multiframe.go
@@ -172,7 +172,10 @@ func (group *KzgEncoderGroup) UniversalVerify(params rs.EncodingParams, samples 
 		}
 	}
 
-	verifier, _ := group.GetKzgVerifier(params)
+	verifier, err := group.GetKzgVerifier(params)
+	if err != nil {
+		return err
+	}
 	ks := verifier.Ks
 
 	D := params.ChunkLen

--- a/pkg/kzg/kzg.go
+++ b/pkg/kzg/kzg.go
@@ -28,8 +28,6 @@
 package kzg
 
 import (
-	"errors"
-
 	bls "github.com/Layr-Labs/eigenda/pkg/kzg/bn254"
 )
 
@@ -41,10 +39,6 @@ type KZGSettings struct {
 }
 
 func NewKZGSettings(fs *FFTSettings, srs *SRS) (*KZGSettings, error) {
-
-	if uint64(len(srs.G1)) < fs.MaxWidth {
-		return nil, errors.New("srs length is not sufficient")
-	}
 
 	ks := &KZGSettings{
 		FFTSettings: fs,


### PR DESCRIPTION
## Why are these changes needed?

This PR removes a wrong check that requires the G1 SRS size equal to the entire encoded blob size. It also exposes the encoder log.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
