### PR TITLE
Isolate transaction broadcasting latency from regas logic

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -46,6 +46,7 @@ type TimeoutConfig struct {
 	ChainWriteTimeout    time.Duration
 	ChainStateTimeout    time.Duration
 	FireblocksAPITimeout time.Duration
+	TxnBroadcastTimeout  time.Duration
 }
 
 type Config struct {

--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -109,10 +109,11 @@ func makeBatcher(t *testing.T) (*batcherComponents, *bat.Batcher, func() []time.
 		FinalizationBlockDelay:   finalizationBlockDelay,
 	}
 	timeoutConfig := bat.TimeoutConfig{
-		EncodingTimeout:    10 * time.Second,
-		AttestationTimeout: 10 * time.Second,
-		ChainReadTimeout:   10 * time.Second,
-		ChainWriteTimeout:  10 * time.Second,
+		EncodingTimeout:     10 * time.Second,
+		AttestationTimeout:  10 * time.Second,
+		ChainReadTimeout:    10 * time.Second,
+		ChainWriteTimeout:   10 * time.Second,
+		TxnBroadcastTimeout: 10 * time.Second,
 	}
 
 	metrics := bat.NewMetrics("9100", logger)

--- a/disperser/batcher/txn_manager_test.go
+++ b/disperser/batcher/txn_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Layr-Labs/eigenda/common/mock"
 	"github.com/Layr-Labs/eigenda/disperser/batcher"
 	sdkmock "github.com/Layr-Labs/eigensdk-go/chainio/clients/mocks"
+	walletsdk "github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -23,7 +24,7 @@ func TestProcessTransaction(t *testing.T) {
 	w := sdkmock.NewMockWallet(ctrl)
 	logger := logging.NewNoopLogger()
 	metrics := batcher.NewMetrics("9100", logger)
-	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 100*time.Millisecond, logger, metrics.TxnManagerMetrics)
+	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 100*time.Millisecond, 100*time.Millisecond, logger, metrics.TxnManagerMetrics)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	txnManager.Start(ctx)
@@ -36,7 +37,7 @@ func TestProcessTransaction(t *testing.T) {
 		w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(txID, nil),
 		w.EXPECT().GetTransactionReceipt(gomock.Any(), gomock.Any()).Return(&types.Receipt{
 			BlockNumber: new(big.Int).SetUint64(1),
-		}, nil),
+		}, nil).Times(2),
 	)
 
 	err := txnManager.ProcessTransaction(ctx, &batcher.TxnRequest{
@@ -73,7 +74,7 @@ func TestReplaceGasFee(t *testing.T) {
 	w := sdkmock.NewMockWallet(ctrl)
 	logger := logging.NewNoopLogger()
 	metrics := batcher.NewMetrics("9100", logger)
-	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 100*time.Millisecond, logger, metrics.TxnManagerMetrics)
+	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 100*time.Millisecond, 100*time.Millisecond, logger, metrics.TxnManagerMetrics)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	txnManager.Start(ctx)
@@ -86,7 +87,7 @@ func TestReplaceGasFee(t *testing.T) {
 	badTxID := "1234"
 	validTxID := "4321"
 	w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(badTxID, nil)
-	w.EXPECT().GetTransactionReceipt(gomock.Any(), badTxID).Return(nil, errors.New("blah")).AnyTimes()
+	w.EXPECT().GetTransactionReceipt(gomock.Any(), badTxID).Return(nil, walletsdk.ErrReceiptNotYetAvailable).AnyTimes()
 	w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(validTxID, nil)
 	w.EXPECT().GetTransactionReceipt(gomock.Any(), validTxID).Return(&types.Receipt{
 		BlockNumber: new(big.Int).SetUint64(1),
@@ -109,7 +110,7 @@ func TestTransactionReplacementFailure(t *testing.T) {
 	w := sdkmock.NewMockWallet(ctrl)
 	logger := logging.NewNoopLogger()
 	metrics := batcher.NewMetrics("9100", logger)
-	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
+	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, time.Second, 48*time.Second, logger, metrics.TxnManagerMetrics)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	txnManager.Start(ctx)
@@ -142,7 +143,7 @@ func TestSendTransactionReceiptRetry(t *testing.T) {
 	w := sdkmock.NewMockWallet(ctrl)
 	logger := logging.NewNoopLogger()
 	metrics := batcher.NewMetrics("9100", logger)
-	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
+	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, time.Second, 48*time.Second, logger, metrics.TxnManagerMetrics)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	txnManager.Start(ctx)
@@ -153,7 +154,7 @@ func TestSendTransactionReceiptRetry(t *testing.T) {
 	txID := "1234"
 	w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(txID, nil)
 	// assume that the transaction is not mined within the timeout
-	w.EXPECT().GetTransactionReceipt(gomock.Any(), txID).Return(nil, errors.New("blah"))
+	w.EXPECT().GetTransactionReceipt(gomock.Any(), txID).Return(nil, walletsdk.ErrReceiptNotYetAvailable).Times(3)
 	// assume that it fails to send the replacement transaction once
 	w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return("", errors.New("send txn failure"))
 	w.EXPECT().GetTransactionReceipt(gomock.Any(), txID).Return(&types.Receipt{
@@ -180,7 +181,7 @@ func TestSendTransactionRetrySuccess(t *testing.T) {
 	w := sdkmock.NewMockWallet(ctrl)
 	logger := logging.NewNoopLogger()
 	metrics := batcher.NewMetrics("9100", logger)
-	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
+	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, time.Second, 48*time.Second, logger, metrics.TxnManagerMetrics)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	txnManager.Start(ctx)
@@ -191,7 +192,7 @@ func TestSendTransactionRetrySuccess(t *testing.T) {
 	txID := "1234"
 	w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(txID, nil)
 	// assume that the transaction is not mined within the timeout
-	w.EXPECT().GetTransactionReceipt(gomock.Any(), txID).Return(nil, errors.New("blah")).AnyTimes()
+	w.EXPECT().GetTransactionReceipt(gomock.Any(), txID).Return(nil, walletsdk.ErrReceiptNotYetAvailable).AnyTimes()
 
 	// assume that it fails to send the replacement transaction once
 	w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return("", errors.New("send txn failure"))
@@ -222,7 +223,7 @@ func TestSendTransactionRetryFailure(t *testing.T) {
 	w := sdkmock.NewMockWallet(ctrl)
 	logger := logging.NewNoopLogger()
 	metrics := batcher.NewMetrics("9100", logger)
-	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 48*time.Second, logger, metrics.TxnManagerMetrics)
+	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, time.Second, 48*time.Second, logger, metrics.TxnManagerMetrics)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	txnManager.Start(ctx)
@@ -238,7 +239,7 @@ func TestSendTransactionRetryFailure(t *testing.T) {
 	w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return("", sendErr).Times(4)
 
 	// assume that the transaction is not mined within the timeout
-	w.EXPECT().GetTransactionReceipt(gomock.Any(), txID).Return(nil, errors.New("blah")).AnyTimes()
+	w.EXPECT().GetTransactionReceipt(gomock.Any(), txID).Return(nil, walletsdk.ErrReceiptNotYetAvailable).AnyTimes()
 
 	err := txnManager.ProcessTransaction(ctx, &batcher.TxnRequest{
 		Tx:    txn,
@@ -252,4 +253,36 @@ func TestSendTransactionRetryFailure(t *testing.T) {
 	assert.Nil(t, res.Receipt)
 	ethClient.AssertNumberOfCalls(t, "GetLatestGasCaps", 5)
 	ethClient.AssertNumberOfCalls(t, "UpdateGas", 5)
+}
+
+func TestTransactionNotBroadcasted(t *testing.T) {
+	ethClient := &mock.MockEthClient{}
+	ctrl := gomock.NewController(t)
+	w := sdkmock.NewMockWallet(ctrl)
+	logger := logging.NewNoopLogger()
+	metrics := batcher.NewMetrics("9100", logger)
+	txnManager := batcher.NewTxnManager(ethClient, w, 0, 5, 100*time.Millisecond, 48*time.Second, logger, metrics.TxnManagerMetrics)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	defer cancel()
+	txnManager.Start(ctx)
+	txn := types.NewTransaction(0, common.HexToAddress("0x1"), big.NewInt(1e18), 100000, big.NewInt(1e9), []byte{})
+	ethClient.On("GetLatestGasCaps").Return(big.NewInt(1e9), big.NewInt(1e9), nil)
+	ethClient.On("UpdateGas").Return(txn, nil)
+	ethClient.On("BlockNumber").Return(uint64(123), nil)
+	txID := "1234"
+	w.EXPECT().SendTransaction(gomock.Any(), gomock.Any()).Return(txID, nil)
+
+	// assume that the transaction does not get broadcasted to the network
+	w.EXPECT().GetTransactionReceipt(gomock.Any(), txID).Return(nil, walletsdk.ErrNotYetBroadcasted).AnyTimes()
+
+	err := txnManager.ProcessTransaction(ctx, &batcher.TxnRequest{
+		Tx:    txn,
+		Tag:   "test transaction",
+		Value: nil,
+	})
+	<-ctx.Done()
+	assert.NoError(t, err)
+	res := <-txnManager.ReceiptChan()
+	assert.ErrorAs(t, res.Err, &batcher.ErrTransactionNotBroadcasted)
+	assert.Nil(t, res.Receipt)
 }

--- a/disperser/cmd/batcher/config.go
+++ b/disperser/cmd/batcher/config.go
@@ -73,6 +73,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			ChainWriteTimeout:    ctx.GlobalDuration(flags.ChainWriteTimeoutFlag.Name),
 			ChainStateTimeout:    ctx.GlobalDuration(flags.ChainStateTimeoutFlag.Name),
 			FireblocksAPITimeout: ctx.GlobalDuration(flags.FireblocksAPITimeoutFlag.Name),
+			TxnBroadcastTimeout:  ctx.GlobalDuration(flags.TransactionBroadcastTimeoutFlag.Name),
 		},
 		MetricsConfig: batcher.MetricsConfig{
 			HTTPPort:      ctx.GlobalString(flags.MetricsHTTPPort.Name),

--- a/disperser/cmd/batcher/flags/flags.go
+++ b/disperser/cmd/batcher/flags/flags.go
@@ -128,6 +128,13 @@ var (
 		Value:    10 * time.Second,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "FIREBLOCKS_API_TIMEOUT"),
 	}
+	TransactionBroadcastTimeoutFlag = cli.DurationFlag{
+		Name:     "transaction-broadcast-timeout",
+		Usage:    "timeout to broadcast transaction",
+		Required: false,
+		Value:    10 * time.Minute,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "TRANSACTION_BROADCAST_TIMEOUT"),
+	}
 	NumConnectionsFlag = cli.IntFlag{
 		Name:     "num-connections",
 		Usage:    "maximum number of connections to encoders (defaults to 256)",
@@ -217,6 +224,7 @@ var optionalFlags = []cli.Flag{
 	ChainWriteTimeoutFlag,
 	ChainStateTimeoutFlag,
 	FireblocksAPITimeoutFlag,
+	TransactionBroadcastTimeoutFlag,
 	NumConnectionsFlag,
 	FinalizerIntervalFlag,
 	FinalizerPoolSizeFlag,

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -231,7 +231,7 @@ func RunBatcher(ctx *cli.Context) error {
 		return errors.New("no wallet is configured. Either Fireblocks or PrivateKey wallet should be configured")
 	}
 
-	txnManager := batcher.NewTxnManager(client, wallet, config.EthClientConfig.NumConfirmations, 20, config.TimeoutConfig.ChainWriteTimeout, logger, metrics.TxnManagerMetrics)
+	txnManager := batcher.NewTxnManager(client, wallet, config.EthClientConfig.NumConfirmations, 20, config.TimeoutConfig.TxnBroadcastTimeout, config.TimeoutConfig.ChainWriteTimeout, logger, metrics.TxnManagerMetrics)
 	batcher, err := batcher.NewBatcher(config.BatcherConfig, config.TimeoutConfig, queue, dispatcher, ics, asgn, encoderClient, agg, client, finalizer, tx, txnManager, logger, metrics, handleBatchLivenessChan)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.1
 
 require (
 	github.com/Layr-Labs/eigenda/api v0.0.0
-	github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240329221113-a1f7ac9ed7d1
+	github.com/Layr-Labs/eigensdk-go v0.1.6-0.20240409054704-47c41ef999a9
 	github.com/aws/aws-sdk-go-v2 v1.26.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.9
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.12

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwS
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
-github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240329221113-a1f7ac9ed7d1 h1:zzApPt1p63xHV2C1SEu4rsj2BKmZyb3m+7/vKAD2wq8=
-github.com/Layr-Labs/eigensdk-go v0.1.4-0.20240329221113-a1f7ac9ed7d1/go.mod h1:HOSNuZcwaKbP4cnNk9c1hK2B2RitcMQ36Xj2msBBBpE=
+github.com/Layr-Labs/eigensdk-go v0.1.6-0.20240409054704-47c41ef999a9 h1:ma+LjdvSDN5MoK0PI045HfsRoPYxf90ERw9Kv/jGxcs=
+github.com/Layr-Labs/eigensdk-go v0.1.6-0.20240409054704-47c41ef999a9/go.mod h1:HOSNuZcwaKbP4cnNk9c1hK2B2RitcMQ36Xj2msBBBpE=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -147,10 +147,11 @@ func mustMakeDisperser(t *testing.T, cst core.IndexedChainState, store disperser
 		SRSOrder:                 3000,
 	}
 	timeoutConfig := batcher.TimeoutConfig{
-		EncodingTimeout:    10 * time.Second,
-		AttestationTimeout: 10 * time.Second,
-		ChainReadTimeout:   10 * time.Second,
-		ChainWriteTimeout:  10 * time.Second,
+		EncodingTimeout:     10 * time.Second,
+		AttestationTimeout:  10 * time.Second,
+		ChainReadTimeout:    10 * time.Second,
+		ChainWriteTimeout:   10 * time.Second,
+		TxnBroadcastTimeout: 10 * time.Second,
 	}
 
 	p0, _ := mustMakeTestComponents()


### PR DESCRIPTION
## Why are these changes needed?
Currently, we send a replacement transaction if an existing transaction doesn't get confirmed within predetermined timeout. This duration is measured from the time `TxnManager` sends the transaction. If the transaction is published directly on eth network, this would have been a good measure to detect if the transaction is stuck on mempool and if a replacement transaction with higher gas is necessary.

However, when a transaction is submitted via Fireblocks, this is not a good measure to determine if the transaction is stuck on mempool because it takes non-trivial amount of time for Fireblocks to publish the txn to mempool due to multiparty computation. 

This PR breaks down this part of latency (pre-broadcast), and excludes this duration from the timeout watched to create a replacement transaction. For example, if it takes a long time to broadcast the transaction to mempool (due to MPC operation from Fireblocks), no replacement transactions should be created. Only if it takes a long time to confirm transaction onchain after it's been published in mempool, it creates a replacement transaction with higher gas. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
