### PR TITLE
Validate gRPC requests earlier

### DIFF
--- a/contracts/src/core/EigenDAServiceManagerStorage.sol
+++ b/contracts/src/core/EigenDAServiceManagerStorage.sol
@@ -26,25 +26,27 @@ abstract contract EigenDAServiceManagerStorage is IEigenDAServiceManager {
      */
     uint32 public constant BLOCK_STALE_MEASURE = 150;
 
-    /** 
-     * @notice The quorum adversary threshold percentages stored as an ordered bytes array 
-     * this is the percentage of the total stake that must be adversarial to consider a blob invalid
+    /**
+     * @notice The quorum adversary threshold percentages stored as an ordered bytes array
+     * this is the percentage of the total stake that must be adversarial to consider a blob invalid.
+     * The first byte is the threshold for quorum 0, the second byte is the threshold for quorum 1, etc.
      */
     bytes public constant quorumAdversaryThresholdPercentages = hex"2121";
 
-    /** 
-     * @notice The quorum confirmation threshold percentages stored as an ordered bytes array 
-     * this is the percentage of the total stake needed to confirm a blob
+    /**
+     * @notice The quorum confirmation threshold percentages stored as an ordered bytes array
+     * this is the percentage of the total stake needed to confirm a blob.
+     * The first byte is the threshold for quorum 0, the second byte is the threshold for quorum 1, etc.
      */
     bytes public constant quorumConfirmationThresholdPercentages = hex"4242";
 
-    /** 
-     * @notice The quorum numbers required for confirmation stored as an ordered bytes array 
+    /**
+     * @notice The quorum numbers required for confirmation stored as an ordered bytes array
      * these quorum numbers have respective canonical thresholds in the
-     * quorumConfirmationThresholdPercentages and quorumAdversaryThresholdPercentages above
+     * quorumConfirmationThresholdPercentages and quorumAdversaryThresholdPercentages above.
      */
     bytes public constant quorumNumbersRequired = hex"0001";
-    
+
     /// @notice The current batchId
     uint32 public batchId;
 
@@ -54,8 +56,7 @@ abstract contract EigenDAServiceManagerStorage is IEigenDAServiceManager {
     /// @notice address that is permissioned to confirm batches
     address public batchConfirmer;
 
-     // storage gap for upgradeability
-     // slither-disable-next-line shadowing-state
-     uint256[47] private __GAP;
-
+    // storage gap for upgradeability
+    // slither-disable-next-line shadowing-state
+    uint256[47] private __GAP;
 }

--- a/core/data.go
+++ b/core/data.go
@@ -75,17 +75,15 @@ type BlobRequestHeader struct {
 	SecurityParams []*SecurityParam `json:"security_params"`
 }
 
-func (h *BlobRequestHeader) Validate() error {
-	for _, quorum := range h.SecurityParams {
-		if quorum.ConfirmationThreshold < quorum.AdversaryThreshold+10 {
-			return errors.New("invalid request: quorum threshold must be >= 10 + adversary threshold")
-		}
-		if quorum.ConfirmationThreshold > 100 {
-			return errors.New("invalid request: quorum threshold exceeds 100")
-		}
-		if quorum.AdversaryThreshold == 0 {
-			return errors.New("invalid request: adversary threshold equals 0")
-		}
+func (sp *SecurityParam) Validate() error {
+	if sp.ConfirmationThreshold < sp.AdversaryThreshold+10 {
+		return errors.New("invalid request: quorum threshold must be >= 10 + adversary threshold")
+	}
+	if sp.ConfirmationThreshold > 100 {
+		return errors.New("invalid request: quorum threshold exceeds 100")
+	}
+	if sp.AdversaryThreshold == 0 {
+		return errors.New("invalid request: adversary threshold equals 0")
 	}
 	return nil
 }

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -686,7 +686,7 @@ func (t *Transactor) GetQuorumCount(ctx context.Context, blockNumber uint32) (ui
 	})
 }
 
-func (t *Transactor) GetQuorumSecurityParams(ctx context.Context, blockNumber uint32) ([]*core.SecurityParam, error) {
+func (t *Transactor) GetQuorumSecurityParams(ctx context.Context, blockNumber uint32) ([]core.SecurityParam, error) {
 	adversaryThresholdPercentegesBytes, err := t.Bindings.EigenDAServiceManager.QuorumAdversaryThresholdPercentages(&bind.CallOpts{
 		Context:     ctx,
 		BlockNumber: big.NewInt(int64(blockNumber)),
@@ -707,10 +707,10 @@ func (t *Transactor) GetQuorumSecurityParams(ctx context.Context, blockNumber ui
 		return nil, errors.New("adversaryThresholdPercentegesBytes and confirmationThresholdPercentegesBytes have different lengths")
 	}
 
-	securityParams := make([]*core.SecurityParam, len(adversaryThresholdPercentegesBytes))
+	securityParams := make([]core.SecurityParam, len(adversaryThresholdPercentegesBytes))
 
 	for i := range adversaryThresholdPercentegesBytes {
-		securityParams[i] = &core.SecurityParam{
+		securityParams[i] = core.SecurityParam{
 			QuorumID:              core.QuorumID(i),
 			AdversaryThreshold:    adversaryThresholdPercentegesBytes[i],
 			ConfirmationThreshold: confirmationThresholdPercentegesBytes[i],

--- a/core/mock/tx.go
+++ b/core/mock/tx.go
@@ -171,10 +171,10 @@ func (t *MockTransactor) GetQuorumCount(ctx context.Context, blockNumber uint32)
 	return result.(uint8), args.Error(1)
 }
 
-func (t *MockTransactor) GetQuorumSecurityParams(ctx context.Context, blockNumber uint32) ([]*core.SecurityParam, error) {
+func (t *MockTransactor) GetQuorumSecurityParams(ctx context.Context, blockNumber uint32) ([]core.SecurityParam, error) {
 	args := t.Called()
 	result := args.Get(0)
-	return result.([]*core.SecurityParam), args.Error(1)
+	return result.([]core.SecurityParam), args.Error(1)
 }
 
 func (t *MockTransactor) GetRequiredQuorumNumbers(ctx context.Context, blockNumber uint32) ([]uint8, error) {

--- a/core/tx.go
+++ b/core/tx.go
@@ -131,7 +131,7 @@ type Transactor interface {
 	GetQuorumCount(ctx context.Context, blockNumber uint32) (uint8, error)
 
 	// GetQuorumSecurityParams returns the security params for the registered quorums.
-	GetQuorumSecurityParams(ctx context.Context, blockNumber uint32) ([]*SecurityParam, error)
+	GetQuorumSecurityParams(ctx context.Context, blockNumber uint32) ([]SecurityParam, error)
 
 	// GetRequiredQuorumNumbers returns set of required quorum numbers
 	GetRequiredQuorumNumbers(ctx context.Context, blockNumber uint32) ([]QuorumID, error)

--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -70,7 +70,7 @@ func TestDisperseBlobWithRequiredQuorums(t *testing.T) {
 	transactor := &mock.MockTransactor{}
 	transactor.On("GetCurrentBlockNumber").Return(uint32(100), nil)
 	transactor.On("GetQuorumCount").Return(uint8(2), nil)
-	quorumParams := []*core.SecurityParam{
+	quorumParams := []core.SecurityParam{
 		{QuorumID: 0, AdversaryThreshold: 80, ConfirmationThreshold: 100},
 		{QuorumID: 1, AdversaryThreshold: 80, ConfirmationThreshold: 100},
 	}
@@ -349,7 +349,7 @@ func setup(m *testing.M) {
 	transactor := &mock.MockTransactor{}
 	transactor.On("GetCurrentBlockNumber").Return(uint32(100), nil)
 	transactor.On("GetQuorumCount").Return(uint8(2), nil)
-	quorumParams := []*core.SecurityParam{
+	quorumParams := []core.SecurityParam{
 		{QuorumID: 0, AdversaryThreshold: 80, ConfirmationThreshold: 100},
 		{QuorumID: 1, AdversaryThreshold: 80, ConfirmationThreshold: 100},
 	}


### PR DESCRIPTION
## Why are these changes needed?
Moving the validation earlier in the execution flow will have with resource consumption
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
