### PR TITLE
Return transact opts for non-pk EthClient

### DIFF
--- a/common/fireblocks_config.go
+++ b/common/fireblocks_config.go
@@ -9,6 +9,7 @@ const (
 	FireblocksAPISecretPathFlagName    = "fireblocks-api-secret-path"
 	FireblocksBaseURLFlagName          = "fireblocks-api-url"
 	FireblocksVaultAccountNameFlagName = "fireblocks-vault-account-name"
+	FireblocksWalletAddressFlagName    = "fireblocks-wallet-address"
 )
 
 type FireblocksConfig struct {
@@ -16,6 +17,7 @@ type FireblocksConfig struct {
 	SecretKeyPath    string
 	BaseURL          string
 	VaultAccountName string
+	WalletAddress    string
 }
 
 func FireblocksCLIFlags(envPrefix string, flagPrefix string) []cli.Flag {
@@ -44,6 +46,12 @@ func FireblocksCLIFlags(envPrefix string, flagPrefix string) []cli.Flag {
 			Required: false,
 			EnvVar:   PrefixEnvVar(envPrefix, "FIREBLOCKS_VAULT_ACCOUNT_NAME"),
 		},
+		cli.StringFlag{
+			Name:     PrefixFlag(flagPrefix, FireblocksWalletAddressFlagName),
+			Usage:    "Fireblocks Wallet Address. To configure Fireblocks MPC wallet, this field is required. Otherwise, private key must be configured in eth client so that it can fall back to private key wallet.",
+			Required: false,
+			EnvVar:   PrefixEnvVar(envPrefix, "FIREBLOCKS_WALLET_ADDRESS"),
+		},
 	}
 }
 
@@ -53,5 +61,6 @@ func ReadFireblocksCLIConfig(ctx *cli.Context, flagPrefix string) FireblocksConf
 		SecretKeyPath:    ctx.GlobalString(PrefixFlag(flagPrefix, FireblocksAPISecretPathFlagName)),
 		BaseURL:          ctx.GlobalString(PrefixFlag(flagPrefix, FireblocksBaseURLFlagName)),
 		VaultAccountName: ctx.GlobalString(PrefixFlag(flagPrefix, FireblocksVaultAccountNameFlagName)),
+		WalletAddress:    ctx.GlobalString(PrefixFlag(flagPrefix, FireblocksWalletAddressFlagName)),
 	}
 }

