### PR TITLE
[Node] Add GRPC HealthCheck

### DIFF
--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Layr-Labs/eigenda/api"
 	pb "github.com/Layr-Labs/eigenda/api/grpc/node"
 	"github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/common/healthcheck"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/node"
@@ -76,7 +77,6 @@ func (s *Server) Start() {
 			s.logger.Error("retrieval server failed; restarting.", "err", err)
 		}
 	}()
-
 }
 
 func (s *Server) serveDispersal() error {
@@ -95,6 +95,7 @@ func (s *Server) serveDispersal() error {
 	reflection.Register(gs)
 
 	pb.RegisterDispersalServer(gs, s)
+	healthcheck.RegisterHealthServer("node.Dispersal", gs)
 
 	s.logger.Info("port", s.config.InternalDispersalPort, "address", listener.Addr().String(), "GRPC Listening")
 	if err := gs.Serve(listener); err != nil {
@@ -119,6 +120,7 @@ func (s *Server) serveRetrieval() error {
 	reflection.Register(gs)
 
 	pb.RegisterRetrievalServer(gs, s)
+	healthcheck.RegisterHealthServer("node.Retrieval", gs)
 
 	s.logger.Info("port", s.config.InternalRetrievalPort, "address", listener.Addr().String(), "GRPC Listening")
 	if err := gs.Serve(listener); err != nil {


### PR DESCRIPTION
## Why are these changes needed?
Register HealthCheckServers for Dispersal and Retrieval, had this change done couple of weeks ago forgot to push it for review

This should enable via a grpc_client to query `healthcheck` on node as long as socketaddr is known

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
