### PR TITLE
Fix issue with onchain metrics collection interval

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -172,7 +172,7 @@ func (g *Metrics) AcceptBatches(status string, batchSize uint64) {
 }
 
 func (g *Metrics) collectOnchainMetrics() {
-	ticker := time.NewTicker(time.Duration(uint64(g.onchainMetricsInterval)))
+	ticker := time.NewTicker(time.Duration(uint64(g.onchainMetricsInterval) * uint64(time.Second)))
 	defer ticker.Stop()
 
 	// 3 chain RPC calls in each cycle.


### PR DESCRIPTION
## Why are these changes needed?

Currently it's collecting onchain metrics every 180 nanoseconds. Multiplying by `time.Second` gives the desired behavior.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
