### PR TITLE
add open commitment utils

### DIFF
--- a/encoding/utils/openCommitment/open_commitment.go
+++ b/encoding/utils/openCommitment/open_commitment.go
@@ -1,0 +1,134 @@
+package openCommitment
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+// Implement https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_kzg_proof_impl
+func ComputeKzgProof(
+	evalFr []fr.Element,
+	index int,
+	G1srsLagrange []bn254.G1Affine,
+	rootOfUnities []fr.Element,
+) (*bn254.G1Affine, *fr.Element, error) {
+	if len(evalFr) != len(rootOfUnities) {
+		return nil, nil, fmt.Errorf("inconsistent length between blob and root of unities")
+	}
+	if index < 0 || index >= len(evalFr) {
+		return nil, nil, fmt.Errorf("the function only opens points within a blob")
+	}
+
+	polyShift := make([]fr.Element, len(evalFr))
+
+	valueFr := evalFr[index]
+
+	zFr := rootOfUnities[index]
+
+	for i := 0; i < len(polyShift); i++ {
+		polyShift[i].Sub(&evalFr[i], &valueFr)
+	}
+
+	denomPoly := make([]fr.Element, len(rootOfUnities))
+
+	for i := 0; i < len(evalFr); i++ {
+		denomPoly[i].Sub(&rootOfUnities[i], &zFr)
+	}
+
+	quotientPoly := make([]fr.Element, len(rootOfUnities))
+	for i := 0; i < len(quotientPoly); i++ {
+		if denomPoly[i].IsZero() {
+			quotientPoly[i] = computeQuotientEvalOnDomain(zFr, evalFr, valueFr, rootOfUnities)
+		} else {
+			quotientPoly[i].Div(&polyShift[i], &denomPoly[i])
+		}
+	}
+
+	config := ecc.MultiExpConfig{}
+
+	var proof bn254.G1Affine
+	_, err := proof.MultiExp(G1srsLagrange, quotientPoly, config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &proof, &valueFr, nil
+}
+
+func VerifyKzgProof(G1Gen, commitment, proof bn254.G1Affine, G2Gen, G2tau bn254.G2Affine, valueFr, zFr fr.Element) error {
+
+	var valueG1 bn254.G1Affine
+	var valueBig big.Int
+	valueG1.ScalarMultiplication(&G1Gen, valueFr.BigInt(&valueBig))
+
+	var commitMinusValue bn254.G1Affine
+	commitMinusValue.Sub(&commitment, &valueG1)
+
+	var zG2 bn254.G2Affine
+	zG2.ScalarMultiplication(&G2Gen, zFr.BigInt(&valueBig))
+
+	var xMinusZ bn254.G2Affine
+	xMinusZ.Sub(&G2tau, &zG2)
+
+	return PairingsVerify(&commitMinusValue, &G2Gen, &proof, &xMinusZ)
+}
+
+func PairingsVerify(a1 *bn254.G1Affine, a2 *bn254.G2Affine, b1 *bn254.G1Affine, b2 *bn254.G2Affine) error {
+	var negB1 bn254.G1Affine
+	negB1.Neg(b1)
+
+	P := [2]bn254.G1Affine{*a1, negB1}
+	Q := [2]bn254.G2Affine{*a2, *b2}
+
+	ok, err := bn254.PairingCheck(P[:], Q[:])
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("pairingCheck pairing not ok")
+	}
+
+	return nil
+}
+
+func CommitInLagrange(evalFr []fr.Element, G1srsLagrange []bn254.G1Affine) (*bn254.G1Affine, error) {
+	config := ecc.MultiExpConfig{}
+
+	var proof bn254.G1Affine
+	_, err := proof.MultiExp(G1srsLagrange, evalFr, config)
+	if err != nil {
+		return nil, err
+	}
+	return &proof, nil
+}
+
+// Implement https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_quotient_eval_within_domain
+func computeQuotientEvalOnDomain(zFr fr.Element, evalFr []fr.Element, valueFr fr.Element, rootOfunities []fr.Element) fr.Element {
+	var quotient fr.Element
+	var f_i, numerator, denominator, temp fr.Element
+
+	for i := 0; i < len(rootOfunities); i++ {
+		omega_i := rootOfunities[i]
+		if omega_i.Equal(&zFr) {
+			continue
+		}
+
+		f_i.Sub(&evalFr[i], &valueFr)
+		numerator.Mul(&f_i, &omega_i)
+
+		denominator.Sub(&zFr, &omega_i)
+		denominator.Mul(&denominator, &zFr)
+
+		numerator.Mul(&f_i, &omega_i)
+		temp.Div(&numerator, &denominator)
+
+		quotient.Add(&quotient, &temp)
+
+	}
+	return quotient
+}

