### PR TITLE
improve: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/churner/server.go
+++ b/churner/server.go
@@ -2,6 +2,7 @@ package churner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -122,24 +123,24 @@ func (s *Server) checkShouldBeRateLimited(now time.Time, request ChurnRequest) e
 func (s *Server) validateChurnRequest(ctx context.Context, req *pb.ChurnRequest) error {
 
 	if len(req.OperatorRequestSignature) != 64 {
-		return fmt.Errorf("invalid signature length")
+		return errors.New("invalid signature length")
 	}
 
 	if len(req.OperatorToRegisterPubkeyG1) != 64 {
-		return fmt.Errorf("invalid operatorToRegisterPubkeyG1 length")
+		return errors.New("invalid operatorToRegisterPubkeyG1 length")
 	}
 
 	if len(req.OperatorToRegisterPubkeyG2) != 128 {
-		return fmt.Errorf("invalid operatorToRegisterPubkeyG2 length")
+		return errors.New("invalid operatorToRegisterPubkeyG2 length")
 	}
 
 	if len(req.Salt) != 32 {
-		return fmt.Errorf("invalid salt length")
+		return errors.New("invalid salt length")
 	}
 
 	// TODO: ensure that all quorumIDs are valid
 	if len(req.QuorumIds) == 0 {
-		return fmt.Errorf("invalid quorumIds length")
+		return errors.New("invalid quorumIds length")
 	}
 
 	for quorumID := range req.GetQuorumIds() {

--- a/clients/disperser_client.go
+++ b/clients/disperser_client.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"time"
 
@@ -152,7 +153,7 @@ func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []
 	}
 	authHeaderReply, ok := reply.Payload.(*disperser_rpc.AuthenticatedReply_BlobAuthHeader)
 	if !ok {
-		return nil, nil, fmt.Errorf("expected challenge")
+		return nil, nil, errors.New("expected challenge")
 	}
 
 	authHeader := core.BlobAuthHeader{
@@ -163,7 +164,7 @@ func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []
 
 	authData, err := c.signer.SignBlobRequest(authHeader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error signing blob request")
+		return nil, nil, errors.New("error signing blob request")
 	}
 
 	// Process challenge and send back challenge_reply
@@ -182,7 +183,7 @@ func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []
 	}
 	disperseReply, ok := reply.Payload.(*disperser_rpc.AuthenticatedReply_DisperseReply) // Process the final disperse_reply
 	if !ok {
-		return nil, nil, fmt.Errorf("expected DisperseReply")
+		return nil, nil, errors.New("expected DisperseReply")
 	}
 
 	blobStatus, err := disperser.FromBlobStatusProto(disperseReply.DisperseReply.GetResult())

--- a/clients/retrieval_client.go
+++ b/clients/retrieval_client.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Layr-Labs/eigenda/common"
@@ -9,7 +10,6 @@ import (
 	"github.com/Layr-Labs/eigenda/encoding"
 
 	"github.com/gammazero/workerpool"
-	"github.com/wealdtech/go-merkletree"
 	"github.com/wealdtech/go-merkletree/keccak256"
 )
 
@@ -130,7 +130,7 @@ func (r *retrievalClient) RetrieveBlob(
 
 	assignments, info, err := r.assignmentCoordinator.GetAssignments(indexedOperatorState.OperatorState, blobHeader.Length, quorumHeader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get assignments")
+		return nil, errors.New("failed to get assignments")
 	}
 
 	// Fetch chunks from all operators

--- a/common/ratelimit.go
+++ b/common/ratelimit.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 	"strings"
 	"time"
@@ -65,7 +65,7 @@ func GetClientAddress(ctx context.Context, header string, numProxies int, allowD
 	if header == "" || allowDirectConnectionFallback {
 		p, ok := peer.FromContext(ctx)
 		if !ok {
-			return "", fmt.Errorf("failed to get peer from request")
+			return "", errors.New("failed to get peer from request")
 		}
 		addr := p.Addr.String()
 		host, _, err := net.SplitHostPort(addr)
@@ -75,7 +75,7 @@ func GetClientAddress(ctx context.Context, header string, numProxies int, allowD
 		return host, nil
 	}
 
-	return "", fmt.Errorf("failed to get ip")
+	return "", errors.New("failed to get ip")
 }
 
 func splitHeader(header []string) []string {

--- a/common/ratelimit/limiter_cli.go
+++ b/common/ratelimit/limiter_cli.go
@@ -65,7 +65,7 @@ func validateConfig(cfg Config) error {
 	}
 	for _, mult := range cfg.Multipliers {
 		if mult <= 0 {
-			return fmt.Errorf("multiplier must be positive")
+			return errors.New("multiplier must be positive")
 		}
 	}
 	return nil

--- a/common/store/dynamo_store.go
+++ b/common/store/dynamo_store.go
@@ -2,7 +2,7 @@ package store
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/Layr-Labs/eigenda/common"
 	commondynamodb "github.com/Layr-Labs/eigenda/common/aws/dynamodb"
@@ -37,7 +37,7 @@ func (s *dynamodbBucketStore[T]) GetItem(ctx context.Context, requesterID string
 		return nil, err
 	}
 	if item == nil {
-		return nil, fmt.Errorf("item not found")
+		return nil, errors.New("item not found")
 	}
 
 	params := new(T)

--- a/core/auth/authenticator.go
+++ b/core/auth/authenticator.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/Layr-Labs/eigenda/core"
@@ -56,7 +57,7 @@ func (*authenticator) AuthenticateBlobRequest(header core.BlobAuthHeader) error 
 	}
 
 	if !bytes.Equal(pubKey.X.Bytes(), sigPublicKeyECDSA.X.Bytes()) || !bytes.Equal(pubKey.Y.Bytes(), sigPublicKeyECDSA.Y.Bytes()) {
-		return fmt.Errorf("signature doesn't match with provided public key")
+		return errors.New("signature doesn't match with provided public key")
 	}
 
 	return nil

--- a/disperser/apiserver/rate_config.go
+++ b/disperser/apiserver/rate_config.go
@@ -1,7 +1,7 @@
 package apiserver
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"strconv"
 	"strings"
@@ -98,16 +98,16 @@ func ReadCLIConfig(c *cli.Context) (RateConfig, error) {
 
 	numQuorums := len(c.IntSlice(RegisteredQuorumFlagName))
 	if len(c.StringSlice(TotalUnauthBlobRateFlagName)) != numQuorums {
-		return RateConfig{}, fmt.Errorf("number of total unauth blob rates does not match number of quorums")
+		return RateConfig{}, errors.New("number of total unauth blob rates does not match number of quorums")
 	}
 	if len(c.StringSlice(PerUserUnauthBlobRateFlagName)) != numQuorums {
-		return RateConfig{}, fmt.Errorf("number of per user unauth blob intervals does not match number of quorums")
+		return RateConfig{}, errors.New("number of per user unauth blob intervals does not match number of quorums")
 	}
 	if len(c.IntSlice(TotalUnauthThroughputFlagName)) != numQuorums {
-		return RateConfig{}, fmt.Errorf("number of total unauth throughput does not match number of quorums")
+		return RateConfig{}, errors.New("number of total unauth throughput does not match number of quorums")
 	}
 	if len(c.IntSlice(PerUserUnauthThroughputFlagName)) != numQuorums {
-		return RateConfig{}, fmt.Errorf("number of per user unauth throughput does not match number of quorums")
+		return RateConfig{}, errors.New("number of per user unauth throughput does not match number of quorums")
 	}
 
 	quorumRateInfos := make(map[core.QuorumID]QuorumRateInfo)

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -26,10 +26,10 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-var errSystemBlobRateLimit = fmt.Errorf("request ratelimited: system blob limit")
-var errSystemThroughputRateLimit = fmt.Errorf("request ratelimited: system throughput limit")
-var errAccountBlobRateLimit = fmt.Errorf("request ratelimited: account blob limit")
-var errAccountThroughputRateLimit = fmt.Errorf("request ratelimited: account throughput limit")
+var errSystemBlobRateLimit = errors.New("request ratelimited: system blob limit")
+var errSystemThroughputRateLimit = errors.New("request ratelimited: system throughput limit")
+var errAccountBlobRateLimit = errors.New("request ratelimited: account blob limit")
+var errAccountThroughputRateLimit = errors.New("request ratelimited: account throughput limit")
 
 const systemAccountKey = "system"
 
@@ -182,10 +182,10 @@ func (s *DispersalServer) validateBlobRequest(ctx context.Context, blob *core.Bl
 
 	securityParams := blob.RequestHeader.SecurityParams
 	if len(securityParams) == 0 {
-		return fmt.Errorf("invalid request: security_params must not be empty")
+		return errors.New("invalid request: security_params must not be empty")
 	}
 	if len(securityParams) > 256 {
-		return fmt.Errorf("invalid request: security_params must not exceed 256")
+		return errors.New("invalid request: security_params must not exceed 256")
 	}
 
 	seenQuorums := make(map[uint8]struct{})
@@ -193,7 +193,7 @@ func (s *DispersalServer) validateBlobRequest(ctx context.Context, blob *core.Bl
 	// to uint8, so it cannot be greater than 254.
 	for _, param := range securityParams {
 		if _, ok := seenQuorums[param.QuorumID]; ok {
-			return fmt.Errorf("invalid request: security_params must not contain duplicate quorum_id")
+			return errors.New("invalid request: security_params must not contain duplicate quorum_id")
 		}
 		seenQuorums[param.QuorumID] = struct{}{}
 
@@ -212,10 +212,10 @@ func (s *DispersalServer) validateBlobRequest(ctx context.Context, blob *core.Bl
 	blobSize := len(blob.Data)
 	// The blob size in bytes must be in range [1, maxBlobSize].
 	if blobSize > maxBlobSize {
-		return fmt.Errorf("blob size cannot exceed 2 MiB")
+		return errors.New("blob size cannot exceed 2 MiB")
 	}
 	if blobSize == 0 {
-		return fmt.Errorf("blob size must be greater than 0")
+		return errors.New("blob size must be greater than 0")
 	}
 
 	if err := blob.RequestHeader.Validate(); err != nil {
@@ -286,7 +286,7 @@ func (s *DispersalServer) disperseBlob(ctx context.Context, blob *core.Blob, aut
 			s.metrics.HandleBlobStoreFailedRequest(quorumId, blobSize, "DisperseBlob")
 		}
 		s.logger.Error("failed to store blob", "err", err)
-		return nil, fmt.Errorf("failed to store blob, please try again later")
+		return nil, errors.New("failed to store blob, please try again later")
 	}
 
 	for _, param := range securityParams {
@@ -443,7 +443,7 @@ func (s *DispersalServer) GetBlobStatus(ctx context.Context, req *pb.BlobStatusR
 
 	requestID := req.GetRequestId()
 	if len(requestID) == 0 {
-		return nil, fmt.Errorf("invalid request: request_id must not be empty")
+		return nil, errors.New("invalid request: request_id must not be empty")
 	}
 
 	s.logger.Info("received a new blob status request", "requestID", string(requestID))
@@ -582,7 +582,7 @@ func (s *DispersalServer) Start(ctx context.Context) error {
 	addr := fmt.Sprintf("%s:%s", disperser.Localhost, s.config.GrpcPort)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
-		return fmt.Errorf("could not start tcp listener")
+		return errors.New("could not start tcp listener")
 	}
 
 	opt := grpc.MaxRecvMsgSize(1024 * 1024 * 300) // 300 MiB
@@ -596,7 +596,7 @@ func (s *DispersalServer) Start(ctx context.Context) error {
 
 	s.logger.Info("port", s.config.GrpcPort, "address", listener.Addr().String(), "GRPC Listening")
 	if err := gs.Serve(listener); err != nil {
-		return fmt.Errorf("could not start GRPC server")
+		return errors.New("could not start GRPC server")
 	}
 
 	return nil

--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -15,9 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/gammazero/workerpool"
-	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/wealdtech/go-merkletree"
 )
 
 const (
@@ -213,22 +211,22 @@ func (b *Batcher) updateConfirmationInfo(
 	txnReceipt *types.Receipt,
 ) ([]*disperser.BlobMetadata, error) {
 	if txnReceipt.BlockNumber == nil {
-		return nil, fmt.Errorf("HandleSingleBatch: error getting transaction receipt block number")
+		return nil, errors.New("HandleSingleBatch: error getting transaction receipt block number")
 	}
 	if len(batchData.blobs) == 0 {
-		return nil, fmt.Errorf("failed to process confirmed batch: no blobs from transaction manager metadata")
+		return nil, errors.New("failed to process confirmed batch: no blobs from transaction manager metadata")
 	}
 	if batchData.batchHeader == nil {
-		return nil, fmt.Errorf("failed to process confirmed batch: batch header from transaction manager metadata is nil")
+		return nil, errors.New("failed to process confirmed batch: batch header from transaction manager metadata is nil")
 	}
 	if len(batchData.blobHeaders) == 0 {
-		return nil, fmt.Errorf("failed to process confirmed batch: no blob headers from transaction manager metadata")
+		return nil, errors.New("failed to process confirmed batch: no blob headers from transaction manager metadata")
 	}
 	if batchData.merkleTree == nil {
-		return nil, fmt.Errorf("failed to process confirmed batch: merkle tree from transaction manager metadata is nil")
+		return nil, errors.New("failed to process confirmed batch: merkle tree from transaction manager metadata is nil")
 	}
 	if batchData.aggSig == nil {
-		return nil, fmt.Errorf("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
+		return nil, errors.New("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
 	}
 	headerHash, err := batchData.batchHeader.GetBatchHeaderHash()
 	if err != nil {
@@ -316,12 +314,12 @@ func (b *Batcher) updateConfirmationInfo(
 
 func (b *Batcher) ProcessConfirmedBatch(ctx context.Context, receiptOrErr *ReceiptOrErr) error {
 	if receiptOrErr.Metadata == nil {
-		return fmt.Errorf("failed to process confirmed batch: no metadata from transaction manager response")
+		return errors.New("failed to process confirmed batch: no metadata from transaction manager response")
 	}
 	confirmationMetadata := receiptOrErr.Metadata.(confirmationMetadata)
 	blobs := confirmationMetadata.blobs
 	if len(blobs) == 0 {
-		return fmt.Errorf("failed to process confirmed batch: no blobs from transaction manager metadata")
+		return errors.New("failed to process confirmed batch: no blobs from transaction manager metadata")
 	}
 	if receiptOrErr.Err != nil {
 		_ = b.handleFailure(ctx, blobs, FailConfirmBatch)
@@ -329,7 +327,7 @@ func (b *Batcher) ProcessConfirmedBatch(ctx context.Context, receiptOrErr *Recei
 	}
 	if confirmationMetadata.aggSig == nil {
 		_ = b.handleFailure(ctx, blobs, FailNoAggregatedSignature)
-		return fmt.Errorf("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
+		return errors.New("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
 	}
 	b.logger.Info("received ConfirmBatch transaction receipt", "blockNumber", receiptOrErr.Receipt.BlockNumber, "txnHash", receiptOrErr.Receipt.TxHash.Hex())
 
@@ -440,7 +438,7 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	// TODO(mooselumph): Determine whether to confirm the batch based on the number of successes
 	if numPassed == 0 {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailNoSignatures)
-		return fmt.Errorf("HandleSingleBatch: no blobs received sufficient signatures")
+		return errors.New("HandleSingleBatch: no blobs received sufficient signatures")
 	}
 
 	// Confirm the batch
@@ -483,7 +481,7 @@ func serializeProof(proof *merkletree.Proof) []byte {
 
 func (b *Batcher) parseBatchIDFromReceipt(ctx context.Context, txReceipt *types.Receipt) (uint32, error) {
 	if len(txReceipt.Logs) == 0 {
-		return 0, fmt.Errorf("failed to get transaction receipt with logs")
+		return 0, errors.New("failed to get transaction receipt with logs")
 	}
 	for _, log := range txReceipt.Logs {
 		if len(log.Topics) == 0 {
@@ -514,7 +512,7 @@ func (b *Batcher) parseBatchIDFromReceipt(ctx context.Context, txReceipt *types.
 			return unpackedData[0].(uint32), nil
 		}
 	}
-	return 0, fmt.Errorf("failed to find BatchConfirmed log from the transaction")
+	return 0, errors.New("failed to find BatchConfirmed log from the transaction")
 }
 
 func (b *Batcher) getBatchID(ctx context.Context, txReceipt *types.Receipt) (uint32, error) {

--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -3,7 +3,7 @@ package batcher_test
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
+	"errors"
 	"math/big"
 	"runtime"
 	"testing"
@@ -268,7 +268,7 @@ func TestBlobFailures(t *testing.T) {
 		assert.Equal(t, 3, len(heartbeats), "Expected heartbeats, but none were received")
 	}()
 
-	confirmationErr := fmt.Errorf("error")
+	confirmationErr := errors.New("error")
 	blobStore := components.blobStore
 	ctx := context.Background()
 	requestedAt, blobKey := queueBlob(t, ctx, &blob, blobStore)
@@ -437,7 +437,7 @@ func TestBlobRetry(t *testing.T) {
 	assert.Equal(t, disperser.Processing, meta.BlobStatus)
 
 	// Trigger a retry
-	confirmationErr := fmt.Errorf("error")
+	confirmationErr := errors.New("error")
 	err = batcher.ProcessConfirmedBatch(ctx, &bat.ReceiptOrErr{
 		Receipt:  nil,
 		Err:      confirmationErr,

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/encoding"
-	"github.com/wealdtech/go-merkletree"
 )
 
 const encodingInterval = 2 * time.Second
@@ -99,7 +98,7 @@ func NewEncodingStreamer(
 	metrics *EncodingStreamerMetrics,
 	logger common.Logger) (*EncodingStreamer, error) {
 	if config.EncodingQueueLimit <= 0 {
-		return nil, fmt.Errorf("EncodingQueueLimit should be greater than 0")
+		return nil, errors.New("EncodingQueueLimit should be greater than 0")
 	}
 	return &EncodingStreamer{
 		StreamerConfig:         config,

--- a/disperser/batcher/encoding_streamer_test.go
+++ b/disperser/batcher/encoding_streamer_test.go
@@ -3,7 +3,7 @@ package batcher_test
 import (
 	"context"
 	"crypto/rand"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -322,7 +322,7 @@ func TestEncodingFailure(t *testing.T) {
 	assert.Nil(t, err)
 
 	cst.On("GetCurrentBlockNumber").Return(uint(10), nil)
-	encoderClient.On("EncodeBlob", tmock.Anything, tmock.Anything, tmock.Anything).Return(nil, nil, fmt.Errorf("errrrr"))
+	encoderClient.On("EncodeBlob", tmock.Anything, tmock.Anything, tmock.Anything).Return(nil, nil, errors.New("error"))
 	// request encoding
 	out := make(chan batcher.EncodingResultOrStatus)
 	err = encodingStreamer.RequestEncoding(context.Background(), out)

--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -2,7 +2,7 @@ package dispatcher
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	commonpb "github.com/Layr-Labs/eigenda/api/grpc/common"
@@ -130,10 +130,10 @@ func GetStoreChunksRequest(blobMessages []*core.BlobMessage, header *core.BatchH
 
 func getBlobMessage(blob *core.BlobMessage) (*node.Blob, error) {
 	if blob.BlobHeader == nil {
-		return nil, fmt.Errorf("blob header is nil")
+		return nil, errors.New("blob header is nil")
 	}
 	if blob.BlobHeader.Commitment == nil {
-		return nil, fmt.Errorf("blob header commitment is nil")
+		return nil, errors.New("blob header commitment is nil")
 	}
 	commitData := &commonpb.G1Commitment{
 		X: blob.BlobHeader.Commitment.X.Marshal(),

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -152,7 +153,7 @@ func RunBatcher(ctx *cli.Context) error {
 	metrics := batcher.NewMetrics(config.MetricsConfig.HTTPPort, logger)
 
 	if len(config.BatcherConfig.EncoderSocket) == 0 {
-		return fmt.Errorf("encoder socket must be specified")
+		return errors.New("encoder socket must be specified")
 	}
 	encoderClient, err := encoder.NewEncoderClient(config.BatcherConfig.EncoderSocket, config.TimeoutConfig.EncodingTimeout)
 	if err != nil {

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -187,7 +188,7 @@ func FromBlobStatusProto(status disperser_rpc.BlobStatus) (*BlobStatus, error) {
 	var res BlobStatus
 	switch status {
 	case disperser_rpc.BlobStatus_UNKNOWN:
-		return nil, fmt.Errorf("unexpected blob status BlobStatus_UNKNOWN")
+		return nil, errors.New("unexpected blob status BlobStatus_UNKNOWN")
 	case disperser_rpc.BlobStatus_PROCESSING:
 		res = Processing
 		return &res, nil

--- a/disperser/encoder/server.go
+++ b/disperser/encoder/server.go
@@ -2,6 +2,7 @@ package encoder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -48,7 +49,7 @@ func (s *Server) EncodeBlob(ctx context.Context, req *pb.EncodeBlobRequest) (*pb
 	default:
 		s.metrics.IncrementRateLimitedBlobRequestNum()
 		s.logger.Warn("rate limiting as request pool is full", "requestPoolSize", s.config.RequestPoolSize, "maxConcurrentRequests", s.config.MaxConcurrentRequests)
-		return nil, fmt.Errorf("too many requests")
+		return nil, errors.New("too many requests")
 	}
 	s.runningRequests <- struct{}{}
 	defer s.popRequest()

--- a/encoding/fft/recover_from_samples.go
+++ b/encoding/fft/recover_from_samples.go
@@ -25,6 +25,7 @@
 package fft
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
@@ -40,17 +41,15 @@ func (fs *FFTSettings) ShiftPoly(poly []fr.Element) {
 	invFactor.Inverse(&shiftFactor)
 	var tmp fr.Element
 	for i := 0; i < len(poly); i++ {
-		
+
 		tmp.Set(&poly[i])
 
-		
 		poly[i].Mul(&tmp, &factorPower)
 
 		// TODO: pre-compute all these shift scalars
-		
+
 		tmp.Set(&factorPower)
 
-		
 		factorPower.Mul(&tmp, &invFactor)
 	}
 }
@@ -58,21 +57,21 @@ func (fs *FFTSettings) ShiftPoly(poly []fr.Element) {
 // unshift poly, in-place. Multiplies each coeff with shift_factor**i
 func (fs *FFTSettings) UnshiftPoly(poly []fr.Element) {
 	var shiftFactor fr.Element
-	
+
 	shiftFactor.SetInt64(int64(5))
 	var factorPower fr.Element
 	factorPower.SetOne()
-	
+
 	var tmp fr.Element
 	for i := 0; i < len(poly); i++ {
 		tmp.Set(&poly[i])
-		
+
 		poly[i].Mul(&tmp, &factorPower)
-		
+
 		// TODO: pre-compute all these shift scalars
-		
+
 		tmp.Set(&factorPower)
-		
+
 		factorPower.Mul(&tmp, &shiftFactor)
 	}
 }
@@ -94,17 +93,17 @@ func (fs *FFTSettings) RecoverPolyFromSamples(samples []*fr.Element, zeroPolyFn 
 
 	for i, s := range samples {
 		if (s == nil) != zeroEval[i].IsZero() {
-			return nil, fmt.Errorf("bad zero eval")
+			return nil, errors.New("bad zero eval")
 		}
 	}
 
 	polyEvaluationsWithZero := make([]fr.Element, len(samples))
 	for i, s := range samples {
 		if s == nil {
-			
+
 			polyEvaluationsWithZero[i].SetZero()
 		} else {
-			
+
 			polyEvaluationsWithZero[i].Mul(s, &zeroEval[i])
 		}
 	}
@@ -130,7 +129,7 @@ func (fs *FFTSettings) RecoverPolyFromSamples(samples []*fr.Element, zeroPolyFn 
 
 	evalShiftedReconstructedPoly := evalShiftedPolyWithZero
 	for i := 0; i < len(evalShiftedReconstructedPoly); i++ {
-		
+
 		evalShiftedReconstructedPoly[i].Div(&evalShiftedPolyWithZero[i], &evalShiftedZeroPoly[i])
 	}
 	shiftedReconstructedPoly, err := fs.FFT(evalShiftedReconstructedPoly, true)

--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -2,6 +2,7 @@ package kzg
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -86,7 +87,7 @@ func ReadG2PointOnPowerOf2(exponent uint64, g *KzgConfig) (bn254.G2Affine, error
 	}
 
 	if len(g.G2PowerOf2Path) == 0 {
-		return bn254.G2Affine{}, fmt.Errorf("G2PathPowerOf2 path is empty")
+		return bn254.G2Affine{}, errors.New("G2PathPowerOf2 path is empty")
 	}
 
 	g2point, err := ReadG2PointSection(g.G2PowerOf2Path, exponent, exponent+1, 1)

--- a/encoding/kzg/prover/prover.go
+++ b/encoding/kzg/prover/prover.go
@@ -51,7 +51,7 @@ func NewProver(config *kzg.KzgConfig, loadG2Points bool) (*Prover, error) {
 	// PreloadEncoder is by default not used by operator node, PreloadEncoder
 	if loadG2Points {
 		if len(config.G2Path) == 0 {
-			return nil, fmt.Errorf("G2Path is empty. However, object needs to load G2Points")
+			return nil, errors.New("G2Path is empty. However, object needs to load G2Points")
 		}
 
 		s2, err = kzg.ReadG2Points(config.G2Path, config.SRSNumberToLoad, config.NumWorker)
@@ -72,7 +72,7 @@ func NewProver(config *kzg.KzgConfig, loadG2Points bool) (*Prover, error) {
 	} else {
 		// todo, there are better ways to handle it
 		if len(config.G2PowerOf2Path) == 0 {
-			return nil, fmt.Errorf("G2PowerOf2Path is empty. However, object needs to load G2Points")
+			return nil, errors.New("G2PowerOf2Path is empty. However, object needs to load G2Points")
 		}
 	}
 
@@ -242,7 +242,6 @@ func (g *Prover) newProver(params encoding.EncodingParams) (*ParametrizedProver,
 		FFTPointsT: fftPointsT,
 	}, nil
 }
-
 
 // Detect the precomputed table from the specified directory
 // the file name follow the name convention of

--- a/encoding/kzg/verifier/verifier.go
+++ b/encoding/kzg/verifier/verifier.go
@@ -51,7 +51,7 @@ func NewVerifier(config *kzg.KzgConfig, loadG2Points bool) (*Verifier, error) {
 	// PreloadEncoder is by default not used by operator node, PreloadEncoder
 	if loadG2Points {
 		if len(config.G2Path) == 0 {
-			return nil, fmt.Errorf("G2Path is empty. However, object needs to load G2Points")
+			return nil, errors.New("G2Path is empty. However, object needs to load G2Points")
 		}
 
 		s2, err = kzg.ReadG2Points(config.G2Path, config.SRSNumberToLoad, config.NumWorker)
@@ -72,7 +72,7 @@ func NewVerifier(config *kzg.KzgConfig, loadG2Points bool) (*Verifier, error) {
 	} else {
 		// todo, there are better ways to handle it
 		if len(config.G2PowerOf2Path) == 0 {
-			return nil, fmt.Errorf("G2PowerOf2Path is empty. However, object needs to load G2Points")
+			return nil, errors.New("G2PowerOf2Path is empty. However, object needs to load G2Points")
 		}
 	}
 
@@ -320,7 +320,7 @@ func PairingsVerify(a1 *bn254.G1Affine, a2 *bn254.G2Affine, b1 *bn254.G1Affine, 
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("PairingCheck pairing not ok. SRS is invalid")
+		return errors.New("PairingCheck pairing not ok. SRS is invalid")
 	}
 
 	return nil

--- a/encoding/params.go
+++ b/encoding/params.go
@@ -67,7 +67,7 @@ func ValidateEncodingParams(params EncodingParams, blobLength, SRSOrder int) err
 	}
 
 	if int(params.ChunkLength*params.NumChunks) < blobLength {
-		return fmt.Errorf("the supplied encoding parameters are not sufficient for the size of the data input")
+		return errors.New("the supplied encoding parameters are not sufficient for the size of the data input")
 	}
 
 	return nil

--- a/encoding/rs/encode.go
+++ b/encoding/rs/encode.go
@@ -1,7 +1,7 @@
 package rs
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"time"
 
@@ -109,7 +109,7 @@ func (g *Encoder) MakeFrames(
 func (g *Encoder) ExtendPolyEval(coeffs []fr.Element) ([]fr.Element, []fr.Element, error) {
 
 	if len(coeffs) > int(g.NumEvaluations()) {
-		return nil, nil, fmt.Errorf("the provided encoding parameters are not sufficient for the size of the data input")
+		return nil, nil, errors.New("the provided encoding parameters are not sufficient for the size of the data input")
 	}
 
 	pdCoeffs := make([]fr.Element, g.NumEvaluations())

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -206,7 +207,7 @@ func (s *Server) RetrieveChunks(ctx context.Context, in *pb.RetrieveChunksReques
 	}
 
 	if !allow {
-		return nil, fmt.Errorf("request rate limited")
+		return nil, errors.New("request rate limited")
 	}
 
 	chunks, ok := s.node.Store.GetChunks(ctx, batchHeaderHash, int(in.GetBlobIndex()), uint8(in.GetQuorumId()))
@@ -255,7 +256,7 @@ func (s *Server) getBlobHeader(ctx context.Context, batchHeaderHash [32]byte, bl
 
 	blobHeaderBytes, err := s.node.Store.GetBlobHeader(ctx, batchHeaderHash, blobIndex)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get the blob header from Store")
+		return nil, nil, errors.New("failed to get the blob header from Store")
 	}
 
 	var protoBlobHeader pb.BlobHeader

--- a/retriever/server.go
+++ b/retriever/server.go
@@ -2,7 +2,7 @@ package retriever
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	pb "github.com/Layr-Labs/eigenda/api/grpc/retriever"
 	"github.com/Layr-Labs/eigenda/clients"
@@ -53,7 +53,7 @@ func (s *Server) RetrieveBlob(ctx context.Context, req *pb.BlobRequest) (*pb.Blo
 	s.logger.Info("Received request: ", "BatchHeaderHash", req.GetBatchHeaderHash(), "BlobIndex", req.GetBlobIndex())
 	s.metrics.IncrementRetrievalRequestCounter()
 	if len(req.GetBatchHeaderHash()) != 32 {
-		return nil, fmt.Errorf("got invalid batch header hash")
+		return nil, errors.New("got invalid batch header hash")
 	}
 	var batchHeaderHash [32]byte
 	copy(batchHeaderHash[:], req.GetBatchHeaderHash())


### PR DESCRIPTION
Thanks for your reminder that all parameterless fmt.Errorf has been modified.