### PR TITLE
fix: Don't mark blob as confirmed if already confirmed

### DIFF
--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -214,6 +214,16 @@ func TestBatcherIterations(t *testing.T) {
 	count, size = components.encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, 0, count)
 	assert.Equal(t, uint64(0), size)
+
+	// confirmed metadata should be immutable and not be updated
+	existingBlobIndex := meta1.ConfirmationInfo.BlobIndex
+	meta1, err = blobStore.MarkBlobConfirmed(ctx, meta1, &disperser.ConfirmationInfo{
+		BlobIndex: existingBlobIndex + 1,
+	})
+	assert.NoError(t, err)
+	// check confirmation info isn't updated
+	assert.Equal(t, existingBlobIndex, meta1.ConfirmationInfo.BlobIndex)
+	assert.Equal(t, disperser.Confirmed, meta1.BlobStatus)
 }
 
 func TestBlobFailures(t *testing.T) {

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -71,6 +71,15 @@ func (q *BlobStore) GetBlobContent(ctx context.Context, blobHash disperser.BlobH
 }
 
 func (q *BlobStore) MarkBlobConfirmed(ctx context.Context, existingMetadata *disperser.BlobMetadata, confirmationInfo *disperser.ConfirmationInfo) (*disperser.BlobMetadata, error) {
+	// TODO (ian-shim): remove this check once we are sure that the metadata is never overwritten
+	refreshedMetadata, err := q.GetBlobMetadata(ctx, existingMetadata.GetBlobKey())
+	if err != nil {
+		return nil, err
+	}
+	alreadyConfirmed, _ := refreshedMetadata.IsConfirmed()
+	if alreadyConfirmed {
+		return refreshedMetadata, nil
+	}
 	blobKey := existingMetadata.GetBlobKey()
 	if _, ok := q.Metadata[blobKey]; !ok {
 		return nil, disperser.ErrBlobNotFound


### PR DESCRIPTION
## Why are these changes needed?
There seems to be a race condition that results in some blobs being encoded/dispersed multiple times. 
This affects the centralized retriever at the disperser because duplicate dispersals overwrite/corrupt the metadata from the initial confirmation. 
This PR is a temporary solution that makes a confirmed metadata immutable. No additional dispersals would overwrite the existing confirmation metadata. Note that it does it in a way that is very inefficient, adding an extra call to retrieve the metadata for every `MarkBlobConfirmed` call. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
