### PR TITLE
Update graph-ts to 0.32.0

### DIFF
--- a/subgraphs/package.json
+++ b/subgraphs/package.json
@@ -3,7 +3,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@graphprotocol/graph-cli": "0.51.0",
-    "@graphprotocol/graph-ts": "0.31.3"
+    "@graphprotocol/graph-ts": "0.32.0"
   },
   "devDependencies": { "matchstick-as": "0.5.0" }
 }


### PR DESCRIPTION
## Why are these changes needed?

There's no version of `0.31.3` and this is causing a problem when running inabox fresh install. Updating it to `0.32.0` isn't causing any problem for testing on aws ubuntu setup

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
