### PR TITLE
Add fireblocks API timeout

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -40,11 +40,12 @@ type QuorumInfo struct {
 }
 
 type TimeoutConfig struct {
-	EncodingTimeout    time.Duration
-	AttestationTimeout time.Duration
-	ChainReadTimeout   time.Duration
-	ChainWriteTimeout  time.Duration
-	ChainStateTimeout  time.Duration
+	EncodingTimeout      time.Duration
+	AttestationTimeout   time.Duration
+	ChainReadTimeout     time.Duration
+	ChainWriteTimeout    time.Duration
+	ChainStateTimeout    time.Duration
+	FireblocksAPITimeout time.Duration
 }
 
 type Config struct {

--- a/disperser/cmd/batcher/config.go
+++ b/disperser/cmd/batcher/config.go
@@ -67,11 +67,12 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			FinalizationBlockDelay:   ctx.GlobalUint(flags.FinalizationBlockDelayFlag.Name),
 		},
 		TimeoutConfig: batcher.TimeoutConfig{
-			EncodingTimeout:    ctx.GlobalDuration(flags.EncodingTimeoutFlag.Name),
-			AttestationTimeout: ctx.GlobalDuration(flags.AttestationTimeoutFlag.Name),
-			ChainReadTimeout:   ctx.GlobalDuration(flags.ChainReadTimeoutFlag.Name),
-			ChainWriteTimeout:  ctx.GlobalDuration(flags.ChainWriteTimeoutFlag.Name),
-			ChainStateTimeout:  ctx.GlobalDuration(flags.ChainStateTimeoutFlag.Name),
+			EncodingTimeout:      ctx.GlobalDuration(flags.EncodingTimeoutFlag.Name),
+			AttestationTimeout:   ctx.GlobalDuration(flags.AttestationTimeoutFlag.Name),
+			ChainReadTimeout:     ctx.GlobalDuration(flags.ChainReadTimeoutFlag.Name),
+			ChainWriteTimeout:    ctx.GlobalDuration(flags.ChainWriteTimeoutFlag.Name),
+			ChainStateTimeout:    ctx.GlobalDuration(flags.ChainStateTimeoutFlag.Name),
+			FireblocksAPITimeout: ctx.GlobalDuration(flags.FireblocksAPITimeoutFlag.Name),
 		},
 		MetricsConfig: batcher.MetricsConfig{
 			HTTPPort:      ctx.GlobalString(flags.MetricsHTTPPort.Name),

--- a/disperser/cmd/batcher/flags/flags.go
+++ b/disperser/cmd/batcher/flags/flags.go
@@ -121,6 +121,13 @@ var (
 		Value:    15 * time.Second,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "CHAIN_STATE_TIMEOUT"),
 	}
+	FireblocksAPITimeoutFlag = cli.DurationFlag{
+		Name:     "fireblocks-write-timeout",
+		Usage:    "connection timeout to get API response from Fireblocks",
+		Required: false,
+		Value:    10 * time.Second,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "FIREBLOCKS_API_TIMEOUT"),
+	}
 	NumConnectionsFlag = cli.IntFlag{
 		Name:     "num-connections",
 		Usage:    "maximum number of connections to encoders (defaults to 256)",
@@ -209,6 +216,7 @@ var optionalFlags = []cli.Flag{
 	ChainReadTimeoutFlag,
 	ChainWriteTimeoutFlag,
 	ChainStateTimeoutFlag,
+	FireblocksAPITimeoutFlag,
 	NumConnectionsFlag,
 	FinalizerIntervalFlag,
 	FinalizerPoolSizeFlag,

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -191,7 +191,7 @@ func RunBatcher(ctx *cli.Context) error {
 			apiKey,
 			[]byte(secretKey),
 			config.FireblocksConfig.BaseURL,
-			config.TimeoutConfig.ChainReadTimeout,
+			config.TimeoutConfig.FireblocksAPITimeout,
 			logger.With("component", "FireblocksClient"),
 		)
 		if err != nil {


### PR DESCRIPTION
## Why are these changes needed?
Fireblocks http client was sharing the same timeout as `ChainReadTimeout`. The http client does more than reading from chain and a separate longer timeout seems appropriate. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
