### PR TITLE
Add a defensive check on blob status

### DIFF
--- a/disperser/batcher/finalizer.go
+++ b/disperser/batcher/finalizer.go
@@ -124,6 +124,10 @@ func (f *finalizer) updateBlobs(ctx context.Context, metadatas []*disperser.Blob
 	for _, m := range metadatas {
 		stageTimer := time.Now()
 		blobKey := m.GetBlobKey()
+		if m.BlobStatus != disperser.Confirmed {
+			f.logger.Error("FinalizeBlobs: the blob retrieved by status Confirmed is not actually confirmed", "blobKey", blobKey.String())
+			continue
+		}
 		confirmationMetadata, err := f.blobStore.GetBlobMetadata(ctx, blobKey)
 		if err != nil {
 			f.logger.Error("FinalizeBlobs: error getting confirmed metadata", "blobKey", blobKey.String(), "err", err)


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
