### PR TITLE
Backward compatibility with using entire g2

### DIFF
--- a/encoding/kzg/verifier/verifier.go
+++ b/encoding/kzg/verifier/verifier.go
@@ -70,21 +70,24 @@ func NewVerifier(config *kzg.KzgConfig, loadG2Points bool) (*Verifier, error) {
 			return nil, err
 		}
 	} else {
-		if len(config.G2PowerOf2Path) == 0 {
-			return nil, errors.New("G2PowerOf2Path is empty. However, object needs to load G2Points")
+		if len(config.G2PowerOf2Path) == 0 && len(config.G2Path) == 0 {
+			return nil, errors.New("both G2Path and G2PowerOf2Path are empty. However, object needs to load G2Points")
 		}
 
-		if config.SRSOrder == 0 {
-			return nil, errors.New("SRS order cannot be 0")
-		}
+		if len(config.G2PowerOf2Path) != 0 {
+			if config.SRSOrder == 0 {
+				return nil, errors.New("SRS order cannot be 0")
+			}
 
-		maxPower := uint64(math.Log2(float64(config.SRSOrder)))
-		_, err := kzg.ReadG2PointSection(config.G2PowerOf2Path, 0, maxPower, 1)
-		if err != nil {
-			return nil, fmt.Errorf("file located at %v is invalid", config.G2PowerOf2Path)
+			maxPower := uint64(math.Log2(float64(config.SRSOrder)))
+			_, err := kzg.ReadG2PointSection(config.G2PowerOf2Path, 0, maxPower, 1)
+			if err != nil {
+				return nil, fmt.Errorf("file located at %v is invalid", config.G2PowerOf2Path)
+			}
+		} else {
+			log.Println("verifier requires accesses to entire g2 points. It is a legacy usage. For most operators, it is likely because G2_POWER_OF_2_PATH is improperly configured.")
 		}
 	}
-
 	srs, err := kzg.NewSrs(s1, s2)
 	if err != nil {
 		log.Println("Could not create srs", err)

--- a/operators/churner/churner.go
+++ b/operators/churner/churner.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	bipMultiplier     = big.NewInt(10000)
-	secondsTillExpiry = 90 * time.Second
+	secondsTillExpiry = 3600 * time.Second
 )
 
 type ChurnRequest struct {
@@ -285,7 +285,7 @@ func (c *churner) sign(ctx context.Context, operatorToRegisterAddress gethcommon
 	var salt [32]byte
 	copy(salt[:], saltKeccak256)
 
-	// set expiry to 90s in the future
+	// set expiry to 3600s in the future
 	expiry := big.NewInt(now.Add(secondsTillExpiry).Unix())
 
 	// sign and return signature


### PR DESCRIPTION
## Why are these changes needed?

This is a correction for PR #472 which checks g2powerof2 file before starting node. However, #472 prevents a legacy usage that the operator might only have the entire g2 file.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
