### PR TITLE
Addressing feedback in the operator registration/quorum metrics

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -172,7 +172,7 @@ func (g *Metrics) AcceptBatches(status string, batchSize uint64) {
 }
 
 func (g *Metrics) collectOnchainMetrics() {
-	ticker := time.NewTicker(time.Duration(uint64(g.onchainMetricsInterval)))
+	ticker := time.NewTicker(time.Duration(uint64(g.onchainMetricsInterval) * time.Second))
 	defer ticker.Stop()
 
 	// 3 chain RPC calls in each cycle.

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -65,7 +65,7 @@ func NewMetrics(eigenMetrics eigenmetrics.Metrics, reg *prometheus.Registry, log
 			prometheus.GaugeOpts{
 				Namespace: Namespace,
 				Name:      "registered_quorums",
-				Help:      "the quorums the DA node is registered",
+				Help:      "the quorums the DA node is registered, breakdown by quorum's ID and the type of information about the quorum. The type can be `stake_share`, representing the operator's stake share (in basis points); and `rank`, representing the operator's ranking (1 being the highest) by stake share within the quorum",
 			},
 			[]string{"quorum", "type"},
 		),

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -172,7 +172,7 @@ func (g *Metrics) AcceptBatches(status string, batchSize uint64) {
 }
 
 func (g *Metrics) collectOnchainMetrics() {
-	ticker := time.NewTicker(time.Duration(uint64(g.onchainMetricsInterval) * time.Second))
+	ticker := time.NewTicker(time.Duration(g.onchainMetricsInterval) * time.Second)
 	defer ticker.Stop()
 
 	// 3 chain RPC calls in each cycle.


### PR DESCRIPTION
## Why are these changes needed?
To improve the UX based on feedback:
- The unit of `stake_share` is not super clear -- so expand the help message of the metric
- Time unit for ticker

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
