### PR TITLE
Update metrics not to double count blob failures

### DIFF
--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -611,7 +611,7 @@ func (e *EncodingStreamer) validateMetadataQuorums(metadatas []*disperser.BlobMe
 		if valid {
 			validMetadata = append(validMetadata, metadata)
 		} else {
-			err := e.blobStore.HandleBlobFailure(context.Background(), metadata, 0)
+			_, err := e.blobStore.HandleBlobFailure(context.Background(), metadata, 0)
 			if err != nil {
 				e.logger.Error("error handling blob failure", "err", err)
 			}

--- a/disperser/batcher/finalizer.go
+++ b/disperser/batcher/finalizer.go
@@ -179,7 +179,7 @@ func (f *finalizer) updateBlobs(ctx context.Context, metadatas []*disperser.Blob
 		confirmationBlockNumber, err := f.getTransactionBlockNumber(ctx, confirmationMetadata.ConfirmationInfo.ConfirmationTxnHash)
 		if errors.Is(err, ethereum.NotFound) {
 			// The confirmed block is finalized, but the transaction is not found. It means the transaction should be considered forked/invalid and the blob should be considered as failed.
-			err := f.blobStore.HandleBlobFailure(ctx, m, f.maxNumRetriesPerBlob)
+			_, err := f.blobStore.HandleBlobFailure(ctx, m, f.maxNumRetriesPerBlob)
 			if err != nil {
 				f.logger.Error("error marking blob as failed", "blobKey", blobKey.String(), "err", err)
 			}

--- a/disperser/common/blobstore/shared_storage.go
+++ b/disperser/common/blobstore/shared_storage.go
@@ -233,11 +233,11 @@ func (s *SharedBlobStore) GetBlobMetadata(ctx context.Context, metadataKey dispe
 	return s.blobMetadataStore.GetBlobMetadata(ctx, metadataKey)
 }
 
-func (s *SharedBlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) error {
+func (s *SharedBlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) (bool, error) {
 	if metadata.NumRetries < maxRetry {
-		return s.IncrementBlobRetryCount(ctx, metadata)
+		return true, s.IncrementBlobRetryCount(ctx, metadata)
 	} else {
-		return s.MarkBlobFailed(ctx, metadata.GetBlobKey())
+		return false, s.MarkBlobFailed(ctx, metadata.GetBlobKey())
 	}
 }
 

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -260,11 +260,11 @@ func (q *BlobStore) GetBlobMetadata(ctx context.Context, blobKey disperser.BlobK
 	return nil, disperser.ErrBlobNotFound
 }
 
-func (q *BlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) error {
+func (q *BlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) (bool, error) {
 	if metadata.NumRetries < maxRetry {
-		return q.IncrementBlobRetryCount(ctx, metadata)
+		return true, q.IncrementBlobRetryCount(ctx, metadata)
 	} else {
-		return q.MarkBlobFailed(ctx, metadata.GetBlobKey())
+		return false, q.MarkBlobFailed(ctx, metadata.GetBlobKey())
 	}
 }
 

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -165,7 +165,8 @@ type BlobStore interface {
 	// GetBlobMetadata returns a blob metadata given a metadata key
 	GetBlobMetadata(ctx context.Context, blobKey BlobKey) (*BlobMetadata, error)
 	// HandleBlobFailure handles a blob failure by either incrementing the retry count or marking the blob as failed
-	HandleBlobFailure(ctx context.Context, metadata *BlobMetadata, maxRetry uint) error
+	// Returns a boolean indicating whether the blob should be retried and an error
+	HandleBlobFailure(ctx context.Context, metadata *BlobMetadata, maxRetry uint) (bool, error)
 }
 
 type Dispatcher interface {


### PR DESCRIPTION
## Why are these changes needed?
Right now, it's reporting retryable failures as `Failed` blobs. It should only be reported if it permanently failed dispersal.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
