### PR TITLE
[fix] remove space from op type

### DIFF
--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -136,7 +136,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	}
 
 	op := ctx.GlobalString(OperationFlag.Name)
-	if op != "opt-in" && op != "opt-out" && op != "list-quorums " {
+	if op != "opt-in" && op != "opt-out" && op != "list-quorums" {
 		return nil, errors.New("unsupported operation type")
 	}
 


### PR DESCRIPTION
## Why are these changes needed?

Extra space in op type `list-quorums`

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
