### PR TITLE
Optimize the quorum bitmap lookup when there is just one operator

### DIFF
--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -588,6 +588,27 @@ func (t *Transactor) GetCurrentQuorumBitmapByOperatorId(ctx context.Context, ope
 }
 
 func (t *Transactor) GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Context, operatorIds []core.OperatorID, blockNumber uint32) ([]*big.Int, error) {
+	if len(operatorIds) == 0 {
+		return []*big.Int{}, nil
+	}
+	// When there is just one operator, we can get result by a single RPC with
+	// getQuorumBitmapsAtBlockNumber() in OperatorStateRetrievercontract (v.s. 2
+	// RPCs in the general case)
+	if len(operatorIds) == 1 {
+		byteId := [32]byte(operatorIds[0])
+		bitmap, err := t.Bindings.OpStateRetriever.GetQuorumBitmapsAtBlockNumber(&bind.CallOpts{
+			Context: ctx,
+		}, t.Bindings.RegCoordinatorAddr, [][32]byte{byteId}, blockNumber)
+		if err != nil {
+			if err.Error() == "RegistryCoordinator.getQuorumBitmapIndexAtBlockNumber: no bitmap update found for operatorId at block number" {
+				return []*big.Int{big.NewInt(0)}, nil
+			} else {
+				return nil, err
+			}
+		}
+		return bitmap, nil
+	}
+
 	quorumCount, err := t.GetQuorumCount(ctx, blockNumber)
 	if err != nil {
 		return nil, err

--- a/core/eth/tx.go
+++ b/core/eth/tx.go
@@ -600,7 +600,7 @@ func (t *Transactor) GetQuorumBitmapForOperatorsAtBlockNumber(ctx context.Contex
 			Context: ctx,
 		}, t.Bindings.RegCoordinatorAddr, [][32]byte{byteId}, blockNumber)
 		if err != nil {
-			if err.Error() == "RegistryCoordinator.getQuorumBitmapIndexAtBlockNumber: no bitmap update found for operatorId at block number" {
+			if err.Error() == "execution reverted: RegistryCoordinator.getQuorumBitmapIndexAtBlockNumber: no bitmap update found for operatorId at block number" {
 				return []*big.Int{big.NewInt(0)}, nil
 			} else {
 				return nil, err


### PR DESCRIPTION
## Why are these changes needed?
We are going to add operator registration metric at Node. When operator is querying their own metrics from the chain, we'd want to reduce the number of RPC calls needed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
