### PR TITLE
Detect wrapped url error timeout

### DIFF
--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -428,7 +428,7 @@ func (t *Transactor) GetOperatorStakesForQuorums(ctx context.Context, quorums []
 		Context: ctx,
 	}, t.Bindings.RegCoordinatorAddr, quorumBytes, blockNumber)
 	if err != nil {
-		t.Logger.Error("Failed to fetch operator state", err)
+		t.Logger.Error("Failed to fetch operator state", "err", err)
 		return nil, err
 	}
 

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -137,7 +137,11 @@ func (e *EncodingStreamer) Start(ctx context.Context) error {
 						// ignore canceled errors because canceled encoding requests are normal
 						continue
 					}
-					e.logger.Error("error processing encoded blobs", "err", err)
+					if strings.Contains(err.Error(), "too many requests") {
+						e.logger.Warn("encoding request ratelimited", "err", err)
+					} else {
+						e.logger.Error("error processing encoded blobs", "err", err)
+					}
 				}
 			}
 		}

--- a/disperser/batcher/txn_manager.go
+++ b/disperser/batcher/txn_manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net/url"
 	"sync"
 	"time"
 
@@ -157,11 +158,12 @@ func (t *txnManager) ProcessTransaction(ctx context.Context, req *TxnRequest) er
 			return fmt.Errorf("failed to update gas price: %w", err)
 		}
 		txID, err = t.wallet.SendTransaction(ctx, txn)
-		terr, ok := err.(interface {
-			Timeout() bool
-		})
-		didTimeout := ok && terr.Timeout()
-		if didTimeout {
+		var urlErr *url.Error
+		didTimeout := false
+		if errors.As(err, &urlErr) {
+			didTimeout = urlErr.Timeout()
+		}
+		if didTimeout || errors.Is(err, context.DeadlineExceeded) {
 			t.logger.Warn("failed to send txn due to timeout", "tag", req.Tag, "hash", req.Tx.Hash().Hex(), "numRetries", retryFromFailure, "maxRetry", maxSendTransactionRetry, "err", err)
 			retryFromFailure++
 			continue


### PR DESCRIPTION
## Why are these changes needed?
Current way of detecting url error with type assertion doesn't work if the `err` being matched is wrapping url error. 
This PR updates it so that it matches a url error from the error tree and then calling `Timeout` from the matched instance.

playground: https://goplay.tools/snippet/reDY2KH7bUD
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
