### PR TITLE
feat(node): support execution without ecdsa key

### DIFF
--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -100,7 +100,7 @@ var (
 	}
 	EcdsaKeyFileFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "ecdsa-key-file"),
-		Required: true,
+		Required: false,
 		Usage:    "Path to the encrypted ecdsa private key",
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "ECDSA_KEY_FILE"),
 	}
@@ -113,7 +113,7 @@ var (
 	}
 	EcdsaKeyPasswordFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "ecdsa-key-password"),
-		Required: true,
+		Required: false,
 		Usage:    "Password to decrypt ecdsa private key",
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "ECDSA_KEY_PASSWORD"),
 	}
@@ -244,9 +244,7 @@ var requiredFlags = []cli.Flag{
 	QuorumIDListFlag,
 	DbPathFlag,
 	BlsKeyFileFlag,
-	EcdsaKeyFileFlag,
 	BlsKeyPasswordFlag,
-	EcdsaKeyPasswordFlag,
 	BlsOperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 	PubIPProviderFlag,
@@ -266,6 +264,8 @@ var optionalFlags = []cli.Flag{
 	InternalRetrievalPortFlag,
 	ClientIPHeaderFlag,
 	ChurnerUseSecureGRPC,
+	EcdsaKeyFileFlag,
+	EcdsaKeyPasswordFlag,
 }
 
 func init() {


### PR DESCRIPTION
## Why are these changes needed?

It is desirable to run an EigenDA Node without providing access to the Eigenlayer Node Operator ECDSA key. If EigenDA Node is started in a configuration that does not use this key, it should not require the configuration to still specify a key and attempt to decrypt it.

There are configuration options which drive a runtime-need for the ECDSA key.
1. opting-in at startup
2. automatic IP checking and updating

When started in a configuration that requires the ECDSA key but no key is provided, a startup error message results.
<img width="1325" alt="Screenshot 2024-04-03 at 9 26 32 AM" src="https://github.com/Layr-Labs/eigenda/assets/107570428/d10e5f46-2915-456c-b1f5-d619d3f72351">
<img width="1338" alt="Screenshot 2024-04-03 at 9 27 46 AM" src="https://github.com/Layr-Labs/eigenda/assets/107570428/996409b7-88f0-4c85-9c01-5d5b257fcc9d">

**NOTE** This only impacts node, not node-plugin. The ECDSA key is still required when running node-plugin commands.

## Checks

- [x] I've made sure the lint is passing in this PR. (golangci-lint github action command)
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests (test-contracts and unit-tests github actions commands)
   - [ ] Integration tests
   - [ ] This PR is not tested :(
