### PR TITLE
don't count metadata not found as internal error

### DIFF
--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -350,7 +350,7 @@ func TestRetrieveBlobFailsWhenBlobNotConfirmed(t *testing.T) {
 	// Try to retrieve the blob before it is confirmed
 	_, err = retrieveBlob(t, dispersalServer, requestID, 2)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "rpc error: code = Internal desc = failed to get blob metadata, please retry")
+	assert.Equal(t, "rpc error: code = InvalidArgument desc = no metadata found for the given batch header hash and blob index", err.Error())
 
 }
 

--- a/disperser/common/blobstore/blob_metadata_store.go
+++ b/disperser/common/blobstore/blob_metadata_store.go
@@ -61,6 +61,11 @@ func (s *BlobMetadataStore) GetBlobMetadata(ctx context.Context, metadataKey dis
 			Value: metadataKey.MetadataHash,
 		},
 	})
+
+	if item == nil {
+		return nil, fmt.Errorf("%w: metadata not found for key %s", disperser.ErrMetadataNotFound, metadataKey)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +204,7 @@ func (s *BlobMetadataStore) GetBlobMetadataInBatch(ctx context.Context, batchHea
 	}
 
 	if len(items) == 0 {
-		return nil, fmt.Errorf("there is no metadata for batch %s and blob index %d", batchHeaderHash, blobIndex)
+		return nil, fmt.Errorf("%w: there is no metadata for batch %s and blob index %d", disperser.ErrMetadataNotFound, batchHeaderHash, blobIndex)
 	}
 
 	if len(items) > 1 {

--- a/disperser/errors.go
+++ b/disperser/errors.go
@@ -3,5 +3,6 @@ package disperser
 import "errors"
 
 var (
-	ErrBlobNotFound = errors.New("blob not found")
+	ErrBlobNotFound     = errors.New("blob not found")
+	ErrMetadataNotFound = errors.New("metadata not found")
 )


### PR DESCRIPTION
## Why are these changes needed?

Invalid requests to retrieve blobs or get blob status are currently treated as internal errors. 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
