### PR TITLE
Atomically pass or fail rate limit check

### DIFF
--- a/common/mock/ratelimiter.go
+++ b/common/mock/ratelimiter.go
@@ -9,6 +9,8 @@ import (
 type NoopRatelimiter struct {
 }
 
-func (r *NoopRatelimiter) AllowRequest(ctx context.Context, retrieverID string, blobSize uint, rate common.RateParam) (bool, error) {
-	return true, nil
+var _ common.RateLimiter = &NoopRatelimiter{}
+
+func (r *NoopRatelimiter) AllowRequest(ctx context.Context, params []common.RequestParams) (bool, *common.RequestParams, error) {
+	return true, nil, nil
 }

--- a/common/ratelimit.go
+++ b/common/ratelimit.go
@@ -23,6 +23,15 @@ type RequestParams struct {
 }
 
 type RateLimiter interface {
+	// AllowRequest checks whether the request should be allowed. If the request is allowed, the function returns true.
+	// If the request is not allowed, the function returns false and the RequestParams of the request that was not allowed.
+	// In order to for the request to be allowed, all of the requests represented by the RequestParams slice must be allowed.
+	// Each RequestParams object represents a single request. Each request is subjected to the same GlobalRateParams, but the
+	// individual parameters of the request can differ.
+	//
+	// If CountFailed is set to true in the GlobalRateParams, AllowRequest will count failed requests towards the rate limit.
+	// If CountFailed is set to false, the rate limiter will stop processing requests as soon as it encounters a request that
+	// is not allowed.
 	AllowRequest(ctx context.Context, params []RequestParams) (bool, *RequestParams, error)
 }
 

--- a/common/ratelimit.go
+++ b/common/ratelimit.go
@@ -15,8 +15,15 @@ import (
 // ID is the authenticated Account ID. For retrieval requests, the requester ID will be the requester's IP address.
 type RequesterID = string
 
+type RequestParams struct {
+	RequesterID RequesterID
+	BlobSize    uint
+	Rate        RateParam
+	Info        interface{}
+}
+
 type RateLimiter interface {
-	AllowRequest(ctx context.Context, requesterID RequesterID, blobSize uint, rate RateParam) (bool, error)
+	AllowRequest(ctx context.Context, params []RequestParams) (bool, *RequestParams, error)
 }
 
 type GlobalRateParams struct {

--- a/common/ratelimit/limiter.go
+++ b/common/ratelimit/limiter.go
@@ -25,6 +25,15 @@ func NewRateLimiter(rateParams common.GlobalRateParams, bucketStore BucketStore,
 	}
 }
 
+// AllowRequest checks whether the request should be allowed. If the request is allowed, the function returns true.
+// If the request is not allowed, the function returns false and the RequestParams of the request that was not allowed.
+// In order to for the request to be allowed, all of the requests represented by the RequestParams slice must be allowed.
+// Each RequestParams object represents a single request. Each request is subjected to the same GlobalRateParams, but the
+// individual parameters of the request can differ.
+//
+// If CountFailed is set to true in the GlobalRateParams, AllowRequest will count failed requests towards the rate limit.
+// If CountFailed is set to false, the rate limiter will stop processing requests as soon as it encounters a request that
+// is not allowed.
 func (d *rateLimiter) AllowRequest(ctx context.Context, params []common.RequestParams) (bool, *common.RequestParams, error) {
 
 	updatedBucketParams := make([]*common.RateBucketParams, len(params))

--- a/common/ratelimit/ratelimit_test.go
+++ b/common/ratelimit/ratelimit_test.go
@@ -40,13 +40,21 @@ func TestRatelimit(t *testing.T) {
 
 	retreiverID := "testRetriever"
 
+	params := []common.RequestParams{
+		{
+			RequesterID: retreiverID,
+			BlobSize:    10,
+			Rate:        100,
+		},
+	}
+
 	for i := 0; i < 10; i++ {
-		allow, err := ratelimiter.AllowRequest(ctx, retreiverID, 10, 100)
+		allow, _, err := ratelimiter.AllowRequest(ctx, params)
 		assert.NoError(t, err)
 		assert.Equal(t, true, allow)
 	}
 
-	allow, err := ratelimiter.AllowRequest(ctx, retreiverID, 10, 100)
+	allow, _, err := ratelimiter.AllowRequest(ctx, params)
 	assert.NoError(t, err)
 	assert.Equal(t, false, allow)
 }

--- a/disperser/apiserver/ratelimit_test.go
+++ b/disperser/apiserver/ratelimit_test.go
@@ -39,7 +39,7 @@ func TestRatelimit(t *testing.T) {
 		Data:                data50KiB,
 		CustomQuorumNumbers: []uint32{0},
 	})
-	assert.ErrorContains(t, err, "account throughput limit")
+	assert.ErrorContains(t, err, "Account throughput rate limit")
 
 	// Try with non-allowlisted IP. Should fail with account blob limit because blob rate (3 blobs/s) X bucket size (3s) is smaller than 20 blobs.
 	numLimited := 0
@@ -49,7 +49,7 @@ func TestRatelimit(t *testing.T) {
 			Data:                data1KiB,
 			CustomQuorumNumbers: []uint32{1},
 		})
-		if err != nil && strings.Contains(err.Error(), "account blob limit") {
+		if err != nil && strings.Contains(err.Error(), "Account blob rate limit") {
 			numLimited++
 		}
 	}
@@ -100,7 +100,7 @@ func TestAuthRatelimit(t *testing.T) {
 	simulateClient(t, signer, "2.2.2.2", data50KiB, []uint32{0}, errorChan, false)
 
 	err = <-errorChan
-	assert.ErrorContains(t, err, "account throughput limit")
+	assert.ErrorContains(t, err, "Account throughput rate limit")
 
 	// Should fail with account blob limit because blob rate (3 blobs/s) X bucket size (3s) is smaller than 10 blobs.
 	for i := 0; i < 20; i++ {
@@ -109,7 +109,7 @@ func TestAuthRatelimit(t *testing.T) {
 	numLimited := 0
 	for i := 0; i < 20; i++ {
 		err = <-errorChan
-		if err != nil && strings.Contains(err.Error(), "account blob limit") {
+		if err != nil && strings.Contains(err.Error(), "Account blob rate limit") {
 			numLimited++
 		}
 	}

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -449,9 +449,9 @@ func (s *DispersalServer) checkRateLimitsAndAddRatesToHeader(ctx context.Context
 		if !ok {
 			return api.NewInternalError("failed to cast limiterInfo")
 		}
-		errorString := fmt.Sprintf("request ratelimited: %s for quorum %d", info.RateType.String(), info.QuorumID)
 		s.metrics.HandleSystemRateLimitedRequest(fmt.Sprint(info.QuorumID), blobSize, "DisperseBlob")
-		return api.NewResourceExhaustedError(fmt.Sprintf("request ratelimited: %s", info.Name))
+		errorString := fmt.Sprintf("request ratelimited: %s for quorum %d", info.RateType.String(), info.QuorumID)
+		return api.NewResourceExhaustedError(errorString)
 	}
 
 	return nil

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -29,11 +29,6 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-var errSystemBlobRateLimit = errors.New("request ratelimited: system blob limit")
-var errSystemThroughputRateLimit = errors.New("request ratelimited: system throughput limit")
-var errAccountBlobRateLimit = errors.New("request ratelimited: account blob limit")
-var errAccountThroughputRateLimit = errors.New("request ratelimited: account throughput limit")
-
 const systemAccountKey = "system"
 
 const maxBlobSize = 2 * 1024 * 1024 // 2 MiB

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -200,8 +200,15 @@ func (s *Server) RetrieveChunks(ctx context.Context, in *pb.RetrieveChunksReques
 	encodedBlobSize := encoding.GetBlobSize(encoding.GetEncodedBlobLength(blobHeader.Length, quorumInfo.ConfirmationThreshold, quorumInfo.AdversaryThreshold))
 	rate := quorumInfo.QuorumRate
 
+	params := []common.RequestParams{
+		{
+			RequesterID: retrieverID,
+			BlobSize:    encodedBlobSize,
+			Rate:        rate,
+		},
+	}
 	s.mu.Lock()
-	allow, err := s.ratelimiter.AllowRequest(ctx, retrieverID, encodedBlobSize, rate)
+	allow, _, err := s.ratelimiter.AllowRequest(ctx, params)
 	s.mu.Unlock()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Why are these changes needed?

The system is currently vulnerable to a request deducting against the system-level rate limits even if the request is rejected at the account level. 

This PR addresses this issue by making the ratelimiting check atomic across the different levels and quorums.  The rate limit buckets will only be updated if the request passes all checks. 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
