### PR TITLE
Create a json/text logger based on specified flag

### DIFF
--- a/common/aws/dynamodb/client_test.go
+++ b/common/aws/dynamodb/client_test.go
@@ -13,7 +13,6 @@ import (
 	commondynamodb "github.com/Layr-Labs/eigenda/common/aws/dynamodb"
 	test_utils "github.com/Layr-Labs/eigenda/common/aws/dynamodb/utils"
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -55,7 +54,11 @@ func setup(m *testing.M) {
 	}
 
 	loggerConfig := common.DefaultLoggerConfig()
-	logger := logging.NewSlogJsonLogger(loggerConfig.OutputWriter, &loggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(loggerConfig)
+	if err != nil {
+		teardown()
+		panic("failed to create logger")
+	}
 
 	clientConfig = commonaws.ClientConfig{
 		Region:          "us-east-1",
@@ -63,7 +66,7 @@ func setup(m *testing.M) {
 		SecretAccessKey: "localstack",
 		EndpointURL:     fmt.Sprintf("http://0.0.0.0:%s", localStackPort),
 	}
-	var err error
+
 	dynamoClient, err = commondynamodb.NewClient(clientConfig, logger)
 	if err != nil {
 		teardown()

--- a/common/logger_config.go
+++ b/common/logger_config.go
@@ -1,19 +1,30 @@
 package common
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 
+	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/urfave/cli"
 )
 
 const (
-	PathFlagName  = "log.path"
-	LevelFlagName = "log.level"
+	PathFlagName   = "log.path"
+	LevelFlagName  = "log.level"
+	FormatFlagName = "log.format"
+)
+
+type LogFormat string
+
+const (
+	JSONLogFormat LogFormat = "json"
+	TextLogFormat LogFormat = "text"
 )
 
 type LoggerConfig struct {
+	Format       LogFormat
 	OutputWriter io.Writer
 	HandlerOpts  slog.HandlerOptions
 }
@@ -32,11 +43,18 @@ func LoggerCLIFlags(envPrefix string, flagPrefix string) []cli.Flag {
 			Value:  "",
 			EnvVar: PrefixEnvVar(envPrefix, "LOG_PATH"),
 		},
+		cli.StringFlag{
+			Name:   PrefixFlag(flagPrefix, FormatFlagName),
+			Usage:  "The format of the log file. Accepted options are 'json' and 'text'",
+			Value:  "json",
+			EnvVar: PrefixEnvVar(envPrefix, "LOG_FORMAT"),
+		},
 	}
 }
 
 func DefaultLoggerConfig() LoggerConfig {
 	return LoggerConfig{
+		Format:       JSONLogFormat,
 		OutputWriter: os.Stdout,
 		HandlerOpts: slog.HandlerOptions{
 			AddSource: true,
@@ -47,6 +65,15 @@ func DefaultLoggerConfig() LoggerConfig {
 
 func ReadLoggerCLIConfig(ctx *cli.Context, flagPrefix string) (*LoggerConfig, error) {
 	cfg := DefaultLoggerConfig()
+	format := ctx.GlobalString(PrefixFlag(flagPrefix, FormatFlagName))
+	if format == "json" {
+		cfg.Format = JSONLogFormat
+	} else if format == "text" {
+		cfg.Format = TextLogFormat
+	} else {
+		return nil, fmt.Errorf("invalid log file format %s", format)
+	}
+
 	path := ctx.GlobalString(PrefixFlag(flagPrefix, PathFlagName))
 	if path != "" {
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
@@ -64,4 +91,14 @@ func ReadLoggerCLIConfig(ctx *cli.Context, flagPrefix string) (*LoggerConfig, er
 	cfg.HandlerOpts.Level = level
 
 	return &cfg, nil
+}
+
+func NewLogger(cfg LoggerConfig) (logging.Logger, error) {
+	if cfg.Format == JSONLogFormat {
+		return logging.NewSlogJsonLogger(cfg.OutputWriter, &cfg.HandlerOpts), nil
+	}
+	if cfg.Format == TextLogFormat {
+		return logging.NewSlogTextLogger(cfg.OutputWriter, &cfg.HandlerOpts), nil
+	}
+	return nil, fmt.Errorf("unknown log format: %s", cfg.Format)
 }

--- a/disperser/Makefile
+++ b/disperser/Makefile
@@ -56,8 +56,8 @@ run_encoder: build_encoder
   --kzg.cache-path ../inabox/resources/kzg/SRSTables \
   --kzg.srs-order 3000 \
   --kzg.num-workers 12 \
-  --disperser-encoder.log.level-std trace \
-  --disperser-encoder.log.level-file trace
+  --disperser-encoder.log.level-std debug \
+  --disperser-encoder.log.level-file debug
 
 run_dataapi_tests:
 	go test -v disperser/dataapi

--- a/disperser/cmd/apiserver/main.go
+++ b/disperser/cmd/apiserver/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/disperser/apiserver"
 	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 
 	"github.com/Layr-Labs/eigenda/common/aws/dynamodb"
 	"github.com/Layr-Labs/eigenda/common/aws/s3"
@@ -53,8 +52,10 @@ func RunDisperserServer(ctx *cli.Context) error {
 		return err
 	}
 
-	logger := logging.NewSlogJsonLogger(config.LoggerConfig.OutputWriter, &config.LoggerConfig.HandlerOpts)
-
+	logger, err := common.NewLogger(config.LoggerConfig)
+	if err != nil {
+		return err
+	}
 	client, err := geth.NewClient(config.EthClientConfig, logger)
 	if err != nil {
 		logger.Error("Cannot create chain.Client", "err", err)

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/shurcooL/graphql"
 
+	"github.com/Layr-Labs/eigenda/common"
 	coreindexer "github.com/Layr-Labs/eigenda/core/indexer"
 	"github.com/Layr-Labs/eigenda/core/thegraph"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 
 	"github.com/Layr-Labs/eigenda/common/aws/dynamodb"
 	"github.com/Layr-Labs/eigenda/common/aws/s3"
@@ -76,7 +76,10 @@ func RunBatcher(ctx *cli.Context) error {
 		return err
 	}
 
-	logger := logging.NewSlogJsonLogger(config.LoggerConfig.OutputWriter, &config.LoggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(config.LoggerConfig)
+	if err != nil {
+		return err
+	}
 
 	bucketName := config.BlobstoreConfig.BucketName
 	s3Client, err := s3.NewClient(context.Background(), config.AwsClientConfig, logger)

--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/aws/dynamodb"
 	"github.com/Layr-Labs/eigenda/common/aws/s3"
 	"github.com/Layr-Labs/eigenda/common/geth"
@@ -17,7 +18,6 @@ import (
 	"github.com/Layr-Labs/eigenda/disperser/dataapi"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi/prometheus"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi/subgraph"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/urfave/cli"
 )
 
@@ -55,7 +55,11 @@ func RunDataApi(ctx *cli.Context) error {
 		return err
 	}
 
-	logger := logging.NewSlogJsonLogger(config.LoggerConfig.OutputWriter, &config.LoggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(config.LoggerConfig)
+	if err != nil {
+		return err
+	}
+
 	s3Client, err := s3.NewClient(context.Background(), config.AwsClientConfig, logger)
 	if err != nil {
 		return err

--- a/disperser/cmd/encoder/main.go
+++ b/disperser/cmd/encoder/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/disperser/cmd/encoder/flags"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/urfave/cli"
 )
 
@@ -43,7 +43,11 @@ func RunEncoderServer(ctx *cli.Context) error {
 		return err
 	}
 
-	logger := logging.NewSlogJsonLogger(config.LoggerConfig.OutputWriter, &config.LoggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(config.LoggerConfig)
+	if err != nil {
+		return err
+	}
+
 	enc, err := NewEncoderGRPCServer(config, logger)
 	if err != nil {
 		return err

--- a/inabox/AnvilStateGen_README.md
+++ b/inabox/AnvilStateGen_README.md
@@ -54,8 +54,8 @@ services:
       CACHE_PATH: /data/kzg/SRSTables
       SRS_ORDER: 300000
       CHALLENGE_ORDER: 300000
-      STD_LOG_LEVEL: "trace"
-      FILE_LOG_LEVEL: "trace"
+      STD_LOG_LEVEL: "debug"
+      FILE_LOG_LEVEL: "debug"
       VERBOSE: true
       NUM_CONNECTIONS: 50
       AWS_ENDPOINT_URL:
@@ -138,8 +138,8 @@ services:
       CACHE_PATH: /data/kzg/SRSTables
       SRS_ORDER: 300000
       CHALLENGE_ORDER: 300000
-      STD_LOG_LEVEL: "trace"
-      FILE_LOG_LEVEL: "trace"
+      STD_LOG_LEVEL: "debug"
+      FILE_LOG_LEVEL: "debug"
       VERBOSE: true
       NUM_CONNECTIONS: 50
       AWS_ENDPOINT_URL:

--- a/inabox/templates/testconfig-anvil-docker.yaml
+++ b/inabox/templates/testconfig-anvil-docker.yaml
@@ -44,8 +44,8 @@ services:
       SRS_ORDER: 3000
       SRS_LOAD: 2900
       CHALLENGE_ORDER: 3000
-      STD_LOG_LEVEL: "trace"
-      FILE_LOG_LEVEL: "trace"
+      LOG_LEVEL: "debug"
+      LOG_FORMAT: "text"
       VERBOSE: true
       NUM_CONNECTIONS: 50
       AWS_ENDPOINT_URL: http://host.docker.internal:4570

--- a/inabox/templates/testconfig-anvil-nochurner.yaml
+++ b/inabox/templates/testconfig-anvil-nochurner.yaml
@@ -43,8 +43,8 @@ services:
       SRS_ORDER: 3000
       SRS_LOAD: 2900
       CHALLENGE_ORDER: 3000
-      STD_LOG_LEVEL: "trace"
-      FILE_LOG_LEVEL: "trace"
+      LOG_LEVEL: "debug"
+      LOG_FORMAT: "text"
       VERBOSE: true
       NUM_CONNECTIONS: 50
       AWS_ENDPOINT_URL: http://localhost:4570

--- a/inabox/templates/testconfig-anvil-nograph.yaml
+++ b/inabox/templates/testconfig-anvil-nograph.yaml
@@ -43,8 +43,8 @@ services:
       SRS_ORDER: 3000
       SRS_LOAD: 2900
       CHALLENGE_ORDER: 3000
-      STD_LOG_LEVEL: "trace"
-      FILE_LOG_LEVEL: "trace"
+      LOG_LEVEL: "debug"
+      LOG_FORMAT: "text"
       VERBOSE: true
       NUM_CONNECTIONS: 50
       AWS_ENDPOINT_URL: http://localhost:4570

--- a/inabox/templates/testconfig-anvil.yaml
+++ b/inabox/templates/testconfig-anvil.yaml
@@ -44,8 +44,8 @@ services:
       SRS_ORDER: 3000
       SRS_LOAD: 2900
       CHALLENGE_ORDER: 3000
-      STD_LOG_LEVEL: "trace"
-      FILE_LOG_LEVEL: "trace"
+      LOG_LEVEL: "debug"
+      LOG_FORMAT: "text"
       VERBOSE: true
       NUM_CONNECTIONS: 50
       AWS_ENDPOINT_URL: http://localhost:4570

--- a/inabox/templates/testconfig-docker-anvil.yaml
+++ b/inabox/templates/testconfig-docker-anvil.yaml
@@ -48,5 +48,6 @@ services:
       SRS_ORDER: 3000
       SRS_LOAD: 2000
       CHALLENGE_ORDER: 3000
-      STD_LOG_LEVEL: "trace"
+      LOG_LEVEL: "debug"
+      LOG_FORMAT: "text"
       VERBOSE: true

--- a/inabox/templates/testconfig-geth.yaml
+++ b/inabox/templates/testconfig-geth.yaml
@@ -35,5 +35,6 @@ services:
       SRS_ORDER: 3000
       SRS_LOAD: 3000
       CHALLENGE_ORDER: 3000
-      STD_LOG_LEVEL: "trace"
+      LOG_LEVEL: "debug"
+      LOG_FORMAT: "text"
       VERBOSE: true

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -112,7 +112,8 @@ var _ = BeforeSuite(func() {
 		testConfig.StartBinaries()
 	}
 	loggerConfig := common.DefaultLoggerConfig()
-	logger = logging.NewSlogTextLogger(loggerConfig.OutputWriter, &loggerConfig.HandlerOpts)
+	logger, err = common.NewLogger(loggerConfig)
+	Expect(err).To(BeNil())
 
 	pk := testConfig.Pks.EcdsaMap["default"].PrivateKey
 	pk = strings.TrimPrefix(pk, "0x")

--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common/pubip"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 
 	"github.com/urfave/cli"
 
@@ -50,7 +49,11 @@ func NodeMain(ctx *cli.Context) error {
 		return err
 	}
 
-	logger := logging.NewSlogTextLogger(config.LoggingConfig.OutputWriter, &config.LoggingConfig.HandlerOpts)
+	logger, err := common.NewLogger(config.LoggerConfig)
+	if err != nil {
+		return err
+	}
+
 	pubIPProvider := pubip.ProviderOrDefault(config.PubIPProvider)
 
 	// Create the node.

--- a/node/config.go
+++ b/node/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	UseSecureGrpc                 bool
 
 	EthClientConfig geth.EthClientConfig
-	LoggingConfig   common.LoggerConfig
+	LoggerConfig    common.LoggerConfig
 	EncoderConfig   kzg.KzgConfig
 }
 
@@ -162,7 +162,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		PrivateBls:                    privateBls,
 		EthClientConfig:               ethClientConfig,
 		EncoderConfig:                 kzg.ReadCLIConfig(ctx),
-		LoggingConfig:                 *loggerConfig,
+		LoggerConfig:                  *loggerConfig,
 		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
 		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
 		PubIPProvider:                 ctx.GlobalString(flags.PubIPProviderFlag.Name),

--- a/node/grpc/server_test.go
+++ b/node/grpc/server_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Layr-Labs/eigenda/encoding/kzg/verifier"
 	"github.com/Layr-Labs/eigenda/node"
 	"github.com/Layr-Labs/eigenda/node/grpc"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/metrics"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	"github.com/prometheus/client_golang/prometheus"
@@ -86,7 +85,11 @@ func newTestServer(t *testing.T, mockValidator bool) *grpc.Server {
 		NumBatchValidators:        runtime.GOMAXPROCS(0),
 	}
 	loggerConfig := common.DefaultLoggerConfig()
-	logger := logging.NewSlogTextLogger(loggerConfig.OutputWriter, &loggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(loggerConfig)
+	if err != nil {
+		panic("failed to create a logger")
+	}
+
 	err = os.MkdirAll(config.DbPath, os.ModePerm)
 	if err != nil {
 		panic("failed to create a directory for db")

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Layr-Labs/eigenda/node"
 	"github.com/Layr-Labs/eigenda/node/plugin"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/urfave/cli"
 )
 
@@ -77,7 +76,11 @@ func pluginOps(ctx *cli.Context) {
 	log.Printf("Info: ECDSA key read and decrypted from %s", config.EcdsaKeyFile)
 
 	loggerConfig := common.DefaultLoggerConfig()
-	logger := logging.NewSlogJsonLogger(loggerConfig.OutputWriter, &loggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(loggerConfig)
+	if err != nil {
+		log.Printf("Error: failed to create logger: %v", err)
+		return
+	}
 
 	ethConfig := geth.EthClientConfig{
 		RPCURL:           config.ChainRpcUrl,

--- a/node/plugin/tests/plugin_test.go
+++ b/node/plugin/tests/plugin_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
 	"github.com/Layr-Labs/eigenda/node/plugin"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -199,8 +198,8 @@ func getOperatorId(t *testing.T, operator deploy.OperatorVars) [32]byte {
 	assert.NoError(t, err)
 	assert.NotNil(t, privateKey)
 	loggerConfig := common.DefaultLoggerConfig()
-	logger := logging.NewSlogJsonLogger(loggerConfig.OutputWriter, &loggerConfig.HandlerOpts)
-	assert.NotNil(t, logger)
+	logger, err := common.NewLogger(loggerConfig)
+	assert.NoError(t, err)
 
 	ethConfig := geth.EthClientConfig{
 		RPCURL:           operator.NODE_CHAIN_RPC,
@@ -233,8 +232,8 @@ func getOperatorId(t *testing.T, operator deploy.OperatorVars) [32]byte {
 func getTransactor(t *testing.T, operator deploy.OperatorVars) *eth.Transactor {
 	hexPk := strings.TrimPrefix(testConfig.Pks.EcdsaMap[testConfig.Deployers[0].Name].PrivateKey, "0x")
 	loggerConfig := common.DefaultLoggerConfig()
-	logger := logging.NewSlogJsonLogger(loggerConfig.OutputWriter, &loggerConfig.HandlerOpts)
-	assert.NotNil(t, logger)
+	logger, err := common.NewLogger(loggerConfig)
+	assert.NoError(t, err)
 
 	ethConfig := geth.EthClientConfig{
 		RPCURL:           operator.NODE_CHAIN_RPC,

--- a/operators/churner/cmd/main.go
+++ b/operators/churner/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	pb "github.com/Layr-Labs/eigenda/api/grpc/churner"
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/geth"
 	"github.com/Layr-Labs/eigenda/common/healthcheck"
 	"github.com/Layr-Labs/eigenda/core/eth"
@@ -14,7 +15,6 @@ import (
 	"github.com/Layr-Labs/eigenda/core/thegraph"
 	"github.com/Layr-Labs/eigenda/operators/churner"
 	"github.com/Layr-Labs/eigenda/operators/churner/flags"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
@@ -63,7 +63,10 @@ func run(ctx *cli.Context) error {
 	if err != nil {
 		log.Fatalf("failed to parse the command line flags: %v", err)
 	}
-	logger := logging.NewSlogJsonLogger(config.LoggerConfig.OutputWriter, &config.LoggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(config.LoggerConfig)
+	if err != nil {
+		log.Fatalf("failed to create logger: %v", err)
+	}
 
 	log.Println("Starting geth client")
 	gethClient, err := geth.NewClient(config.EthClientConfig, logger)

--- a/retriever/cmd/main.go
+++ b/retriever/cmd/main.go
@@ -9,6 +9,7 @@ import (
 
 	pb "github.com/Layr-Labs/eigenda/api/grpc/retriever"
 	"github.com/Layr-Labs/eigenda/clients"
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/geth"
 	"github.com/Layr-Labs/eigenda/common/healthcheck"
 	"github.com/Layr-Labs/eigenda/core"
@@ -19,7 +20,6 @@ import (
 	"github.com/Layr-Labs/eigenda/retriever"
 	retrivereth "github.com/Layr-Labs/eigenda/retriever/eth"
 	"github.com/Layr-Labs/eigenda/retriever/flags"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli"
@@ -72,7 +72,10 @@ func RetrieverMain(ctx *cli.Context) error {
 	if err != nil {
 		log.Fatalf("failed to parse the command line flags: %v", err)
 	}
-	logger := logging.NewSlogJsonLogger(config.LoggerConfig.OutputWriter, &config.LoggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(config.LoggerConfig)
+	if err != nil {
+		log.Fatalf("failed to create logger: %v", err)
+	}
 
 	nodeClient := clients.NewNodeClient(config.Timeout)
 	v, err := verifier.NewVerifier(&config.EncoderConfig, false)

--- a/test/synthetic-test/synthetic_client_test.go
+++ b/test/synthetic-test/synthetic_client_test.go
@@ -116,7 +116,12 @@ func setUpClients(pk string, rpcUrl string, mockRollUpContractAddress string, re
 	}
 
 	loggerConfig := common.DefaultLoggerConfig()
-	ethLogger := logging.NewSlogJsonLogger(loggerConfig.OutputWriter, &loggerConfig.HandlerOpts)
+	ethLogger, err := common.NewLogger(loggerConfig)
+	if err != nil {
+		logger.Printf("Error: %v", err)
+		return nil
+	}
+
 	pk = strings.TrimPrefix(pk, "0X")
 	pk = strings.TrimPrefix(pk, "0x")
 	ethClient, err := geth.NewClient(geth.EthClientConfig{

--- a/tools/traffic/generator.go
+++ b/tools/traffic/generator.go
@@ -24,7 +24,10 @@ type TrafficGenerator struct {
 
 func NewTrafficGenerator(config *Config) (*TrafficGenerator, error) {
 	loggerConfig := common.DefaultLoggerConfig()
-	logger := logging.NewSlogJsonLogger(loggerConfig.OutputWriter, &loggerConfig.HandlerOpts)
+	logger, err := common.NewLogger(loggerConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	return &TrafficGenerator{
 		Logger:          logger,


### PR DESCRIPTION
## Why are these changes needed?
#323 should have kept the log format flags so that it can create json/text logger based on the specified flag.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
