### PR TITLE
Sort quorum IDs before aggregation

### DIFF
--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -149,7 +149,7 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 
 			// If operator is not in quorum, skip
 			if !ok {
-				a.Logger.Error("Operator not found in quorum", "operatorID", operatorIDHex, "operatorAddress", operatorAddr, "socket", socket)
+				a.Logger.Error("Operator not found in quorum", "operatorID", operatorIDHex, "operatorAddress", operatorAddr, "socket", socket, "quorumID", id)
 				continue
 			}
 

--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
@@ -426,6 +427,7 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	for quorumID := range batch.State.Operators {
 		quorumIDs = append(quorumIDs, quorumID)
 	}
+	slices.Sort(quorumIDs)
 
 	stageTimer = time.Now()
 	aggSig, err := b.Aggregator.AggregateSignatures(ctx, batch.State, quorumIDs, headerHash, update)


### PR DESCRIPTION
## Why are these changes needed?
Quorum numbers should be sorted to make sure APKs are in the right order as quorum numbers specified in [signature checker](https://github.com/Layr-Labs/eigenda/blob/master/core/eth/tx.go#L436)
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
