### PR TITLE
set all metrics to 0 for unregistered quorums

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -246,7 +246,6 @@ func (g *Metrics) collectOnchainMetrics() {
 				// Reset the cache to false for all quorum for next cycle
 				g.allQuorumCache[q] = false
 			}
-
 		}
 	}
 }


### PR DESCRIPTION
## Why are these changes needed?

- Currently if someone deregisters then the metrics for rank and stake share are set to previous value. Which doesn't help operators with real data and they see wrong graph
- This way we set those unregistered operator metrics to 0.
- When node restarts all the metrics will be cleared and cache will build again

please verify if logic looks sane

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
