### PR TITLE
fix: fix null pointer reference

### DIFF
--- a/disperser/dataapi/nonsigner_handler.go
+++ b/disperser/dataapi/nonsigner_handler.go
@@ -223,8 +223,10 @@ func computeNumResponsible(batches []*BatchNonSigningInfo, operatorQuorumInterva
 	for op, val := range operatorQuorumIntervals {
 		for q, intervals := range val {
 			numBatches := 0
-			for _, interval := range intervals {
-				numBatches = numBatches + ComputeNumBatches(quorumBatches[q], interval.StartBlock, interval.EndBlock)
+			if _, ok := quorumBatches[q]; ok {
+				for _, interval := range intervals {
+					numBatches = numBatches + ComputeNumBatches(quorumBatches[q], interval.StartBlock, interval.EndBlock)
+				}
 			}
 			if _, ok := numResponsible[op]; !ok {
 				numResponsible[op] = make(map[uint8]int)

--- a/disperser/dataapi/nonsigner_utils.go
+++ b/disperser/dataapi/nonsigner_utils.go
@@ -11,11 +11,11 @@ type NumBatchesAtBlock struct {
 	NumBatches  int
 }
 
-// QueryBatches represents number of batches at different block numbers, as well
-// as accumulated number of batches from the first block in NumBatches.
+// QuorumBatches represents number of batches at different block numbers, as well
+// as accumulated number of batches from the first block in NumBatches, for a quorum.
 // The NumBatches is in ascending order by NumBatchesAtBlock.BlockNumber, and
 // AccuBatches[i] is corresponding to NumBatches[i].
-type QueryBatches struct {
+type QuorumBatches struct {
 	NumBatches  []*NumBatchesAtBlock
 	AccuBatches []int
 }
@@ -196,22 +196,22 @@ func validateQuorumEvents(added []*OperatorQuorum, removed []*OperatorQuorum, st
 }
 
 // ComputeNumBatches returns the number of batches in the block interval [startBlock, endBlock].
-func ComputeNumBatches(queryBatches *QueryBatches, startBlock, endBlock uint32) int {
-	start := getLowerBoundIndex(queryBatches.NumBatches, startBlock)
-	end := getUpperBoundIndex(queryBatches.NumBatches, endBlock)
+func ComputeNumBatches(quorumBatches *QuorumBatches, startBlock, endBlock uint32) int {
+	start := getLowerBoundIndex(quorumBatches.NumBatches, startBlock)
+	end := getUpperBoundIndex(quorumBatches.NumBatches, endBlock)
 	num := 0
 	if end > 0 {
-		num = queryBatches.AccuBatches[end-1]
+		num = quorumBatches.AccuBatches[end-1]
 	}
 	if start > 0 {
-		num = num - queryBatches.AccuBatches[start-1]
+		num = num - quorumBatches.AccuBatches[start-1]
 	}
 	return num
 }
 
 // CreatQuorumBatches returns quorumBatches, where quorumBatches[q] is a list of
-// QueryBatches in ascending order by block number.
-func CreatQuorumBatches(batches []*BatchNonSigningInfo) map[uint8]*QueryBatches {
+// QuorumBatches in ascending order by block number.
+func CreatQuorumBatches(batches []*BatchNonSigningInfo) map[uint8]*QuorumBatches {
 	quorumBatchMap := make(map[uint8]map[uint32]int)
 	for _, batch := range batches {
 		for _, q := range batch.QuorumNumbers {
@@ -221,7 +221,7 @@ func CreatQuorumBatches(batches []*BatchNonSigningInfo) map[uint8]*QueryBatches 
 			quorumBatchMap[q][batch.ReferenceBlockNumber]++
 		}
 	}
-	quorumBatches := make(map[uint8]*QueryBatches)
+	quorumBatches := make(map[uint8]*QuorumBatches)
 	for q, s := range quorumBatchMap {
 		numBatches := make([]*NumBatchesAtBlock, 0)
 		for block, num := range s {
@@ -243,7 +243,7 @@ func CreatQuorumBatches(batches []*BatchNonSigningInfo) map[uint8]*QueryBatches 
 		for i := 1; i < len(numBatches); i++ {
 			accuBatches[i] = numBatches[i].NumBatches + accuBatches[i-1]
 		}
-		quorumBatches[q] = &QueryBatches{
+		quorumBatches[q] = &QuorumBatches{
 			NumBatches:  numBatches,
 			AccuBatches: accuBatches,
 		}

--- a/disperser/dataapi/nonsigner_utils_test.go
+++ b/disperser/dataapi/nonsigner_utils_test.go
@@ -382,11 +382,11 @@ func TestCreateOperatorQuorumIntervals(t *testing.T) {
 }
 
 func TestComputeNumBatches(t *testing.T) {
-	queryBatches := &dataapi.QueryBatches{
+	quorumBatches := &dataapi.QuorumBatches{
 		NumBatches:  []*dataapi.NumBatchesAtBlock{},
 		AccuBatches: []int{},
 	}
-	assert.Equal(t, 0, dataapi.ComputeNumBatches(queryBatches, 1, 4))
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(quorumBatches, 1, 4))
 
 	numBatches := []*dataapi.NumBatchesAtBlock{
 		{
@@ -394,14 +394,14 @@ func TestComputeNumBatches(t *testing.T) {
 			NumBatches:  2,
 		},
 	}
-	queryBatches = &dataapi.QueryBatches{
+	quorumBatches = &dataapi.QuorumBatches{
 		NumBatches:  numBatches,
 		AccuBatches: []int{2},
 	}
-	assert.Equal(t, 0, dataapi.ComputeNumBatches(queryBatches, 1, 4))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 1, 5))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 5, 5))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 5, 6))
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(quorumBatches, 1, 4))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 1, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 5, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 5, 6))
 
 	numBatches = []*dataapi.NumBatchesAtBlock{
 		{
@@ -421,27 +421,27 @@ func TestComputeNumBatches(t *testing.T) {
 			NumBatches:  2,
 		},
 	}
-	queryBatches = &dataapi.QueryBatches{
+	quorumBatches = &dataapi.QuorumBatches{
 		NumBatches:  numBatches,
 		AccuBatches: []int{2, 4, 6, 8},
 	}
 
-	assert.Equal(t, 0, dataapi.ComputeNumBatches(queryBatches, 1, 4))
-	assert.Equal(t, 0, dataapi.ComputeNumBatches(queryBatches, 21, 22))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 1, 5))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 5, 5))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 5, 9))
-	assert.Equal(t, 4, dataapi.ComputeNumBatches(queryBatches, 5, 10))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 6, 10))
-	assert.Equal(t, 4, dataapi.ComputeNumBatches(queryBatches, 5, 14))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 6, 14))
-	assert.Equal(t, 6, dataapi.ComputeNumBatches(queryBatches, 5, 15))
-	assert.Equal(t, 8, dataapi.ComputeNumBatches(queryBatches, 5, 20))
-	assert.Equal(t, 8, dataapi.ComputeNumBatches(queryBatches, 5, 22))
-	assert.Equal(t, 8, dataapi.ComputeNumBatches(queryBatches, 1, 22))
-	assert.Equal(t, 6, dataapi.ComputeNumBatches(queryBatches, 6, 22))
-	assert.Equal(t, 4, dataapi.ComputeNumBatches(queryBatches, 11, 22))
-	assert.Equal(t, 2, dataapi.ComputeNumBatches(queryBatches, 16, 22))
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(quorumBatches, 1, 4))
+	assert.Equal(t, 0, dataapi.ComputeNumBatches(quorumBatches, 21, 22))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 1, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 5, 5))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 5, 9))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(quorumBatches, 5, 10))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 6, 10))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(quorumBatches, 5, 14))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 6, 14))
+	assert.Equal(t, 6, dataapi.ComputeNumBatches(quorumBatches, 5, 15))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(quorumBatches, 5, 20))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(quorumBatches, 5, 22))
+	assert.Equal(t, 8, dataapi.ComputeNumBatches(quorumBatches, 1, 22))
+	assert.Equal(t, 6, dataapi.ComputeNumBatches(quorumBatches, 6, 22))
+	assert.Equal(t, 4, dataapi.ComputeNumBatches(quorumBatches, 11, 22))
+	assert.Equal(t, 2, dataapi.ComputeNumBatches(quorumBatches, 16, 22))
 }
 
 func TestCreatQuorumBatches(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
Currently the nonsigning rate has a bug to handle quorums when: 1) operator has opted in to the quorum; but 2) the quorum has no batches.

Tested: locally tested and it worked

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
