### PR TITLE
Pass in gas price caps explicitly for Fireblocks transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.1
 
 require (
 	github.com/Layr-Labs/eigenda/api v0.0.0
-	github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240323004904-d57bfdd5ab62
+	github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240325043411-952752534f30
 	github.com/aws/aws-sdk-go-v2 v1.21.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.43
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.10.40

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240322013921-268e19c1a25b h1:6rXV1Co
 github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240322013921-268e19c1a25b/go.mod h1:J+d9zxN4VyMtchmsPzGASFcCjpnh1eT4aE2ggiqOz/g=
 github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240323004904-d57bfdd5ab62 h1:0dZkkl3b6VA3W+JJ9jNQHWD9BdY289nqleobACJnXn0=
 github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240323004904-d57bfdd5ab62/go.mod h1:J+d9zxN4VyMtchmsPzGASFcCjpnh1eT4aE2ggiqOz/g=
+github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240325043411-952752534f30 h1:CPndbhgC5QKdAM9tq8FZLUFozqknKpz+Cy25sMU8lMM=
+github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240325043411-952752534f30/go.mod h1:J+d9zxN4VyMtchmsPzGASFcCjpnh1eT4aE2ggiqOz/g=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=


### PR DESCRIPTION
## Why are these changes needed?
Updates `eigensdk` version to the latest which includes an update that takes [gas fee caps](https://github.com/Layr-Labs/eigensdk-go/pull/160) as arguments instead of relying on Fireblocks gas estimation.
`TxnManager` already estimates gas at a generous level and handles [gas bumps](https://github.com/Layr-Labs/eigenda/blob/master/disperser/batcher/txn_manager.go#L256-L262) for replacement transactions which is read directly by the Fireblocks wallet. So no code changes should be necessary to have gas price caps passed in. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
