### PR TITLE
Report number of signers/nonsigners by quorum

### DIFF
--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -454,15 +454,7 @@ func (t *Transactor) BuildConfirmBatchTxn(ctx context.Context, batchHeader *core
 		// TODO: instead of recalculating the operator id, we should just pass it in from the caller
 		nonSignerOperatorIds[i] = HashPubKeyG1(signatureAggregation.NonSigners[i])
 	}
-	sigAgg, err := json.Marshal(signatureAggregation)
-	if err == nil {
-		t.Logger.Debug("[BuildConfirmBatchTxn]", "signatureAggregation", string(sigAgg))
-	}
 
-	t.Logger.Debug("[GetCheckSignaturesIndices]", "regCoordinatorAddr", t.Bindings.RegCoordinatorAddr.Hex(), "refBlockNumber", batchHeader.ReferenceBlockNumber, "quorumNumbers", gethcommon.Bytes2Hex(quorumNumbers))
-	for _, ns := range nonSignerOperatorIds {
-		t.Logger.Debug("[GetCheckSignaturesIndices]", "nonSignerOperatorId", gethcommon.Bytes2Hex(ns[:]))
-	}
 	checkSignaturesIndices, err := t.Bindings.OpStateRetriever.GetCheckSignaturesIndices(
 		&bind.CallOpts{
 			Context: ctx,


### PR DESCRIPTION
## Why are these changes needed?
Instead of reporting total number of signers/nonsigners, break down by quorum
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
