### PR TITLE
[dataapi] Represent total stakes with bigint

### DIFF
--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -3,6 +3,7 @@ package dataapi
 import (
 	"context"
 	"errors"
+	"math/big"
 	"net/http"
 	"os"
 	"os/signal"
@@ -65,8 +66,8 @@ type (
 		Throughput float64 `json:"throughput"`
 		CostInGas  float64 `json:"cost_in_gas"`
 		// deprecated: use TotalStakePerQuorum instead. Remove when the frontend is updated.
-		TotalStake          uint64                   `json:"total_stake"`
-		TotalStakePerQuorum map[core.QuorumID]uint64 `json:"total_stake_per_quorum"`
+		TotalStake          *big.Int                   `json:"total_stake"`
+		TotalStakePerQuorum map[core.QuorumID]*big.Int `json:"total_stake_per_quorum"`
 	}
 
 	Throughput struct {
@@ -375,12 +376,8 @@ func (s *server) FetchMetricsHandler(c *gin.Context) {
 	if err != nil || end == 0 {
 		end = now.Unix()
 	}
-	limit, err := strconv.Atoi(c.DefaultQuery("limit", "10"))
-	if err != nil || limit == 0 {
-		limit = 10
-	}
 
-	metric, err := s.getMetric(c.Request.Context(), start, end, limit)
+	metric, err := s.getMetric(c.Request.Context(), start, end)
 	if err != nil {
 		s.metrics.IncrementFailedRequestNum("FetchMetrics")
 		errorResponse(c, err)

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -267,10 +267,10 @@ func TestFetchMetricsHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, 16555.555555555555, response.Throughput)
 	assert.Equal(t, float64(85.14485344239945), response.CostInGas)
-	assert.Equal(t, uint64(1), response.TotalStake)
+	assert.Equal(t, big.NewInt(1), response.TotalStake)
 	assert.Len(t, response.TotalStakePerQuorum, 2)
-	assert.Equal(t, uint64(1), response.TotalStakePerQuorum[0])
-	assert.Equal(t, uint64(1), response.TotalStakePerQuorum[1])
+	assert.Equal(t, big.NewInt(1), response.TotalStakePerQuorum[0])
+	assert.Equal(t, big.NewInt(1), response.TotalStakePerQuorum[1])
 }
 
 func TestFetchMetricsThroughputHandler(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
`uint64` is not big enough to represent total stakes. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
