### PR TITLE
Name the ejection token to follow custom header format

### DIFF
--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -334,7 +334,8 @@ func (s *server) EjectOperatorsHandler(c *gin.Context) {
 	}))
 	defer timer.ObserveDuration()
 
-	token := c.GetHeader(ejectionTokenParam)
+	token := "foobar"
+	// token := c.GetHeader(ejectionTokenParam)
 	if token != s.ejectionToken {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -33,7 +33,8 @@ const (
 	maxWorkerPoolLimit   = 10
 	maxQueryBatchesLimit = 2
 
-	cacheControlParam = "Cache-Control"
+	ejectionTokenParam = "X-Ejection-Token"
+	cacheControlParam  = "Cache-Control"
 
 	// Cache control for responses.
 	// The time unit is second for max age.
@@ -333,7 +334,7 @@ func (s *server) EjectOperatorsHandler(c *gin.Context) {
 	}))
 	defer timer.ObserveDuration()
 
-	token := c.GetHeader("X-Ejection-Token")
+	token := c.GetHeader(ejectionTokenParam)
 	if token != s.ejectionToken {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -334,7 +334,7 @@ func (s *server) EjectOperatorsHandler(c *gin.Context) {
 	}))
 	defer timer.ObserveDuration()
 
-	token := c.GetHeader("ejection_token")
+	token := c.GetHeader(ejectionTokenParam)
 	if token != s.ejectionToken {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -281,7 +281,7 @@ func (s *server) Start() error {
 	config := cors.DefaultConfig()
 	config.AllowOrigins = s.allowOrigins
 	config.AllowCredentials = true
-	config.AllowMethods = []string{"GET", "POST", "HEAD", "OPTIONS"}
+	config.AllowMethods = []string{"GET", "HEAD", "OPTIONS"}
 
 	if s.serverMode != gin.ReleaseMode {
 		config.AllowOrigins = []string{"*"}

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -280,7 +280,7 @@ func (s *server) Start() error {
 	config := cors.DefaultConfig()
 	config.AllowOrigins = s.allowOrigins
 	config.AllowCredentials = true
-	config.AllowMethods = []string{"GET", "HEAD", "OPTIONS"}
+	config.AllowMethods = []string{"GET", "POST", "HEAD", "OPTIONS"}
 
 	if s.serverMode != gin.ReleaseMode {
 		config.AllowOrigins = []string{"*"}
@@ -333,7 +333,7 @@ func (s *server) EjectOperatorsHandler(c *gin.Context) {
 	}))
 	defer timer.ObserveDuration()
 
-	token := c.GetHeader("ejection_token")
+	token := c.GetHeader("X-Ejection-Token")
 	if token != s.ejectionToken {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -281,7 +281,7 @@ func (s *server) Start() error {
 	config := cors.DefaultConfig()
 	config.AllowOrigins = s.allowOrigins
 	config.AllowCredentials = true
-	config.AllowMethods = []string{"GET", "HEAD", "OPTIONS"}
+	config.AllowMethods = []string{"GET", "POST", "HEAD", "OPTIONS"}
 
 	if s.serverMode != gin.ReleaseMode {
 		config.AllowOrigins = []string{"*"}

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -334,8 +334,7 @@ func (s *server) EjectOperatorsHandler(c *gin.Context) {
 	}))
 	defer timer.ObserveDuration()
 
-	token := "foobar"
-	// token := c.GetHeader(ejectionTokenParam)
+	token := c.GetHeader("ejection_token")
 	if token != s.ejectionToken {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -370,7 +370,7 @@ func TestEjectOperatorHandler(t *testing.T) {
 
 	w2 := httptest.NewRecorder()
 	req2 := httptest.NewRequest(http.MethodGet, reqStr, nil)
-	req2.Header.Set("ejection_token", "deadbeef")
+	req2.Header.Set("X-Ejection-Token", "deadbeef")
 	ctxWithDeadline2, cancel2 := context.WithTimeout(req2.Context(), 500*time.Microsecond)
 	defer cancel2()
 	req2 = req2.WithContext(ctxWithDeadline2)


### PR DESCRIPTION
## Why are these changes needed?
The naming as "ejection_token" will be dropped.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
