### PR TITLE
[dataapi] Initialize geth client with address

### DIFF
--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -82,7 +82,12 @@ func RunDataApi(ctx *cli.Context) error {
 		return err
 	}
 
-	client, err := geth.NewMultiHomingClient(config.EthClientConfig, gethcommon.HexToAddress(config.FireblocksConfig.WalletAddress), logger)
+	sender := gethcommon.Address{}
+	if !config.FireblocksConfig.Disable {
+		sender = gethcommon.HexToAddress(config.FireblocksConfig.WalletAddress)
+	}
+
+	client, err := geth.NewMultiHomingClient(config.EthClientConfig, sender, logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why are these changes needed?
Make sure sender address is passed in when initializing non-private key wallet.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
