### PR TITLE
Blob retrieval instructions in inabox README file

### DIFF
--- a/inabox/README.md
+++ b/inabox/README.md
@@ -153,6 +153,22 @@ TRACE[10-12|22:02:13.376] [batcher] AggregateSignatures took       duration=10.6
 TRACE[10-12|22:02:13.376] [batcher] Confirming batch...            caller=batcher.go:198
 ```
 
+Validate the blob was stored in a batch:
+
+```
+# Update the value of INSERT_REQUEST_ID with the result of your disperse call
+
+grpcurl -plaintext -d '{"request_id": "INSERT_REQUEST_ID"}' localhost:32003 disperser.Disperser/GetBlobStatus
+```
+
+Retrieve a blob:
+
+```
+# Note the value for batch_header_hash can be obtained from the result of your
+# call to GetBlobStatus via info.blob_verification_proof.batch_metadata.batch_header_hash.
+
+grpcurl -plaintext ./api/proto/disperser/disperser.proto -d '{"batch_header_hash": "INSERT_VALUE", "blob_index":"0"}' localhost:32003 disperser.Disperser/RetrieveBlob
+```
 ### Cleanup
 
 If you followed [Option 1](#option-1-simplest) above, you can run the following command in order to clean up the test infra:

--- a/inabox/README.md
+++ b/inabox/README.md
@@ -167,7 +167,7 @@ Retrieve a blob:
 # Note the value for batch_header_hash can be obtained from the result of your
 # call to GetBlobStatus via info.blob_verification_proof.batch_metadata.batch_header_hash.
 
-grpcurl -plaintext ./api/proto/disperser/disperser.proto -d '{"batch_header_hash": "INSERT_VALUE", "blob_index":"0"}' localhost:32003 disperser.Disperser/RetrieveBlob
+grpcurl -plaintext -d '{"batch_header_hash": "INSERT_VALUE", "blob_index":"0"}' localhost:32003 disperser.Disperser/RetrieveBlob
 ```
 ### Cleanup
 

--- a/inabox/README.md
+++ b/inabox/README.md
@@ -158,7 +158,7 @@ Validate the blob was stored in a batch:
 ```
 # Update the value of INSERT_REQUEST_ID with the result of your disperse call
 
-grpcurl -plaintext -d '{"request_id": "INSERT_REQUEST_ID"}' localhost:32003 disperser.Disperser/GetBlobStatus
+$ grpcurl -plaintext -d '{"request_id": "INSERT_REQUEST_ID"}' localhost:32003 disperser.Disperser/GetBlobStatus
 ```
 
 Retrieve a blob:
@@ -167,7 +167,7 @@ Retrieve a blob:
 # Note the value for batch_header_hash can be obtained from the result of your
 # call to GetBlobStatus via info.blob_verification_proof.batch_metadata.batch_header_hash.
 
-grpcurl -plaintext -d '{"batch_header_hash": "INSERT_VALUE", "blob_index":"0"}' localhost:32003 disperser.Disperser/RetrieveBlob
+$ grpcurl -plaintext -d '{"batch_header_hash": "INSERT_VALUE", "blob_index":"0"}' localhost:32003 disperser.Disperser/RetrieveBlob
 ```
 ### Cleanup
 


### PR DESCRIPTION
## Why are these changes needed?

The change in a README file in inabox directory was necessary in order to clarify that blobs dispersed to local eigenDA also can be retrieved. It will be useful for developers using the eidenDA for their projects. 

We can use GetBlobStatus to get info about the dispersed blob and then use RetrieveBlob to get data from the blob.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
