### PR TITLE
Clean up the fireblock flag

### DIFF
--- a/disperser/cmd/dataapi/flags/flags.go
+++ b/disperser/cmd/dataapi/flags/flags.go
@@ -139,13 +139,6 @@ var (
 		Value:    "9100",
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "METRICS_HTTP_PORT"),
 	}
-	FireblockAPITimeoutFlag = cli.DurationFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "fireblocks-api-timeout"),
-		Usage:    "the timeout for the fireblocks api",
-		Required: false,
-		Value:    3 * time.Minute,
-		EnvVar:   common.PrefixEnvVar(envVarPrefix, "FIREBLOCKS_API_TIMEOUT"),
-	}
 	TxnTimeoutFlag = cli.DurationFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "txn-timeout"),
 		Usage:    "the timeout for the transaction",
@@ -173,7 +166,6 @@ var requiredFlags = []cli.Flag{
 	DisperserHostnameFlag,
 	ChurnerHostnameFlag,
 	BatcherHealthEndptFlag,
-	FireblockAPITimeoutFlag,
 	TxnTimeoutFlag,
 }
 


### PR DESCRIPTION
## Why are these changes needed?
It will fail to buid/run dataapi server with duplicate flags

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
