### PR TITLE
Use histogram for dispersal e2e latency

### DIFF
--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -200,7 +200,7 @@ func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
 		BatchProcLatencyHistogram: promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
-				Name:      "batch_process_latency_ms",
+				Name:      "batch_process_latency_histogram_ms",
 				Help:      "batch process latency histogram in milliseconds",
 				// In minutes: 1, 2, 3, 5, 8, 10, 13, 15, 21, 34, 55, 89
 				Buckets: []float64{60_000, 120_000, 180_000, 300_000, 480_000, 600_000, 780_000, 900_000, 1_260_000, 2_040_000, 3_300_000, 5_340_000},


### PR DESCRIPTION
## Why are these changes needed?
The dispersal e2e latency SLI needs histogram metric.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
