### PR TITLE
Query non-signers between start and stop times. 

### DIFF
--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -374,6 +374,18 @@ const docTemplate = `{
                         "description": "Interval to query for operators nonsigning percentage [default: 3600]",
                         "name": "interval",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start time (UTC) to query for operators nonsigning percentage",
+                        "name": "start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End time (UTC) to query for operators nonsigning percentage",
+                        "name": "stop",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -497,6 +509,9 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "big.Int": {
+            "type": "object"
+        },
         "core.SecurityParam": {
             "type": "object",
             "properties": {
@@ -645,12 +660,16 @@ const docTemplate = `{
                 },
                 "total_stake": {
                     "description": "deprecated: use TotalStakePerQuorum instead. Remove when the frontend is updated.",
-                    "type": "integer"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/big.Int"
+                        }
+                    ]
                 },
                 "total_stake_per_quorum": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": "integer"
+                        "$ref": "#/definitions/big.Int"
                     }
                 }
             }

--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -377,14 +377,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Start time (UTC) to query for operators nonsigning percentage",
-                        "name": "start",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
                         "description": "End time (UTC) to query for operators nonsigning percentage",
-                        "name": "stop",
+                        "name": "end",
                         "in": "query"
                     }
                 ],

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -373,14 +373,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "Start time (UTC) to query for operators nonsigning percentage",
-                        "name": "start",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
                         "description": "End time (UTC) to query for operators nonsigning percentage",
-                        "name": "stop",
+                        "name": "end",
                         "in": "query"
                     }
                 ],

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -370,6 +370,18 @@
                         "description": "Interval to query for operators nonsigning percentage [default: 3600]",
                         "name": "interval",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start time (UTC) to query for operators nonsigning percentage",
+                        "name": "start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End time (UTC) to query for operators nonsigning percentage",
+                        "name": "stop",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -493,6 +505,9 @@
         }
     },
     "definitions": {
+        "big.Int": {
+            "type": "object"
+        },
         "core.SecurityParam": {
             "type": "object",
             "properties": {
@@ -641,12 +656,16 @@
                 },
                 "total_stake": {
                     "description": "deprecated: use TotalStakePerQuorum instead. Remove when the frontend is updated.",
-                    "type": "integer"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/big.Int"
+                        }
+                    ]
                 },
                 "total_stake_per_quorum": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": "integer"
+                        "$ref": "#/definitions/big.Int"
                     }
                 }
             }

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -454,13 +454,9 @@ paths:
         in: query
         name: interval
         type: integer
-      - description: Start time (UTC) to query for operators nonsigning percentage
-        in: query
-        name: start
-        type: string
       - description: End time (UTC) to query for operators nonsigning percentage
         in: query
-        name: stop
+        name: end
         type: string
       produces:
       - application/json

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -1,4 +1,6 @@
 definitions:
+  big.Int:
+    type: object
   core.SecurityParam:
     properties:
       adversaryThreshold:
@@ -103,12 +105,13 @@ definitions:
       throughput:
         type: number
       total_stake:
+        allOf:
+        - $ref: '#/definitions/big.Int'
         description: 'deprecated: use TotalStakePerQuorum instead. Remove when the
           frontend is updated.'
-        type: integer
       total_stake_per_quorum:
         additionalProperties:
-          type: integer
+          $ref: '#/definitions/big.Int'
         type: object
     type: object
   dataapi.NonSigner:
@@ -451,6 +454,14 @@ paths:
         in: query
         name: interval
         type: integer
+      - description: Start time (UTC) to query for operators nonsigning percentage
+        in: query
+        name: start
+        type: string
+      - description: End time (UTC) to query for operators nonsigning percentage
+        in: query
+        name: stop
+        type: string
       produces:
       - application/json
       responses:

--- a/disperser/dataapi/nonsigner_handler.go
+++ b/disperser/dataapi/nonsigner_handler.go
@@ -12,8 +12,8 @@ import (
 	"github.com/Layr-Labs/eigenda/core/eth"
 )
 
