### PR TITLE
Index operator state by quorum id not quorum index

### DIFF
--- a/core/eth/state.go
+++ b/core/eth/state.go
@@ -23,12 +23,12 @@ func NewChainState(tx core.Transactor, client common.EthClient) *ChainState {
 var _ core.ChainState = (*ChainState)(nil)
 
 func (cs *ChainState) GetOperatorStateByOperator(ctx context.Context, blockNumber uint, operator core.OperatorID) (*core.OperatorState, error) {
-	operatorsByQuorum, quorumIds, err := cs.Tx.GetOperatorStakes(ctx, operator, uint32(blockNumber))
+	operatorsByQuorum, _, err := cs.Tx.GetOperatorStakes(ctx, operator, uint32(blockNumber))
 	if err != nil {
 		return nil, err
 	}
 
-	return getOperatorState(operatorsByQuorum, quorumIds, uint32(blockNumber))
+	return getOperatorState(operatorsByQuorum, uint32(blockNumber))
 
 }
 
@@ -38,7 +38,7 @@ func (cs *ChainState) GetOperatorState(ctx context.Context, blockNumber uint, qu
 		return nil, err
 	}
 
-	return getOperatorState(operatorsByQuorum, quorums, uint32(blockNumber))
+	return getOperatorState(operatorsByQuorum, uint32(blockNumber))
 }
 
 func (cs *ChainState) GetCurrentBlockNumber() (uint, error) {
@@ -51,7 +51,7 @@ func (cs *ChainState) GetCurrentBlockNumber() (uint, error) {
 	return uint(header.Number.Uint64()), nil
 }
 
-func getOperatorState(operatorsByQuorum core.OperatorStakes, quorumIds []core.QuorumID, blockNumber uint32) (*core.OperatorState, error) {
+func getOperatorState(operatorsByQuorum core.OperatorStakes, blockNumber uint32) (*core.OperatorState, error) {
 	operators := make(map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo)
 	totals := make(map[core.QuorumID]*core.OperatorInfo)
 

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -370,6 +370,7 @@ func (t *Transactor) GetOperatorStakes(ctx context.Context, operator core.Operat
 		return nil, nil, err
 	}
 
+	// BitmapToQuorumIds returns an ordered list of quorums in ascending order, which is the same order as the state_ returned by the contract
 	quorumIds := BitmapToQuorumIds(quorumBitmap)
 
 	state := make(core.OperatorStakes, len(state_))

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -370,9 +370,11 @@ func (t *Transactor) GetOperatorStakes(ctx context.Context, operator core.Operat
 		return nil, nil, err
 	}
 
+	quorumIds := BitmapToQuorumIds(quorumBitmap)
+
 	state := make(core.OperatorStakes, len(state_))
 	for i := range state_ {
-		quorumID := core.QuorumID(i)
+		quorumID := quorumIds[i]
 		state[quorumID] = make(map[core.OperatorIndex]core.OperatorStake, len(state_[i]))
 		for j, op := range state_[i] {
 			operatorIndex := core.OperatorIndex(j)
@@ -382,8 +384,6 @@ func (t *Transactor) GetOperatorStakes(ctx context.Context, operator core.Operat
 			}
 		}
 	}
-
-	quorumIds := BitmapToQuorumIds(quorumBitmap)
 
 	return state, quorumIds, nil
 }


### PR DESCRIPTION
## Why are these changes needed?

Uses the `quorumID` instead of the quorum index in the `operatorState` returned by the `chainState` implementation.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
