### PR TITLE
optimize encoder interpolation latency

### DIFF
--- a/disperser/cmd/encoder/main.go
+++ b/disperser/cmd/encoder/main.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	"github.com/Layr-Labs/eigenda/common"
+
 
 	"github.com/Layr-Labs/eigenda/disperser/cmd/encoder/flags"
 	"github.com/urfave/cli"
@@ -55,11 +55,6 @@ func RunEncoderServer(ctx *cli.Context) error {
 		return err
 	}
 	defer enc.Close()
-
-	// Start pprof
-	go func() {
-		http.ListenAndServe(":6060", nil)
-	}()
 
 	err = enc.Start(context.Background())
 	if err != nil {

--- a/disperser/cmd/encoder/main.go
+++ b/disperser/cmd/encoder/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Layr-Labs/eigenda/common"
 
-
 	"github.com/Layr-Labs/eigenda/disperser/cmd/encoder/flags"
 	"github.com/urfave/cli"
 )

--- a/disperser/cmd/encoder/main.go
+++ b/disperser/cmd/encoder/main.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/Layr-Labs/eigenda/common"
+
 	"github.com/Layr-Labs/eigenda/disperser/cmd/encoder/flags"
 	"github.com/urfave/cli"
 )
@@ -53,6 +55,11 @@ func RunEncoderServer(ctx *cli.Context) error {
 		return err
 	}
 	defer enc.Close()
+
+	// Start pprof
+	go func() {
+		http.ListenAndServe(":6060", nil)
+	}()
 
 	err = enc.Start(context.Background())
 	if err != nil {

--- a/encoding/kzg/prover/parametrized_prover.go
+++ b/encoding/kzg/prover/parametrized_prover.go
@@ -225,7 +225,7 @@ func (p *ParametrizedProver) proofWorker(
 				points: nil,
 				err:    err,
 			}
-			return
+			continue
 		}
 
 		for i := 0; i < len(coeffs); i++ {

--- a/encoding/kzg/prover/parametrized_prover.go
+++ b/encoding/kzg/prover/parametrized_prover.go
@@ -225,11 +225,10 @@ func (p *ParametrizedProver) proofWorker(
 				points: nil,
 				err:    err,
 			}
-			continue
-		}
-
-		for i := 0; i < len(coeffs); i++ {
-			coeffStore[i][j] = coeffs[i]
+		} else {
+			for i := 0; i < len(coeffs); i++ {
+				coeffStore[i][j] = coeffs[i]
+			}
 		}
 	}
 

--- a/encoding/kzg/prover/parametrized_prover.go
+++ b/encoding/kzg/prover/parametrized_prover.go
@@ -225,6 +225,7 @@ func (p *ParametrizedProver) proofWorker(
 				points: nil,
 				err:    err,
 			}
