### PR TITLE
add checks on curve, and serialize using gnark

### DIFF
--- a/core/attestation.go
+++ b/core/attestation.go
@@ -48,15 +48,17 @@ func (p *G1Point) VerifyEquivalence(p2 *G2Point) (bool, error) {
 }
 
 func (p *G1Point) Serialize() []byte {
-	return bn254utils.SerializeG1(p.G1Affine)
+	res := p.RawBytes()
+	return res[:]
 }
 
 func (p *G1Point) Deserialize(data []byte) (*G1Point, error) {
-	point, err := bn254utils.DeserializeG1(data)
+	var point bn254.G1Affine
+	_, err := point.SetBytes(data)
 	if err != nil {
 		return nil, err
 	}
-	return &G1Point{point}, nil
+	return &G1Point{&point}, nil
 }
 
 func (p *G1Point) Clone() *G1Point {

--- a/core/attestation.go
+++ b/core/attestation.go
@@ -87,15 +87,17 @@ func (p *G2Point) Sub(p2 *G2Point) {
 }
 
 func (p *G2Point) Serialize() []byte {
-	return bn254utils.SerializeG2(p.G2Affine)
+	res := p.RawBytes()
+	return res[:]
 }
 
 func (p *G2Point) Deserialize(data []byte) (*G2Point, error) {
-	point, err := bn254utils.DeserializeG2(data)
+	var point bn254.G2Affine
+	_, err := point.SetBytes(data)
 	if err != nil {
 		return nil, err
 	}
-	return &G2Point{point}, nil
+	return &G2Point{&point}, nil
 }
 
 func (p *G2Point) Clone() *G2Point {

--- a/core/bn254/attestation.go
+++ b/core/bn254/attestation.go
@@ -93,34 +93,6 @@ func MulByGeneratorG2(a *fr.Element) *bn254.G2Affine {
 	return new(bn254.G2Affine).ScalarMultiplication(g2Gen, a.BigInt(new(big.Int)))
 }
 
-func SerializeG1(p *bn254.G1Affine) []byte {
-	res := p.RawBytes()
-	return res[:]
-}
-
-func DeserializeG1(b []byte) (*bn254.G1Affine, error) {
-	var p bn254.G1Affine
-	_, err := p.SetBytes(b)
-	if err != nil {
-		return nil, err
-	}
-	return &p, nil
-}
-
-func SerializeG2(p *bn254.G2Affine) []byte {
-	res := p.RawBytes()
-	return res[:]
-}
-
-func DeserializeG2(b []byte) (*bn254.G2Affine, error) {
-	var p bn254.G2Affine
-	_, err := p.SetBytes(b)
-	if err != nil {
-		return nil, err
-	}
-	return &p, nil
-}
-
 func MakePubkeyRegistrationData(privKey *fr.Element, operatorAddress common.Address) *bn254.G1Affine {
 	toHash := make([]byte, 0)
 	toHash = append(toHash, crypto.Keccak256([]byte("BN254PubkeyRegistration(address operator)"))...)

--- a/core/bn254/attestation.go
+++ b/core/bn254/attestation.go
@@ -94,7 +94,7 @@ func MulByGeneratorG2(a *fr.Element) *bn254.G2Affine {
 }
 
 func SerializeG1(p *bn254.G1Affine) []byte {
-	res := p.Bytes()
+	res := p.RawBytes()
 	return res[:]
 }
 
@@ -108,7 +108,7 @@ func DeserializeG1(b []byte) (*bn254.G1Affine, error) {
 }
 
 func SerializeG2(p *bn254.G2Affine) []byte {
-	res := p.Bytes()
+	res := p.RawBytes()
 	return res[:]
 }
 

--- a/core/bn254/attestation.go
+++ b/core/bn254/attestation.go
@@ -94,7 +94,7 @@ func MulByGeneratorG2(a *fr.Element) *bn254.G2Affine {
 }
 
 func SerializeG1(p *bn254.G1Affine) []byte {
-	res := p.RawBytes()
+	res := p.Bytes()
 	return res[:]
 }
 
@@ -108,7 +108,7 @@ func DeserializeG1(b []byte) (*bn254.G1Affine, error) {
 }
 
 func SerializeG2(p *bn254.G2Affine) []byte {
-	res := p.RawBytes()
+	res := p.Bytes()
 	return res[:]
 }
 

--- a/core/bn254/attestation.go
+++ b/core/bn254/attestation.go
@@ -1,7 +1,6 @@
 package bn254
 
 import (
-	"errors"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
@@ -95,59 +94,31 @@ func MulByGeneratorG2(a *fr.Element) *bn254.G2Affine {
 }
 
 func SerializeG1(p *bn254.G1Affine) []byte {
-	b := make([]byte, 0)
-	tmp := p.X.Bytes()
-	for i := 0; i < 32; i++ {
-		b = append(b, tmp[i])
-	}
-	tmp = p.Y.Bytes()
-	for i := 0; i < 32; i++ {
-		b = append(b, tmp[i])
-	}
-	return b
+	res := p.RawBytes()
+	return res[:]
 }
 
 func DeserializeG1(b []byte) (*bn254.G1Affine, error) {
-	if len(b) != 64 {
-		return nil, errors.New("could not deserialize G1 point: length must be exactly 64")
+	var p bn254.G1Affine
+	_, err := p.SetBytes(b)
+	if err != nil {
+		return nil, err
 	}
-	p := new(bn254.G1Affine)
-	p.X.SetBytes(b[0:32])
-	p.Y.SetBytes(b[32:64])
-	return p, nil
+	return &p, nil
 }
 
 func SerializeG2(p *bn254.G2Affine) []byte {
-	b := make([]byte, 0)
-	tmp := p.X.A0.Bytes()
-	for i := 0; i < 32; i++ {
-		b = append(b, tmp[i])
-	}
-	tmp = p.X.A1.Bytes()
-	for i := 0; i < 32; i++ {
-		b = append(b, tmp[i])
-	}
-	tmp = p.Y.A0.Bytes()
-	for i := 0; i < 32; i++ {
-		b = append(b, tmp[i])
-	}
-	tmp = p.Y.A1.Bytes()
-	for i := 0; i < 32; i++ {
-		b = append(b, tmp[i])
-	}
-	return b
+	res := p.RawBytes()
+	return res[:]
 }
 
 func DeserializeG2(b []byte) (*bn254.G2Affine, error) {
-	if len(b) != 128 {
-		return nil, errors.New("could not deserialize G2 point: length must be exactly 128")
+	var p bn254.G2Affine
+	_, err := p.SetBytes(b)
+	if err != nil {
+		return nil, err
 	}
-	p := new(bn254.G2Affine)
-	p.X.A0.SetBytes(b[0:32])
-	p.X.A1.SetBytes(b[32:64])
-	p.Y.A0.SetBytes(b[64:96])
-	p.Y.A1.SetBytes(b[96:128])
-	return p, nil
+	return &p, nil
 }
 
 func MakePubkeyRegistrationData(privKey *fr.Element, operatorAddress common.Address) *bn254.G1Affine {

--- a/core/serialization.go
+++ b/core/serialization.go
@@ -364,16 +364,16 @@ func (h *BlobHeader) Serialize() ([]byte, error) {
 func (h *BlobHeader) Deserialize(data []byte) (*BlobHeader, error) {
 	err := decode(data, h)
 
-	if !(*bn254.G1Affine)(h.BlobCommitments.Commitment).IsOnCurve() {
-		return nil, fmt.Errorf("in BlobHeader Commitment is not on the curve")
+	if !(*bn254.G1Affine)(h.BlobCommitments.Commitment).IsInSubGroup() {
+		return nil, fmt.Errorf("in BlobHeader Commitment is in the subgroup")
 	}
 
-	if !(*bn254.G2Affine)(h.BlobCommitments.LengthCommitment).IsOnCurve() {
-		return nil, fmt.Errorf("in BlobHeader LengthCommitment is not on the curve")
+	if !(*bn254.G2Affine)(h.BlobCommitments.LengthCommitment).IsInSubGroup() {
+		return nil, fmt.Errorf("in BlobHeader LengthCommitment is not in the subgroup")
 	}
 
-	if !(*bn254.G2Affine)(h.BlobCommitments.LengthProof).IsOnCurve() {
-		return nil, fmt.Errorf("in BlobHeader LengthProof is not on the curve")
+	if !(*bn254.G2Affine)(h.BlobCommitments.LengthProof).IsInSubGroup() {
+		return nil, fmt.Errorf("in BlobHeader LengthProof is not in the subgroup")
 	}
 
 	return h, err

--- a/core/serialization.go
+++ b/core/serialization.go
@@ -365,7 +365,7 @@ func (h *BlobHeader) Deserialize(data []byte) (*BlobHeader, error) {
 	err := decode(data, h)
 
 	if !(*bn254.G1Affine)(h.BlobCommitments.Commitment).IsInSubGroup() {
-		return nil, fmt.Errorf("in BlobHeader Commitment is in the subgroup")
+		return nil, fmt.Errorf("in BlobHeader Commitment is not in the subgroup")
 	}
 
 	if !(*bn254.G2Affine)(h.BlobCommitments.LengthCommitment).IsInSubGroup() {

--- a/core/serialization.go
+++ b/core/serialization.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 
 	binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDAServiceManager"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/wealdtech/go-merkletree"
@@ -362,6 +363,19 @@ func (h *BlobHeader) Serialize() ([]byte, error) {
 
 func (h *BlobHeader) Deserialize(data []byte) (*BlobHeader, error) {
 	err := decode(data, h)
+
+	if !(*bn254.G1Affine)(h.BlobCommitments.Commitment).IsOnCurve() {
+		return nil, fmt.Errorf("in BlobHeader Commitment is not on the curve")
+	}
+
+	if !(*bn254.G2Affine)(h.BlobCommitments.LengthCommitment).IsOnCurve() {
+		return nil, fmt.Errorf("in BlobHeader LengthCommitment is not on the curve")
+	}
+
+	if !(*bn254.G2Affine)(h.BlobCommitments.LengthProof).IsOnCurve() {
+		return nil, fmt.Errorf("in BlobHeader LengthProof is not on the curve")
+	}
+
 	return h, err
 }
 

--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"fmt"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 )
@@ -39,11 +40,15 @@ func Decode(b []byte) (Frame, error) {
 }
 
 func (c *G1Commitment) Serialize() ([]byte, error) {
-	return encode(c)
+	res := (*bn254.G1Affine)(c).Bytes()
+	return res[:], nil
 }
 
 func (c *G1Commitment) Deserialize(data []byte) (*G1Commitment, error) {
-	err := decode(data, c)
+	_, err := (*bn254.G1Affine)(c).SetBytes(data)
+	if err != nil {
+		return nil, err
+	}
 	return c, err
 }
 
@@ -55,15 +60,24 @@ func (c *G1Commitment) UnmarshalJSON(data []byte) error {
 	}
 	c.X = g1Point.X
 	c.Y = g1Point.Y
+
+	if !(*bn254.G1Affine)(c).IsOnCurve() {
+		return fmt.Errorf("G1Commitment not on the curve")
+	}
+
 	return nil
 }
 
 func (c *G2Commitment) Serialize() ([]byte, error) {
-	return encode(c)
+	res := (*bn254.G2Affine)(c).Bytes()
+	return res[:], nil
 }
 
 func (c *G2Commitment) Deserialize(data []byte) (*G2Commitment, error) {
-	err := decode(data, c)
+	_, err := (*bn254.G2Affine)(c).SetBytes(data)
+	if err != nil {
+		return nil, err
+	}
 	return c, err
 }
 
@@ -75,6 +89,10 @@ func (c *G2Commitment) UnmarshalJSON(data []byte) error {
 	}
 	c.X = g2Point.X
 	c.Y = g2Point.Y
+
+	if !(*bn254.G2Affine)(c).IsOnCurve() {
+		return fmt.Errorf("G2Commitment not on the curve")
+	}
 	return nil
 }
 

--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -15,6 +15,10 @@ func (c *Frame) Serialize() ([]byte, error) {
 
 func (c *Frame) Deserialize(data []byte) (*Frame, error) {
 	err := decode(data, c)
+	if !c.Proof.IsInSubGroup() {
+		return nil, fmt.Errorf("proof is in not the subgroup")
+	}
+
 	return c, err
 }
 

--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -19,9 +19,6 @@ func (c *Frame) Deserialize(data []byte) (*Frame, error) {
 		return nil, fmt.Errorf("proof is in not the subgroup")
 	}
 
-	if c.Proof.IsInfinity() {
-		return nil, fmt.Errorf("proof is infinity")
-	}
 	return c, err
 }
 

--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -61,8 +61,8 @@ func (c *G1Commitment) UnmarshalJSON(data []byte) error {
 	c.X = g1Point.X
 	c.Y = g1Point.Y
 
-	if !(*bn254.G1Affine)(c).IsOnCurve() {
-		return fmt.Errorf("G1Commitment not on the curve")
+	if !(*bn254.G1Affine)(c).IsInSubGroup() {
+		return fmt.Errorf("G1Commitment not in the subgroup")
 	}
 
 	return nil
@@ -90,8 +90,8 @@ func (c *G2Commitment) UnmarshalJSON(data []byte) error {
 	c.X = g2Point.X
 	c.Y = g2Point.Y
 
-	if !(*bn254.G2Affine)(c).IsOnCurve() {
-		return fmt.Errorf("G2Commitment not on the curve")
+	if !(*bn254.G2Affine)(c).IsInSubGroup() {
+		return fmt.Errorf("G2Commitment not in the subgroup")
 	}
 	return nil
 }

--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -19,6 +19,9 @@ func (c *Frame) Deserialize(data []byte) (*Frame, error) {
 		return nil, fmt.Errorf("proof is in not the subgroup")
 	}
 
+	if c.Proof.IsInfinity() {
+		return nil, fmt.Errorf("proof is infinity")
+	}
 	return c, err
 }
 
@@ -82,6 +85,7 @@ func (c *G2Commitment) Deserialize(data []byte) (*G2Commitment, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return c, err
 }
 

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -168,8 +168,6 @@ func (s *Server) validateStoreChunkRequest(in *pb.StoreChunksRequest) error {
 		if blob.GetHeader() == nil {
 			return api.NewInvalidArgError("missing blob header in request")
 		}
-		GetBlobHeaderFromProto(blob.GetHeader())
-
 		if len(blob.GetHeader().GetQuorumHeaders()) == 0 {
 			return api.NewInvalidArgError("missing quorum headers in request")
 		}

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -168,6 +168,9 @@ func (s *Server) validateStoreChunkRequest(in *pb.StoreChunksRequest) error {
 		if blob.GetHeader() == nil {
 			return api.NewInvalidArgError("missing blob header in request")
 		}
+		if ValidatePointsFromBlobHeader(blob.GetHeader()) != nil {
+			return api.NewInvalidArgError("invalid points contained in the blob header in request")
+		}
 		if len(blob.GetHeader().GetQuorumHeaders()) == 0 {
 			return api.NewInvalidArgError("missing quorum headers in request")
 		}

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -168,6 +168,8 @@ func (s *Server) validateStoreChunkRequest(in *pb.StoreChunksRequest) error {
 		if blob.GetHeader() == nil {
 			return api.NewInvalidArgError("missing blob header in request")
 		}
+		GetBlobHeaderFromProto(blob.GetHeader())
+
 		if len(blob.GetHeader().GetQuorumHeaders()) == 0 {
 			return api.NewInvalidArgError("missing quorum headers in request")
 		}

--- a/node/grpc/utils.go
+++ b/node/grpc/utils.go
@@ -89,7 +89,7 @@ func GetBlobHeaderFromProto(h *pb.BlobHeader) (*core.BlobHeader, error) {
 	}
 
 	if !(*bn254.G2Affine)(&lengthCommitment).IsInSubGroup() {
-		return nil, errors.New("lengthCommitment is in the subgroup")
+		return nil, errors.New("lengthCommitment is not in the subgroup")
 	}
 
 	if h.GetLengthProof() != nil {

--- a/node/grpc/utils.go
+++ b/node/grpc/utils.go
@@ -75,8 +75,8 @@ func GetBlobHeaderFromProto(h *pb.BlobHeader) (*core.BlobHeader, error) {
 		Y: *commitY,
 	}
 
-	if !(*bn254.G1Affine)(commitment).IsOnCurve() {
-		return nil, errors.New("commitment is not on curve")
+	if !(*bn254.G1Affine)(commitment).IsInSubGroup() {
+		return nil, errors.New("commitment is not in the subgroup")
 	}
 
 	var lengthCommitment, lengthProof encoding.G2Commitment
@@ -87,8 +87,8 @@ func GetBlobHeaderFromProto(h *pb.BlobHeader) (*core.BlobHeader, error) {
 		lengthCommitment.Y.A1 = *new(fp.Element).SetBytes(h.GetLengthCommitment().GetYA1())
 	}
 
-	if !(*bn254.G2Affine)(&lengthCommitment).IsOnCurve() {
-		return nil, errors.New("lengthCommitment is not on curve")
+	if !(*bn254.G2Affine)(&lengthCommitment).IsInSubGroup() {
+		return nil, errors.New("lengthCommitment is in the subgroup")
 	}
 
 	if h.GetLengthProof() != nil {
@@ -98,8 +98,8 @@ func GetBlobHeaderFromProto(h *pb.BlobHeader) (*core.BlobHeader, error) {
 		lengthProof.Y.A1 = *new(fp.Element).SetBytes(h.GetLengthProof().GetYA1())
 	}
 
-	if !(*bn254.G2Affine)(&lengthProof).IsOnCurve() {
-		return nil, errors.New("lengthProof is not on curve")
+	if !(*bn254.G2Affine)(&lengthProof).IsInSubGroup() {
+		return nil, errors.New("lengthProof is not in the subgroup")
 	}
 
 	quorumHeaders := make([]*core.BlobQuorumInfo, len(h.GetQuorumHeaders()))

--- a/node/grpc/utils.go
+++ b/node/grpc/utils.go
@@ -80,10 +80,6 @@ func GetBlobHeaderFromProto(h *pb.BlobHeader) (*core.BlobHeader, error) {
 		return nil, errors.New("commitment is not in the subgroup")
 	}
 
-	if (*bn254.G1Affine)(commitment).IsInfinity() {
-		return nil, fmt.Errorf("commitment is infinity")
-	}
-
 	var lengthCommitment, lengthProof encoding.G2Commitment
 	if h.GetLengthCommitment() != nil {
 		lengthCommitment.X.A0 = *new(fp.Element).SetBytes(h.GetLengthCommitment().GetXA0())
@@ -96,10 +92,6 @@ func GetBlobHeaderFromProto(h *pb.BlobHeader) (*core.BlobHeader, error) {
 		return nil, errors.New("lengthCommitment is in the subgroup")
 	}
 
-	if (*bn254.G2Affine)(&lengthCommitment).IsInfinity() {
-		return nil, fmt.Errorf("commitment is infinity")
-	}
-
 	if h.GetLengthProof() != nil {
 		lengthProof.X.A0 = *new(fp.Element).SetBytes(h.GetLengthProof().GetXA0())
 		lengthProof.X.A1 = *new(fp.Element).SetBytes(h.GetLengthProof().GetXA1())
@@ -109,10 +101,6 @@ func GetBlobHeaderFromProto(h *pb.BlobHeader) (*core.BlobHeader, error) {
 
 	if !(*bn254.G2Affine)(&lengthProof).IsInSubGroup() {
 		return nil, errors.New("lengthProof is not in the subgroup")
-	}
-
-	if (*bn254.G2Affine)(&lengthProof).IsInfinity() {
-		return nil, fmt.Errorf("commitment is infinity")
 	}
 
 	quorumHeaders := make([]*core.BlobQuorumInfo, len(h.GetQuorumHeaders()))


### PR DESCRIPTION
## Why are these changes needed?

Add more checks on g1, g2 checks, as suggested by Sigp. It contains some overlap with previous PR #407.

The new code uses Gnark to check if a point(G1, G2) is on the subgroup, and which is eventually called if a point is in the curve inside the [gnark](https://github.com/Consensys/gnark-crypto/blob/v0.12.1/ecc/bn254/g1.go#L415) library. 

Since G1Commitment serde are only used in communication offchain, replacing with gnark setBytes and Bytes() is safe.

ONE Important issue is that: 

the previous serde code assigns wrong value for G2Point,  see https://github.com/Layr-Labs/eigenda/pull/407/files#diff-5480a750aef8baded2523848b6b296388101bc41127b739c7c25d232e3358abaL139 
and see https://github.com/consensys/gnark-crypto/blob/v0.12.1/ecc/bn254/marshal.go#L1092

But since everything is internal, between disperser to node, and between node to churner.

However, since this part is so pervasively used, it might be a good idea to keep the original, but adding the checks to the wrong point. But it did a silly mark to the core

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
