### PR TITLE
simplify mock rollup

### DIFF
--- a/contracts/script/MockRollupDeployer.s.sol
+++ b/contracts/script/MockRollupDeployer.s.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
+
 pragma solidity ^0.8.9;
 
 import "forge-std/Script.sol";
@@ -11,27 +12,22 @@ contract MockRollupDeployer is Script {
     MockRollup public mockRollup;
 
     BN254.G1Point public s1 = BN254.generatorG1().scalar_mul(2);
-    uint256 public illegalValue = 1555;
     
-    // forge script script/MockRollupDeployer.s.sol:MockRollupDeployer --sig "run(address, bytes32, uint256)" <DASM address> <security hash> <stake> --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvvv
-    // <security hash> = keccak256(abi.encode(blobHeader.quorumBlobParams))
-    function run(address _eigenDAServiceManager, uint256 _stakeRequired) external {
+    // forge script script/MockRollupDeployer.s.sol:MockRollupDeployer --sig "run(address)" <DASM address> --rpc-url $RPC_URL --private-key $PRIVATE_KEY -vvvv // --broadcast
+    function run(address _eigenDAServiceManager) external {
         vm.startBroadcast();
 
         mockRollup = new MockRollup(
             IEigenDAServiceManager(_eigenDAServiceManager),
-            s1,
-            illegalValue,
-            _stakeRequired
+            s1
         );
+
+        vm.stopBroadcast();
 
         string memory output = "eigenDA mock rollup deployment output";
         vm.serializeAddress(output, "mockRollup", address(mockRollup));
-
         string memory finalJson = vm.serializeString(output, "object", output);
-
         vm.createDir("./script/output", true);
         vm.writeJson(finalJson, "./script/output/mock_rollup_deploy_output.json");
-        vm.stopBroadcast();
     }
 }

--- a/contracts/src/rollup/MockRollup.sol
+++ b/contracts/src/rollup/MockRollup.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-
 pragma solidity ^0.8.9;
 
 import {EigenDARollupUtils} from "../libraries/EigenDARollupUtils.sol";
@@ -8,47 +7,26 @@ import {IEigenDAServiceManager} from "../interfaces/IEigenDAServiceManager.sol";
 import {BN254} from "eigenlayer-middleware/libraries/BN254.sol";
 
 struct Commitment {
-    address validator; // validator who posted the commitment
+    address confirmer; // confirmer who posted the commitment
     uint32 dataLength; // length of the data
     BN254.G1Point polynomialCommitment; // commitment to the polynomial
 }
 
-/**
- * @title MockRollup
- * @author Layr Labs, Inc.
- * @notice This contract is used to emulate a rollup contract for the purpose of testing the rollup interface.
- */
 contract MockRollup {
-    
+
     IEigenDAServiceManager public eigenDAServiceManager; // EigenDASM contract
     BN254.G1Point public tau; //power of tau
-    uint256 public illegalValue; // special "illegal" value that should not be included in blob
-    uint256 public stakeRequired; // amount of stake required to register as a validator
 
-    ///@notice mapping of validators who have registered
-    mapping(address => bool) public validators;
-    ///@notice mapping of validators who have been blacklisted
-    mapping(address => bool) public blacklist;
     ///@notice mapping of timestamps to commitments
     mapping(uint256 => Commitment) public commitments;
 
-    constructor(IEigenDAServiceManager _eigenDAServiceManager, BN254.G1Point memory _tau, uint256 _illegalValue, uint256 _stakeRequired) {
+    constructor(IEigenDAServiceManager _eigenDAServiceManager, BN254.G1Point memory _tau) {
         eigenDAServiceManager = _eigenDAServiceManager;
         tau = _tau;
-        illegalValue = _illegalValue;
-        stakeRequired = _stakeRequired;
-    }
-
-    ///@notice registers msg.sender as validator by putting up 1 ether of stake
-    function registerValidator() external payable {
-        require(msg.value == stakeRequired, "MockRollup.registerValidator: Must send stake required to register");
-        require(!validators[msg.sender], "MockRollup.registerValidator: Validator already registered");
-        require(!blacklist[msg.sender], "MockRollup.registerValidator: Validator blacklisted");
-        validators[msg.sender] = true;
     }
 
     /**
-     * @notice a function for validators to post a commitment to a blob on behalf of the rollup
+     * @notice a function for a confirmer to post a commitment to a blob and verfiy it on EigenDA
      * @param blobHeader the blob header
      * @param blobVerificationProof the blob verification proof
      */
@@ -56,39 +34,33 @@ contract MockRollup {
         IEigenDAServiceManager.BlobHeader memory blobHeader, 
         EigenDARollupUtils.BlobVerificationProof memory blobVerificationProof
     ) external { 
-        require(validators[msg.sender], "MockRollup.postCommitment: Validator not registered");
-        require(commitments[block.timestamp].validator == address(0), "MockRollup.postCommitment: Commitment already posted");
+        // require commitment has not already been posted
+        require(commitments[block.timestamp].confirmer == address(0), "MockRollup.postCommitment: Commitment already posted");
 
         // verify that the blob was included in the batch
         EigenDARollupUtils.verifyBlob(blobHeader, eigenDAServiceManager, blobVerificationProof);
 
+        // store the commitment
         commitments[block.timestamp] = Commitment(msg.sender, blobHeader.dataLength, blobHeader.commitment);
     }
 
     /**
-     * @notice a function for users to challenge a commitment that contains the illegal value
+     * @notice a function for users to challenge a commitment against a provided value
      * @param timestamp the timestamp of the commitment being challenged
      * @param point the point on the polynomial to evaluate
      * @param proof revelvant KZG proof 
+     * @param challengeValue The value expected upon opening the commitment
      */
-    function challengeCommitment(uint256 timestamp, uint256 point, BN254.G2Point memory proof) external {
+    function challengeCommitment(uint256 timestamp, uint256 point, BN254.G2Point memory proof, uint256 challengeValue) external returns (bool) {
         Commitment memory commitment = commitments[timestamp];
-        require(commitment.validator != address(0), "MockRollup.challengeCommitment: Commitment not posted");
+        // require the commitment exists
+        require(commitment.confirmer != address(0), "MockRollup.challengeCommitment: Commitment not posted");
 
         // point on the polynomial must be less than the length of the data stored
         require(point < commitment.dataLength, "MockRollup.challengeCommitment: Point must be less than data length");
 
-        // verify that the commitment contains the illegal value
-        require(EigenDARollupUtils.openCommitment(point, illegalValue, tau, commitment.polynomialCommitment, proof), "MockRollup.challengeCommitment: Does not evaluate to illegal value");
-            
-        // blacklist the validator
-        validators[commitment.validator] = false;
-        blacklist[commitment.validator] = true;
-
-        // send validators stake to the user who challenged the commitment
-        (bool success, ) = msg.sender.call{value: 1 ether}("");
-        require(success);
-        
+        // verify that the commitment contains the challenge value
+        return EigenDARollupUtils.openCommitment(point, challengeValue, tau, commitment.polynomialCommitment, proof);
     }
 
 }


### PR DESCRIPTION
## Why are these changes needed?

Removes unneeded parts of the mock rollup to simplify testing of blob verification

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
