### PR TITLE
[5/N][multi quorum ejection] Compute num batches per quorum and block range

### DIFF
--- a/disperser/dataapi/nonsigner_utils.go
+++ b/disperser/dataapi/nonsigner_utils.go
@@ -193,7 +193,6 @@ func validateQuorumEvents(added []*OperatorQuorum, removed []*OperatorQuorum, st
 func ComputeNumBatches(intervals []*NumBatchesAtBlock, startBlock, endBlock uint32) int {
 	start := getLowerBoundIndex(intervals, startBlock)
 	end := getUpperBoundIndex(intervals, endBlock)
-	fmt.Println("XXX start:", start, "end:", end, "startBlock:", startBlock, "endBlock:", endBlock)
 	num := 0
 	if end > 0 {
 		num = intervals[end-1].AccuBatches
@@ -205,7 +204,7 @@ func ComputeNumBatches(intervals []*NumBatchesAtBlock, startBlock, endBlock uint
 }
 
 // CreatQuorumBatches returns quorumBatches, where quorumBatches[q] is a list of
-// NumBatchesAtBlocks in ascending by block number.
+// NumBatchesAtBlocks in ascending order by block number.
 func CreatQuorumBatches(batches []*BatchNonSigningInfo) map[uint8][]*NumBatchesAtBlock {
 	quorumBatchMap := make(map[uint8]map[uint32]int)
 	for _, batch := range batches {

--- a/disperser/dataapi/nonsigner_utils_test.go
+++ b/disperser/dataapi/nonsigner_utils_test.go
@@ -19,21 +19,12 @@ func TestCreateOperatorQuorumIntervalsWithInvalidArgs(t *testing.T) {
 	addedQuorums := map[string][]*dataapi.OperatorQuorum{}
 	removedQuorums := map[string][]*dataapi.OperatorQuorum{}
 
-	// Empty initial quorums
-	operatorInitialQuorum := map[string][]uint8{
-		"operator-1": {},
-		"operator-2": {0x01},
-	}
-	_, err := dataapi.CreateOperatorQuorumIntervals(10, 25, operatorInitialQuorum, addedQuorums, removedQuorums)
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "must be in at least one quorum"))
-
 	// StartBlock > EndBlock
-	operatorInitialQuorum = map[string][]uint8{
+	operatorInitialQuorum := map[string][]uint8{
 		"operator-1": {0x00},
 		"operator-2": {0x00},
 	}
-	_, err = dataapi.CreateOperatorQuorumIntervals(100, 25, operatorInitialQuorum, addedQuorums, removedQuorums)
+	_, err := dataapi.CreateOperatorQuorumIntervals(100, 25, operatorInitialQuorum, addedQuorums, removedQuorums)
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "endBlock must be no less than startBlock"))
 
@@ -388,4 +379,97 @@ func TestCreateOperatorQuorumIntervals(t *testing.T) {
 	assert.ElementsMatch(t, []uint8{0x00}, quorumIntervals.GetQuorums("operator-2", 20))
 	assert.ElementsMatch(t, []uint8{0x00, 0x02}, quorumIntervals.GetQuorums("operator-2", 22))
 	assert.ElementsMatch(t, []uint8{0x00, 0x02}, quorumIntervals.GetQuorums("operator-2", 25))
+}
+
+func TestComputeNumBatches(t *testing.T) {
+	intervals := []*dataapi.NumBatchesAtBlock{}
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(intervals, 1, 4))
+
+	intervals = []*dataapi.NumBatchesAtBlock{
+		{
+			BlockNumber: 5,
+			AccuBatches: 2,
+		},
+	}
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(intervals, 1, 4))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 1, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 5, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 5, 6))
+
+	intervals = []*dataapi.NumBatchesAtBlock{
+		{
+			BlockNumber: 5,
+			AccuBatches: 2,
+		},
+		{
+			BlockNumber: 10,
+			AccuBatches: 4,
+		},
+		{
+			BlockNumber: 15,
+			AccuBatches: 6,
+		},
+		{
+			BlockNumber: 20,
+			AccuBatches: 8,
+		},
+	}
+
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(intervals, 1, 4))
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(intervals, 21, 22))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 1, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 5, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 5, 9))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(intervals, 5, 10))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 6, 10))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(intervals, 5, 14))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 6, 14))
+	assert.Equal(t, 6, dataapi.ComputeNumBatches(intervals, 5, 15))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(intervals, 5, 20))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(intervals, 5, 22))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(intervals, 1, 22))
+	assert.Equal(t, 6, dataapi.ComputeNumBatches(intervals, 6, 22))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(intervals, 11, 22))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 16, 22))
+}
+
+func TestCreatQuorumBatches(t *testing.T) {
+	batchNonSigningInfo := []*dataapi.BatchNonSigningInfo{
+		{
+			QuorumNumbers:        []uint8{0, 1},
+			ReferenceBlockNumber: 2,
+		},
+		{
+			QuorumNumbers:        []uint8{0},
+			ReferenceBlockNumber: 2,
+		},
+		{
+			QuorumNumbers:        []uint8{1, 2},
+			ReferenceBlockNumber: 4,
+		},
+	}
+
+	quorumBatches := dataapi.CreatQuorumBatches(batchNonSigningInfo)
+
+	assert.Equal(t, 3, len(quorumBatches))
+
+	q0, ok := quorumBatches[0]
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(q0))
+	assert.Equal(t, uint32(2), q0[0].BlockNumber)
+	assert.Equal(t, 2, q0[0].AccuBatches)
+
+	q1, ok := quorumBatches[1]
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(q1))
+	assert.Equal(t, uint32(2), q1[0].BlockNumber)
+	assert.Equal(t, 1, q1[0].AccuBatches)
+	assert.Equal(t, uint32(4), q1[1].BlockNumber)
+	assert.Equal(t, 2, q1[1].AccuBatches)
+
+	q2, ok := quorumBatches[2]
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(q2))
+	assert.Equal(t, uint32(4), q2[0].BlockNumber)
+	assert.Equal(t, 1, q2[0].AccuBatches)
 }

