### PR TITLE
Add more blob metadata mretrics

### DIFF
--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -120,7 +120,11 @@ func NewDynamoDBCollector(blobMetadataStore *blobstore.BlobMetadataStore, logger
 		metricsCache: make(map[disperser.BlobStatus]int),
 	}
 
-	go collector.periodicFetch()
+	if blobMetadataStore != nil {
+		go collector.periodicFetch()
+	} else {
+		logger.Warn("BlobMetadataStore is nil, metrics will not be collected")
+	}
 
 	return collector
 }

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -144,7 +144,6 @@ func (collector *DynamoDBCollector) Collect(ch chan<- prometheus.Metric) {
 		disperser.Confirmed,
 		disperser.Failed,
 		disperser.InsufficientSignatures,
-		disperser.Finalized,
 	} {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()


### PR DESCRIPTION
## Why are these changes needed?
- Adds `Confirmed`, `InsufficientSignatures`, and `Failed` metadata status counts
- Added a scrape duration metric for the collector.
- Timeout is 30 seconds

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
