### PR TITLE
Enhance TestLinCombG1 with random polynomial 

### DIFF
--- a/pkg/kzg/bn254/bn254_gnark_test.go
+++ b/pkg/kzg/bn254/bn254_gnark_test.go
@@ -134,10 +134,28 @@ func TestNegG1(t *testing.T) {
 }
 
 func TestLinCombG1(t *testing.T) {
-	// TODO: use random poly and g1 points
-	poly := []Fr{
-		ToFr("1"), ToFr("2"), ToFr("3"), ToFr("4"), ToFr("5"),
-	}
+	// random numbers for interval [1, 50]
+    rand.Seed(time.Now().UnixNano())
+
+    // generate random numbers and convert them to Fr
+    nums := make([]int, 5)
+    sum := 0
+    for i := range nums {
+        nums[i] = rand.Intn(50) + 1
+        sum += nums[i]
+    }
+
+	// for testing purposes in the future
+	// t.Logf("Random numbers: %v", nums)
+    // t.Logf("Sum of random numbers: %d", sum)
+
+    poly := []Fr{
+        ToFr(strconv.Itoa(nums[0])),
+        ToFr(strconv.Itoa(nums[1])),
+        ToFr(strconv.Itoa(nums[2])),
+        ToFr(strconv.Itoa(nums[3])),
+        ToFr(strconv.Itoa(nums[4])),
+    }
 	one := GenG1
 	val := []G1Point{
 		one, one, one, one, one,

--- a/pkg/kzg/bn254/bn254_gnark_test.go
+++ b/pkg/kzg/bn254/bn254_gnark_test.go
@@ -7,7 +7,10 @@ import (
 	"bytes"
 	"encoding/hex"
 	"testing"
-
+	"math/rand"
+    "time" 
+	"strconv"
+	
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/kzg/bn254/bn254_gnark_test.go
+++ b/pkg/kzg/bn254/bn254_gnark_test.go
@@ -162,13 +162,13 @@ func TestLinCombG1(t *testing.T) {
 	}
 	lin := LinCombG1(val, poly)
 
-	var scalar Fr
-	AsFr(&scalar, uint64(15))
-	var product G1Point
-	MulG1(&product, &one, &scalar)
-	if *lin != product {
-		t.Fatal("Linear combination != product!")
-	}
+    var scalar Fr
+    AsFr(&scalar, uint64(sum))
+    var product G1Point
+    MulG1(&product, &one, &scalar)
+    if *lin != product {
+        t.Fatal("Linear combination != product!")
+    }
 }
 
 func TestZeroG2(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?

These changes introduce randomness to the polynomial coefficients used in the `TestLinCombG1` unit test. Previously, the test used fixed coefficients, which limited its ability to thoroughly validate the `LinCombG1` function across a broader range of inputs. By generating random coefficients within the interval `[1, 50]`, we significantly enhance the test's robustness and its ability to uncover potential issues under varied conditions. This approach aligns with best practices in testing, where input variability can help ensure the reliability and correctness of the code under test.

Additionally, while addressing a TODO comment about utilizing random polynomial coefficients and G1 points, these changes directly contribute to making the test suite more comprehensive and capable of catching errors that fixed inputs might not. However, it's worth noting that the current changes only implement randomness in the polynomial coefficients and not in the G1 points themselves. Future enhancements should consider introducing randomness to the G1 points to fully address the TODO and further increase the test coverage. Will look into this matter.

TODO in question:
https://github.com/Layr-Labs/eigenda/blob/3c66c994e6ffb09afcf957b68fe6e01d34d614bf/pkg/kzg/bn254/bn254_gnark_test.go#L260-L278

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [x] This PR is not tested :(
 

Picture of the test, ran with the command to print out numbers: 


<img src="https://github.com/Layr-Labs/eigenda/assets/83395536/da587f36-dd4d-41a2-a6cd-1b52f1976409" width="500">