--- a/common/geth/instrumented_client.go
+++ b/common/geth/instrumented_client.go
@@ -32,7 +32,7 @@ type InstrumentedEthClient struct {
 var _ common.EthClient = (*InstrumentedEthClient)(nil)
 
 func NewInstrumentedEthClient(config EthClientConfig, rpcCallsCollector *rpccalls.Collector, logger logging.Logger) (*InstrumentedEthClient, error) {
-	ethClient, err := NewClient(config, logger)
+	ethClient, err := NewClient(config, gethcommon.Address{}, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/core/indexer/state_test.go
+++ b/core/indexer/state_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -78,7 +79,7 @@ func mustMakeOperatorTransactor(env *deploy.Config, op deploy.OperatorVars, logg
 		NumConfirmations: 0,
 	}
 
-	c, err := geth.NewClient(config, logger)
+	c, err := geth.NewClient(config, gethcommon.Address{}, logger)
 	Expect(err).ToNot(HaveOccurred())
 
 	tx, err := eth.NewTransactor(logger, c, op.NODE_BLS_OPERATOR_STATE_RETRIVER, op.NODE_EIGENDA_SERVICE_MANAGER)
@@ -98,7 +99,7 @@ func mustMakeTestClients(env *deploy.Config, privateKey string, logger logging.L
 		NumConfirmations: 0,
 	}
 
-	client, err := geth.NewClient(config, logger)
+	client, err := geth.NewClient(config, gethcommon.Address{}, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/core/thegraph/state_integration_test.go
+++ b/core/thegraph/state_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core/thegraph"
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/shurcooL/graphql"
 	"github.com/stretchr/testify/assert"
 )
@@ -109,7 +110,7 @@ func mustMakeTestClient(t *testing.T, env *deploy.Config, privateKey string, log
 		NumConfirmations: 0,
 	}
 
-	client, err := geth.NewClient(config, logger)
+	client, err := geth.NewClient(config, gethcommon.Address{}, logger)
 	assert.NoError(t, err)
 	return client
 }

--- a/disperser/cmd/apiserver/main.go
+++ b/disperser/cmd/apiserver/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core/eth"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/disperser/cmd/apiserver/flags"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli"
 )
 
@@ -56,7 +57,7 @@ func RunDisperserServer(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	client, err := geth.NewClient(config.EthClientConfig, logger)
+	client, err := geth.NewClient(config.EthClientConfig, gethcommon.Address{}, logger)
 	if err != nil {
 		logger.Error("Cannot create chain.Client", "err", err)
 		return err

--- a/disperser/cmd/batcher/config.go
+++ b/disperser/cmd/batcher/config.go
@@ -37,12 +37,20 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	ethClientConfig := geth.ReadEthClientConfig(ctx)
+	fireblocksConfig := common.ReadFireblocksCLIConfig(ctx, flags.FlagPrefix)
+	if len(fireblocksConfig.APIKey) > 0 &&
+		len(fireblocksConfig.SecretKeyPath) > 0 &&
+		len(fireblocksConfig.BaseURL) > 0 &&
+		len(fireblocksConfig.VaultAccountName) > 0 {
+		ethClientConfig = geth.ReadEthClientConfigRPCOnly(ctx)
+	}
 	config := Config{
 		BlobstoreConfig: blobstore.Config{
 			BucketName: ctx.GlobalString(flags.S3BucketNameFlag.Name),
 			TableName:  ctx.GlobalString(flags.DynamoDBTableNameFlag.Name),
 		},
-		EthClientConfig: geth.ReadEthClientConfig(ctx),
+		EthClientConfig: ethClientConfig,
 		AwsClientConfig: aws.ReadClientConfig(ctx, flags.FlagPrefix),
 		EncoderConfig:   kzg.ReadCLIConfig(ctx),
 		LoggerConfig:    *loggerConfig,
@@ -76,7 +84,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
 		IndexerDataDir:                ctx.GlobalString(flags.IndexerDataDirFlag.Name),
 		IndexerConfig:                 indexer.ReadIndexerConfig(ctx),
-		FireblocksConfig:              common.ReadFireblocksCLIConfig(ctx, flags.FlagPrefix),
+		FireblocksConfig:              fireblocksConfig,
 	}
 	return config, nil
 }

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/fireblocks"
 	walletsdk "github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
 	"github.com/Layr-Labs/eigensdk-go/signerv2"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/urfave/cli"
@@ -102,7 +103,7 @@ func RunBatcher(ctx *cli.Context) error {
 	}, logger)
 	asgn := &core.StdAssignmentCoordinator{}
 
-	client, err := geth.NewClient(config.EthClientConfig, logger)
+	client, err := geth.NewClient(config.EthClientConfig, gethcommon.HexToAddress(config.FireblocksConfig.WalletAddress), logger)
 	if err != nil {
 		logger.Error("Cannot create chain.Client", "err", err)
 		return err
@@ -171,7 +172,8 @@ func RunBatcher(ctx *cli.Context) error {
 	if len(config.FireblocksConfig.APIKey) > 0 &&
 		len(config.FireblocksConfig.SecretKeyPath) > 0 &&
 		len(config.FireblocksConfig.BaseURL) > 0 &&
-		len(config.FireblocksConfig.VaultAccountName) > 0 {
+		len(config.FireblocksConfig.VaultAccountName) > 0 &&
+		len(config.FireblocksConfig.WalletAddress) > 0 {
 		secretKey, err := os.ReadFile(config.FireblocksConfig.SecretKeyPath)
 		if err != nil {
 			return fmt.Errorf("cannot read fireblocks secret from %s: %w", config.FireblocksConfig.SecretKeyPath, err)
@@ -190,6 +192,14 @@ func RunBatcher(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
+		sender, err := wallet.SenderAddress(context.Background())
+		if err != nil {
+			return err
+		}
+		if sender.Cmp(gethcommon.HexToAddress(config.FireblocksConfig.WalletAddress)) != 0 {
+			return fmt.Errorf("configured wallet address %s does not match derived address %s", config.FireblocksConfig.WalletAddress, sender.Hex())
+		}
+		logger.Info("Initialized Fireblocks wallet", "vaultAccountName", config.FireblocksConfig.VaultAccountName, "address", sender.Hex())
 	} else if len(config.EthClientConfig.PrivateKeyString) > 0 {
 		privateKey, err := crypto.HexToECDSA(config.EthClientConfig.PrivateKeyString)
 		if err != nil {

--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Layr-Labs/eigenda/disperser/dataapi"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi/prometheus"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi/subgraph"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli"
 )
 
@@ -75,7 +76,7 @@ func RunDataApi(ctx *cli.Context) error {
 		return err
 	}
 
-	client, err := geth.NewClient(config.EthClientConfig, logger)
+	client, err := geth.NewClient(config.EthClientConfig, gethcommon.Address{}, logger)
 	if err != nil {
 		return err
 	}

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -122,7 +122,7 @@ var _ = BeforeSuite(func() {
 		RPCURL:           testConfig.Deployers[0].RPC,
 		PrivateKeyString: pk,
 		NumConfirmations: numConfirmations,
-	}, logger)
+	}, gcommon.Address{}, logger)
 	Expect(err).To(BeNil())
 	rpcClient, err = ethrpc.Dial(testConfig.Deployers[0].RPC)
 	Expect(err).To(BeNil())
@@ -138,7 +138,7 @@ func setupRetrievalClient(testConfig *deploy.Config) error {
 		PrivateKeyString: "351b8eca372e64f64d514f90f223c5c4f86a04ff3dcead5c27293c547daab4ca", // just random private key
 		NumConfirmations: numConfirmations,
 	}
-	client, err := geth.NewClient(ethClientConfig, logger)
+	client, err := geth.NewClient(ethClientConfig, gcommon.Address{}, logger)
 	if err != nil {
 		return err
 	}

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Layr-Labs/eigenda/node"
 	"github.com/Layr-Labs/eigenda/node/plugin"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli"
 )
 
@@ -87,7 +88,7 @@ func pluginOps(ctx *cli.Context) {
 		PrivateKeyString: *privateKey,
 		NumConfirmations: config.NumConfirmations,
 	}
-	client, err := geth.NewClient(ethConfig, logger)
+	client, err := geth.NewClient(ethConfig, gethcommon.Address{}, logger)
 	if err != nil {
 		log.Printf("Error: failed to create eth client: %v", err)
 		return

--- a/node/plugin/tests/plugin_test.go
+++ b/node/plugin/tests/plugin_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
 	"github.com/Layr-Labs/eigenda/node/plugin"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -190,7 +191,7 @@ func getOperatorId(t *testing.T, operator deploy.OperatorVars) [32]byte {
 		PrivateKeyString: *privateKey,
 	}
 
-	client, err := geth.NewClient(ethConfig, logger)
+	client, err := geth.NewClient(ethConfig, gethcommon.Address{}, logger)
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 
@@ -225,7 +226,7 @@ func getTransactor(t *testing.T, operator deploy.OperatorVars) *eth.Transactor {
 		NumConfirmations: 0,
 	}
 
-	client, err := geth.NewClient(ethConfig, logger)
+	client, err := geth.NewClient(ethConfig, gethcommon.Address{}, logger)
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 

--- a/operators/churner/cmd/main.go
+++ b/operators/churner/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core/thegraph"
 	"github.com/Layr-Labs/eigenda/operators/churner"
 	"github.com/Layr-Labs/eigenda/operators/churner/flags"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
@@ -69,7 +70,7 @@ func run(ctx *cli.Context) error {
 	}
 
 	log.Println("Starting geth client")
-	gethClient, err := geth.NewClient(config.EthClientConfig, logger)
+	gethClient, err := geth.NewClient(config.EthClientConfig, gethcommon.Address{}, logger)
 	if err != nil {
 		log.Fatalln("could not start tcp listener", err)
 	}

--- a/operators/churner/tests/churner_test.go
+++ b/operators/churner/tests/churner_test.go
@@ -193,7 +193,7 @@ func createTransactorFromScratch(privateKey, operatorStateRetriever, serviceMana
 		NumConfirmations: 0,
 	}
 
-	gethClient, err := geth.NewClient(ethClientCfg, logger)
+	gethClient, err := geth.NewClient(ethClientCfg, gethcommon.Address{}, logger)
 	if err != nil {
 		log.Fatalln("could not start tcp listener", err)
 	}

--- a/retriever/cmd/main.go
+++ b/retriever/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Layr-Labs/eigenda/retriever"
 	retrivereth "github.com/Layr-Labs/eigenda/retriever/eth"
 	"github.com/Layr-Labs/eigenda/retriever/flags"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli"
@@ -82,7 +83,7 @@ func RetrieverMain(ctx *cli.Context) error {
 	if err != nil {
 		log.Fatalln("could not start tcp listener", err)
 	}
-	gethClient, err := geth.NewClient(config.EthClientConfig, logger)
+	gethClient, err := geth.NewClient(config.EthClientConfig, gethcommon.Address{}, logger)
 	if err != nil {
 		log.Fatalln("could not start tcp listener", err)
 	}


### PR DESCRIPTION
## Why are these changes needed?
Currently, `GetNoSendTransactOpts` isn't supported without a private key. This change allows eth client to configure sender address and return transact opts with the specified sender address and noop signer method, so that transactions can be constructed. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
