### PR TITLE
[1/N][multi quorum ejection] Fetch batch nonsigning info

### DIFF
--- a/disperser/dataapi/subgraph/api.go
+++ b/disperser/dataapi/subgraph/api.go
@@ -23,6 +23,7 @@ type (
 		QueryBatchesByBlockTimestampRange(ctx context.Context, start, end uint64) ([]*Batches, error)
 		QueryOperators(ctx context.Context, first int) ([]*Operator, error)
 		QueryBatchNonSigningOperatorIdsInInterval(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningOperatorIds, error)
+		QueryBatchNonSigningInfo(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningInfo, error)
 		QueryDeregisteredOperatorsGreaterThanBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*Operator, error)
 		QueryRegisteredOperatorsGreaterThanBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*Operator, error)
 		QueryOperatorInfoByOperatorIdAtBlockNumber(ctx context.Context, operatorId core.OperatorID, blockNumber uint32) (*IndexedOperatorInfo, error)
@@ -107,6 +108,35 @@ func (a *api) QueryOperators(ctx context.Context, first int) ([]*Operator, error
 	}
 
 	return result.OperatorRegistereds, nil
+}
+
+func (a *api) QueryBatchNonSigningInfo(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningInfo, error) {
+	nonSigningAfter := time.Now().Add(-time.Duration(intervalSeconds) * time.Second).Unix()
+	variables := map[string]any{
+		"blockTimestamp_gt": graphql.Int(nonSigningAfter),
+	}
+	skip := 0
+
+	result := new(queryBatchNonSigningInfo)
+	batchNonSigningInfo := make([]*BatchNonSigningInfo, 0)
+	for {
+		variables["first"] = graphql.Int(maxEntriesPerQuery)
+		variables["skip"] = graphql.Int(skip)
+
+		err := a.uiMonitoringGql.Query(ctx, &result, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(result.BatchNonSigningInfo) == 0 {
+			break
+		}
+		batchNonSigningInfo = append(batchNonSigningInfo, result.BatchNonSigningInfo...)
+
+		skip += maxEntriesPerQuery
+	}
+
+	return batchNonSigningInfo, nil
 }
 
 func (a *api) QueryBatchNonSigningOperatorIdsInInterval(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningOperatorIds, error) {

--- a/disperser/dataapi/subgraph/mock/api.go
+++ b/disperser/dataapi/subgraph/mock/api.go
@@ -67,6 +67,17 @@ func (m *MockSubgraphApi) QueryOperators(ctx context.Context, first int) ([]*sub
 	return value, args.Error(1)
 }
 
+func (m *MockSubgraphApi) QueryBatchNonSigningInfo(ctx context.Context, first int64) ([]*subgraph.BatchNonSigningInfo, error) {
+	args := m.Called()
+
+	var value []*subgraph.BatchNonSigningInfo
+	if args.Get(0) != nil {
+		value = args.Get(0).([]*subgraph.BatchNonSigningInfo)
+	}
+
+	return value, args.Error(1)
+}
+
 func (m *MockSubgraphApi) QueryBatchNonSigningOperatorIdsInInterval(ctx context.Context, first int64) ([]*subgraph.BatchNonSigningOperatorIds, error) {
 	args := m.Called()
 

--- a/disperser/dataapi/subgraph/queries.go
+++ b/disperser/dataapi/subgraph/queries.go
@@ -36,6 +36,19 @@ type (
 			} `graphql:"nonSigners"`
 		} `graphql:"nonSigning"`
 	}
+	BatchNonSigningInfo struct {
+		BatchId         graphql.String
+		BatchHeaderHash graphql.String
+		BatchHeader     struct {
+			QuorumNumbers        []graphql.String `json:"quorumNumbers"`
+			ReferenceBlockNumber graphql.String
+		}
+		NonSigning struct {
+			NonSigners []struct {
+				OperatorId graphql.String `graphql:"operatorId"`
+			} `graphql:"nonSigners"`
+		} `graphql:"nonSigning"`
+	}
 	SocketUpdates struct {
 		Socket graphql.String
 	}
@@ -69,6 +82,9 @@ type (
 	}
 	queryBatchNonSigningOperatorIdsInInterval struct {
 		BatchNonSigningOperatorIds []*BatchNonSigningOperatorIds `graphql:"batches(first: $first, skip: $skip, where: {blockTimestamp_gt: $blockTimestamp_gt})"`
+	}
+	queryBatchNonSigningInfo struct {
+		BatchNonSigningInfo []*BatchNonSigningInfo `graphql:"batches(first: $first, skip: $skip, where: {blockTimestamp_gt: $blockTimestamp_gt})"`
 	}
 	queryOperatorRegisteredsGTBlockTimestamp struct {
 		OperatorRegistereds []*Operator `graphql:"operatorRegistereds(orderBy: blockTimestamp, where: {blockTimestamp_gt: $blockTimestamp_gt})"`


### PR DESCRIPTION
## Why are these changes needed?
This is part of the work to compute operator nonsigning rate for ejection in multi quorum.

Roughly the first step in https://docs.google.com/document/d/13nxDXTAxRhT18qZrEkTtS2F7CxjlM0qA-2EGim1bu1k/edit

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
