### PR TITLE
Instrument the store batch

### DIFF
--- a/node/store.go
+++ b/node/store.go
@@ -274,7 +274,7 @@ func (s *Store) StoreBatch(ctx context.Context, header *core.BatchHeader, blobs 
 		log.Error("Failed to write the batch into local database:", "err", err)
 		return nil, err
 	}
-	log.Debug("StoreBatch succeeded", "chunk serialization duration", serializationDuration, "bytes encoding duration", encodingDuration, "write batch duration", time.Since(start))
+	log.Debug("StoreBatch succeeded", "chunk serialization duration", serializationDuration, "bytes encoding duration", encodingDuration, "write batch duration", time.Since(start), "total bytes", size)
 
 	return &keys, nil
 }


### PR DESCRIPTION
## Why are these changes needed?
An example output (with the optimization in https://github.com/Layr-Labs/eigenda/pull/547):

`StoreBatch succeeded chunk serialization duration 2.397µs bytes encoding duration 30.849738ms write batch duration 218.298804ms total store batch duration 249.422258ms total bytes 74000580`

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
