### PR TITLE
[DataApi] Get BlobCount By AccountID

### DIFF
--- a/disperser/apiserver/ratelimit_test.go
+++ b/disperser/apiserver/ratelimit_test.go
@@ -244,7 +244,7 @@ func simulateClient(t *testing.T, signer core.BlobRequestSigner, origin string, 
 
 	authHeader := core.BlobAuthHeader{
 		BlobCommitments: encoding.BlobCommitments{},
-		AccountID:       "",
+		AccountID:       "test",
 		Nonce:           authHeaderReply.BlobAuthHeader.ChallengeParameter,
 	}
 

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -450,6 +450,11 @@ func (s *DispersalServer) checkRateLimitsAndAddRatesToHeader(ctx context.Context
 		// Update the quorum rate
 		blob.RequestHeader.SecurityParams[i].QuorumRate = accountRates.Throughput
 
+		// Update AccountID to accountKey
+		// This is a combination of origin and authenticatedAddress
+		// AccountId is later used to track blobs sent by the same account
+		blob.RequestHeader.BlobAuthHeader.AccountID = accountKey
+
 		// Get the encoded blob size from the blob header. Calculation is done in a way that nodes can replicate
 		encodedLength := encoding.GetEncodedBlobLength(length, uint8(param.ConfirmationThreshold), uint8(param.AdversaryThreshold))
 		encodedSize := encoding.GetBlobSize(encodedLength)

--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -730,9 +730,13 @@ func simulateBlobConfirmation(t *testing.T, requestID []byte, blobSize uint, sec
 		BlobStatus:   disperser.Processing,
 		Expiry:       0,
 		NumRetries:   0,
+		AccountID:    "test",
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: core.BlobRequestHeader{
 				SecurityParams: securityParams,
+				BlobAuthHeader: core.BlobAuthHeader{
+					AccountID: "test",
+				},
 			},
 			RequestedAt: requestedAt,
 			BlobSize:    blobSize,

--- a/disperser/common/blobstore/blob_metadata_store.go
+++ b/disperser/common/blobstore/blob_metadata_store.go
@@ -220,9 +220,8 @@ func (s *BlobMetadataStore) GetBlobMetadataInBatch(ctx context.Context, batchHea
 	return metadata, nil
 }
 
-// GetBlobMetadataByAccount Count returns the count of all the metadata with the given status
-// Because this function scans the entire index, it should only be used for status with a limited number of items.
-// It should only be used to filter "Processing" status. To support other status, a streaming version should be implemented.
+// GetBlobMetadataByAccount returns the count of all the metadata with the given status
+// Because this function scans the entire index, it should only be used to get limited number of items.
 func (s *BlobMetadataStore) GetBlobMetadataCountByAccountID(ctx context.Context, accountID core.AccountID) (int32, error) {
 	count, err := s.dynamoDBClient.QueryIndexCount(ctx, s.tableName, accountIdIndexName, "AccountID = :accountID", commondynamodb.ExpresseionValues{
 		":accountID": &types.AttributeValueMemberS{

--- a/disperser/common/blobstore/blob_metadata_store_test.go
+++ b/disperser/common/blobstore/blob_metadata_store_test.go
@@ -297,13 +297,6 @@ func TestBlobMetadataStoreWithAccountId(t *testing.T) {
 	err = blobMetadataStore.QueueNewBlobMetadata(ctx, metadata2)
 	assert.NoError(t, err)
 
-	fetchedMetadata, err := blobMetadataStore.GetBlobMetadata(ctx, blobKey1)
-	assert.NoError(t, err)
-	assert.Equal(t, metadata1, fetchedMetadata)
-	fetchedMetadata, err = blobMetadataStore.GetBlobMetadata(ctx, blobKey2)
-	assert.NoError(t, err)
-	assert.Equal(t, metadata2, fetchedMetadata)
-
 	processing, err := blobMetadataStore.GetBlobMetadataByStatus(ctx, disperser.Processing)
 	assert.NoError(t, err)
 	assert.Len(t, processing, 1)
@@ -316,34 +309,6 @@ func TestBlobMetadataStoreWithAccountId(t *testing.T) {
 	blobCountByAccountId, err := blobMetadataStore.GetBlobMetadataCountByAccountID(ctx, "test")
 	assert.NoError(t, err)
 	assert.Equal(t, int32(2), blobCountByAccountId)
-
-	err = blobMetadataStore.IncrementNumRetries(ctx, metadata1)
-	assert.NoError(t, err)
-	fetchedMetadata, err = blobMetadataStore.GetBlobMetadata(ctx, blobKey1)
-	assert.NoError(t, err)
-	metadata1.NumRetries = 1
-	assert.Equal(t, metadata1, fetchedMetadata)
-
-	finalized, err := blobMetadataStore.GetBlobMetadataByStatus(ctx, disperser.Finalized)
-	assert.NoError(t, err)
-	assert.Len(t, finalized, 1)
-	assert.Equal(t, metadata2, finalized[0])
-
-	finalizedCount, err := blobMetadataStore.GetBlobMetadataByStatusCount(ctx, disperser.Finalized)
-	assert.NoError(t, err)
-	assert.Equal(t, int32(1), finalizedCount)
-
-	confirmedMetadata := getConfirmedMetadata(t, blobKey1)
-	err = blobMetadataStore.UpdateBlobMetadata(ctx, blobKey1, confirmedMetadata)
-	assert.NoError(t, err)
-
-	metadata, err := blobMetadataStore.GetBlobMetadataInBatch(ctx, confirmedMetadata.ConfirmationInfo.BatchHeaderHash, confirmedMetadata.ConfirmationInfo.BlobIndex)
-	assert.NoError(t, err)
-	assert.Equal(t, metadata, confirmedMetadata)
-
-	confirmedCount, err := blobMetadataStore.GetBlobMetadataByStatusCount(ctx, disperser.Confirmed)
-	assert.NoError(t, err)
-	assert.Equal(t, int32(1), confirmedCount)
 
 	deleteItems(t, []commondynamodb.Key{
 		{

--- a/disperser/common/blobstore/blobstore_test.go
+++ b/disperser/common/blobstore/blobstore_test.go
@@ -31,6 +31,9 @@ var (
 	blob = &core.Blob{
 		RequestHeader: core.BlobRequestHeader{
 			SecurityParams: securityParams,
+			BlobAuthHeader: core.BlobAuthHeader{
+				AccountID: "test",
+			},
 		},
 
 		Data: []byte("test"),
@@ -85,10 +88,6 @@ func setup(m *testing.M) {
 		EndpointURL:     fmt.Sprintf("http://0.0.0.0:%s", localStackPort),
 	}
 
-	fmt.Printf("Creating dynamodb table %s\n", metadataTableName)
-	fmt.Printf("Table Schema: %v\n", blobstore.GenerateTableSchema(metadataTableName, 10, 10).AttributeDefinitions)
-	fmt.Printf("Table Schema: %v\n", blobstore.GenerateTableSchema(metadataTableName, 10, 10).KeySchema)
-	fmt.Printf("Table Schema: %v\n", blobstore.GenerateTableSchema(metadataTableName, 10, 10).GlobalSecondaryIndexes)
 	_, err := test_utils.CreateTable(context.Background(), cfg, metadataTableName, blobstore.GenerateTableSchema(metadataTableName, 10, 10))
 	if err != nil {
 		teardown()

--- a/disperser/common/blobstore/blobstore_test.go
+++ b/disperser/common/blobstore/blobstore_test.go
@@ -31,9 +31,6 @@ var (
 	blob = &core.Blob{
 		RequestHeader: core.BlobRequestHeader{
 			SecurityParams: securityParams,
-			BlobAuthHeader: core.BlobAuthHeader{
-				AccountID: "test",
-			},
 		},
 
 		Data: []byte("test"),

--- a/disperser/common/blobstore/blobstore_test.go
+++ b/disperser/common/blobstore/blobstore_test.go
@@ -31,7 +31,11 @@ var (
 	blob = &core.Blob{
 		RequestHeader: core.BlobRequestHeader{
 			SecurityParams: securityParams,
+			BlobAuthHeader: core.BlobAuthHeader{
+				AccountID: "test",
+			},
 		},
+
 		Data: []byte("test"),
 	}
 	s3Client   = cmock.NewS3Client()
@@ -84,6 +88,10 @@ func setup(m *testing.M) {
 		EndpointURL:     fmt.Sprintf("http://0.0.0.0:%s", localStackPort),
 	}
 
+	fmt.Printf("Creating dynamodb table %s\n", metadataTableName)
+	fmt.Printf("Table Schema: %v\n", blobstore.GenerateTableSchema(metadataTableName, 10, 10).AttributeDefinitions)
+	fmt.Printf("Table Schema: %v\n", blobstore.GenerateTableSchema(metadataTableName, 10, 10).KeySchema)
+	fmt.Printf("Table Schema: %v\n", blobstore.GenerateTableSchema(metadataTableName, 10, 10).GlobalSecondaryIndexes)
 	_, err := test_utils.CreateTable(context.Background(), cfg, metadataTableName, blobstore.GenerateTableSchema(metadataTableName, 10, 10))
 	if err != nil {
 		teardown()

--- a/disperser/common/blobstore/shared_storage.go
+++ b/disperser/common/blobstore/shared_storage.go
@@ -101,6 +101,7 @@ func (s *SharedBlobStore) StoreBlob(ctx context.Context, blob *core.Blob, reques
 	metadata := disperser.BlobMetadata{
 		BlobHash:     blobHash,
 		MetadataHash: metadataHash,
+		AccountID:    blob.RequestHeader.AccountID,
 		NumRetries:   0,
 		BlobStatus:   disperser.Processing,
 		Expiry:       expiry,
@@ -235,6 +236,10 @@ func (s *SharedBlobStore) GetAllBlobMetadataByBatch(ctx context.Context, batchHe
 // GetMetadata returns a blob metadata given a metadata key
 func (s *SharedBlobStore) GetBlobMetadata(ctx context.Context, metadataKey disperser.BlobKey) (*disperser.BlobMetadata, error) {
 	return s.blobMetadataStore.GetBlobMetadata(ctx, metadataKey)
+}
+
+func (s *SharedBlobStore) GetBlobMetadataCountByAccountID(ctx context.Context, accountID core.AccountID) (int32, error) {
+	return s.blobMetadataStore.GetBlobMetadataCountByAccountID(ctx, accountID)
 }
 
 func (s *SharedBlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) (bool, error) {

--- a/disperser/common/blobstore/shared_storage_test.go
+++ b/disperser/common/blobstore/shared_storage_test.go
@@ -86,9 +86,11 @@ func TestSharedBlobStore(t *testing.T) {
 		BlobStatus:   disperser.Processing,
 		Expiry:       0,
 		NumRetries:   0,
+		AccountID:    "test",
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: core.BlobRequestHeader{
 				SecurityParams: securityParams,
+				BlobAuthHeader: blob.RequestHeader.BlobAuthHeader,
 			},
 			RequestedAt: requestedAt,
 			BlobSize:    blobSize,
@@ -138,9 +140,11 @@ func TestSharedBlobStore(t *testing.T) {
 		BlobStatus:   disperser.Processing,
 		Expiry:       0,
 		NumRetries:   0,
+		AccountID:    "test",
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: core.BlobRequestHeader{
 				SecurityParams: securityParams,
+				BlobAuthHeader: blob.RequestHeader.BlobAuthHeader,
 			},
 			RequestedAt: requestedAt,
 			BlobSize:    blobSize2,

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -55,6 +55,7 @@ func (q *BlobStore) StoreBlob(ctx context.Context, blob *core.Blob, requestedAt 
 		BlobHash:     blobHash,
 		MetadataHash: blobKey.MetadataHash,
 		BlobStatus:   disperser.Processing,
+		AccountID:    blob.RequestHeader.AccountID,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
@@ -268,6 +269,18 @@ func (q *BlobStore) GetBlobMetadata(ctx context.Context, blobKey disperser.BlobK
 		return meta, nil
 	}
 	return nil, disperser.ErrBlobNotFound
+}
+
+func (q *BlobStore) GetBlobMetadataCountByAccountID(ctx context.Context, accountID core.AccountID) (int32, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	count := int32(0)
+	for _, meta := range q.Metadata {
+		if meta.AccountID == accountID {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func (q *BlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) (bool, error) {

--- a/disperser/dataapi/blobs_handlers.go
+++ b/disperser/dataapi/blobs_handlers.go
@@ -35,6 +35,21 @@ func (s *server) getBlobs(ctx context.Context, limit int) ([]*BlobMetadataRespon
 	return s.convertBlobMetadatasToBlobMetadataResponse(ctx, blobMetadatas)
 }
 
+func (s *server) getBlobCountByAccountId(ctx context.Context, accountID string) (*BlobCountForAccountIdResponse, error) {
+	s.logger.Info("Calling get blob", "AccountId", accountID)
+
+	metadataCount, err := s.blobstore.GetBlobMetadataCountByAccountID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.logger.Debug("Got blob metadata count for AccountId", "AccountId", accountID, "metadataCount", metadataCount)
+	return &BlobCountForAccountIdResponse{
+		Count:     metadataCount,
+		AccountId: accountID,
+	}, nil
+}
+
 func (s *server) convertBlobMetadatasToBlobMetadataResponse(ctx context.Context, metadatas []*disperser.BlobMetadata) ([]*BlobMetadataResponse, error) {
 	var (
 		err               error

--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -114,6 +114,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/feed/blobs/{accountId}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feed"
+                ],
+                "summary": "Fetch blob metadata count by AccountId",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "AccountId",
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.BlobCountForAccountIdResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/feed/blobs/{blob_key}": {
             "get": {
                 "produces": [
@@ -628,6 +674,17 @@ const docTemplate = `{
                 },
                 "quorumRate": {
                     "description": "Rate Limit. This is a temporary measure until the node can derive rates on its own using rollup authentication. This is used\nfor restricting the rate at which retrievers are able to download data from the DA node to a multiple of the rate at which the\ndata was posted to the DA node.",
+                    "type": "integer"
+                }
+            }
+        },
+        "dataapi.BlobCountForAccountIdResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "count": {
                     "type": "integer"
                 }
             }

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -110,6 +110,52 @@
                 }
             }
         },
+        "/feed/blobs/{accountId}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feed"
+                ],
+                "summary": "Fetch blob metadata count by AccountId",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "AccountId",
+                        "name": "accountId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.BlobCountForAccountIdResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/feed/blobs/{blob_key}": {
             "get": {
                 "produces": [
@@ -624,6 +670,17 @@
                 },
                 "quorumRate": {
                     "description": "Rate Limit. This is a temporary measure until the node can derive rates on its own using rollup authentication. This is used\nfor restricting the rate at which retrievers are able to download data from the DA node to a multiple of the rate at which the\ndata was posted to the DA node.",
+                    "type": "integer"
+                }
+            }
+        },
+        "dataapi.BlobCountForAccountIdResponse": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string"
+                },
+                "count": {
                     "type": "integer"
                 }
             }

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -22,6 +22,13 @@ definitions:
           data was posted to the DA node.
         type: integer
     type: object
+  dataapi.BlobCountForAccountIdResponse:
+    properties:
+      account_id:
+        type: string
+      count:
+        type: integer
+    type: object
   dataapi.BlobMetadataResponse:
     properties:
       batch_header_hash:
@@ -303,6 +310,36 @@ paths:
           schema:
             $ref: '#/definitions/dataapi.ErrorResponse'
       summary: Fetch blobs metadata list
+      tags:
+      - Feed
+  /feed/blobs/{accountId}:
+    get:
+      parameters:
+      - description: AccountId
+        in: path
+        name: accountId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dataapi.BlobCountForAccountIdResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+      summary: Fetch blob metadata count by AccountId
       tags:
       - Feed
   /feed/blobs/{blob_key}:

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -250,7 +250,7 @@ func (s *server) Start() error {
 		{
 			feed.GET("/blobs", s.FetchBlobsHandler)
 			feed.GET("/blobs/:blob_key", s.FetchBlobHandler)
-			feed.GET("/blobs/:accountId", s.FetchBlobCountByAccountIdHandler)
+			feed.GET("/blobs/count/:accountId", s.FetchBlobCountByAccountIdHandler)
 		}
 		operatorsInfo := v1.Group("/operators-info")
 		{

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -256,10 +256,10 @@ func TestFetchBlobCountByAccountIdHandler(t *testing.T) {
 	// mark Blob confirmed with accountId test1
 	markBlobConfirmed(t, &blob, key, expectedBatchHeaderHash, "test1", blobstore)
 	accountId := "test1"
-	r.GET("/v1/feed/blobs/:accountId", testDataApiServer.FetchBlobCountByAccountIdHandler)
+	r.GET("/v1/feed/blobs/count/:accountId", testDataApiServer.FetchBlobCountByAccountIdHandler)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/v1/feed/blobs/"+accountId, nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/feed/blobs/count/"+accountId, nil)
 	r.ServeHTTP(w, req)
 
 	res := w.Result()
@@ -288,10 +288,10 @@ func TestFetchBlobCountByAccountIdInvalidHandler(t *testing.T) {
 	// BlobAccountId is "test"
 	// Search by AccountId test1
 	accountId := "test3"
-	r.GET("/v1/feed/blobs/:accountId", testDataApiServer.FetchBlobCountByAccountIdHandler)
+	r.GET("/v1/feed/blobs/count/:accountId", testDataApiServer.FetchBlobCountByAccountIdHandler)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/v1/feed/blobs/"+accountId, nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/feed/blobs/count/"+accountId, nil)
 	r.ServeHTTP(w, req)
 
 	res := w.Result()

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -69,9 +69,10 @@ func ParseBlobKey(key string) (BlobKey, error) {
 }
 
 type BlobMetadata struct {
-	BlobHash     BlobHash     `json:"blob_hash"`
-	MetadataHash MetadataHash `json:"metadata_hash"`
-	BlobStatus   BlobStatus   `json:"blob_status"`
+	BlobHash     BlobHash       `json:"blob_hash"`
+	MetadataHash MetadataHash   `json:"metadata_hash"`
+	BlobStatus   BlobStatus     `json:"blob_status"`
+	AccountID    core.AccountID `json:"account_id"`
 	// Expiry is unix epoch time in seconds at which the blob will expire
 	Expiry uint64 `json:"expiry"`
 	// NumRetries is the number of times the blob has been retried
@@ -168,6 +169,8 @@ type BlobStore interface {
 	GetAllBlobMetadataByBatch(ctx context.Context, batchHeaderHash [32]byte) ([]*BlobMetadata, error)
 	// GetBlobMetadata returns a blob metadata given a metadata key
 	GetBlobMetadata(ctx context.Context, blobKey BlobKey) (*BlobMetadata, error)
+	// GetBlobMetadataCountByAccountID returns a list of blob metadata for blobs with the given accountId
+	GetBlobMetadataCountByAccountID(ctx context.Context, accountID core.AccountID) (int32, error)
 	// HandleBlobFailure handles a blob failure by either incrementing the retry count or marking the blob as failed
 	// Returns a boolean indicating whether the blob should be retried and an error
 	HandleBlobFailure(ctx context.Context, metadata *BlobMetadata, maxRetry uint) (bool, error)


### PR DESCRIPTION
## Why are these changes needed?
These changes enable querying blob count by AccountId

## Changes
1. Add GSI AccountId
2. Add method to GetBlobMetadataCount by AccountId
3. Assign accountKey to `accountId` in BlobAuthHeader.
4. Update DataApiHandler to getBlobMetadataCount by AccountId
5. Define DataApi Endpt for getting BlobCount by AccountId


## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
