### PR TITLE
Optimize the node store writing perf

### DIFF
--- a/node/store.go
+++ b/node/store.go
@@ -233,6 +233,20 @@ func (s *Store) StoreBatch(ctx context.Context, header *core.BatchHeader, blobs 
 		keys = append(keys, blobHeaderKey)
 		values = append(values, blobHeaderBytes)
 
+		// Get raw chunks
+		rawBlob := blobsProto[idx]
+		if len(rawBlob.GetBundles()) != len(blob.Bundles) {
+			return nil, errors.New("internal error: the number of bundles in pased blob must be the same as in raw blob")
+		}
+		rawChunks := make(map[core.QuorumID][][]byte)
+		for i, chunks := range rawBlob.GetBundles() {
+			quorumID := uint8(rawBlob.GetHeader().GetQuorumHeaders()[i].GetQuorumId())
+			rawChunks[quorumID] = make([][]byte, len(chunks.GetChunks()))
+			for j, chunk := range chunks.GetChunks() {
+				rawChunks[quorumID][j] = chunk
+			}
+		}
+
 		// blob chunks
 		for quorumID, bundle := range blob.Bundles {
 			key, err := EncodeBlobKey(batchHeaderHash, idx, quorumID)
@@ -242,12 +256,8 @@ func (s *Store) StoreBatch(ctx context.Context, header *core.BatchHeader, blobs 
 			}
 
 			bundleRaw := make([][]byte, len(bundle))
-			for i, chunk := range bundle {
-				bundleRaw[i], err = chunk.Serialize()
-				if err != nil {
-					log.Error("Cannot serialize chunk:", "err", err)
-					return nil, err
-				}
+			for i := 0; i < len(bundle); i++ {
+				bundleRaw[i] = rawChunks[quorumID][i]
 			}
 			chunkBytes, err := encodeChunks(bundleRaw)
 			if err != nil {

--- a/node/store_test.go
+++ b/node/store_test.go
@@ -76,9 +76,6 @@ func CreateBatch(t *testing.T) (*core.BatchHeader, []*core.BlobMessage, []*pb.Bl
 	}
 	chunk1bytes, err := chunk1.Serialize()
 	assert.Nil(t, err)
-	for i := 0; i < 10000; i++ {
-		chunk1.Coeffs = append(chunk1.Coeffs, encoding.ONE)
-	}
 
 	blobMessage := []*core.BlobMessage{
 		{

--- a/node/store_test.go
+++ b/node/store_test.go
@@ -74,6 +74,11 @@ func CreateBatch(t *testing.T) (*core.BatchHeader, []*core.BlobMessage, []*pb.Bl
 		Proof:  commitment,
 		Coeffs: []encoding.Symbol{encoding.ONE},
 	}
+	chunk1bytes, err := chunk1.Serialize()
+	assert.Nil(t, err)
+	for i := 0; i < 10000; i++ {
+		chunk1.Coeffs = append(chunk1.Coeffs, encoding.ONE)
+	}
 
 	blobMessage := []*core.BlobMessage{
 		{
@@ -163,12 +168,21 @@ func CreateBatch(t *testing.T) (*core.BatchHeader, []*core.BlobMessage, []*pb.Bl
 		Length:        uint32(50),
 		QuorumHeaders: []*pb.BlobQuorumInfo{quorumHeaderProto},
 	}
+	bundles := []*pb.Bundle{
+		{
+			Chunks: [][]byte{
+				chunk1bytes,
+			},
+		},
+	}
 	blobs := []*pb.Blob{
 		{
-			Header: blobHeaderProto0,
+			Header:  blobHeaderProto0,
+			Bundles: bundles,
 		},
 		{
-			Header: blobHeaderProto1,
+			Header:  blobHeaderProto1,
+			Bundles: bundles,
 		},
 	}
 	return &batchHeader, blobMessage, blobs


### PR DESCRIPTION
## Why are these changes needed?
About half of the node store writing time was spent on unnecessary serialization of chunks.

See the "chunk serialization duration" v.s. "write batch duration", which are the two dominant components of db writing and are roughly the same. With this PR, the "chunk serialization duration" will become negligible.

![Screenshot 2024-05-07 at 8 55 40 PM](https://github.com/Layr-Labs/eigenda/assets/99709935/a14749bd-45d0-4831-953f-69d66928d2c2)


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
