### PR TITLE
remove g2 point section logs

### DIFF
--- a/pkg/encoding/utils/pointsIO.go
+++ b/pkg/encoding/utils/pointsIO.go
@@ -290,8 +290,7 @@ func ReadG2PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 	}()
 
 	n := to - from
-
-	startTimer := time.Now()
+	
 	g2r := bufio.NewReaderSize(g2f, int(n*G2PointBytes))
 
 	_, err = g2f.Seek(int64(from*G2PointBytes), 0)
@@ -307,12 +306,6 @@ func ReadG2PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 	if err != nil {
 		return nil, err
 	}
-
-	// measure reading time
-	t := time.Now()
-	elapsed := t.Sub(startTimer)
-	log.Printf("    Reading G2 points (%v bytes) takes %v\n", (n * G2PointBytes), elapsed)
-	startTimer = time.Now()
 
 	s2Outs := make([]bls.G2Point, n)
 
@@ -340,9 +333,5 @@ func ReadG2PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 		}
 	}
 
-	// measure parsing time
-	t = time.Now()
-	elapsed = t.Sub(startTimer)
-	log.Println("    Parsing takes", elapsed)
 	return s2Outs, nil
 }


### PR DESCRIPTION
## Why are these changes needed?

- Remove repeated log lines from reading G2 point

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
