### PR TITLE
update latestServeUntilBlock

### DIFF
--- a/contracts/src/core/EigenDAServiceManager.sol
+++ b/contracts/src/core/EigenDAServiceManager.sol
@@ -139,9 +139,9 @@ contract EigenDAServiceManager is EigenDAServiceManagerStorage, ServiceManagerBa
         return batchId;
     }
 
-    /// @notice Returns the block until which operators must serve.
-    function latestServeUntilBlock() external view returns (uint32) {
-        return uint32(block.number) + STORE_DURATION_BLOCKS + BLOCK_STALE_MEASURE;
+    /// @notice Given the current block number, returns the block until which operators must serve.
+    function latestServeUntilBlock(uint32 currentBlockNumber) external view returns (uint32) {
+        return currentBlockNumber + STORE_DURATION_BLOCKS + BLOCK_STALE_MEASURE;
     }
 
 }

--- a/contracts/src/interfaces/IEigenDAServiceManager.sol
+++ b/contracts/src/interfaces/IEigenDAServiceManager.sol
@@ -79,8 +79,8 @@ interface IEigenDAServiceManager is IServiceManager {
     /// @notice Returns the current batchId
     function taskNumber() external view returns (uint32);
 
-    /// @notice Returns the block until which operators must serve.
-    function latestServeUntilBlock() external view returns (uint32);
+    /// @notice Given the current block number, returns the block until which operators must serve.
+    function latestServeUntilBlock(uint32 currentBlockNumber) external view returns (uint32);
 
     /// @notice The maximum amount of blocks in the past that the service will consider stake amounts to still be 'valid'.
     function BLOCK_STALE_MEASURE() external view returns (uint32);


### PR DESCRIPTION
allows one to pass in the current block number opposed to reading block.number

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
