### PR TITLE
Increase grpc message size limit

### DIFF
--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -112,7 +112,7 @@ func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.BlobMessage, 
 		return nil, err
 	}
 
-	opt := grpc.MaxCallSendMsgSize(1024 * 1024 * 1024)
+	opt := grpc.MaxCallSendMsgSize(60 * 1024 * 1024 * 1024)
 	c.logger.Debug("sending chunks to operator", "operator", op.Socket, "size", totalSize)
 	reply, err := gc.StoreChunks(ctx, request, opt)
 

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -87,7 +87,7 @@ func (s *Server) serveDispersal() error {
 		s.logger.Fatalf("Could not start tcp listener: %v", err)
 	}
 
-	opt := grpc.MaxRecvMsgSize(1024 * 1024 * 1024) // 1 GiB
+	opt := grpc.MaxRecvMsgSize(60 * 1024 * 1024 * 1024) // 60 GiB
 	gs := grpc.NewServer(opt)
 
 	// Register reflection service on gRPC server


### PR DESCRIPTION
## Why are these changes needed?
As the batch interval increases, the amount of data over gRPC increases per dispersal. 
Increasing this to 60GiB = (600s batch interval * 10 MiB/s * coding rate of 10)
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
