### PR TITLE
make ecdsa optional for certain operations

### DIFF
--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -125,12 +125,17 @@ func pluginOps(ctx *cli.Context) {
 	}
 
 	if config.Operation == plugin.OperationListQuorums {
+		operatorAddress, err := tx.OperatorIDToAddress(context.Background(), operatorID)
+		if err != nil {
+			log.Printf("Error: failed to get operator address for operatorID: %x, error: %v", operatorID, err)
+			return
+		}
 		quorumIds, err := tx.GetRegisteredQuorumIdsForOperator(context.Background(), operatorID)
 		if err != nil {
 			log.Printf("Error: failed to get quorum(s) for operatorID: %x, operator address: %x, error: %v", operatorID, sk.Address, err)
 			return
 		}
-		log.Printf("Info: operator ID: %x, operator address: %x, current quorums: %v", operatorID, sk.Address, quorumIds)
+		log.Printf("Info: operator ID: %x, operator address: %x, current quorums: %v", operatorID, operatorAddress, quorumIds)
 		return
 	}
 

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -132,10 +132,10 @@ func pluginOps(ctx *cli.Context) {
 		}
 		quorumIds, err := tx.GetRegisteredQuorumIdsForOperator(context.Background(), operatorID)
 		if err != nil {
-			log.Printf("Error: failed to get quorum(s) for operatorID: %x, operator address: %x, error: %v", operatorID, sk.Address, err)
+			log.Printf("Error: failed to get quorum(s) for operatorID: %x, operator address: %x, error: %v", operatorID, operatorAddress.Hex(), err)
 			return
 		}
-		log.Printf("Info: operator ID: %x, operator address: %x, current quorums: %v", operatorID, operatorAddress, quorumIds)
+		log.Printf("Info: operator ID: %x, operator address: %x, current quorums: %v", operatorID, operatorAddress.Hex(), quorumIds)
 		return
 	}
 

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -150,7 +150,10 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		return nil, errors.New("unsupported operation type")
 	}
 
-	if op != OperationListQuorums && len(ctx.GlobalString(EcdsaKeyFileFlag.Name)) == 0 && len(ctx.GlobalString(EcdsaKeyPasswordFlag.Name)) == 0 {
+	// ECDSA key is only required for opt-in, opt-out and update-socket operations
+	if (op == OperationOptIn || op == OperationOptOut || op == OperationUpdateSocket) &&
+		len(ctx.GlobalString(EcdsaKeyFileFlag.Name)) == 0 &&
+		len(ctx.GlobalString(EcdsaKeyPasswordFlag.Name)) == 0 {
 		return nil, errors.New("opt-in, opt-out and update-socket operations require ECDSA key file and password")
 	}
 

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -39,7 +39,7 @@ var (
 	// The files for encrypted private keys.
 	EcdsaKeyFileFlag = cli.StringFlag{
 		Name:     "ecdsa-key-file",
-		Required: true,
+		Required: false,
 		Usage:    "Path to the encrypted ecdsa key",
 		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "ECDSA_KEY_FILE"),
 	}
@@ -53,7 +53,7 @@ var (
 	// The passwords to decrypt the private keys.
 	EcdsaKeyPasswordFlag = cli.StringFlag{
 		Name:     "ecdsa-key-password",
-		Required: true,
+		Required: false,
 		Usage:    "Password to decrypt the ecdsa key",
 		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "ECDSA_KEY_PASSWORD"),
 	}
@@ -148,6 +148,10 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	}
 	if op != OperationOptIn && op != OperationOptOut && op != OperationUpdateSocket && op != OperationListQuorums {
 		return nil, errors.New("unsupported operation type")
+	}
+
+	if op != OperationListQuorums && len(ctx.GlobalString(EcdsaKeyFileFlag.Name)) == 0 && len(ctx.GlobalString(EcdsaKeyPasswordFlag.Name)) == 0 {
+		return nil, errors.New("opt-in, opt-out and update-socket operations require ECDSA key file and password")
 	}
 
 	return &Config{


### PR DESCRIPTION
## Why are these changes needed?

- This makes ECDSA optional for `list-quorums`
- It re-orders some codebase but ecdsa keys are too deep tied to make it pretty. I am also thinking a bit about future where folks wants this util just to generate payload without the need of ecdsa key and then they can use smart contract or cold key to sign some other way.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
