### PR TITLE
[node] Add checks for RPC node health

### DIFF
--- a/common/ethclient.go
+++ b/common/ethclient.go
@@ -57,4 +57,5 @@ type EthClient interface {
 	UpdateGas(ctx context.Context, tx *types.Transaction, value, gasTipCap, gasFeeCap *big.Int) (*types.Transaction, error)
 	EnsureTransactionEvaled(ctx context.Context, tx *types.Transaction, tag string) (*types.Receipt, error)
 	EnsureAnyTransactionEvaled(ctx context.Context, txs []*types.Transaction, tag string) (*types.Receipt, error)
+	IsSynced(ctx context.Context) (bool, error)
 }

--- a/common/geth/client.go
+++ b/common/geth/client.go
@@ -250,6 +250,15 @@ func (c *EthClient) EnsureAnyTransactionEvaled(ctx context.Context, txs []*types
 	return receipt, nil
 }
 
+// IsSynced returns true if the client is synced with the network.
+func (c *EthClient) IsSynced(ctx context.Context) (bool, error) {
+	syncProgress, err := c.SyncProgress(ctx)
+	if err != nil {
+		return false, fmt.Errorf("IsSynced: failed to get sync progress: %w", err)
+	}
+	return syncProgress == nil, nil
+}
+
 // waitMined takes multiple transactions and waits for any of them to be mined on the blockchain and returns the receipt.
 // If the context times out but the receipt is available, it returns both receipt and error, noting that the transaction is confirmed but has not accumulated the required number of confirmations.
 // Taken from https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/bind/util.go#L32,