--- a/disperser/dataapi/nonsigner_utils_test.go
+++ b/disperser/dataapi/nonsigner_utils_test.go
@@ -399,18 +399,22 @@ func TestComputeNumBatches(t *testing.T) {
 	intervals = []*dataapi.NumBatchesAtBlock{
 		{
 			BlockNumber: 5,
+			NumBatches:  2,
 			AccuBatches: 2,
 		},
 		{
 			BlockNumber: 10,
+			NumBatches:  2,
 			AccuBatches: 4,
 		},
 		{
 			BlockNumber: 15,
+			NumBatches:  2,
 			AccuBatches: 6,
 		},
 		{
 			BlockNumber: 20,
+			NumBatches:  2,
 			AccuBatches: 8,
 		},
 	}
@@ -434,6 +438,7 @@ func TestComputeNumBatches(t *testing.T) {
 }
 
 func TestCreatQuorumBatches(t *testing.T) {
+	// The nonsigning info for a list of batches.
 	batchNonSigningInfo := []*dataapi.BatchNonSigningInfo{
 		{
 			QuorumNumbers:        []uint8{0, 1},

--- a/disperser/dataapi/nonsigner_utils_test.go
+++ b/disperser/dataapi/nonsigner_utils_test.go
@@ -382,59 +382,66 @@ func TestCreateOperatorQuorumIntervals(t *testing.T) {
 }
 
 func TestComputeNumBatches(t *testing.T) {
-	intervals := []*dataapi.NumBatchesAtBlock{}
-	assert.Equal(t, 0, dataapi.ComputeNumBatches(intervals, 1, 4))
-
-	intervals = []*dataapi.NumBatchesAtBlock{
-		{
-			BlockNumber: 5,
-			AccuBatches: 2,
-		},
+	queryBatches := &dataapi.QueryBatches{
+		NumBatches:  []*dataapi.NumBatchesAtBlock{},
+		AccuBatches: []int{},
 	}
-	assert.Equal(t, 0, dataapi.ComputeNumBatches(intervals, 1, 4))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 1, 5))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 5, 5))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 5, 6))
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(queryBatches, 1, 4))
 
-	intervals = []*dataapi.NumBatchesAtBlock{
+	numBatches := []*dataapi.NumBatchesAtBlock{
 		{
 			BlockNumber: 5,
 			NumBatches:  2,
-			AccuBatches: 2,
+		},
+	}
+	queryBatches = &dataapi.QueryBatches{
+		NumBatches:  numBatches,
+		AccuBatches: []int{2},
+	}
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(queryBatches, 1, 4))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 1, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 5, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 5, 6))
+
+	numBatches = []*dataapi.NumBatchesAtBlock{
+		{
+			BlockNumber: 5,
+			NumBatches:  2,
 		},
 		{
 			BlockNumber: 10,
 			NumBatches:  2,
-			AccuBatches: 4,
 		},
 		{
 			BlockNumber: 15,
 			NumBatches:  2,
-			AccuBatches: 6,
 		},
 		{
 			BlockNumber: 20,
 			NumBatches:  2,
-			AccuBatches: 8,
 		},
 	}
