### PR TITLE
Fix operator address format and add address to response

### DIFF
--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -550,6 +550,9 @@
                 "operator_id": {
                     "type": "string"
                 },
+				"operator_address": {
+                    "type": "string"
+                },
                 "percentage": {
                     "type": "number"
                 },

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -550,7 +550,7 @@
                 "operator_id": {
                     "type": "string"
                 },
-				"operator_address": {
+                "operator_address": {
                     "type": "string"
                 },
                 "percentage": {

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -116,6 +116,8 @@ definitions:
     properties:
       operator_id:
         type: string
+      operator_address:
+        type: string
       percentage:
         type: number
       total_batches:

--- a/disperser/dataapi/nonsigner_handler.go
+++ b/disperser/dataapi/nonsigner_handler.go
@@ -51,8 +51,11 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, intervalSeconds 
 
 	// Create a mapping from address to operatorID.
 	nonsignerAddressToId := make(map[string]core.OperatorID)
+	nonsignerIdToAddress := make(map[string]string)
 	for i := range nonsigners {
-		nonsignerAddressToId[nonsignerAddresses[i].Hex()] = nonsigners[i]
+		addr := strings.ToLower(nonsignerAddresses[i].Hex())
+		nonsignerAddressToId[addr] = nonsigners[i]
+		nonsignerIdToAddress[nonsigners[i].Hex()] = addr
 	}
 
 	// Create operators' quorum intervals.
@@ -84,6 +87,7 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, intervalSeconds 
 				}
 				nonsignerMetric := OperatorNonsigningPercentageMetrics{
 					OperatorId:           fmt.Sprintf("0x%s", op),
+					OperatorAddress:      nonsignerIdToAddress[op],
 					QuorumId:             q,
 					TotalUnsignedBatches: unsignedCount,
 					TotalBatches:         totalCount,

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -81,6 +81,7 @@ type (
 
 	OperatorNonsigningPercentageMetrics struct {
 		OperatorId           string  `json:"operator_id"`
+		OperatorAddress      string  `json:"operator_address"`
 		QuorumId             uint8   `json:"quorum_id"`
 		TotalUnsignedBatches int     `json:"total_unsigned_batches"`
 		TotalBatches         int     `json:"total_batches"`


### PR DESCRIPTION
## Why are these changes needed?
- Fix a bug in address formatting: we use lower case and mixed case together, which makes it not able to match operators
- Add operator address to response, this will make it easier because operators look at the data by address

Tested:
Ran locally and got:

`{"meta":{"size":44},"data":[{"operator_id":"0x1c6b5141b14413d1272da7d09584e2a62d1074b836d41bb10ac34e87df41f3be","operator_address":"0xdc59c4d517758e943ded1574f20b10c6bfc0f04c","quorum_id":0,"total_unsigned_batches":434,"total_batches":434,"percentage":100},{"operator_id":"0x1d440e1f3778d49fac0276a77e4e4890973ca6e30188d774819654d6857528b1","operator_address":"0xd99b2e164f9f29e530fe40d4a0d8c60f5159b393","quorum_id":0,"total_unsigned_batches":174,"total_batches":174,"percentage":100},{"operator_id":"0x2e3c05fce3527d4ebac0a63d358882b2fb7fa480df459ec98c542222bf3117c9","operator_address":"0x0d0ced7081e0451abd87f976f21c406527f5c90b","quorum_id":0,"total_unsigned_batches":818,"total_batches":818,"percentage":100},{"operator_id":"0x31e3ea7e75e64b750002f6a66fa5c89862fbf12752a803721fee839ceae31025","operator_address":"0x715f4e7584bab8c5664cc2a95717642fab2cc507","quorum_id":0,"total_unsigned_batches":1054,"total_batches":1054,"percentage":100},{"operator_id":"0x3e819c50cd9c86c5ef1a900401f95190f65fc6f061125421bfa03f0f0ae56eba","operator_address":"0x0fef87dba8aa3a1f3a7665b51ca341e137ef96fe","quorum_id":0,"total_unsigned_batches":250,"total_batches":250,"percentage":100},{"operator_id":"0x4c564d7c1ed0a745422a5d785b718597dba9d529d87d340a401c7319c5c3aa61","operator_address":"0xf7b07211eb70b5baded30e3e74712bcc2008a01f","quorum_id":0,"total_unsigned_batches":818,"total_batches":818,"percentage":100},{"operator_id":"0x4f307f051b6a228a933e0dd8edbd9a9aac950a9e9b75959e93bdb2d9ae453ada","operator_address":"0xe3c694453d69caea4edcbb0bb8d24accc6932565","quorum_id":0,"total_unsigned_batches":1054,"total_batches":1054,"percentage":100},{"operator_id":"0x6a066d2fd8f0815fb347bcfe0fd45eea3e6d3bc2ebe2faaf936a6110835c4708","operator_address":"0x2612a26eb9c5b6f002cb40789d9b4b49c710ea17","quorum_id":0,"total_unsigned_batches":881,"total_batches":881,"percentage":100},{"operator_id":"0x6b0fcc986aca6c4b5f8272683d61612da8cc65c1760c505fd585b5cbc0a99c5d","operator_address":"0xced4bd09bba9a4487d2255f84fcce402420038ef","quorum_id":0,"total_unsigned_batches":794,"total_batches":794,"percentage":100},{"operator_id":"0x70ccb39b4bdcd7769eaaf1face9068a8b061f7a3e447492bd1dacf43ac3e79b7","operator_address":"0x7c2eb067bd97cc7b798cf6b3d3cc18508775946f","quorum_id":0,"total_unsigned_batches":426,"total_batches":426,"percentage":100},{"operator_id":"0x817c119843de860391090aa01bb39731066838977745be7467f549f8c28a79b5","operator_address":"0xd7c1d2b609390683bbdd185130ceb748eb2e7310","quorum_id":0,"total_unsigned_batches":1064,"total_batches":1064,"percentage":100},{"operator_id":"0x95cead86f8bad3f605a1522c9e8fa893b7c6154ca27047b60520fad763269041","operator_address":"0x5f27203659c240cdf910999642e257fef0e96077","quorum_id":0,"total_unsigned_batches":386,"total_batches":386,"percentage":100},{"operator_id":"0x9f018fa5c580cce497c54832c0e955baae268cd2b279c40fc155f37cadcf3df6","operator_address":"0x78fdde7a5006cc64e109aed99ca7b0ad3d8687bb","quorum_id":1,"total_unsigned_batches":2,"total_batches":2,"percentage":100},{"operator_id":"0xa2e6ec89b8afeed41cb3d919b835e6b5c4b85c917b7e869b8e6c4367007044ad","operator_address":"0xd8f642848bfcaae2119ba1781117557ff45b1db4","quorum_id":0,"total_unsigned_batches":1052,"total_batches":1052,"percentage":100},{"operator_id":"0xd1a82f31c4f97e4de3dfbd517bcf0b71fb0520e475015e915ee114cb36740129","operator_address":"0xd847062ff3e50d6cec36f7d1b8923bf597768b6d","quorum_id":0,"total_unsigned_batches":1124,"total_batches":1124,"percentage":100},{"operator_id":"0xe02eb821060cd7b07b2f998d5409117190a38200eff09700ffaa322c5819008d","operator_address":"0x51b38dfab8b4266e0cdd76bfa6941792ae19738d","quorum_id":0,"total_unsigned_batches":843,"total_batches":843,"percentage":100},{"operator_id":"0xedfa99ef794eb370cc98cf23a9812d5fee6003eb313032e75d9e6cd55703e67c","operator_address":"0xc7b8134e0589deb7534fd0c68d0fbf707959b713","quorum_id":0,"total_unsigned_batches":1054,"total_batches":1054,"percentage":100},{"operator_id":"0xefb45317c27a2b82a1c6f8d939a14b769e53b677e19a53665d03ce8e376df45f","operator_address":"0xfc837b01d4196dca9d441e42ac792484bab96d11","quorum_id":0,"total_unsigned_batches":120,"total_batches":120,"percentage":100},{"operator_id":"0xf3cbbd02a20044c58ed57c8dfee9fd5d70858c3d3f449051651f0d5649031ac1","operator_address":"0xbc0a9e6ddb719aabc1da9783bc91c37401b3daea","quorum_id":0,"total_unsigned_batches":803,"total_batches":803,"percentage":100},{"operator_id":"0x3bb3f206227d6da7e37ac71cba47a501a6c970f384ec23df95fcea1c2cfcf036","operator_address":"0x5cd6d276cc1f8c98175a1e4ffd0313c3967fb9c6","quorum_id":0,"total_unsigned_batches":338,"total_batches":913,"percentage":37.02},{"operator_id":"0x43c1d143eef7164fd2101ca1589cd8fa0c6192e7537c3cf524d06ad07653caf6","operator_address":"0xc369bb3f82a92c1086edf4228b4c190fdf6aea8d","quorum_id":0,"total_unsigned_batches":71,"total_batches":374,"percentage":18.98},{"operator_id":"0x9f018fa5c580cce497c54832c0e955baae268cd2b279c40fc155f37cadcf3df6","operator_address":"0x78fdde7a5006cc64e109aed99ca7b0ad3d8687bb","quorum_id":0,"total_unsigned_batches":221,"total_batches":1274,"percentage":17.35},{"operator_id":"0x8c49a63ece568fa11e4a596e10ea409c9c83937b1446b67ca97a06a5ffba2a39","operator_address":"0x3764a3569f1509bcf9ec11ed40a19defeeb4f727","quorum_id":0,"total_unsigned_batches":38,"total_batches":308,"percentage":12.34},{"operator_id":"0x4a2e98e2323f0667679ef60029ada8a34501f4bada0954cdf146b924a3f50ca3","operator_address":"0x3e31908e30b3051dfe056b1d0902b164d78cd8b8","quorum_id":0,"total_unsigned_batches":94,"total_batches":1274,"percentage":7.38},{"operator_id":"0x2d11a222f9e9db4efe9954ab708a116a4f99058fa2dabaaa4b1dbed3e0ee424c","operator_address":"0xbb317a0d78056847b513a1a1685b01cf14321a90","quorum_id":0,"total_unsigned_batches":70,"total_batches":1051,"percentage":6.66},{"operator_id":"0x5d8558f06af3a8ae30d6859b658b80c368e1564c0fad8a0f15e1b2c30262bda3","operator_address":"0xa8c128bd6f5a314b46202dd7c68e7e2422ed61f2","quorum_id":0,"total_unsigned_batches":76,"total_batches":1662,"percentage":4.57},{"operator_id":"0xc8b26a972195c043984122d47182a5bea186c4fff95d552469ed15bef2a13ea9","operator_address":"0x234649b2d3c67e74f073f9c95fa8b10846c93a6b","quorum_id":0,"total_unsigned_batches":32,"total_batches":1054,"percentage":3.04},{"operator_id":"0x23ccd10361a9f12ba8b8c1e0e0b07ff6d5ed1438a809391b0f5dadbcc0cb116b","operator_address":"0x9aac36049eeafe2b130c4f6e38071f2945fff5f6","quorum_id":0,"total_unsigned_batches":19,"total_batches":799,"percentage":2.38},{"operator_id":"0xeadd14807b8185b808b95a5623f8b251d62bc8ee6549c926ddec047f11fb368f","operator_address":"0x4e59e88207ac04e6615d79ae565e877dd80bcf8e","quorum_id":0,"total_unsigned_batches":20,"total_batches":1054,"percentage":1.9},{"operator_id":"0xcb3206c8cde3805ff8af3956c0e9ee0c527fa06b28dfed0c33e4c41e43313bc0","operator_address":"0xfca6d2bcb0775c29d8924d3dcf0b7446e8cb2e69","quorum_id":0,"total_unsigned_batches":5,"total_batches":433,"percentage":1.15},{"operator_id":"0x4b2baa691a002ab5eb956949e48374af47d9a2933052aff98a5ccf32941af8d1","operator_address":"0x5df2cb42029056318077f18c9ef5d72e95725cdf","quorum_id":0,"total_unsigned_batches":8,"total_batches":765,"percentage":1.05},{"operator_id":"0x29f7bf28855f652da9f0c4316466b92781560b24bb69e2156093b4cdc93b1ddc","operator_address":"0x1392d82c6e22cc6e7d48be93050f6f3ebee5986d","quorum_id":0,"total_unsigned_batches":8,"total_batches":809,"percentage":0.99},{"operator_id":"0xf8d3b75da1d572e0bd417b55ba44d119c2eb28c059cfae8ee523634a091de906","operator_address":"0x29e98e743fe0da00a63c19ea22584506a678dfe7","quorum_id":0,"total_unsigned_batches":6,"total_batches":990,"percentage":0.61},{"operator_id":"0x020860aae64318a89f3a7c61cf82acd575d3a7e6b318ceac7c76b63ed4bb120a","operator_address":"0x20caf6c60411b2e4ef27a1b4f829d641ba41984e","quorum_id":0,"total_unsigned_batches":3,"total_batches":749,"percentage":0.4},{"operator_id":"0xad81792163a84a6c8cf335d48799385353b99c2d053b6f66f1c65041ee3d691e","operator_address":"0x86693c61dc76a3d5f953f32b5b47d04043c393a8","quorum_id":0,"total_unsigned_batches":4,"total_batches":1054,"percentage":0.38},{"operator_id":"0x9f80a535ab06889e44d4d1efd4c06f5fbbef89051cd4151fcf434edc755f9ffc","operator_address":"0x9631af6a712d296fedb800132edcf08e493b12cd","quorum_id":0,"total_unsigned_batches":4,"total_batches":1104,"percentage":0.36},{"operator_id":"0x7162f8254c5e087ae8b484a9483332972c52432e5a46273d2a265b2f91997204","operator_address":"0xd5a39e3c763a6e1f37e354f6f3f267fda1c6ccc6","quorum_id":0,"total_unsigned_batches":2,"total_batches":693,"percentage":0.29},{"operator_id":"0x33d1fad765f9477f8d949b1bca5c3f23e983b1eb60ec7d47530bcefcbf10370c","operator_address":"0xc7e74d350785cb177c020e3a2b53d1b7500bb86b","quorum_id":0,"total_unsigned_batches":2,"total_batches":1054,"percentage":0.19},{"operator_id":"0x122769e86fda868d6e30f2c52325b7decdf90dd87894df1fa11a0a98e6f8428b","operator_address":"0x9b066f984eea9e034311b45451a16c827f2f26a9","quorum_id":0,"total_unsigned_batches":2,"total_batches":1218,"percentage":0.16},{"operator_id":"0x5b99ff3ad362280058cad0855a10eef8898b27a47ae1307c3e02b2a1276d8dd6","operator_address":"0xd0f5f61ce21f3290d30a721f27d37d68fa0665f2","quorum_id":0,"total_unsigned_batches":2,"total_batches":1316,"percentage":0.15},{"operator_id":"0x05473ed72c5e2f17a4525f5f3482c40ba31521f33bb138b24f726bd227f821f8","operator_address":"0x53595d37208584f3df0234b99350d301f2a98171","quorum_id":0,"total_unsigned_batches":1,"total_batches":818,"percentage":0.12},{"operator_id":"0x3a552b77ef1900fb007ad48c8d3c350381872ed1364a590b34ac3ce717c1fe8d","operator_address":"0xea2d67a6be1f0a0ccf58068bc209749f8137b4a7","quorum_id":0,"total_unsigned_batches":1,"total_batches":1199,"percentage":0.08},{"operator_id":"0xf581c6a784ee1f5cb9a6900f57ab1677b9e8a02ffbc169ab98ccfd1432a90ab2","operator_address":"0xfc55e8ab411a9844e7c4506f6da353ba6bf5482f","quorum_id":0,"total_unsigned_batches":1,"total_batches":1243,"percentage":0.08},{"operator_id":"0x76f0bcf6c0584b3c7ce79d590a3806f58552638f7228bbb09abdb2387b853c6e","operator_address":"0x9844f84da487ecd22fa2dba07afd44d97ada1be1","quorum_id":0,"total_unsigned_batches":1,"total_batches":1660,"percentage":0.06}]}`

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
