### PR TITLE
Remove duplicate server.Start() of dataapi and Fix error handling

### DIFF
--- a/disperser/cmd/apiserver/main.go
+++ b/disperser/cmd/apiserver/main.go
@@ -69,11 +69,11 @@ func RunDisperserServer(ctx *cli.Context) error {
 	}
 	blockStaleMeasure, err := transactor.GetBlockStaleMeasure(context.Background())
 	if err != nil {
-		return fmt.Errorf("failed to get BLOCK_STALE_MEASURE: %w", err)
+		return fmt.Errorf("failed to get BLOCK_STALE_MEASURE from transactor: %w", err)
 	}
 	storeDurationBlocks, err := transactor.GetStoreDurationBlocks(context.Background())
 	if err != nil || storeDurationBlocks == 0 {
-		return fmt.Errorf("failed to get STORE_DURATION_BLOCKS: %w", err)
+		return fmt.Errorf("failed to get STORE_DURATION_BLOCKS from transactor: %w", err)
 	}
 
 	s3Client, err := s3.NewClient(context.Background(), config.AwsClientConfig, logger)

--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -144,5 +144,5 @@ func RunDataApi(ctx *cli.Context) error {
 		logger.Errorf("Failed to shutdown server: %v", err)
 	}
 
-	return server.Start()
+	return err
 }


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In the existing code, 'server.Start()' is called within the go-routine and then again at the end of the function, which is an unnecessary duplicate call and can cause unintended behavior.

And others are fix error handling for batcher and apiserver.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
