### PR TITLE
Fix create s3 bucket failed in local env

### DIFF
--- a/inabox/deploy/localstack.go
+++ b/inabox/deploy/localstack.go
@@ -105,7 +105,7 @@ func DeployResources(pool *dockertest.Pool, localStackPort, metadataTableName, b
 	changeDirectory(filepath.Join(rootPath, "inabox"))
 	if err := pool.Retry(func() error {
 		fmt.Println("Creating S3 bucket")
-		return execCmd("./create-s3-bucket.sh", []string{}, []string{fmt.Sprintf("AWS_URL=http://0.0.0.0:%s", localStackPort)})
+		return execCmd("./create-s3-bucket.sh", []string{}, []string{fmt.Sprintf("AWS_URL=http://localhost:%s", localStackPort)})
 	}); err != nil {
 		fmt.Println("Could not connect to docker:", err)
 		return err
@@ -115,7 +115,7 @@ func DeployResources(pool *dockertest.Pool, localStackPort, metadataTableName, b
 		Region:          "us-east-1",
 		AccessKey:       "localstack",
 		SecretAccessKey: "localstack",
-		EndpointURL:     fmt.Sprintf("http://0.0.0.0:%s", localStackPort),
+		EndpointURL:     fmt.Sprintf("http://localhost:%s", localStackPort),
 	}
 	_, err := test_utils.CreateTable(context.Background(), cfg, metadataTableName, blobstore.GenerateTableSchema(metadataTableName, 10, 10))
 	if err != nil {


### PR DESCRIPTION
Change to accessing the local loopback address.

## Why are these changes needed?

fix bug:  https://github.com/Layr-Labs/eigenda/issues/342

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
