### PR TITLE
Add a param to return only live nonsigners

### DIFF
--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -437,6 +437,10 @@ paths:
         in: query
         name: end
         type: string
+      - description: 'Whether return only live nonsigners [default: true]'
+        in: query
+        name: live_only
+        type: string
       produces:
       - application/json
       responses:

--- a/disperser/dataapi/nonsigner_handler.go
+++ b/disperser/dataapi/nonsigner_handler.go
@@ -113,7 +113,7 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTi
 					TotalUnsignedBatches: unsignedCount,
 					TotalBatches:         totalCount,
 					Percentage:           pf,
-					StakePercentage:      stakePercentage,
+					StakePercentage:      100 * stakePercentage,
 				}
 				nonsignerMetrics = append(nonsignerMetrics, &nonsignerMetric)
 			}

--- a/disperser/dataapi/nonsigner_handler.go
+++ b/disperser/dataapi/nonsigner_handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core/eth"
 )
 
-func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTime int64) (*OperatorsNonsigningPercentage, error) {
+func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTime int64, liveOnly bool) (*OperatorsNonsigningPercentage, error) {
 	batches, err := s.subgraphClient.QueryBatchNonSigningInfoInInterval(ctx, startTime, endTime)
 	if err != nil {
 		return nil, err
@@ -101,6 +101,9 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTi
 				if stake, ok := state.Operators[q][opID]; ok {
 					p, _ := new(big.Int).Div(new(big.Int).Mul(stake.Stake, big.NewInt(multipler)), state.Totals[q].Stake).Float64()
 					stakePercentage = p / multipler
+				} else if liveOnly {
+					// Operator "opID" isn't live at "endBlock", skip it.
+					continue
 				}
 
 				nonsignerMetric := OperatorNonsigningPercentageMetrics{

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -459,16 +459,17 @@ func (s *server) FetchNonSigners(c *gin.Context) {
 
 // FetchOperatorsNonsigningPercentageHandler godoc
 //
-//	@Summary	Fetch operators non signing percentage
-//	@Tags		Metrics
-//	@Produce	json
-//	@Param		interval	query		int		false	"Interval to query for operators nonsigning percentage [default: 3600]"
-//	@Param		end			query		string	false	"End time (2006-01-02T15:04:05Z) to query for operators nonsigning percentage [default: now]"
-//	@Success	200			{object}	OperatorsNonsigningPercentage
-//	@Failure	400			{object}	ErrorResponse	"error: Bad request"
-//	@Failure	404			{object}	ErrorResponse	"error: Not found"
-//	@Failure	500			{object}	ErrorResponse	"error: Server error"
-//	@Router		/metrics/operator-nonsigning-percentage  [get]
+//		@Summary	Fetch operators non signing percentage
+//		@Tags		Metrics
+//		@Produce	json
+//		@Param		interval	query		int		false	"Interval to query for operators nonsigning percentage [default: 3600]"
+//		@Param		end			query		string	false	"End time (2006-01-02T15:04:05Z) to query for operators nonsigning percentage [default: now]"
+//	 @Param      live_only   query       string false   "Whether return only live nonsigners [default: true]"
+//		@Success	200			{object}	OperatorsNonsigningPercentage
+//		@Failure	400			{object}	ErrorResponse	"error: Bad request"
+//		@Failure	404			{object}	ErrorResponse	"error: Not found"
+//		@Failure	500			{object}	ErrorResponse	"error: Server error"
+//		@Router		/metrics/operator-nonsigning-percentage  [get]
 func (s *server) FetchOperatorsNonsigningPercentageHandler(c *gin.Context) {
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
 		s.metrics.ObserveLatency("FetchOperatorsNonsigningPercentageHandler", f*1000) // make milliseconds
@@ -491,9 +492,18 @@ func (s *server) FetchOperatorsNonsigningPercentageHandler(c *gin.Context) {
 		interval = 3600
 	}
 
+	liveOnly := "true"
+	if c.Query("live_only") != "" {
+		liveOnly = c.Query("live_only")
+		if liveOnly != "true" && liveOnly != "false" {
+			errorResponse(c, errors.New("the live_only param must be \"true\" or \"false\""))
+			return
+		}
+	}
+
 	startTime := endTime.Add(-time.Duration(interval) * time.Second)
 
-	metric, err := s.getOperatorNonsigningRate(c.Request.Context(), startTime.Unix(), endTime.Unix())
+	metric, err := s.getOperatorNonsigningRate(c.Request.Context(), startTime.Unix(), endTime.Unix(), liveOnly == "true")
 	if err != nil {
 		s.metrics.IncrementFailedRequestNum("FetchOperatorsNonsigningPercentageHandler")
 		errorResponse(c, err)

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -370,7 +370,7 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 	assert.Equal(t, uint8(0), responseData.QuorumId)
 	assert.Equal(t, float64(100), responseData.Percentage)
 	assert.Equal(t, "0xe22dae12a0074f20b8fc96a0489376db34075e545ef60c4845d264a732568311", operatorId)
-	assert.Equal(t, float64(0.5), responseData.StakePercentage)
+	assert.Equal(t, float64(50), responseData.StakePercentage)
 
 	responseData = response.Data[1]
 	operatorId = responseData.OperatorId
@@ -379,7 +379,7 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 	assert.Equal(t, uint8(1), responseData.QuorumId)
 	assert.Equal(t, float64(100), responseData.Percentage)
 	assert.Equal(t, "0xe22dae12a0074f20b8fc96a0489376db34075e545ef60c4845d264a732568311", operatorId)
-	assert.Equal(t, float64(0.25), responseData.StakePercentage)
+	assert.Equal(t, float64(25), responseData.StakePercentage)
 }
 
 func TestCheckBatcherHealthExpectServing(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
There are use cases to query just live nonsigners and all nonsigners in a time range.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