--- a/common/geth/multihoming_client.go
+++ b/common/geth/multihoming_client.go
@@ -2,6 +2,7 @@ package geth
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -830,4 +831,13 @@ func (m *MultiHomingClient) EnsureAnyTransactionEvaled(ctx context.Context, txs 
 func (m *MultiHomingClient) GetNoSendTransactOpts() (*bind.TransactOpts, error) {
 	_, instance := m.GetRPCInstance()
 	return instance.GetNoSendTransactOpts()
+}
+
+// IsSynced returns true if the client is synced with the network.
+func (c *MultiHomingClient) IsSynced(ctx context.Context) (bool, error) {
+	syncProgress, err := c.SyncProgress(ctx)
+	if err != nil {
+		return false, fmt.Errorf("IsSynced: failed to get sync progress: %w", err)
+	}
+	return syncProgress == nil, nil
 }

--- a/common/mock/ethclient.go
+++ b/common/mock/ethclient.go
@@ -289,3 +289,9 @@ func (mock *MockEthClient) EnsureAnyTransactionEvaled(ctx context.Context, txs [
 
 	return result, args.Error(1)
 }
+
+func (mock *MockEthClient) IsSynced(ctx context.Context) (bool, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.(bool), args.Error(1)
+}

--- a/core/eth/state.go
+++ b/core/eth/state.go
@@ -51,6 +51,11 @@ func (cs *ChainState) GetCurrentBlockNumber() (uint, error) {
 	return uint(header.Number.Uint64()), nil
 }
 
+func (cs *ChainState) EthClientOnline() (bool, error) {
+	ctx := context.Background()
+	return cs.Client.IsSynced(ctx)
+}
+
 func getOperatorState(operatorsByQuorum core.OperatorStakes, blockNumber uint32) (*core.OperatorState, error) {
 	operators := make(map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo)
 	totals := make(map[core.QuorumID]*core.OperatorInfo)

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -223,3 +223,8 @@ func (d *ChainDataMock) GetCurrentBlockNumber() (uint, error) {
 func (d *ChainDataMock) Start(context.Context) error {
 	return nil
 }
+
+func (d *ChainDataMock) EthClientOnline() (bool, error) {
+	args := d.Called()
+	return args.Get(0).(bool), args.Error(1)
+}

--- a/core/state.go
+++ b/core/state.go
@@ -85,6 +85,7 @@ type ChainState interface {
 	GetCurrentBlockNumber() (uint, error)
 	GetOperatorState(ctx context.Context, blockNumber uint, quorums []QuorumID) (*OperatorState, error)
 	GetOperatorStateByOperator(ctx context.Context, blockNumber uint, operator OperatorID) (*OperatorState, error)
+	EthClientOnline() (bool, error)
 	// GetOperatorQuorums(blockNumber uint, operator OperatorId) ([]uint, error)
 }
 

--- a/core/thegraph/state_test.go
+++ b/core/thegraph/state_test.go
@@ -25,6 +25,26 @@ func (m mockGraphQLQuerier) Query(ctx context.Context, q any, variables map[stri
 	return m.QueryFn(ctx, q, variables)
 }
 
+type mockChainState struct {
+	GetCurrentBlockNumberFn func() (uint, error)
+}
+
+func (m mockChainState) GetCurrentBlockNumber() (uint, error) {
+	return m.GetCurrentBlockNumberFn()
+}
+
+func (m *mockChainState) GetOperatorState(ctx context.Context, blockNumber uint, quorums []core.QuorumID) (*core.OperatorState, error) {
+	return nil, nil
+}
+
+func (m *mockChainState) GetOperatorStateByOperator(ctx context.Context, blockNumber uint, operator core.OperatorID) (*core.OperatorState, error) {
+	return nil, nil
+}
+
+func (m *mockChainState) EthClientOnline() (bool, error) {
+	return true, nil
+}
+
 func TestIndexedChainState_GetIndexedOperatorState(t *testing.T) {
 	logger := logging.NewNoopLogger()
 


### PR DESCRIPTION
## Why are these changes needed?

EigenDA relies on a healthy JSON-RPC endpoint to conduct many of its operations. Currently, such an endpoint could be unhealthy, and while EigenDA will throw errors, these won't tell if they are related to the JSON-RPC being unhealthy. In this case, the EigenDA operator can suspect it could be an EigenDA bug, an issue on the Dispersers, JSON-RPC endpoint, a networking issue in the machine, etc.

If EigenDA can conduct health checks on the JSON-RPC node (by checking the `eth_syncing` endpoint), troubleshooting would be considerably more robust.

This PR add such health checks in the following places:
- When initializing the EthClient
- As a goroutine periodically checking if the JSON-RPC endpoint is healthy
- Optionally when checking if significant operations failed due to the endpoint being unhealthy (`ValidateBatch`)

The following logs shows instances of the aforementioned changes (tested on Nethermind's Holesky EigenDA node):

JSON-RPC node unhealthy
```
2024/04/11 18:35:02 Initializing Node
time=2024-04-11T18:35:03.953Z level=INFO source=/app/common/geth/instrumented_client.go:52 msg="Checking if eth client is online" online=false err=<nil>
2024/04/11 18:35:03 application failed: cannot create chain.Client: the RPC node is not synced. The node will not be able to process batches successfully until it is synced
```

Goroutine check
```
time=2024-04-11T18:36:38.050Z level=INFO source=/app/node/node.go:469 msg="Start checkRPCNodeSynced goroutine in background to periodically check if the RPC node is synced and online" component=Node
time=2024-04-11T18:36:38.050Z level=INFO source=/app/node/node.go:450 msg="Start checkCurrentNodeIp goroutine in background to detect the current public IP of the operator node" component=Node
time=2024-04-11T18:36:38.050Z level=INFO source=/app/node/node.go:252 msg="Start expireLoop goroutine in background to periodically remove expired batches on the node" component=Node
time=2024-04-11T18:36:38.050Z level=INFO source=/app/node/node.go:427 msg="Start checkRegisteredNodeIpOnChain goroutine in background to subscribe the operator socket change events onchain" component=Node
```

This fork use [Bump v0.6.1 (#458)](https://github.com/Layr-Labs/eigenda/pull/458) as a stable reference.

This PR also introduces a Chain ID check at the EigenDA initialization for the Operators to double check if they target JSON-RPC endpoint is pointing to the proper Network:

```
2024/04/11 18:09:55 Initializing Node
time=2024-04-11T18:09:57.489Z level=INFO source=/app/node/node.go:108 msg="Detected network of configured RPC Node" network=Mainnet
2024/04/11 18:09:57 application failed: no contract code at given address
time=2024-04-11T18:09:57.727Z level=ERROR source=/app/core/eth/tx.go:750 msg="Failed to fetch DelegationManager address" component=Transactor err="no contract code at given address"
```

In the above logs, EigenDA is intended to be used for Holesky but a Mainnet JSON-RPC node was used. The node is synced and healthy, but the `Transactor` fails due to being on Mainnet instead of Holesky. This would help to tell the Operator rapidly what the issue is.
 
## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
