### PR TITLE
Fix: Match wrapped errors

### DIFF
--- a/core/validator.go
+++ b/core/validator.go
@@ -132,7 +132,7 @@ func (v *chunkValidator) ValidateBatch(blobs []*BlobMessage, operatorState *Oper
 		// for each quorum
 		for _, quorumHeader := range blob.BlobHeader.QuorumInfos {
 			chunks, assignment, params, err := v.validateBlobQuorum(quorumHeader, blob, operatorState)
-			if err == ErrBlobQuorumSkip {
+			if errors.Is(err, ErrBlobQuorumSkip) {
 				continue
 			} else if err != nil {
 				return err

--- a/node/node.go
+++ b/node/node.go
@@ -303,7 +303,7 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 		if err != nil {
 			// If batch already exists, we don't store it again, but we should not
 			// error out in such case.
-			if err == ErrBatchAlreadyExist {
+			if errors.Is(err, ErrBatchAlreadyExist) {
 				storeChan <- storeResult{err: nil, keys: nil, latency: 0}
 			} else {
 				storeChan <- storeResult{err: fmt.Errorf("failed to store batch: %w", err), keys: nil, latency: 0}


### PR DESCRIPTION
## Why are these changes needed?
Match wrapped errors with `errors.Is()` instead of comparison with `==`
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
