### PR TITLE
Common helper method for parsing fireblocks config

### DIFF
--- a/common/fireblocks_config.go
+++ b/common/fireblocks_config.go
@@ -1,8 +1,16 @@
 package common
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"time"
 
+	"github.com/Layr-Labs/eigenda/common/aws/secretmanager"
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/fireblocks"
+	walletsdk "github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	gcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli"
 )
 
@@ -93,4 +101,53 @@ func ReadFireblocksCLIConfig(ctx *cli.Context, flagPrefix string) FireblocksConf
 		Disable:          ctx.GlobalBool(PrefixFlag(flagPrefix, FireblocksDisable)),
 		APITimeout:       ctx.GlobalDuration(PrefixFlag(flagPrefix, FireblocksAPITimeoutFlagName)),
 	}
+}
+
+func NewFireblocksWallet(config *FireblocksConfig, ethClient EthClient, logger logging.Logger) (walletsdk.Wallet, error) {
+	if config.Disable {
+		logger.Info("Fireblocks wallet disabled")
+		return nil, fmt.Errorf("fireblocks wallet is disabled")
+	}
+
+	validConfigflag := len(config.APIKeyName) > 0 &&
+		len(config.SecretKeyName) > 0 &&
+		len(config.BaseURL) > 0 &&
+		len(config.VaultAccountName) > 0 &&
+		len(config.WalletAddress) > 0 &&
+		len(config.Region) > 0
+	if !validConfigflag {
+		return nil, errors.New("fireblocks config is either invalid or incomplete")
+	}
+	apiKey, err := secretmanager.ReadStringFromSecretManager(context.Background(), config.APIKeyName, config.Region)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read fireblocks api key %s from secret manager: %w", config.APIKeyName, err)
+	}
+	secretKey, err := secretmanager.ReadStringFromSecretManager(context.Background(), config.SecretKeyName, config.Region)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read fireblocks secret key %s from secret manager: %w", config.SecretKeyName, err)
+	}
+	fireblocksClient, err := fireblocks.NewClient(
+		apiKey,
+		[]byte(secretKey),
+		config.BaseURL,
+		config.APITimeout,
+		logger.With("component", "FireblocksClient"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	wallet, err := walletsdk.NewFireblocksWallet(fireblocksClient, ethClient, config.VaultAccountName, logger.With("component", "FireblocksWallet"))
+	if err != nil {
+		return nil, err
+	}
+	sender, err := wallet.SenderAddress(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if sender.Cmp(gcommon.HexToAddress(config.WalletAddress)) != 0 {
+		return nil, fmt.Errorf("configured wallet address %s does not match derived address %s", config.WalletAddress, sender.Hex())
+	}
+	logger.Info("Initialized Fireblocks wallet", "vaultAccountName", config.VaultAccountName, "address", sender.Hex())
+
+	return wallet, nil
 }


### PR DESCRIPTION
## Why are these changes needed?
This PR factors out Fireblocks config parsing logic to a common helper method which can be shared and used to create a new Fireblocks wallet.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