+	queryBatches = &dataapi.QueryBatches{
+		NumBatches:  numBatches,
+		AccuBatches: []int{2, 4, 6, 8},
+	}
 
-	assert.Equal(t, 0, dataapi.ComputeNumBatches(intervals, 1, 4))
-	assert.Equal(t, 0, dataapi.ComputeNumBatches(intervals, 21, 22))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 1, 5))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 5, 5))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 5, 9))
-	assert.Equal(t, 4, dataapi.ComputeNumBatches(intervals, 5, 10))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 6, 10))
-	assert.Equal(t, 4, dataapi.ComputeNumBatches(intervals, 5, 14))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 6, 14))
-	assert.Equal(t, 6, dataapi.ComputeNumBatches(intervals, 5, 15))
-	assert.Equal(t, 8, dataapi.ComputeNumBatches(intervals, 5, 20))
-	assert.Equal(t, 8, dataapi.ComputeNumBatches(intervals, 5, 22))
-	assert.Equal(t, 8, dataapi.ComputeNumBatches(intervals, 1, 22))
-	assert.Equal(t, 6, dataapi.ComputeNumBatches(intervals, 6, 22))
-	assert.Equal(t, 4, dataapi.ComputeNumBatches(intervals, 11, 22))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(intervals, 16, 22))
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(queryBatches, 1, 4))
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(queryBatches, 21, 22))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 1, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 5, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 5, 9))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(queryBatches, 5, 10))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 6, 10))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(queryBatches, 5, 14))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 6, 14))
+	assert.Equal(t, 6, dataapi.ComputeNumBatches(queryBatches, 5, 15))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(queryBatches, 5, 20))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(queryBatches, 5, 22))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(queryBatches, 1, 22))
+	assert.Equal(t, 6, dataapi.ComputeNumBatches(queryBatches, 6, 22))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(queryBatches, 11, 22))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 16, 22))
 }
 
 func TestCreatQuorumBatches(t *testing.T) {
@@ -460,21 +467,21 @@ func TestCreatQuorumBatches(t *testing.T) {
 
 	q0, ok := quorumBatches[0]
 	assert.True(t, ok)
-	assert.Equal(t, 1, len(q0))
-	assert.Equal(t, uint32(2), q0[0].BlockNumber)
-	assert.Equal(t, 2, q0[0].AccuBatches)
+	assert.Equal(t, 1, len(q0.NumBatches))
+	assert.Equal(t, uint32(2), q0.NumBatches[0].BlockNumber)
+	assert.Equal(t, 2, q0.AccuBatches[0])
 
 	q1, ok := quorumBatches[1]
 	assert.True(t, ok)
-	assert.Equal(t, 2, len(q1))
-	assert.Equal(t, uint32(2), q1[0].BlockNumber)
-	assert.Equal(t, 1, q1[0].AccuBatches)
-	assert.Equal(t, uint32(4), q1[1].BlockNumber)
-	assert.Equal(t, 2, q1[1].AccuBatches)
+	assert.Equal(t, 2, len(q1.NumBatches))
+	assert.Equal(t, uint32(2), q1.NumBatches[0].BlockNumber)
+	assert.Equal(t, 1, q1.AccuBatches[0])
+	assert.Equal(t, uint32(4), q1.NumBatches[1].BlockNumber)
+	assert.Equal(t, 2, q1.AccuBatches[1])
 
 	q2, ok := quorumBatches[2]
 	assert.True(t, ok)
-	assert.Equal(t, 1, len(q2))
-	assert.Equal(t, uint32(4), q2[0].BlockNumber)
-	assert.Equal(t, 1, q2[0].AccuBatches)
+	assert.Equal(t, 1, len(q2.NumBatches))
+	assert.Equal(t, uint32(4), q2.NumBatches[0].BlockNumber)
+	assert.Equal(t, 1, q2.AccuBatches[0])
 }


### PR DESCRIPTION
## Why are these changes needed?
This is part of the work to compute operator nonsigning rate for ejection in multi quorum.

Roughly, this is the first 50% of step 4 in https://docs.google.com/document/d/13nxDXTAxRhT18qZrEkTtS2F7CxjlM0qA-2EGim1bu1k/edit (compute num batches a <operator, quorum> is responsible for)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
