### PR TITLE
Handle bitmap lookup for nonexistent operators

### DIFF
--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -582,7 +582,7 @@ func (t *Transactor) GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Contex
 	type BitmapIndexOrError struct {
 		bitmapIndex int
 		// The index is referring to the position of operator in operatorIds slice,
-		// i.e. the bitmap here (if err is nil) is for operatorIds[index].
+		// i.e. the bitmapIndex here is for operatorIds[index].
 		index int
 		err   error
 	}

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -600,6 +600,7 @@ func (t *Transactor) GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Contex
 				// set the bitmap index to -1, so we could continue to get results for other
 				// operators.
 				indexChan <- BitmapIndexOrError{bitmapIndex: -1, index: i, err: err}
+				t.Logger.Info("Failed to get bitmap index for operator", "operatorId", id.Hex(), "err", err)
 			} else {
 				indexChan <- BitmapIndexOrError{bitmapIndex: int(result[0]), index: i, err: err}
 			}

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -577,16 +577,40 @@ func (t *Transactor) GetCurrentQuorumBitmapByOperatorId(ctx context.Context, ope
 }
 
 func (t *Transactor) GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Context, operatorIds []core.OperatorID, blockNumber uint32) ([]*big.Int, error) {
-	// Get indices in batch (1 RPC).
-	byteOperatorIds := make([][32]byte, len(operatorIds))
-	for i := range operatorIds {
-		byteOperatorIds[i] = [32]byte(operatorIds[i])
+	// Get the bitmap indices for all the given operators.
+	type BitmapIndexOrError struct {
+		bitmapIndex int
+		index       int
+		err         error
 	}
-	quorumBitmapIndices, err := t.Bindings.RegistryCoordinator.GetQuorumBitmapIndicesAtBlockNumber(&bind.CallOpts{
-		Context: ctx,
-	}, blockNumber, byteOperatorIds)
-	if err != nil {
-		return nil, err
+	indexChan := make(chan BitmapIndexOrError, len(operatorIds))
+	indexPool := workerpool.New(maxNumWorkerPoolThreads)
+	for i, id := range operatorIds {
+		i := i
+		byteId := [32]byte(id)
+		indexPool.Submit(func() {
+			result, err := t.Bindings.RegistryCoordinator.GetQuorumBitmapIndicesAtBlockNumber(&bind.CallOpts{
+				Context: ctx,
+			}, blockNumber, [][32]byte{byteId})
+			if err != nil || len(result) != -1 {
+				// If the bitmap index isn't found for an operator, instead of erroring out,
+				// set the bitmap index to -1, so we could continue to get results for other
+				// operators.
+				indexChan <- BitmapIndexOrError{bitmapIndex: -1, index: i, err: err}
+			} else {
+				indexChan <- BitmapIndexOrError{bitmapIndex: int(result[0]), index: i, err: err}
+			}
+		})
+	}
+	indexPool.StopWait()
+	close(indexChan)
+	quorumBitmapIndices := make([]int, len(operatorIds))
+	for result := range indexChan {
+		if result.err != nil {
+			quorumBitmapIndices[result.index] = -1
+		} else {
+			quorumBitmapIndices[result.index] = result.bitmapIndex
+		}
 	}
 
 	// Get bitmaps in N RPCs, but in parallel.
@@ -604,6 +628,10 @@ func (t *Transactor) GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Contex
 		bitmapIndex := bitmapIndex
 		op := operatorIds[i]
 		pool.Submit(func() {
+			if bitmapIndex == -1 {
+				resultChan <- BitmapOrError{bitmap: nil, index: i, err: errors.New("no bitmap found for operator")}
+				return
+			}
 			bm, err := t.Bindings.RegistryCoordinator.GetQuorumBitmapAtBlockNumberByIndex(&bind.CallOpts{
 				Context: ctx,
 			}, op, blockNumber, big.NewInt(int64(bitmapIndex)))
@@ -616,9 +644,10 @@ func (t *Transactor) GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Contex
 	bitmaps := make([]*big.Int, len(quorumBitmapIndices))
 	for result := range resultChan {
 		if result.err != nil {
-			return nil, result.err
+			bitmaps[result.index] = big.NewInt(0)
+		} else {
+			bitmaps[result.index] = result.bitmap
 		}
-		bitmaps[result.index] = result.bitmap
 	}
 	return bitmaps, nil
 }

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -595,7 +595,7 @@ func (t *Transactor) GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Contex
 			result, err := t.Bindings.RegistryCoordinator.GetQuorumBitmapIndicesAtBlockNumber(&bind.CallOpts{
 				Context: ctx,
 			}, blockNumber, [][32]byte{byteId})
-			if err != nil || len(result) != -1 {
+			if err != nil || len(result) != 1 {
 				// If the bitmap index isn't found for an operator, instead of erroring out,
 				// set the bitmap index to -1, so we could continue to get results for other
 				// operators.

--- a/core/tx.go
+++ b/core/tx.go
@@ -101,11 +101,9 @@ type Transactor interface {
 	// GetCurrentQuorumBitmapByOperatorId returns the current quorum bitmap for the operator.
 	GetCurrentQuorumBitmapByOperatorId(ctx context.Context, operatorId OperatorID) (*big.Int, error)
 
-	// GetQuorumBitmapForOperatorsAtBlockNumber returns the quorum bitmaps for the operators
-	// at the given block number.
-	// The result slice will be of same length as "operatorIds", with the i-th entry be the
-	// result for the operatorIds[i]. If an operator failed to find bitmap, the corresponding
-	// result entry will be an empty bitmap.
+	// GetQuorumBitmapForOperatorsAtBlockNumber returns the quorum bitmaps for the operators at the given block number.
+	// The result slice will be of same length as "operatorIds", with the i-th entry be the result for the operatorIds[i].
+	// If an operator failed to find bitmap, the corresponding result entry will be an empty bitmap.
 	GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Context, operatorIds []OperatorID, blockNumber uint32) ([]*big.Int, error)
 
 	// GetOperatorSetParams returns operator set params for the quorum.

--- a/core/tx.go
+++ b/core/tx.go
@@ -103,7 +103,10 @@ type Transactor interface {
 
 	// GetQuorumBitmapForOperatorsAtBlockNumber returns the quorum bitmaps for the operators
 	// at the given block number.
-	GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Context, operatorId []OperatorID, blockNumber uint32) ([]*big.Int, error)
+	// The result slice will be of same length as "operatorIds", with the i-th entry be the
+	// result for the operatorIds[i]. If an operator failed to find bitmap, the corresponding
+	// result entry will be an empty bitmap.
+	GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Context, operatorIds []OperatorID, blockNumber uint32) ([]*big.Int, error)
 
 	// GetOperatorSetParams returns operator set params for the quorum.
 	GetOperatorSetParams(ctx context.Context, quorumID QuorumID) (*OperatorSetParam, error)

--- a/disperser/dataapi/nonsigner_utils.go
+++ b/disperser/dataapi/nonsigner_utils.go
@@ -112,7 +112,7 @@ func CreateOperatorQuorumIntervals(
 				}
 				i++
 			} else {
-				if err := removeQuorums(removed[j], openQuorum, operatorQuorumIntervals); err != nil {
+				if err := removeQuorums(op, removed[j], openQuorum, operatorQuorumIntervals); err != nil {
 					return nil, err
 				}
 				j++
@@ -127,7 +127,7 @@ func CreateOperatorQuorumIntervals(
 			}
 		}
 		for ; j < len(removed); j++ {
-			if err := removeQuorums(removed[j], openQuorum, operatorQuorumIntervals); err != nil {
+			if err := removeQuorums(op, removed[j], openQuorum, operatorQuorumIntervals); err != nil {
 				return nil, err
 			}
 		}
@@ -148,29 +148,28 @@ func CreateOperatorQuorumIntervals(
 
 // removeQuorums handles a quorum removal event, which marks the end of membership in a quorum,
 // so it'll form a block interval.
-func removeQuorums(operatorQuorum *OperatorQuorum, openQuorum map[uint8]uint32, result OperatorQuorumIntervals) error {
-	op := operatorQuorum.Operator
+func removeQuorums(operatorId string, operatorQuorum *OperatorQuorum, openQuorum map[uint8]uint32, result OperatorQuorumIntervals) error {
 	for _, q := range operatorQuorum.QuorumNumbers {
 		start, ok := openQuorum[q]
 		if !ok {
 			msg := "cannot remove a quorum %d, the operator %s is not yet in the quorum " +
 				"at block number %d"
-			return fmt.Errorf(msg, q, op, operatorQuorum.BlockNumber)
+			return fmt.Errorf(msg, q, operatorId, operatorQuorum.BlockNumber)
 		}
 		if start >= operatorQuorum.BlockNumber {
 			msg := "deregistration block number %d must be strictly greater than its " +
 				"registration block number %d, for operator %s, quorum %d"
-			return fmt.Errorf(msg, operatorQuorum.BlockNumber, start, op, q)
+			return fmt.Errorf(msg, operatorQuorum.BlockNumber, start, operatorId, q)
 		}
 		interval := BlockInterval{
 			StartBlock: start,
 			// The operator is NOT live at the block it's deregistered.
 			EndBlock: operatorQuorum.BlockNumber - 1,
 		}
-		if _, ok = result[op][q]; !ok {
-			result[op][q] = make([]BlockInterval, 0)
+		if _, ok = result[operatorId][q]; !ok {
+			result[operatorId][q] = make([]BlockInterval, 0)
 		}
-		result[op][q] = append(result[op][q], interval)
+		result[operatorId][q] = append(result[operatorId][q], interval)
 		delete(openQuorum, q)
 	}
 	return nil


### PR DESCRIPTION
## Why are these changes needed?
The `GetQuorumBitmapIndicesAtBlockNumber` will revert if any of the operator is not found, and hence fail all the operators.

This PR goes back to use single RPC call for each operator to handle this issue.

Ideally, the smart contract APIs should have better error handling, e.g. distinguishing between NOT_FOUND and real error.

Tested: ran this for the entire history since V2 contracts. It turned out not a big perf cost.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