+			return
 		}
 
 		for i := 0; i < len(coeffs); i++ {

--- a/encoding/rs/encode.go
+++ b/encoding/rs/encode.go
@@ -164,12 +164,12 @@ func (g *Encoder) interpolyWorker(
 		err := rb.ReverseBitOrderFr(ys)
 		if err != nil {
 			results <- err
-			return
+			continue
 		}
 		coeffs, err := g.GetInterpolationPolyCoeff(ys, uint32(j))
 		if err != nil {
 			results <- err
-			return
+			continue
 		}
 
 		frames[k].Coeffs = coeffs

--- a/encoding/rs/encode.go
+++ b/encoding/rs/encode.go
@@ -164,10 +164,12 @@ func (g *Encoder) interpolyWorker(
 		err := rb.ReverseBitOrderFr(ys)
 		if err != nil {
 			results <- err
+			return
 		}
 		coeffs, err := g.GetInterpolationPolyCoeff(ys, uint32(j))
 		if err != nil {
 			results <- err
+			return
 		}
 
 		frames[k].Coeffs = coeffs

--- a/encoding/rs/encode.go
+++ b/encoding/rs/encode.go
@@ -118,33 +118,6 @@ func (g *Encoder) MakeFrames(
 		return nil, nil, fmt.Errorf("proof worker error: %v", err)
 	}
 
-	/*
-		for i := uint64(0); i < uint64(g.NumChunks); i++ {
-
-			// finds out which coset leader i-th node is having
-			j := rb.ReverseBitsLimited(uint32(g.NumChunks), uint32(i))
-
-			// mutltiprover return proof in butterfly order
-			frame := Frame{}
-			indices = append(indices, j)
-
-			ys := polyEvals[g.ChunkLength*i : g.ChunkLength*(i+1)]
-			err := rb.ReverseBitOrderFr(ys)
-			if err != nil {
-				return nil, nil, err
-			}
-			coeffs, err := g.GetInterpolationPolyCoeff(ys, uint32(j))
-			if err != nil {
-				return nil, nil, err
-			}
-
-			frame.Coeffs = coeffs
-
-			frames[k] = frame
-			k++
-		}
-	*/
-
 	return frames, indices, nil
 }
 

--- a/encoding/rs/encode.go
+++ b/encoding/rs/encode.go
@@ -73,7 +73,6 @@ func (g *Encoder) MakeFrames(
 	if err != nil {
 		return nil, nil, err
 	}
-	
 
 	indices := make([]uint32, 0)
 	frames := make([]Frame, g.NumChunks)
@@ -96,15 +95,12 @@ func (g *Encoder) MakeFrames(
 		)
 	}
 
-	k := uint64(0)
 	for i := uint64(0); i < g.NumChunks; i++ {
 		j := rb.ReverseBitsLimited(uint32(g.NumChunks), uint32(i))
 		jr := JobRequest{
-			Index:      uint64(i),
-			FrameIndex: k,
+			Index: i,
 		}
 		jobChan <- jr
-		k++
 		indices = append(indices, j)
 	}
 	close(jobChan)
@@ -147,8 +143,7 @@ func (g *Encoder) ExtendPolyEval(coeffs []fr.Element) ([]fr.Element, []fr.Elemen
 }
 
 type JobRequest struct {
-	Index      uint64
-	FrameIndex uint64
+	Index uint64
 }
 
 func (g *Encoder) interpolyWorker(
@@ -160,7 +155,6 @@ func (g *Encoder) interpolyWorker(
 
 	for jr := range jobChan {
 		i := jr.Index
-		k := jr.FrameIndex
 		j := rb.ReverseBitsLimited(uint32(g.NumChunks), uint32(i))
 		ys := polyEvals[g.ChunkLength*i : g.ChunkLength*(i+1)]
 		err := rb.ReverseBitOrderFr(ys)
@@ -174,7 +168,7 @@ func (g *Encoder) interpolyWorker(
 			continue
 		}
 
-		frames[k].Coeffs = coeffs
+		frames[i].Coeffs = coeffs
 	}
 
 	results <- nil

--- a/encoding/rs/encode.go
+++ b/encoding/rs/encode.go
@@ -56,8 +56,8 @@ func (g *Encoder) Encode(inputFr []fr.Element) (*GlobalPoly, []Frame, []uint32, 
 		return nil, nil, nil, err
 	}
 
-	log.Printf("  SUMMARY: Encode %v byte among %v numNode takes %v\n",
-		len(inputFr)*encoding.BYTES_PER_COEFFICIENT, g.NumChunks, time.Since(start))
+	log.Printf("  SUMMARY: RSEncode %v byte among %v numNode with chunkSize %v takes %v\n",
+		len(inputFr)*encoding.BYTES_PER_COEFFICIENT, g.NumChunks, g.ChunkLength, time.Since(start))
 
 	return poly, frames, indices, nil
 }

--- a/encoding/rs/encode.go
+++ b/encoding/rs/encode.go
@@ -2,6 +2,7 @@ package rs
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"time"
 

--- a/encoding/rs/encoder.go
+++ b/encoding/rs/encoder.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/encoding/fft"
-	//"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
 
 type Encoder struct {

--- a/encoding/rs/encoder.go
+++ b/encoding/rs/encoder.go
@@ -2,9 +2,11 @@ package rs
 
 import (
 	"math"
+	"runtime"
 
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/encoding/fft"
+	//"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
 
 type Encoder struct {
@@ -13,6 +15,8 @@ type Encoder struct {
 	Fs *fft.FFTSettings
 
 	verbose bool
+
+	NumRSWorker int
 }
 
 // The function creates a high level struct that determines the encoding the a data of a
@@ -37,6 +41,7 @@ func NewEncoder(params encoding.EncodingParams, verbose bool) (*Encoder, error) 
 		EncodingParams: params,
 		Fs:             fs,
 		verbose:        verbose,
+		NumRSWorker:    runtime.GOMAXPROCS(0),
 	}, nil
 
 }

--- a/encoding/rs/interpolation.go
+++ b/encoding/rs/interpolation.go
@@ -64,25 +64,18 @@ func (g *Encoder) GetInterpolationPolyEval(
 // Since both F W are invertible, c = W^-1 F^-1 d, convert it back. F W W^-1 F^-1 d = c
 func (g *Encoder) GetInterpolationPolyCoeff(chunk []fr.Element, k uint32) ([]fr.Element, error) {
 	coeffs := make([]fr.Element, g.ChunkLength)
-	//w := g.Fs.ExpandedRootsOfUnity[uint64(k)]
 	shiftedInterpolationPoly := make([]fr.Element, len(chunk))
 	err := g.Fs.InplaceFFT(chunk, shiftedInterpolationPoly, true)
 	if err != nil {
 		return coeffs, err
 	}
 
-	wInvPowLookup := make([]fr.Element, len(chunk))
-
 	mod := int32(len(g.Fs.ExpandedRootsOfUnity) - 1)
 
-	// We cam lookup the inverse power by counting RootOfUnity backward
-	for i := int32(0); i < int32(len(chunk)); i++ {
-		j := (-int32(k)*i)%mod + mod
-		wInvPowLookup[i] = g.Fs.ExpandedRootsOfUnity[j]
-	}
-
 	for i := 0; i < len(chunk); i++ {
-		coeffs[i].Mul(&shiftedInterpolationPoly[i], &wInvPowLookup[i])
+		// We cam lookup the inverse power by counting RootOfUnity backward
+		j := (-int32(k)*int32(i))%mod + mod
+		coeffs[i].Mul(&shiftedInterpolationPoly[i], &g.Fs.ExpandedRootsOfUnity[j])
 	}
 
 	return coeffs, nil

--- a/encoding/rs/interpolation.go
+++ b/encoding/rs/interpolation.go
@@ -73,7 +73,7 @@ func (g *Encoder) GetInterpolationPolyCoeff(chunk []fr.Element, k uint32) ([]fr.
 	mod := int32(len(g.Fs.ExpandedRootsOfUnity) - 1)
 
 	for i := 0; i < len(chunk); i++ {
-		// We cam lookup the inverse power by counting RootOfUnity backward
+		// We can lookup the inverse power by counting RootOfUnity backward
 		j := (-int32(k)*int32(i))%mod + mod
 		coeffs[i].Mul(&shiftedInterpolationPoly[i], &g.Fs.ExpandedRootsOfUnity[j])
 	}

--- a/encoding/rs/interpolation.go
+++ b/encoding/rs/interpolation.go
@@ -54,9 +54,9 @@ func (g *Encoder) GetInterpolationPolyEval(
 	//var tmp, tmp2 fr.Element
 	for i := 0; i < len(interpolationPoly); i++ {
 		shiftedInterpolationPoly[i].Mul(&interpolationPoly[i], &wPow)
-		
+
 		wPow.Mul(&wPow, &w)
-		
+
 	}
 
 	err := g.Fs.InplaceFFT(shiftedInterpolationPoly, evals, false)
@@ -74,18 +74,45 @@ func (g *Encoder) GetInterpolationPolyCoeff(chunk []fr.Element, k uint32) ([]fr.
 	}
 	var wPow fr.Element
 	wPow.SetOne()
-	
+
 	var tmp, tmp2 fr.Element
 	for i := 0; i < len(chunk); i++ {
 		tmp.Inverse(&wPow)
-		
+
 		tmp2.Mul(&shiftedInterpolationPoly[i], &tmp)
-		
+
 		coeffs[i].Set(&tmp2)
-		
+
 		tmp.Mul(&wPow, &w)
-		
+
 		wPow.Set(&tmp)
 	}
 	return coeffs, nil
 }
+
+/*
+// exp is the exponent for the entire fft inverse root of unity array
+func (g *Encoder) GetInvRootOfUnityArray(exp uint8) []fr.Element {
+	rous, ok := g.InvRootOfUnityTable[exp]
+	if !ok {
+		rous = g.CreateRootsOfUnityArray(exp)
+		g.InvRootOfUnityTable[exp] = rous
+	}
+	return rous
+}
+
+func (g *Encoder) CreateRootsOfUnityArray(exp uint8) []fr.Element {
+	w := g.Fs.ExpandedRootsOfUnity[uint64(k)]
+	for i := 0; i < len(chunk); i++ {
+		tmp.Inverse(&wPow)
+
+		tmp2.Mul(&shiftedInterpolationPoly[i], &tmp)
+
+		coeffs[i].Set(&tmp2)
+
+		tmp.Mul(&wPow, &w)
+
+		wPow.Set(&tmp)
+	}
+}
+*/


### PR DESCRIPTION
## Why are these changes needed?

This PR optimize encoder interpolation latency by

- parallelizing FFT computation in RS
- Removing computation of inverse Powers Of RootOfUnity by looking up an array backward

Previously, encoding 2MB data would take 2-3sec. After the change, the computation can be contained about 300ms

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