-func (s *server) getOperatorNonsigningRate(ctx context.Context, intervalSeconds int64) (*OperatorsNonsigningPercentage, error) {
-	batches, err := s.subgraphClient.QueryBatchNonSigningInfoInInterval(ctx, intervalSeconds)
+func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTime int64) (*OperatorsNonsigningPercentage, error) {
+	batches, err := s.subgraphClient.QueryBatchNonSigningInfoInInterval(ctx, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -316,7 +316,10 @@ func TestFetchMetricsThroughputHandler(t *testing.T) {
 func TestFetchUnsignedBatchesHandler(t *testing.T) {
 	r := setUpRouter()
 
-	mockSubgraphApi.On("QueryBatchNonSigningInfo").Return(batchNonSigningInfo, nil)
+	stopTime := time.Now()
+	startTime := stopTime.Add(time.Hour)
+
+	mockSubgraphApi.On("QueryBatchNonSigningInfo", startTime.Unix(), stopTime.Unix()).Return(batchNonSigningInfo, nil)
 	addr1 := gethcommon.HexToAddress("0x00000000219ab540356cbb839cbe05303d7705fa")
 	addr2 := gethcommon.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
 	mockTx.On("BatchOperatorIDToAddress").Return([]gethcommon.Address{addr1, addr2}, nil)
@@ -327,7 +330,8 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 	r.GET("/v1/metrics/operator-nonsigning-percentage", testDataApiServer.FetchOperatorsNonsigningPercentageHandler)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/v1/metrics/operator-nonsigning-percentage", nil)
+	reqStr := fmt.Sprintf("/v1/metrics/operator-nonsigning-percentage?start=%s&stop=%s", startTime.Format("2006-01-02T15:04:05Z"), stopTime.Format("2006-01-02T15:04:05Z"))
+	req := httptest.NewRequest(http.MethodGet, reqStr, nil)
 	ctxWithDeadline, cancel := context.WithTimeout(req.Context(), 500*time.Microsecond)
 	defer cancel()
 

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -317,7 +317,8 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 	r := setUpRouter()
 
 	stopTime := time.Now()
-	startTime := stopTime.Add(time.Hour)
+	interval := 3600
+	startTime := stopTime.Add(-time.Duration(interval) * time.Second)
 
 	mockSubgraphApi.On("QueryBatchNonSigningInfo", startTime.Unix(), stopTime.Unix()).Return(batchNonSigningInfo, nil)
 	addr1 := gethcommon.HexToAddress("0x00000000219ab540356cbb839cbe05303d7705fa")
@@ -330,7 +331,7 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 	r.GET("/v1/metrics/operator-nonsigning-percentage", testDataApiServer.FetchOperatorsNonsigningPercentageHandler)
 
 	w := httptest.NewRecorder()
-	reqStr := fmt.Sprintf("/v1/metrics/operator-nonsigning-percentage?start=%s&stop=%s", startTime.Format("2006-01-02T15:04:05Z"), stopTime.Format("2006-01-02T15:04:05Z"))
+	reqStr := fmt.Sprintf("/v1/metrics/operator-nonsigning-percentage?interval=%v&end=%s", interval, stopTime.Format("2006-01-02T15:04:05Z"))
 	req := httptest.NewRequest(http.MethodGet, reqStr, nil)
 	ctxWithDeadline, cancel := context.WithTimeout(req.Context(), 500*time.Microsecond)
 	defer cancel()

--- a/disperser/dataapi/subgraph/api.go
+++ b/disperser/dataapi/subgraph/api.go
@@ -23,7 +23,7 @@ type (
 		QueryBatchesByBlockTimestampRange(ctx context.Context, start, end uint64) ([]*Batches, error)
 		QueryOperators(ctx context.Context, first int) ([]*Operator, error)
 		QueryBatchNonSigningOperatorIdsInInterval(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningOperatorIds, error)
-		QueryBatchNonSigningInfo(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningInfo, error)
+		QueryBatchNonSigningInfo(ctx context.Context, startTime, endTime int64) ([]*BatchNonSigningInfo, error)
 		QueryDeregisteredOperatorsGreaterThanBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*Operator, error)
 		QueryRegisteredOperatorsGreaterThanBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*Operator, error)
 		QueryOperatorInfoByOperatorIdAtBlockNumber(ctx context.Context, operatorId core.OperatorID, blockNumber uint32) (*IndexedOperatorInfo, error)
@@ -112,10 +112,11 @@ func (a *api) QueryOperators(ctx context.Context, first int) ([]*Operator, error
 	return result.OperatorRegistereds, nil
 }
 
-func (a *api) QueryBatchNonSigningInfo(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningInfo, error) {
-	nonSigningAfter := time.Now().Add(-time.Duration(intervalSeconds) * time.Second).Unix()
+func (a *api) QueryBatchNonSigningInfo(ctx context.Context, startTime, endTime int64) ([]*BatchNonSigningInfo, error) {
+
 	variables := map[string]any{
-		"blockTimestamp_gt": graphql.Int(nonSigningAfter),
+		"blockTimestamp_gt": graphql.Int(startTime),
+		"blockTimestamp_lt": graphql.Int(endTime),
 	}
 	skip := 0
 

--- a/disperser/dataapi/subgraph/mock/api.go
+++ b/disperser/dataapi/subgraph/mock/api.go
@@ -68,7 +68,7 @@ func (m *MockSubgraphApi) QueryOperators(ctx context.Context, first int) ([]*sub
 }
 
 func (m *MockSubgraphApi) QueryBatchNonSigningInfo(ctx context.Context, startTime, endTime int64) ([]*subgraph.BatchNonSigningInfo, error) {
-	args := m.Called()
+	args := m.Called(startTime, endTime)
 
 	var value []*subgraph.BatchNonSigningInfo
 	if args.Get(0) != nil {

--- a/disperser/dataapi/subgraph/mock/api.go
+++ b/disperser/dataapi/subgraph/mock/api.go
@@ -67,7 +67,7 @@ func (m *MockSubgraphApi) QueryOperators(ctx context.Context, first int) ([]*sub
 	return value, args.Error(1)
 }
 
-func (m *MockSubgraphApi) QueryBatchNonSigningInfo(ctx context.Context, first int64) ([]*subgraph.BatchNonSigningInfo, error) {
+func (m *MockSubgraphApi) QueryBatchNonSigningInfo(ctx context.Context, startTime, endTime int64) ([]*subgraph.BatchNonSigningInfo, error) {
 	args := m.Called()
 
 	var value []*subgraph.BatchNonSigningInfo

--- a/disperser/dataapi/subgraph/queries.go
+++ b/disperser/dataapi/subgraph/queries.go
@@ -92,7 +92,7 @@ type (
 		BatchNonSigningOperatorIds []*BatchNonSigningOperatorIds `graphql:"batches(first: $first, skip: $skip, where: {blockTimestamp_gt: $blockTimestamp_gt})"`
 	}
 	queryBatchNonSigningInfo struct {
-		BatchNonSigningInfo []*BatchNonSigningInfo `graphql:"batches(first: $first, skip: $skip, where: {blockTimestamp_gt: $blockTimestamp_gt})"`
+		BatchNonSigningInfo []*BatchNonSigningInfo `graphql:"batches(first: $first, skip: $skip, where: {blockTimestamp_gt: $blockTimestamp_gt, blockTimestamp_lt: $blockTimestamp_lt})"`
 	}
 	queryOperatorRegisteredsGTBlockTimestamp struct {
 		OperatorRegistereds []*Operator `graphql:"operatorRegistereds(orderBy: blockTimestamp, where: {blockTimestamp_gt: $blockTimestamp_gt})"`

--- a/disperser/dataapi/subgraph_client.go
+++ b/disperser/dataapi/subgraph_client.go
@@ -24,7 +24,7 @@ type (
 		QueryBatchesWithLimit(ctx context.Context, limit, skip int) ([]*Batch, error)
 		QueryOperatorsWithLimit(ctx context.Context, limit int) ([]*Operator, error)
 		QueryBatchNonSigningOperatorIdsInInterval(ctx context.Context, intervalSeconds int64) (map[string]int, error)
-		QueryBatchNonSigningInfoInInterval(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningInfo, error)
+		QueryBatchNonSigningInfoInInterval(ctx context.Context, startTime, endTime int64) ([]*BatchNonSigningInfo, error)
 		QueryOperatorQuorumEvent(ctx context.Context, startBlock, endBlock uint32) (*OperatorQuorumEvents, error)
 		QueryIndexedDeregisteredOperatorsForTimeWindow(ctx context.Context, days int32) (*IndexedDeregisteredOperatorState, error)
 	}
@@ -126,8 +126,8 @@ func (sc *subgraphClient) QueryOperatorsWithLimit(ctx context.Context, limit int
 	return operators, nil
 }
 
-func (sc *subgraphClient) QueryBatchNonSigningInfoInInterval(ctx context.Context, intervalSeconds int64) ([]*BatchNonSigningInfo, error) {
-	batchNonSigningInfoGql, err := sc.api.QueryBatchNonSigningInfo(ctx, intervalSeconds)
+func (sc *subgraphClient) QueryBatchNonSigningInfoInInterval(ctx context.Context, startTime, endTime int64) ([]*BatchNonSigningInfo, error) {
+	batchNonSigningInfoGql, err := sc.api.QueryBatchNonSigningInfo(ctx, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}

--- a/disperser/dataapi/subgraph_client_test.go
+++ b/disperser/dataapi/subgraph_client_test.go
@@ -487,7 +487,7 @@ func TestQueryIndexedDeregisteredOperatorsForTimeWindow(t *testing.T) {
 
 func TestQueryBatchNonSigningInfoInInterval(t *testing.T) {
 	mockSubgraphApi := &subgraphmock.MockSubgraphApi{}
-	mockSubgraphApi.On("QueryBatchNonSigningInfo").Return(batchNonSigningInfo, nil)
+	mockSubgraphApi.On("QueryBatchNonSigningInfo", int64(0), int64(1)).Return(batchNonSigningInfo, nil)
 	subgraphClient := dataapi.NewSubgraphClient(mockSubgraphApi, logging.NewNoopLogger())
 	result, err := subgraphClient.QueryBatchNonSigningInfoInInterval(context.Background(), 0, 1)
 	assert.NoError(t, err)

--- a/disperser/dataapi/subgraph_client_test.go
+++ b/disperser/dataapi/subgraph_client_test.go
@@ -489,7 +489,7 @@ func TestQueryBatchNonSigningInfoInInterval(t *testing.T) {
 	mockSubgraphApi := &subgraphmock.MockSubgraphApi{}
 	mockSubgraphApi.On("QueryBatchNonSigningInfo").Return(batchNonSigningInfo, nil)
 	subgraphClient := dataapi.NewSubgraphClient(mockSubgraphApi, logging.NewNoopLogger())
-	result, err := subgraphClient.QueryBatchNonSigningInfoInInterval(context.Background(), int64(1))
+	result, err := subgraphClient.QueryBatchNonSigningInfoInInterval(context.Background(), 0, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(result))
 


### PR DESCRIPTION
## Why are these changes needed?

Allows for investigation of non-signer statistics over arbitrary intervals. 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
