### PR TITLE
Fix the operator nonsigning rate

### DIFF
--- a/disperser/dataapi/subgraph/queries.go
+++ b/disperser/dataapi/subgraph/queries.go
@@ -62,7 +62,7 @@ type (
 		Batches []*Batches `graphql:"batches(orderDirection: $orderDirection, orderBy: $orderBy, first: $first, skip: $skip)"`
 	}
 	queryBatchesByBlockTimestampRange struct {
-		Batches []*Batches `graphql:"batches(first: $first, orderBy: blockTimestamp, where: {and: [{ blockTimestamp_gte: $blockTimestamp_gte}, {blockTimestamp_lte: $blockTimestamp_lte}]})"`
+		Batches []*Batches `graphql:"batches(first: $first, skip: $skip, orderBy: blockTimestamp, where: {and: [{ blockTimestamp_gte: $blockTimestamp_gte}, {blockTimestamp_lte: $blockTimestamp_lte}]})"`
 	}
 	queryOperatorRegistereds struct {
 		OperatorRegistereds []*Operator `graphql:"operatorRegistereds(first: $first)"`


### PR DESCRIPTION
## Why are these changes needed?
Currently the nonsigning rate is incorrect.

Tested:
Querying the nonsigning rate in past 10h, it looks correct:

`{"meta":{"size":49},"data":[{"operator_id":"0x45511e592e63f31ee9d590d400a88fea67d774959e8311c60e80c5dd8007821b","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0x7b54829d8a8be836e7638db296e501f012d398878f342a70cd5bffb146679c6f","total_unsigned_batches":2,"total_batches":598,"percentage":0.33},{"operator_id":"0x8d2fd307bf1408b5e634351d42a71a0d17dcd0e6db371b1c0b788139a0e6c208","total_unsigned_batches":1,"total_batches":598,"percentage":0.17},{"operator_id":"0x9f31c7c8b78550dc43040d975487891d4b929d8e9d32df2ac9ae7f2502226043","total_unsigned_batches":522,"total_batches":598,"percentage":87.29},{"operator_id":"0x31456e33bc61e1be0bde864f02a882f806584d9adfda8979b717c8ac0242ba34","total_unsigned_batches":2,"total_batches":598,"percentage":0.33},{"operator_id":"0xd7842337b7f6bcce4f22ac750fe27b45070cb0e78980dc88d118e848e5178fa5","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0xf8d3b75da1d572e0bd417b55ba44d119c2eb28c059cfae8ee523634a091de906","total_unsigned_batches":96,"total_batches":598,"percentage":16.05},{"operator_id":"0x98478a8aeba89118cf99efc813aa7b8910869ebfd339319519ac4f2af65f5a79","total_unsigned_batches":111,"total_batches":598,"percentage":18.56},{"operator_id":"0x5e8e432454851e5c24510657c7e7ba2d5f6dbc72fa156fc81e2666ce1f92473a","total_unsigned_batches":14,"total_batches":36,"percentage":38.89},{"operator_id":"0xba26efbb6d3173920b489a6bb2f0ab2b1bdc9296cedf5299c68c8d65b4bdd71f","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0xad61768cf8a0557916323486213d15f56351e89c1cc91030a0b18b45e650f73a","total_unsigned_batches":1,"total_batches":592,"percentage":0.17},{"operator_id":"0x6fe765637b9ffc71caf877cb964fb08c8502737ae650174930b83edb9e15a600","total_unsigned_batches":6,"total_batches":598,"percentage":1},{"operator_id":"0x1426175cdf0919375d7a5559024c3b64694f9c8aa3591a83a053f1d5bf5419d4","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0x439d8d4b3c3a04df3e603d7bd05c4f6a0eca8a316f88fea6ee937a758bd6b4a6","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0xc8b26a972195c043984122d47182a5bea186c4fff95d552469ed15bef2a13ea9","total_unsigned_batches":16,"total_batches":598,"percentage":2.68},{"operator_id":"0x5665034e83828be0b3821a74fa1da53334f7c515a79e19233113c0598aac9c13","total_unsigned_batches":1,"total_batches":598,"percentage":0.17},{"operator_id":"0xbdd4d72a247c12658c64ae65e93139705fc6b786b329cd8021027b49012b9d0c","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0x7031a161b62bfa469901ba7a33f76e8da9cda3adc95ee5237b4031c286cde34f","total_unsigned_batches":72,"total_batches":598,"percentage":12.04},{"operator_id":"0x23ccd10361a9f12ba8b8c1e0e0b07ff6d5ed1438a809391b0f5dadbcc0cb116b","total_unsigned_batches":75,"total_batches":598,"percentage":12.54},{"operator_id":"0xb2fbbcf956835cd35ba685b7dfb9bd4b896de72f9e8e3bc7f4ff9f03ce439899","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0x5940ccbc19a60628ccd15945d8ec3b8d466a6975430f8c1ee7b5144bd5d5fb4c","total_unsigned_batches":114,"total_batches":598,"percentage":19.06},{"operator_id":"0xcd27aadc65a1d967f39219af8d1562965c7b27cb4a270687ea5f1245ed153d45","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0xce9f2ec1d7299a3ebacb58a21c5bc0bba8e34b8d0ba231f39b2755266051ec2c","total_unsigned_batches":1,"total_batches":473,"percentage":0.21},{"operator_id":"0x66673ad95053510fca73600cc3b8f013d046a8c3f7e7fd572e44767f9ef49459","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0xdeab4083da525aee0f2fe06bd9177528a2bf02c7aefe087e266fdcb5a28a4b97","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0xac10422180bf1a65946ce3282209ab638b2c1a1246906a1157927b510b93a502","total_unsigned_batches":1,"total_batches":598,"percentage":0.17},{"operator_id":"0xf581c6a784ee1f5cb9a6900f57ab1677b9e8a02ffbc169ab98ccfd1432a90ab2","total_unsigned_batches":41,"total_batches":598,"percentage":6.86},{"operator_id":"0xedfa99ef794eb370cc98cf23a9812d5fee6003eb313032e75d9e6cd55703e67c","total_unsigned_batches":3,"total_batches":598,"percentage":0.5},{"operator_id":"0x2ff81250b5063eefd6fbea4c530683546a9bf1607d7c34838de72d1cabc3e151","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0x50a30064c297bbeb0b2934de27f678b2b491221b0b1af9ac7890267c38f79651","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0xe484bac7e9d948e479214f80ef3efd8777f7c7555655e88a661110dcea8046d7","total_unsigned_batches":598,"total_batches":598,"percentage":100},{"operator_id":"0x4f307f051b6a228a933e0dd8edbd9a9aac950a9e9b75959e93bdb2d9ae453ada","total_unsigned_batches":2,"total_batches":598,"percentage":0.33},{"operator_id":"0xc8a289d0cc1a5c472f6bdf80931bc84e2fd367cdc3f11482a58a8b54e5936489","total_unsigned_batches":1,"total_batches":598,"percentage":0.17},{"operator_id":"0xe60d6cdcb5288ad42c161d7413c589181ba02ac57f052e1fc7553985636a8967","total_unsigned_batches":598,"total_batches":598,"percentage":100},]}`

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
