### PR TITLE
Remove the update-quorums command support

### DIFF
--- a/node/operator.go
+++ b/node/operator.go
@@ -103,22 +103,6 @@ func DeregisterOperator(ctx context.Context, KeyPair *core.KeyPair, transactor c
 	return transactor.DeregisterOperator(ctx, KeyPair.GetPubKeyG1(), blockNumber)
 }
 
-// UpdateOperatorQuorums updates the quorums for the given operator
-func UpdateOperatorQuorums(
-	ctx context.Context,
-	operator *Operator,
-	transactor core.Transactor,
-	churnerUrl string,
-	useSecureGrpc bool,
-	logger logging.Logger,
-) error {
-	err := DeregisterOperator(ctx, operator.KeyPair, transactor)
-	if err != nil {
-		return fmt.Errorf("failed to deregister operator: %w", err)
-	}
-	return RegisterOperator(ctx, operator, transactor, churnerUrl, useSecureGrpc, logger)
-}
-
 // UpdateOperatorSocket updates the socket for the given operator
 func UpdateOperatorSocket(ctx context.Context, transactor core.Transactor, socket string) error {
 	return transactor.UpdateOperatorSocket(ctx, socket)

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -141,14 +141,6 @@ func pluginOps(ctx *cli.Context) {
 			return
 		}
 		log.Printf("Info: successfully opt-out the EigenDA, for operator ID: %x, operator address: %x", operatorID, sk.Address)
-	} else if config.Operation == "update-quorums" {
-		log.Printf("Info: Operator with Operator Address: %x is updating its quorums: %v", sk.Address, config.QuorumIDList)
-		err = node.UpdateOperatorQuorums(context.Background(), operator, tx, config.ChurnerUrl, true, logger)
-		if err != nil {
-			log.Printf("Error: failed to update quorums for operator ID: %x, operator address: %x, quorums: %v, error: %v", operatorID, sk.Address, config.QuorumIDList, err)
-			return
-		}
-		log.Printf("Info: successfully updated quorums, for operator ID: %x, operator address: %x, socket: %s, and quorums: %v", operatorID, sk.Address, config.Socket, config.QuorumIDList)
 	} else if config.Operation == "update-socket" {
 		log.Printf("Info: Operator with Operator Address: %x is updating its socket: %s", sk.Address, config.Socket)
 		err = node.UpdateOperatorSocket(context.Background(), tx, config.Socket)

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -25,7 +25,7 @@ var (
 	OperationFlag = cli.StringFlag{
 		Name:     "operation",
 		Required: true,
-		Usage:    "Supported operations: opt-in, opt-out, update-quorums",
+		Usage:    "Supported operations: opt-in, opt-out",
 		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "OPERATION"),
 	}
 
@@ -133,7 +133,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	}
 
 	op := ctx.GlobalString(OperationFlag.Name)
-	if op != "opt-in" && op != "opt-out" && op != "update-quorums" {
+	if op != "opt-in" && op != "opt-out" {
 		return nil, errors.New("unsupported operation type")
 	}
 

--- a/node/plugin/tests/plugin_test.go
+++ b/node/plugin/tests/plugin_test.go
@@ -147,19 +147,6 @@ func TestPluginOptInAndQuorumUpdate(t *testing.T) {
 	ids, err := tx.GetNumberOfRegisteredOperatorForQuorum(context.Background(), core.QuorumID(0))
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(1), ids)
-
-	registeredQuorumIds, err = tx.GetRegisteredQuorumIdsForOperator(context.Background(), operatorID)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(registeredQuorumIds))
-	assert.Equal(t, uint8(1), registeredQuorumIds[0])
-
-	ids, err = tx.GetNumberOfRegisteredOperatorForQuorum(context.Background(), core.QuorumID(0))
-	assert.NoError(t, err)
-	assert.Equal(t, uint32(0), ids)
-
-	ids, err = tx.GetNumberOfRegisteredOperatorForQuorum(context.Background(), core.QuorumID(1))
-	assert.NoError(t, err)
-	assert.Equal(t, uint32(1), ids)
 }
 
 func TestPluginInvalidOperation(t *testing.T) {

--- a/node/plugin/tests/plugin_test.go
+++ b/node/plugin/tests/plugin_test.go
@@ -148,9 +148,6 @@ func TestPluginOptInAndQuorumUpdate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(1), ids)
 
-	operator.NODE_QUORUM_ID_LIST = "1"
-	testConfig.RunNodePluginBinary("update-quorums", operator)
-
 	registeredQuorumIds, err = tx.GetRegisteredQuorumIdsForOperator(context.Background(), operatorID)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(registeredQuorumIds))


### PR DESCRIPTION
## Why are these changes needed?
We'll settle on just two commands (with revamped semantics) "opt-in"/"opt-out", based on users feedback.

A separate PR will revamp "opt-in"/"opt-out", and then fix the operator setup repo.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
