### PR TITLE
[Batcher] Additional check in updateBlob method before dereferencing

### DIFF
--- a/disperser/batcher/finalizer.go
+++ b/disperser/batcher/finalizer.go
@@ -135,6 +135,7 @@ func (f *finalizer) updateBlobs(ctx context.Context, metadatas []*disperser.Blob
 			f.logger.Error("FinalizeBlobs: the blob retrieved by status Confirmed is actually", m.BlobStatus.String(), "blobKey", blobKey.String())
 			continue
 		}
+
 		confirmationMetadata, err := f.blobStore.GetBlobMetadata(ctx, blobKey)
 		if err != nil {
 			f.logger.Error("FinalizeBlobs: error getting confirmed metadata", "blobKey", blobKey.String(), "err", err)


### PR DESCRIPTION
## Why are these changes needed?

Handle below Finalizer error by adding checks before deref

2024-02-28 10:15:28.227 | /app/disperser/batcher/finalizer.go:134 +0x14d |  
2024-02-28 10:15:28.227 | github.com/Layr-Labs/eigenda/disperser/batcher.(*finalizer).FinalizeBlobs.func1() |  
2024-02-28 10:15:28.227 | /app/disperser/batcher/finalizer.go:106 +0x32 |  
2024-02-28 10:15:28.227 | github.com/gammazero/workerpool.worker(0x1?, 0x0?, 0x0?) |  
2024-02-28 10:15:28.227 | /go/pkg/mod/github.com/gammazero/workerpool@v1.1.3/workerpool.go:237 +0x22 |  
2024-02-28 10:15:28.227 | created by github.com/gammazero/workerpool.(*WorkerPool).dispatch in goroutine 30758 |  
2024-02-28 10:15:28.227 | /go/pkg/mod/github.com/gammazero/workerpool@v1.1.3/workerpool.go:197 +0x2b3 |  
2024-02-28 10:16:21.309 | 2024/02/28 18:16:21 maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined |  
2024-02-28 10:22:24.239 | panic: runtime error: invalid memory address or nil pointer dereference |  
2024-02-28 10:22:24.239 | [signal SIGSEGV: segmentation violation code=0x1 addr=0xac pc=0xb1a4ad]

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
