### PR TITLE
[dataapi] Return total stakes by quorum

### DIFF
--- a/disperser/dataapi/metrics_handlers.go
+++ b/disperser/dataapi/metrics_handlers.go
@@ -69,6 +69,7 @@ func (s *server) getMetric(ctx context.Context, startTime int64, endTime int64, 
 	return &Metric{
 		Throughput:          troughput,
 		CostInGas:           costInGas,
+		TotalStake:          totalStakePerQuorum[0],
 		TotalStakePerQuorum: totalStakePerQuorum,
 	}, nil
 }

--- a/disperser/dataapi/metrics_handlers.go
+++ b/disperser/dataapi/metrics_handlers.go
@@ -35,7 +35,7 @@ func (s *server) getMetric(ctx context.Context, startTime int64, endTime int64, 
 		return nil, err
 	}
 	if len(operatorState.Operators) != int(quorumCount) {
-		return nil, fmt.Errorf("Requesting for %d quorum (quorumID=%v), but got %v", quorumCount, quorumIDs, operatorState.Operators)
+		return nil, fmt.Errorf("Requesting for %d quorums (quorumID=%v), but got %v", quorumCount, quorumIDs, operatorState.Operators)
 	}
 	totalStakePerQuorum := map[core.QuorumID]uint64{}
 	for quorumID, opInfoByID := range operatorState.Operators {
@@ -52,13 +52,13 @@ func (s *server) getMetric(ctx context.Context, startTime int64, endTime int64, 
 	var (
 		totalBytes   float64
 		timeDuration float64
-		troughput    float64
+		throughput   float64
 		valuesSize   = len(result.Values)
 	)
 	if valuesSize > 1 {
 		totalBytes = result.Values[valuesSize-1].Value - result.Values[0].Value
 		timeDuration = result.Values[valuesSize-1].Timestamp.Sub(result.Values[0].Timestamp).Seconds()
-		troughput = totalBytes / timeDuration
+		throughput = totalBytes / timeDuration
 	}
 
 	costInGas, err := s.calculateTotalCostGasUsed(ctx)
@@ -67,7 +67,7 @@ func (s *server) getMetric(ctx context.Context, startTime int64, endTime int64, 
 	}
 
 	return &Metric{
-		Throughput:          troughput,
+		Throughput:          throughput,
 		CostInGas:           costInGas,
 		TotalStake:          totalStakePerQuorum[0],
 		TotalStakePerQuorum: totalStakePerQuorum,

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -58,9 +58,9 @@ type (
 	}
 
 	Metric struct {
-		Throughput float64 `json:"throughput"`
-		CostInGas  float64 `json:"cost_in_gas"`
-		TotalStake uint64  `json:"total_stake"`
+		Throughput          float64                  `json:"throughput"`
+		CostInGas           float64                  `json:"cost_in_gas"`
+		TotalStakePerQuorum map[core.QuorumID]uint64 `json:"total_stake_per_quorum"`
 	}
 
 	Throughput struct {

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -58,8 +58,10 @@ type (
 	}
 
 	Metric struct {
-		Throughput          float64                  `json:"throughput"`
-		CostInGas           float64                  `json:"cost_in_gas"`
+		Throughput float64 `json:"throughput"`
+		CostInGas  float64 `json:"cost_in_gas"`
+		// deprecated: use TotalStakePerQuorum instead. Remove when the frontend is updated.
+		TotalStake          uint64                   `json:"total_stake"`
 		TotalStakePerQuorum map[core.QuorumID]uint64 `json:"total_stake_per_quorum"`
 	}
 

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -252,6 +252,7 @@ func TestFetchMetricsHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, 16555.555555555555, response.Throughput)
 	assert.Equal(t, float64(85.14485344239945), response.CostInGas)
+	assert.Equal(t, uint64(1), response.TotalStake)
 	assert.Len(t, response.TotalStakePerQuorum, 2)
 	assert.Equal(t, uint64(1), response.TotalStakePerQuorum[0])
 	assert.Equal(t, uint64(1), response.TotalStakePerQuorum[1])

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -228,8 +228,8 @@ func TestFetchMetricsHandler(t *testing.T) {
 	matrix := make(model.Matrix, 0)
 	matrix = append(matrix, s)
 	mockTx.On("GetCurrentBlockNumber").Return(uint32(1), nil)
+	mockTx.On("GetQuorumCount").Return(uint8(2), nil)
 	mockSubgraphApi.On("QueryBatches").Return(subgraphBatches, nil)
-	mockSubgraphApi.On("QueryOperators").Return(subgraphOperatorRegistereds, nil)
 	mockPrometheusApi.On("QueryRange").Return(matrix, nil, nil).Once()
 
 	r.GET("/v1/metrics", testDataApiServer.FetchMetricsHandler)
@@ -252,7 +252,9 @@ func TestFetchMetricsHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, 16555.555555555555, response.Throughput)
 	assert.Equal(t, float64(85.14485344239945), response.CostInGas)
-	assert.Equal(t, uint64(1), response.TotalStake)
+	assert.Len(t, response.TotalStakePerQuorum, 2)
+	assert.Equal(t, uint64(1), response.TotalStakePerQuorum[0])
+	assert.Equal(t, uint64(1), response.TotalStakePerQuorum[1])
 }
 
 func TestFetchMetricsTroughputHandler(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
Previously, `/metrics/` endpoint returned total stake for quorum 0. 
This PR updates it so that it returns total stake for each quorum in a map.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