--- a/encoding/utils/openCommitment/open_commitment_test.go
+++ b/encoding/utils/openCommitment/open_commitment_test.go
@@ -1,0 +1,105 @@
+package openCommitment_test
+
+import (
+	"crypto/rand"
+	"log"
+	"math/big"
+	"runtime"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/encoding"
+	"github.com/Layr-Labs/eigenda/encoding/kzg"
+	kzgProver "github.com/Layr-Labs/eigenda/encoding/kzg/prover"
+	"github.com/Layr-Labs/eigenda/encoding/rs"
+	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
+	oc "github.com/Layr-Labs/eigenda/encoding/utils/openCommitment"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	gettysburgAddressBytes = []byte("Fourscore and seven years ago our fathers brought forth, on this continent, a new nation, conceived in liberty, and dedicated to the proposition that all men are created equal. Now we are engaged in a great civil war, testing whether that nation, or any nation so conceived, and so dedicated, can long endure. We are met on a great battle-field of that war. We have come to dedicate a portion of that field, as a final resting-place for those who here gave their lives, that that nation might live. It is altogether fitting and proper that we should do this. But, in a larger sense, we cannot dedicate, we cannot consecrate—we cannot hallow—this ground. The brave men, living and dead, who struggled here, have consecrated it far above our poor power to add or detract. The world will little note, nor long remember what we say here, but it can never forget what they did here. It is for us the living, rather, to be dedicated here to the unfinished work which they who fought here have thus far so nobly advanced. It is rather for us to be here dedicated to the great task remaining before us—that from these honored dead we take increased devotion to that cause for which they here gave the last full measure of devotion—that we here highly resolve that these dead shall not have died in vain—that this nation, under God, shall have a new birth of freedom, and that government of the people, by the people, for the people, shall not perish from the earth.")
+	kzgConfig              *kzg.KzgConfig
+	numNode                uint64
+	numSys                 uint64
+	numPar                 uint64
+)
+
+func TestOpenCommitment(t *testing.T) {
+	log.Println("Setting up suite")
+
+	kzgConfig = &kzg.KzgConfig{
+		G1Path:          "../../../inabox/resources/kzg/g1.point",
+		G2Path:          "../../../inabox/resources/kzg/g2.point",
+		G2PowerOf2Path:  "../../../inabox/resources/kzg/g2.point.powerOf2",
+		CacheDir:        "../../../inabox/resources/kzg/SRSTables",
+		SRSOrder:        3000,
+		SRSNumberToLoad: 3000,
+		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
+	}
+
+	// input evaluation
+	validInput := codec.ConvertByPaddingEmptyByte(gettysburgAddressBytes)
+	inputFr, err := rs.ToFrArray(validInput)
+	require.Nil(t, err)
+
+	frLen := uint64(len(inputFr))
+	paddedInputFr := make([]fr.Element, encoding.NextPowerOf2(frLen))
+	// pad input Fr to power of 2 for computing FFT
+	for i := 0; i < len(paddedInputFr); i++ {
+		if i < len(inputFr) {
+			paddedInputFr[i].Set(&inputFr[i])
+		} else {
+			paddedInputFr[i].SetZero()
+		}
+	}
+
+	// we need prover only to access kzg SRS, and get kzg commitment of encoding
+	group, err := kzgProver.NewProver(kzgConfig, true)
+	require.Nil(t, err)
+
+	// get root of unit for blob
+	numNode = 4
+	numSys = 4
+	numPar = 0
+	numOpenChallenge := 10
+
+	params := encoding.ParamsFromSysPar(numSys, numPar, uint64(len(validInput)))
+	enc, err := group.GetKzgEncoder(params)
+	require.Nil(t, err)
+	rootOfUnities := enc.Fs.ExpandedRootsOfUnity[:len(enc.Fs.ExpandedRootsOfUnity)-1]
+
+	// Lagrange basis SRS in normal order, not butterfly
+	lagrangeG1SRS, err := enc.Fs.FFTG1(group.Srs.G1[:len(paddedInputFr)], true)
+	require.Nil(t, err)
+
+	// commit in lagrange form
+	commitLagrange, err := oc.CommitInLagrange(paddedInputFr, lagrangeG1SRS)
+	require.Nil(t, err)
+
+	modulo := big.NewInt(int64(len(inputFr)))
+	// pick a random place in the blob to open
+	for k := 0; k < numOpenChallenge; k++ {
+
+		indexBig, err := rand.Int(rand.Reader, modulo)
+		require.Nil(t, err)
+
+		index := int(indexBig.Int64())
+
+		// open at index on the kzg
+		proof, valueFr, err := oc.ComputeKzgProof(paddedInputFr, index, lagrangeG1SRS, rootOfUnities)
+		require.Nil(t, err)
+
+		_, _, g1Gen, g2Gen := bn254.Generators()
+
+		err = oc.VerifyKzgProof(g1Gen, *commitLagrange, *proof, g2Gen, group.Srs.G2[1], *valueFr, rootOfUnities[index])
+		require.Nil(t, err)
+
+		require.Equal(t, *valueFr, inputFr[index])
+
+		//valueBytse := valueFr.Bytes()
+		//fmt.Println("value Byte", string(valueBytse[1:]))
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?

This PR generates KZG proof using identical methods as 4844. i.e. treating data as evaluation

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
