### PR TITLE
RPC requests accounting

### DIFF
--- a/disperser/metrics.go
+++ b/disperser/metrics.go
@@ -91,10 +91,10 @@ func (g *Metrics) ObserveLatency(method string, latencyMs float64) {
 	g.Latency.WithLabelValues(method).Observe(latencyMs)
 }
 
-func (g *Metrics) HandleSuccessfulRpcRequest(statusDetail string, method string) {
+func (g *Metrics) HandleSuccessfulRpcRequest(method string) {
 	g.NumRpcRequests.With(prometheus.Labels{
 		"status_code":   codes.OK.String(),
-		"status_detail": "success",
+		"status_detail": "",
 		"method":        method,
 	}).Inc()
 }
@@ -126,7 +126,15 @@ func (g *Metrics) HandleSystemRateLimitedRpcRequest(method string) {
 func (g *Metrics) HandleAccountRateLimitedRpcRequest(method string) {
 	g.NumRpcRequests.With(prometheus.Labels{
 		"status_code":   codes.ResourceExhausted.String(),
-		"status_detail": SystemRateLimitedFailure,
+		"status_detail": AccountRateLimitedFailure,
+		"method":        method,
+	}).Inc()
+}
+
+func (g *Metrics) HandleRateLimitedRpcRequest(method string) {
+	g.NumRpcRequests.With(prometheus.Labels{
+		"status_code":   codes.ResourceExhausted.String(),
+		"status_detail": "",
 		"method":        method,
 	}).Inc()
 }


### PR DESCRIPTION
## Why are these changes needed?
The current `NumBlobRequests` is counting the same RPC requests multiple times (one for each quorum). This is not right for API accounting.


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
