### PR TITLE
Add checks for g1 and g2 point deserialization

### DIFF
--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -160,8 +160,8 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 
 			// Add to agg signature
 			if aggSigs[ind] == nil {
-				aggSigs[ind] = &Signature{sig.Deserialize(sig.Serialize())}
-				aggPubKeys[ind] = op.PubkeyG2.Deserialize(op.PubkeyG2.Serialize())
+				aggSigs[ind] = &Signature{sig.Copy()}
+				aggPubKeys[ind] = op.PubkeyG2.Copy()
 			} else {
 				aggSigs[ind].Add(sig.G1Point)
 				aggPubKeys[ind].Add(op.PubkeyG2)
@@ -198,7 +198,7 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 		quorumAggKey := state.AggKeys[id]
 		quorumAggPubKeys[ind] = quorumAggKey
 
-		signersAggKey := quorumAggKey.Deserialize(quorumAggKey.Serialize())
+		signersAggKey := quorumAggKey.Copy()
 		for opInd, nsk := range nonSignerKeys {
 			ops := state.Operators[id]
 			if _, ok := ops[nonSignerOperatorIds[opInd]]; ok {

--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -160,8 +160,8 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 
 			// Add to agg signature
 			if aggSigs[ind] == nil {
-				aggSigs[ind] = &Signature{sig.Copy()}
-				aggPubKeys[ind] = op.PubkeyG2.Copy()
+				aggSigs[ind] = &Signature{sig.Clone()}
+				aggPubKeys[ind] = op.PubkeyG2.Clone()
 			} else {
 				aggSigs[ind].Add(sig.G1Point)
 				aggPubKeys[ind].Add(op.PubkeyG2)
@@ -198,7 +198,7 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 		quorumAggKey := state.AggKeys[id]
 		quorumAggPubKeys[ind] = quorumAggKey
 
-		signersAggKey := quorumAggKey.Copy()
+		signersAggKey := quorumAggKey.Clone()
 		for opInd, nsk := range nonSignerKeys {
 			ops := state.Operators[id]
 			if _, ok := ops[nonSignerOperatorIds[opInd]]; ok {

--- a/core/attestation.go
+++ b/core/attestation.go
@@ -59,7 +59,7 @@ func (p *G1Point) Deserialize(data []byte) (*G1Point, error) {
 	return &G1Point{point}, nil
 }
 
-func (p *G1Point) Copy() *G1Point {
+func (p *G1Point) Clone() *G1Point {
 	return &G1Point{&bn254.G1Affine{
 		X: newFpElement(p.X.BigInt(new(big.Int))),
 		Y: newFpElement(p.Y.BigInt(new(big.Int))),
@@ -96,7 +96,7 @@ func (p *G2Point) Deserialize(data []byte) (*G2Point, error) {
 	return &G2Point{point}, nil
 }
 
-func (p *G2Point) Copy() *G2Point {
+func (p *G2Point) Clone() *G2Point {
 	return &G2Point{&bn254.G2Affine{
 		X: struct {
 			A0, A1 fp.Element

--- a/core/attestation.go
+++ b/core/attestation.go
@@ -51,8 +51,19 @@ func (p *G1Point) Serialize() []byte {
 	return bn254utils.SerializeG1(p.G1Affine)
 }
 
-func (p *G1Point) Deserialize(data []byte) *G1Point {
-	return &G1Point{bn254utils.DeserializeG1(data)}
+func (p *G1Point) Deserialize(data []byte) (*G1Point, error) {
+	point, err := bn254utils.DeserializeG1(data)
+	if err != nil {
+		return nil, err
+	}
+	return &G1Point{point}, nil
+}
+
+func (p *G1Point) Copy() *G1Point {
+	return &G1Point{&bn254.G1Affine{
+		X: newFpElement(p.X.BigInt(new(big.Int))),
+		Y: newFpElement(p.Y.BigInt(new(big.Int))),
+	}}
 }
 
 func (p *G1Point) Hash() [32]byte {
@@ -77,8 +88,29 @@ func (p *G2Point) Serialize() []byte {
 	return bn254utils.SerializeG2(p.G2Affine)
 }
 
-func (p *G2Point) Deserialize(data []byte) *G2Point {
-	return &G2Point{bn254utils.DeserializeG2(data)}
+func (p *G2Point) Deserialize(data []byte) (*G2Point, error) {
+	point, err := bn254utils.DeserializeG2(data)
+	if err != nil {
+		return nil, err
+	}
+	return &G2Point{point}, nil
+}
+
+func (p *G2Point) Copy() *G2Point {
+	return &G2Point{&bn254.G2Affine{
+		X: struct {
+			A0, A1 fp.Element
+		}{
+			A0: newFpElement(p.X.A0.BigInt(new(big.Int))),
+			A1: newFpElement(p.X.A1.BigInt(new(big.Int))),
+		},
+		Y: struct {
+			A0, A1 fp.Element
+		}{
+			A0: newFpElement(p.Y.A0.BigInt(new(big.Int))),
+			A1: newFpElement(p.Y.A1.BigInt(new(big.Int))),
+		},
+	}}
 }
 
 type Signature struct {

--- a/core/bn254/attestation.go
+++ b/core/bn254/attestation.go
@@ -1,6 +1,7 @@
 package bn254
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
@@ -106,11 +107,14 @@ func SerializeG1(p *bn254.G1Affine) []byte {
 	return b
 }
 
-func DeserializeG1(b []byte) *bn254.G1Affine {
+func DeserializeG1(b []byte) (*bn254.G1Affine, error) {
+	if len(b) != 64 {
+		return nil, errors.New("could not deserialize point, invalid length")
+	}
 	p := new(bn254.G1Affine)
 	p.X.SetBytes(b[0:32])
 	p.Y.SetBytes(b[32:64])
-	return p
+	return p, nil
 }
 
 func SerializeG2(p *bn254.G2Affine) []byte {
@@ -134,13 +138,16 @@ func SerializeG2(p *bn254.G2Affine) []byte {
 	return b
 }
 
-func DeserializeG2(b []byte) *bn254.G2Affine {
+func DeserializeG2(b []byte) (*bn254.G2Affine, error) {
+	if len(b) != 128 {
+		return nil, errors.New("could not deserialize point, invalid length")
+	}
 	p := new(bn254.G2Affine)
 	p.X.A0.SetBytes(b[0:32])
 	p.X.A1.SetBytes(b[32:64])
 	p.Y.A0.SetBytes(b[64:96])
 	p.Y.A1.SetBytes(b[96:128])
-	return p
+	return p, nil
 }
 
 func MakePubkeyRegistrationData(privKey *fr.Element, operatorAddress common.Address) *bn254.G1Affine {

--- a/core/bn254/attestation.go
+++ b/core/bn254/attestation.go
@@ -109,7 +109,7 @@ func SerializeG1(p *bn254.G1Affine) []byte {
 
 func DeserializeG1(b []byte) (*bn254.G1Affine, error) {
 	if len(b) != 64 {
-		return nil, errors.New("could not deserialize G1 point, length must be exactly 64")
+		return nil, errors.New("could not deserialize G1 point: length must be exactly 64")
 	}
 	p := new(bn254.G1Affine)
 	p.X.SetBytes(b[0:32])

--- a/core/bn254/attestation.go
+++ b/core/bn254/attestation.go
@@ -109,7 +109,7 @@ func SerializeG1(p *bn254.G1Affine) []byte {
 
 func DeserializeG1(b []byte) (*bn254.G1Affine, error) {
 	if len(b) != 64 {
-		return nil, errors.New("could not deserialize point, invalid length")
+		return nil, errors.New("could not deserialize G1 point, length must be exactly 64")
 	}
 	p := new(bn254.G1Affine)
 	p.X.SetBytes(b[0:32])
@@ -140,7 +140,7 @@ func SerializeG2(p *bn254.G2Affine) []byte {
 
 func DeserializeG2(b []byte) (*bn254.G2Affine, error) {
 	if len(b) != 128 {
-		return nil, errors.New("could not deserialize point, invalid length")
+		return nil, errors.New("could not deserialize G2 point: length must be exactly 128")
 	}
 	p := new(bn254.G2Affine)
 	p.X.A0.SetBytes(b[0:32])

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -88,7 +88,7 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 	for ind := core.OperatorIndex(0); ind < d.NumOperators; ind++ {
 		if ind == 0 {
 			key := d.KeyPairs[ind].GetPubKeyG1()
-			aggPubKey = key.Copy()
+			aggPubKey = key.Clone()
 		} else {
 			aggPubKey.Add(d.KeyPairs[ind].GetPubKeyG1())
 		}

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -88,7 +88,7 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 	for ind := core.OperatorIndex(0); ind < d.NumOperators; ind++ {
 		if ind == 0 {
 			key := d.KeyPairs[ind].GetPubKeyG1()
-			aggPubKey = key.Deserialize(key.Serialize())
+			aggPubKey = key.Copy()
 		} else {
 			aggPubKey.Add(d.KeyPairs[ind].GetPubKeyG1())
 		}

--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -121,7 +121,11 @@ func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.BlobMessage, 
 	}
 
 	sigBytes := reply.GetSignature()
-	sig := &core.Signature{G1Point: new(core.Signature).Deserialize(sigBytes)}
+	point, err := new(core.Signature).Deserialize(sigBytes)
+	if err != nil {
+		return nil, err
+	}
+	sig := &core.Signature{G1Point: point}
 	return sig, nil
 }
 

--- a/operators/churner/server.go
+++ b/operators/churner/server.go
@@ -77,7 +77,7 @@ func (s *Server) Churn(ctx context.Context, req *pb.ChurnRequest) (*pb.ChurnRepl
 	request, err := createChurnRequest(req)
 	if err != nil {
 		s.metrics.IncrementFailedRequestNum("Churn", FailReasonInvalidRequest)
-		return nil, api.NewInvalidArgError(fmt.Sprintf("invalid request: %s", err.Error()))
+		return nil, api.NewInvalidArgError(err.Error())
 	}
 
 	operatorToRegisterAddress, err := s.churner.VerifyRequestSignature(ctx, request)

--- a/operators/churner/server.go
+++ b/operators/churner/server.go
@@ -74,7 +74,11 @@ func (s *Server) Churn(ctx context.Context, req *pb.ChurnRequest) (*pb.ChurnRepl
 		return nil, api.NewResourceExhaustedError(fmt.Sprintf("previous approval not expired, retry in %d", s.latestExpiry-now.Unix()))
 	}
 
-	request := createChurnRequest(req)
+	request, err := createChurnRequest(req)
+	if err != nil {
+		s.metrics.IncrementFailedRequestNum("Churn", FailReasonInvalidRequest)
+		return nil, api.NewInvalidArgError(fmt.Sprintf("invalid request: %s", err.Error()))
+	}
 
 	operatorToRegisterAddress, err := s.churner.VerifyRequestSignature(ctx, request)
 	if err != nil {
@@ -171,8 +175,13 @@ func (s *Server) validateChurnRequest(ctx context.Context, req *pb.ChurnRequest)
 
 }
 
-func createChurnRequest(req *pb.ChurnRequest) *ChurnRequest {
-	signature := &core.Signature{G1Point: new(core.G1Point).Deserialize(req.GetOperatorRequestSignature())}
+func createChurnRequest(req *pb.ChurnRequest) (*ChurnRequest, error) {
+
+	sigPoint, err := new(core.G1Point).Deserialize(req.GetOperatorRequestSignature())
+	if err != nil {
+		return nil, err
+	}
+	signature := &core.Signature{G1Point: sigPoint}
 
 	address := gethcommon.HexToAddress(req.GetOperatorAddress())
 
@@ -184,14 +193,23 @@ func createChurnRequest(req *pb.ChurnRequest) *ChurnRequest {
 		quorumIDs[i] = core.QuorumID(id)
 	}
 
+	pubkeyG1, err := new(core.G1Point).Deserialize(req.GetOperatorToRegisterPubkeyG1())
+	if err != nil {
+		return nil, err
+	}
+	pubkeyG2, err := new(core.G2Point).Deserialize(req.GetOperatorToRegisterPubkeyG2())
+	if err != nil {
+		return nil, err
+	}
+
 	return &ChurnRequest{
 		OperatorAddress:            address,
-		OperatorToRegisterPubkeyG1: new(core.G1Point).Deserialize(req.GetOperatorToRegisterPubkeyG1()),
-		OperatorToRegisterPubkeyG2: new(core.G2Point).Deserialize(req.GetOperatorToRegisterPubkeyG2()),
+		OperatorToRegisterPubkeyG1: pubkeyG1,
+		OperatorToRegisterPubkeyG2: pubkeyG2,
 		OperatorRequestSignature:   signature,
 		Salt:                       salt,
 		QuorumIDs:                  quorumIDs,
-	}
+	}, nil
 }
 
 func convertToOperatorsToChurnGrpc(operatorsToChurn []core.OperatorToChurn) []*pb.OperatorToChurn {


### PR DESCRIPTION
## Why are these changes needed?

Ensures that DA nodes cannot panic the disperser by sending an empty signature. 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
