### PR TITLE
Account the invalid requests in disperser metrics

### DIFF
--- a/disperser/metrics.go
+++ b/disperser/metrics.go
@@ -135,6 +135,16 @@ func (g *Metrics) HandleBlobStoreFailedRequest(quorum string, blobBytes int, met
 	}).Add(float64(blobBytes))
 }
 
+// HandleInvalidArgRequest updates the number of invalid argument requests
+func (g *Metrics) HandleInvalidArgRequest(method string) {
+	g.NumBlobRequests.With(prometheus.Labels{
+		"status_code": codes.InvalidArgument.String(),
+		"status":      "failed",
+		"quorum":      "",
+		"method":      method,
+	}).Inc()
+}
+
 // HandleSystemRateLimitedRequest updates the number of system rate limited requests and the size of the blob
 func (g *Metrics) HandleSystemRateLimitedRequest(quorum string, blobBytes int, method string) {
 	g.NumBlobRequests.With(prometheus.Labels{


### PR DESCRIPTION
## Why are these changes needed?
We need to account the invalid requests to have the API endpoint availability metrics.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
