### PR TITLE
Revamp the operator CLI for opt-out

### DIFF
--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -307,7 +308,7 @@ func (t *Transactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Po
 			}
 		}
 		if !found {
-			return fmt.Errorf("operator is not registered in quorum %d at block %d", quorumToDereg, blockNumber)
+			return fmt.Errorf("operatorId %s is not registered in quorum %d at block %d", hex.EncodeToString(operatorId[:]), quorumToDereg, blockNumber)
 		}
 	}
 

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -288,6 +288,9 @@ func (t *Transactor) RegisterOperatorWithChurn(
 // If the operator isn't registered with any of the specified quorums, this function will return error, and
 // no quorum will be deregistered.
 func (t *Transactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Point, blockNumber uint32, quorumIds []core.QuorumID) error {
+	if len(quorumIds) == 0 {
+		return errors.New("no quorum is specified to deregister from")
+	}
 	// Make sure the operator is registered in all the quorums it tries to deregister.
 	operatorId := HashPubKeyG1(pubkeyG1)
 	quorumBitmap, _, err := t.Bindings.OpStateRetriever.GetOperatorState0(&bind.CallOpts{

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"slices"
 
@@ -280,12 +281,15 @@ func (t *Transactor) RegisterOperatorWithChurn(
 	return nil
 }
 
-// DeregisterOperator deregisters an operator with the given public key from the all the quorums that it is
+// DeregisterOperator deregisters an operator with the given public key from the specified the quorums that it is
 // registered with at the supplied block number. To fully deregister an operator, this function should be called
 // with the current block number.
-func (t *Transactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Point, blockNumber uint32) error {
+// If the operator isn't registered with any of the specified quorums, this function will return error, and
+// no quorum will be deregistered.
+func (t *Transactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Point, blockNumber uint32, quorumIds []core.QuorumID) error {
+	// Make sure the operator is registered in all the quorums it tries to deregister.
 	operatorId := HashPubKeyG1(pubkeyG1)
-	quorumBitmap, opStates, err := t.Bindings.OpStateRetriever.GetOperatorState0(&bind.CallOpts{
+	quorumBitmap, _, err := t.Bindings.OpStateRetriever.GetOperatorState0(&bind.CallOpts{
 		Context: ctx,
 	}, t.Bindings.RegCoordinatorAddr, operatorId, blockNumber)
 	if err != nil {
@@ -293,13 +297,19 @@ func (t *Transactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Po
 		return err
 	}
 
-	operatorIdsToSwap := make([][32]byte, len(opStates))
-	for i := range opStates {
-		quorum := opStates[i]
-		operatorIdsToSwap[i] = quorum[len(opStates[i])-1].OperatorId
-	}
-
 	quorumNumbers := bitmapToBytesArray(quorumBitmap)
+	for _, quorumToDereg := range quorumIds {
+		found := false
+		for _, currentQuorum := range quorumNumbers {
+			if quorumToDereg == currentQuorum {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("operator is not registered in quorum %d at block %d", quorumToDereg, blockNumber)
+		}
+	}
 
 	opts, err := t.EthClient.GetNoSendTransactOpts()
 	if err != nil {
@@ -308,7 +318,7 @@ func (t *Transactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Po
 	}
 	tx, err := t.Bindings.RegistryCoordinator.DeregisterOperator(
 		opts,
-		quorumNumbers,
+		quorumIds,
 	)
 	if err != nil {
 		t.Logger.Error("Failed to deregister operator", "err", err)

--- a/core/mock/tx.go
+++ b/core/mock/tx.go
@@ -60,7 +60,7 @@ func (t *MockTransactor) RegisterOperatorWithChurn(
 	return args.Error(0)
 }
 
-func (t *MockTransactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Point, blockNumber uint32) error {
+func (t *MockTransactor) DeregisterOperator(ctx context.Context, pubkeyG1 *core.G1Point, blockNumber uint32, quorumIds []core.QuorumID) error {
 	args := t.Called()
 	return args.Error(0)
 }

--- a/core/tx.go
+++ b/core/tx.go
@@ -63,7 +63,6 @@ type Transactor interface {
 	// DeregisterOperator deregisters an operator with the given public key from the all the quorums that it is
 	// registered with at the supplied block number. To fully deregister an operator, this function should be called
 	// with the current block number.
-	// with the current block number.
 	// If the operator isn't registered with any of the specified quorums, this function will return error, and
 	// no quorum will be deregistered.
 	DeregisterOperator(ctx context.Context, pubkeyG1 *G1Point, blockNumber uint32, quorumIds []QuorumID) error

--- a/core/tx.go
+++ b/core/tx.go
@@ -63,7 +63,10 @@ type Transactor interface {
 	// DeregisterOperator deregisters an operator with the given public key from the all the quorums that it is
 	// registered with at the supplied block number. To fully deregister an operator, this function should be called
 	// with the current block number.
-	DeregisterOperator(ctx context.Context, pubkeyG1 *G1Point, blockNumber uint32) error
+	// with the current block number.
+	// If the operator isn't registered with any of the specified quorums, this function will return error, and
+	// no quorum will be deregistered.
+	DeregisterOperator(ctx context.Context, pubkeyG1 *G1Point, blockNumber uint32, quorumIds []QuorumID) error
 
 	// UpdateOperatorSocket updates the socket of the operator in all the quorums that it is registered with.
 	UpdateOperatorSocket(ctx context.Context, socket string) error

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -81,7 +81,7 @@ var (
 	}
 	QuorumIDListFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "quorum-id-list"),
-		Usage:    "Comma separated list of quorum IDs that the node will participate in. There should be at least one quorum ID. This list can contain quorums node is already registered with. If the node opts in to quorums already registered with, it will be a no-op.",
+		Usage:    "Comma separated list of quorum IDs that the node will participate in. There should be at least one quorum ID. This list must not contain quorums node is already registered with.",
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "QUORUM_ID_LIST"),
 	}

--- a/node/operator.go
+++ b/node/operator.go
@@ -111,6 +111,8 @@ func (c *Operator) getQuorumIdsToRegister(ctx context.Context, transactor core.T
 	for _, quorumID := range c.QuorumIDs {
 		if !slices.Contains(registeredQuorumIds, quorumID) {
 			quorumIdsToRegister = append(quorumIdsToRegister, quorumID)
+		} else {
+			return nil, fmt.Errorf("the operator already registered for quorum %d", quorumID)
 		}
 	}
 

--- a/node/operator.go
+++ b/node/operator.go
@@ -82,8 +82,7 @@ func RegisterOperator(ctx context.Context, operator *Operator, transactor core.T
 }
 
 // DeregisterOperator deregisters the operator with the given public key from the specified quorums that it is registered with at the supplied block number.
-// If the operator isn't registered with any of the specified quorums, this function will
-// return error, and no quorum will be deregistered.
+// If the operator isn't registered with any of the specified quorums, this function will return error, and no quorum will be deregistered.
 func DeregisterOperator(ctx context.Context, operator *Operator, KeyPair *core.KeyPair, transactor core.Transactor) error {
 	blockNumber, err := transactor.GetCurrentBlockNumber(ctx)
 	if err != nil {

--- a/node/operator.go
+++ b/node/operator.go
@@ -25,6 +25,9 @@ type Operator struct {
 
 // RegisterOperator operator registers the operator with the given public key for the given quorum IDs.
 func RegisterOperator(ctx context.Context, operator *Operator, transactor core.Transactor, churnerClient ChurnerClient, logger logging.Logger) error {
+	if len(operator.QuorumIDs) > 1+core.MaxQuorumID {
+		return fmt.Errorf("cannot provide more than %d quorums", 1+core.MaxQuorumID)
+	}
 	quorumsToRegister, err := operator.getQuorumIdsToRegister(ctx, transactor)
 	if err != nil {
 		return fmt.Errorf("failed to get quorum ids to register: %w", err)
@@ -84,6 +87,9 @@ func RegisterOperator(ctx context.Context, operator *Operator, transactor core.T
 // DeregisterOperator deregisters the operator with the given public key from the specified quorums that it is registered with at the supplied block number.
 // If the operator isn't registered with any of the specified quorums, this function will return error, and no quorum will be deregistered.
 func DeregisterOperator(ctx context.Context, operator *Operator, KeyPair *core.KeyPair, transactor core.Transactor) error {
+	if len(operator.QuorumIDs) > 1+core.MaxQuorumID {
+		return fmt.Errorf("cannot provide more than %d quorums", 1+core.MaxQuorumID)
+	}
 	blockNumber, err := transactor.GetCurrentBlockNumber(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current block number: %w", err)

--- a/node/operator.go
+++ b/node/operator.go
@@ -94,13 +94,15 @@ func RegisterOperator(ctx context.Context, operator *Operator, transactor core.T
 	}
 }
 
-// DeregisterOperator deregisters the operator with the given public key from the all the quorums that it is registered with at the supplied block number.
-func DeregisterOperator(ctx context.Context, KeyPair *core.KeyPair, transactor core.Transactor) error {
+// DeregisterOperator deregisters the operator with the given public key from the specified quorums that it is registered with at the supplied block number.
+// If the operator isn't registered with any of the specified quorums, this function will
+// return error, and no quorum will be deregistered.
+func DeregisterOperator(ctx context.Context, operator *Operator, KeyPair *core.KeyPair, transactor core.Transactor) error {
 	blockNumber, err := transactor.GetCurrentBlockNumber(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current block number: %w", err)
 	}
-	return transactor.DeregisterOperator(ctx, KeyPair.GetPubKeyG1(), blockNumber)
+	return transactor.DeregisterOperator(ctx, KeyPair.GetPubKeyG1(), blockNumber, operator.QuorumIDs)
 }
 
 // UpdateOperatorSocket updates the socket for the given operator

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -139,7 +139,7 @@ func pluginOps(ctx *cli.Context) {
 		log.Printf("Info: Operator with Operator Address: %x and OperatorID: %x is opting out of EigenDA", sk.Address, operatorID)
 		err = node.DeregisterOperator(context.Background(), operator, keyPair, tx)
 		if err != nil {
-			log.Printf("Error: failed to opt-out EigenDA Node Network for operator ID: %x, operator address: %x, error: %v", operatorID, sk.Address, err)
+			log.Printf("Error: failed to opt-out EigenDA Node Network for operator ID: %x, operator address: %x, quorums: %v, error: %v", operatorID, sk.Address, config.QuorumIDList, err)
 			return
 		}
 		log.Printf("Info: successfully opt-out the EigenDA, for operator ID: %x, operator address: %x", operatorID, sk.Address)

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -136,7 +136,7 @@ func pluginOps(ctx *cli.Context) {
 		log.Printf("Info: successfully opt-in the EigenDA, for operator ID: %x, operator address: %x, socket: %s, and quorums: %v", operatorID, sk.Address, config.Socket, config.QuorumIDList)
 	} else if config.Operation == "opt-out" {
 		log.Printf("Info: Operator with Operator Address: %x and OperatorID: %x is opting out of EigenDA", sk.Address, operatorID)
-		err = node.DeregisterOperator(context.Background(), keyPair, tx)
+		err = node.DeregisterOperator(context.Background(), operator, keyPair, tx)
 		if err != nil {
 			log.Printf("Error: failed to opt-out EigenDA Node Network for operator ID: %x, operator address: %x, error: %v", operatorID, sk.Address, err)
 			return

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -66,7 +66,7 @@ var (
 	}
 	QuorumIDListFlag = cli.StringFlag{
 		Name:     "quorum-id-list",
-		Usage:    "Comma separated list of quorum IDs that the node will participate in",
+		Usage:    "Comma separated list of quorum IDs that the node will opt-in or opt-out, depending on the OperationFlag",
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "QUORUM_ID_LIST"),
 	}


### PR DESCRIPTION
## Why are these changes needed?
We settle on the operator CLI semantics like this:
- opt-in quorum-list: add quorum-list to the operator (quorum-list must be not yet opted in)
- opt-out quorum-list: remove quorum-list from the operator (quorum-list must be already opted in)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
