### PR TITLE
Log batch header hash hex

### DIFF
--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -127,8 +128,9 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 		if op, ok := state.IndexedOperators[r.Operator]; ok {
 			socket = op.Socket
 		}
+		batchHeaderHashHex := hex.EncodeToString(r.BatchHeaderHash[:])
 		if r.Err != nil {
-			a.Logger.Warn("error returned from messageChan", "operatorID", operatorIDHex, "operatorAddress", operatorAddr, "socket", socket, "batchHeaderHash", r.BatchHeaderHash, "err", r.Err)
+			a.Logger.Warn("error returned from messageChan", "operatorID", operatorIDHex, "operatorAddress", operatorAddr, "socket", socket, "batchHeaderHash", batchHeaderHashHex, "err", r.Err)
 			continue
 		}
 
@@ -171,7 +173,7 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 				aggPubKeys[ind].Add(op.PubkeyG2)
 			}
 		}
-		a.Logger.Info("received signature from operator", "operatorID", operatorIDHex, "operatorAddress", operatorAddr, "socket", socket, "quorumIDs", fmt.Sprint(operatorQuorums), "batchHeaderHash", r.BatchHeaderHash)
+		a.Logger.Info("received signature from operator", "operatorID", operatorIDHex, "operatorAddress", operatorAddr, "socket", socket, "quorumIDs", fmt.Sprint(operatorQuorums), "batchHeaderHash", batchHeaderHashHex)
 	}
 
 	// Aggregate Non signer Pubkey Id

--- a/node/node.go
+++ b/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -304,7 +305,8 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 	}
 	n.Metrics.AcceptBatches("received", batchSize)
 
-	log.Debug("Start processing a batch", "batchHeaderHash", batchHeaderHash, "batchSize (in bytes)", batchSize, "num of blobs", len(blobs), "referenceBlockNumber", header.ReferenceBlockNumber)
+	batchHeaderHashHex := hex.EncodeToString(batchHeaderHash[:])
+	log.Debug("Start processing a batch", "batchHeaderHash", batchHeaderHashHex, "batchSize (in bytes)", batchSize, "num of blobs", len(blobs), "referenceBlockNumber", header.ReferenceBlockNumber)
 
 	// Store the batch.
 	// Run this in a goroutine so we can parallelize the batch storing and batch
@@ -349,7 +351,7 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 		result := <-storeChan
 		if result.keys != nil {
 			if deleteKeysErr := n.Store.DeleteKeys(ctx, result.keys); deleteKeysErr != nil {
-				log.Error("Failed to delete the invalid batch that should be rolled back", "batchHeaderHash", batchHeaderHash, "err", deleteKeysErr)
+				log.Error("Failed to delete the invalid batch that should be rolled back", "batchHeaderHash", batchHeaderHashHex, "err", deleteKeysErr)
 			}
 		}
 		return nil, fmt.Errorf("failed to validate batch: %w", err)


### PR DESCRIPTION
## Why are these changes needed?
Minor update to log batch header hash as hex string instead of byte array for better legibility 

Example output:
```
{"time":"2024-05-09T00:18:39.452095149Z","level":"INFO","source":{"function":"github.com/Layr-Labs/eigenda/core.(*StdSignatureAggregator).AggregateSignatures","file":"/home/runner/work/eigenda/eigenda/core/aggregation.go","line":176},"msg":"received signature from operator","component":"SignatureAggregator","operatorID":"3eb7d5df61c48ec2718d8c8ad52304effc970ae92f19138e032dae07b7c0d629","operatorAddress":"0xf270e0dd5a1cc34cda8fb991307604097e622002","socket":"localhost:32011;32012","quorumIDs":"[0]","batchHeaderHash":"6c4d83cbdf3a0bc2b85f4955368d80adb7fc0d432ae81a3368a81b4b4651e3e0"}
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
