### PR TITLE
Fix: Check nil blob commitment

### DIFF
--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	commonpb "github.com/Layr-Labs/eigenda/api/grpc/common"
@@ -128,6 +129,12 @@ func GetStoreChunksRequest(blobMessages []*core.BlobMessage, header *core.BatchH
 }
 
 func getBlobMessage(blob *core.BlobMessage) (*node.Blob, error) {
+	if blob.BlobHeader == nil {
+		return nil, fmt.Errorf("blob header is nil")
+	}
+	if blob.BlobHeader.Commitment == nil {
+		return nil, fmt.Errorf("blob header commitment is nil")
+	}
 	commitData := &commonpb.G1Commitment{
 		X: blob.BlobHeader.Commitment.X.Marshal(),
 		Y: blob.BlobHeader.Commitment.Y.Marshal(),


### PR DESCRIPTION
## Why are these changes needed?
Guarding a nil pointer exception by checking if the blob commitment is nil and returning proper error
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
