### PR TITLE
Fix: Construct a new map for security params

### DIFF
--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -600,9 +600,7 @@ func (s *DispersalServer) updateQuorumConfig(ctx context.Context) (QuorumConfig,
 			return QuorumConfig{}, err
 		}
 	} else {
-		if newConfig.SecurityParams == nil {
-			newConfig.SecurityParams = make(map[core.QuorumID]core.SecurityParam)
-		}
+		newConfig.SecurityParams = make(map[core.QuorumID]core.SecurityParam)
 		for _, sp := range securityParams {
 			newConfig.SecurityParams[sp.QuorumID] = sp
 		}


### PR DESCRIPTION
## Why are these changes needed?
`newConfig.SecurityParams` is the same object as `s.quorumConfig.SecurityParams`. Instead of overriding existing map, create a new map.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
