### PR TITLE
Use POST instead of GET for ejection requests

### DIFF
--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -249,7 +249,7 @@ func (s *server) Start() error {
 			metrics.GET("/batcher-service-availability", s.FetchBatcherAvailability)
 		}
 		ejection := v1.Group("/ejection")
-		ejection.GET("/operators", s.EjectOperatorsHandler)
+		ejection.POST("/operators", s.EjectOperatorsHandler)
 		swagger := v1.Group("/swagger")
 		{
 			swagger.GET("/*any", ginswagger.WrapHandler(swaggerfiles.Handler))


### PR DESCRIPTION
## Why are these changes needed?
Ejection request is to ask server to perform an action, so the appropriate method will be POST, not GET or PUT.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
