### PR TITLE
Handle uint8 overflow

### DIFF
--- a/core/auth/authenticator.go
+++ b/core/auth/authenticator.go
@@ -30,7 +30,7 @@ func (*authenticator) AuthenticateBlobRequest(header core.BlobAuthHeader) error 
 	sig := header.AuthenticationData
 
 	// Ensure the signature is 65 bytes (Recovery ID is the last byte)
-	if sig == nil || len(sig) != 65 {
+	if len(sig) != 65 {
 		return fmt.Errorf("signature length is unexpected: %d", len(sig))
 	}
 

--- a/core/data.go
+++ b/core/data.go
@@ -76,7 +76,7 @@ type BlobRequestHeader struct {
 }
 
 func (sp *SecurityParam) Validate() error {
-	if sp.ConfirmationThreshold < sp.AdversaryThreshold+10 {
+	if sp.ConfirmationThreshold < sp.AdversaryThreshold || sp.ConfirmationThreshold-sp.AdversaryThreshold < 10 {
 		return errors.New("invalid request: quorum threshold must be >= 10 + adversary threshold")
 	}
 	if sp.ConfirmationThreshold > 100 {


### PR DESCRIPTION
## Why are these changes needed?
Handle int overflow when validating security params
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
