### PR TITLE
Handle txn failure when retrieving txn receipt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.1
 
 require (
 	github.com/Layr-Labs/eigenda/api v0.0.0
-	github.com/Layr-Labs/eigensdk-go v0.1.3-0.20240318050546-8d038f135826
+	github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240322013921-268e19c1a25b
 	github.com/aws/aws-sdk-go-v2 v1.21.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.43
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.10.40

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/Layr-Labs/eigensdk-go v0.1.3-0.20240318050546-8d038f135826 h1:KENAtjyjJu/wBkVihG2cVdQbEKl44LuPqrj8IVqUFeI=
 github.com/Layr-Labs/eigensdk-go v0.1.3-0.20240318050546-8d038f135826/go.mod h1:J+d9zxN4VyMtchmsPzGASFcCjpnh1eT4aE2ggiqOz/g=
+github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240322013921-268e19c1a25b h1:6rXV1CoOp3u+GxMb8meZuCo/LNYpG/iUH511JU39YrY=
+github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240322013921-268e19c1a25b/go.mod h1:J+d9zxN4VyMtchmsPzGASFcCjpnh1eT4aE2ggiqOz/g=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=


### PR DESCRIPTION
## Why are these changes needed?
If the transaction has been submitted by Fireblocks, `wallet.GetTransactionReceipt` [returns](https://github.com/Layr-Labs/eigensdk-go/pull/158/files) `ErrTransactionFailed` if the transaction has failed permanently. 
Check this condition and disregard the transaction for receipt retrieval. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
