### PR TITLE
Timeout disperser grpc streams

### DIFF
--- a/api/grpc/mock/disperser.go
+++ b/api/grpc/mock/disperser.go
@@ -14,6 +14,7 @@ func MakeStreamMock(ctx context.Context) *StreamMock {
 		ctx:            ctx,
 		recvToServer:   make(chan *disperser.AuthenticatedRequest, 10),
 		sentFromServer: make(chan *disperser.AuthenticatedReply, 10),
+		closed:         false,
 	}
 }
 
@@ -22,6 +23,7 @@ type StreamMock struct {
 	ctx            context.Context
 	recvToServer   chan *disperser.AuthenticatedRequest
 	sentFromServer chan *disperser.AuthenticatedReply
+	closed         bool
 }
 
 func (m *StreamMock) Context() context.Context {
@@ -42,6 +44,9 @@ func (m *StreamMock) Recv() (*disperser.AuthenticatedRequest, error) {
 }
 
 func (m *StreamMock) SendFromClient(req *disperser.AuthenticatedRequest) error {
+	if m.closed {
+		return errors.New("closed")
+	}
 	m.recvToServer <- req
 	return nil
 }
@@ -57,4 +62,5 @@ func (m *StreamMock) RecvToClient() (*disperser.AuthenticatedReply, error) {
 func (m *StreamMock) Close() {
 	close(m.recvToServer)
 	close(m.sentFromServer)
+	m.closed = true
 }

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -99,6 +99,7 @@ func NewDispersalServer(
 
 func (s *DispersalServer) DisperseBlobAuthenticated(stream pb.Disperser_DisperseBlobAuthenticatedServer) error {
 
+	// This uses the existing deadline of stream.Context() if it is earlier.
 	ctx, cancel := context.WithTimeout(stream.Context(), s.serverConfig.GrpcTimeout)
 	defer cancel()
 

--- a/disperser/cmd/apiserver/config.go
+++ b/disperser/cmd/apiserver/config.go
@@ -49,7 +49,8 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 	config := Config{
 		AwsClientConfig: aws.ReadClientConfig(ctx, flags.FlagPrefix),
 		ServerConfig: disperser.ServerConfig{
-			GrpcPort: ctx.GlobalString(flags.GrpcPortFlag.Name),
+			GrpcPort:    ctx.GlobalString(flags.GrpcPortFlag.Name),
+			GrpcTimeout: ctx.GlobalDuration(flags.GrpcTimeoutFlag.Name),
 		},
 		BlobstoreConfig: blobstore.Config{
 			BucketName: ctx.GlobalString(flags.S3BucketNameFlag.Name),

--- a/disperser/cmd/apiserver/flags/flags.go
+++ b/disperser/cmd/apiserver/flags/flags.go
@@ -1,6 +1,8 @@
 package flags
 
 import (
+	"time"
+
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/aws"
 	"github.com/Layr-Labs/eigenda/common/geth"
@@ -33,6 +35,13 @@ var (
 		Usage:    "Port at which disperser listens for grpc calls",
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "GRPC_PORT"),
+	}
+	GrpcTimeoutFlag = cli.DurationFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "grpc-stream-timeout"),
+		Usage:    "Timeout for grpc streams",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "GRPC_STREAM_TIMEOUT"),
+		Value:    time.Second * 10,
 	}
 	BlsOperatorStateRetrieverFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
@@ -94,6 +103,7 @@ var optionalFlags = []cli.Flag{
 	EnableMetrics,
 	EnableRatelimiter,
 	BucketStoreSize,
+	GrpcTimeoutFlag,
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/disperser/server_config.go
+++ b/disperser/server_config.go
@@ -1,9 +1,12 @@
 package disperser
 
+import "time"
+
 const (
 	Localhost = "0.0.0.0"
 )
 
 type ServerConfig struct {
-	GrpcPort string
+	GrpcPort    string
+	GrpcTimeout time.Duration
 }


### PR DESCRIPTION
## Why are these changes needed?

Prevents callers from indefinitely using up GRPC stream resources. 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
