### PR TITLE
refactor: make the security param validation a shared function

### DIFF
--- a/core/data.go
+++ b/core/data.go
@@ -75,17 +75,21 @@ type BlobRequestHeader struct {
 	SecurityParams []*SecurityParam `json:"security_params"`
 }
 
-func (sp *SecurityParam) Validate() error {
-	if sp.ConfirmationThreshold < sp.AdversaryThreshold || sp.ConfirmationThreshold-sp.AdversaryThreshold < 10 {
-		return errors.New("invalid request: quorum threshold must be >= 10 + adversary threshold")
+func ValidateSecurityParam(confirmationThreshold, adversaryThreshold uint32) error {
+	if confirmationThreshold > 100 {
+		return errors.New("confimration threshold exceeds 100")
 	}
-	if sp.ConfirmationThreshold > 100 {
-		return errors.New("invalid request: quorum threshold exceeds 100")
+	if adversaryThreshold == 0 {
+		return errors.New("adversary threshold equals 0")
 	}
-	if sp.AdversaryThreshold == 0 {
-		return errors.New("invalid request: adversary threshold equals 0")
+	if confirmationThreshold < adversaryThreshold || confirmationThreshold-adversaryThreshold < 10 {
+		return errors.New("confirmation threshold must be >= 10 + adversary threshold")
 	}
 	return nil
+}
+
+func (sp *SecurityParam) Validate() error {
+	return ValidateSecurityParam(uint32(sp.ConfirmationThreshold), uint32(sp.AdversaryThreshold))
 }
 
 // BlobQuorumInfo contains the quorum IDs and parameters for a blob specific to a given quorum

--- a/core/validator.go
+++ b/core/validator.go
@@ -36,7 +36,7 @@ func NewShardValidator(v encoding.Verifier, asgn AssignmentCoordinator, cst Chai
 }
 
 func (v *shardValidator) validateBlobQuorum(quorumHeader *BlobQuorumInfo, blob *BlobMessage, operatorState *OperatorState) ([]*encoding.Frame, *Assignment, *encoding.EncodingParams, error) {
-	if err := ValidateSecurityParam(uint32(quorumHeader.AdversaryThreshold), uint32(quorumHeader.ConfirmationThreshold)); err != nil {
+	if err := ValidateSecurityParam(uint32(quorumHeader.ConfirmationThreshold), uint32(quorumHeader.AdversaryThreshold)); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/core/validator.go
+++ b/core/validator.go
@@ -36,8 +36,8 @@ func NewShardValidator(v encoding.Verifier, asgn AssignmentCoordinator, cst Chai
 }
 
 func (v *shardValidator) validateBlobQuorum(quorumHeader *BlobQuorumInfo, blob *BlobMessage, operatorState *OperatorState) ([]*encoding.Frame, *Assignment, *encoding.EncodingParams, error) {
-	if quorumHeader.AdversaryThreshold >= quorumHeader.ConfirmationThreshold {
-		return nil, nil, nil, fmt.Errorf("invalid header: confirmation threshold (%d) does not exceed adversary threshold (%d)", quorumHeader.ConfirmationThreshold, quorumHeader.AdversaryThreshold)
+	if err := ValidateSecurityParam(uint32(quorumHeader.AdversaryThreshold), uint32(quorumHeader.ConfirmationThreshold)); err != nil {
+		return nil, nil, nil, err
 	}
 
 	// Check if the operator is a member of the quorum
@@ -59,7 +59,7 @@ func (v *shardValidator) validateBlobQuorum(quorumHeader *BlobQuorumInfo, blob *
 		return nil, nil, nil, fmt.Errorf("number of chunks (%d) does not match assignment (%d) for quorum %d", len(blob.Bundles[quorumHeader.QuorumID]), assignment.NumChunks, quorumHeader.QuorumID)
 	}
 
-	// Validate the chunkLength against the quorum and adversary threshold parameters
+	// Validate the chunkLength against the confirmation and adversary threshold parameters
 	ok, err := v.assignment.ValidateChunkLength(operatorState, blob.BlobHeader.Length, quorumHeader)
 	if err != nil || !ok {
 		return nil, nil, nil, fmt.Errorf("invalid chunk length: %w", err)

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -175,14 +175,8 @@ func (s *Server) validateStoreChunkRequest(in *pb.StoreChunksRequest) error {
 			return api.NewInvalidArgError("the number of quorums must be the same as the number of bundles")
 		}
 		for _, q := range blob.GetHeader().GetQuorumHeaders() {
-			if q.GetAdversaryThreshold() >= q.GetConfirmationThreshold() {
-				return api.NewInvalidArgError("adversary_threshold must be less than confirmation_threshold")
-			}
-			if q.GetConfirmationThreshold() > 100 {
-				return api.NewInvalidArgError("confirmation threshold exceeds 100")
-			}
-			if q.AdversaryThreshold == 0 {
-				return api.NewInvalidArgError("adversary threshold equals 0")
+			if err := core.ValidateSecurityParam(q.GetConfirmationThreshold(), q.GetAdversaryThreshold()); err != nil {
+				return err
 			}
 		}
 	}

--- a/node/grpc/server_test.go
+++ b/node/grpc/server_test.go
@@ -310,12 +310,12 @@ func TestStoreChunksRequestValidation(t *testing.T) {
 	req, _, _, _, _ = makeStoreChunksRequest(t, 66, 66)
 	_, err = server.StoreChunks(context.Background(), req)
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "adversary_threshold must be less than confirmation_threshold"))
+	assert.True(t, strings.Contains(err.Error(), "confirmation threshold must be >= 10 + adversary threshold"))
 
 	req, _, _, _, _ = makeStoreChunksRequest(t, 101, 66)
 	_, err = server.StoreChunks(context.Background(), req)
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "confirmation threshold exceeds 100"))
+	assert.True(t, strings.Contains(err.Error(), "confimration threshold exceeds 100"))
 
 	req, _, _, _, _ = makeStoreChunksRequest(t, 66, 0)
 	_, err = server.StoreChunks(context.Background(), req)


### PR DESCRIPTION
## Why are these changes needed?
This will reduce code duplication, and make the security param validation logic consistent across the system.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
