### PR TITLE
Add reachability check loop to expose reachability failures in node logs

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -1,7 +1,7 @@
 GITCOMMIT := $(shell git rev-parse --short HEAD)
 GITDATE := $(shell git log -1 --format=%cd --date=unix)
 
-# GitVersion provides the semantic versioning for the project
+# GitVersion provides the semantic versioning for the project. If docker is not installed, semver fallsback to 0.0.0
 SEMVER := $(shell docker run --rm --volume "${PWD}/../:/repo" gittools/gitversion:5.12.0 /repo -output json -showvariable SemVer)
 ifeq ($(SEMVER), )
 SEMVER = "0.0.0"
@@ -19,7 +19,7 @@ docker: docker-node docker-plugin
 docker-node:
 	cd ../ && docker build --build-arg SEMVER=${SEMVER} --build-arg GITCOMMIT=${GITCOMMIT} --build-arg GITDATE=${GITDATE} . -t opr-node:${SEMVER} -t opr-node:latest -f node/cmd/Dockerfile
 
-docker-nodeplugin:
+docker-plugin:
 	cd ../ && docker build --build-arg SEMVER=${SEMVER} --build-arg GITCOMMIT=${GITCOMMIT} --build-arg GITDATE=${GITDATE} . -t opr-nodeplugin:${SEMVER} -t opr-nodeplugin:latest -f node/plugin/cmd/Dockerfile
 
 semver:

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,10 +1,10 @@
 GITCOMMIT := $(shell git rev-parse --short HEAD)
 GITDATE := $(shell git log -1 --format=%cd --date=unix)
 
-# GitVersion provides the semantic versioning for the project. If docker is not installed, semver fallsback to 0.0.0
+# GitVersion provides the semantic versioning for the project. 
 SEMVER := $(shell docker run --rm --volume "${PWD}/../:/repo" gittools/gitversion:5.12.0 /repo -output json -showvariable SemVer)
 ifeq ($(SEMVER), )
-SEMVER = "0.0.0"
+SEMVER = "0.0.0" # Fallback if docker is not installed or gitversion fails
 endif
 
 build: clean

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,3 +1,12 @@
+GITCOMMIT := $(shell git rev-parse --short HEAD)
+GITDATE := $(shell git log -1 --format=%cd --date=unix)
+
+# GitVersion provides the semantic versioning for the project
+SEMVER := $(shell docker run --rm --volume "${PWD}/../:/repo" gittools/gitversion:5.12.0 /repo -output json -showvariable SemVer)
+ifeq ($(SEMVER), )
+SEMVER = "0.0.0"
+endif
+
 build: clean
 	go mod tidy
 	go build -o ./bin/node ./cmd
@@ -8,7 +17,10 @@ clean:
 docker: docker-node docker-plugin
 
 docker-node:
-	cd ../ && docker build . -t opr-node -f node/cmd/Dockerfile
+	cd ../ && docker build --build-arg SEMVER=${SEMVER} --build-arg GITCOMMIT=${GITCOMMIT} --build-arg GITDATE=${GITDATE} . -t opr-node:${SEMVER} -t opr-node:latest -f node/cmd/Dockerfile
 
-docker-plugin:
-	cd ../ && docker build . -t opr-nodeplugin -f node/plugin/cmd/Dockerfile
+docker-nodeplugin:
+	cd ../ && docker build --build-arg SEMVER=${SEMVER} --build-arg GITCOMMIT=${GITCOMMIT} --build-arg GITDATE=${GITDATE} . -t opr-nodeplugin:${SEMVER} -t opr-nodeplugin:latest -f node/plugin/cmd/Dockerfile
+
+semver:
+	echo "${SEMVER}"

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,7 +1,14 @@
+build: clean
+	go mod tidy
+	go build -o ./bin/node ./cmd
+
 clean:
 	rm -rf ./bin
 
-build: clean
-	# cd .. && make protoc
-	go mod tidy
-	go build -o ./bin/node ./cmd
+docker: docker-node docker-plugin
+
+docker-node:
+	cd ../ && docker build . -t opr-node -f node/cmd/Dockerfile
+
+docker-plugin:
+	cd ../ && docker build . -t opr-nodeplugin -f node/plugin/cmd/Dockerfile

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -181,6 +181,21 @@ var (
 		Value:    "180",
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "EXPIRATION_POLL_INTERVAL"),
 	}
+	ReachabilityPollIntervalSecFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "reachability-poll-interval"),
+		Usage:    "How often (in second) to check if node is reachabile from DA backend",
+		Required: false,
+		Value:    "300",
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "REACHABILITY_POLL_INTERVAL"),
+	}
+	// Optional DataAPI URL. If not set, reachability checks are disabled
+	DataApiUrlFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "dataapi-url"),
+		Usage:    "URL of the DataAPI",
+		Required: false,
+		Value:    "",
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "DATAAPI_URL"),
+	}
 	// NumBatchValidators is the maximum number of parallel workers used to
 	// validate a batch (defaults to 128).
 	NumBatchValidatorsFlag = cli.IntFlag{
@@ -263,6 +278,7 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	RegisterAtNodeStartFlag,
 	ExpirationPollIntervalSecFlag,
+	ReachabilityPollIntervalSecFlag,
 	EnableTestModeFlag,
 	OverrideBlockStaleMeasureFlag,
 	OverrideStoreDurationBlocksFlag,
@@ -274,6 +290,7 @@ var optionalFlags = []cli.Flag{
 	ChurnerUseSecureGRPC,
 	EcdsaKeyFileFlag,
 	EcdsaKeyPasswordFlag,
+	DataApiUrlFlag,
 }
 
 func init() {

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -183,9 +183,9 @@ var (
 	}
 	ReachabilityPollIntervalSecFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "reachability-poll-interval"),
-		Usage:    "How often (in second) to check if node is reachabile from DA backend",
+		Usage:    "How often (in second) to check if node is reachabile from Disperser",
 		Required: false,
-		Value:    "300",
+		Value:    "60",
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "REACHABILITY_POLL_INTERVAL"),
 	}
 	// Optional DataAPI URL. If not set, reachability checks are disabled

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -43,6 +43,8 @@ type Metrics struct {
 	AccuSocketUpdates prometheus.Counter
 	// avs node spec eigen_ metrics: https://eigen.nethermind.io/docs/spec/metrics/metrics-prom-spec
 	EigenMetrics eigenmetrics.Metrics
+	// Reachability gauge to monitoring the reachability of the node's retrieval/dispersal sockets
+	ReachabilityGauge *prometheus.GaugeVec
 
 	registry *prometheus.Registry
 	// socketAddr is the address at which the metrics server will be listening.
@@ -128,6 +130,14 @@ func NewMetrics(eigenMetrics eigenmetrics.Metrics, reg *prometheus.Registry, log
 				Name:      "eigenda_node_socket_updates_total",
 				Help:      "the total number of node's socket address updates",
 			},
+		),
+		ReachabilityGauge: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Name:      "reachability_status",
+				Help:      "the reachability status of the nodes retrievel/dispersal sockets",
+			},
+			[]string{"service"},
 		),
 		EigenMetrics:           eigenMetrics,
 		logger:                 logger.With("component", "NodeMetrics"),

--- a/node/node.go
+++ b/node/node.go
@@ -459,8 +459,9 @@ func (n *Node) checkCurrentNodeIp(ctx context.Context) {
 	}
 }
 
+// OperatorReachabilityResponse is the response object for the reachability check
 type OperatorReachabilityResponse struct {
-	OperatorId      string `json:"operator_id"`
+	OperatorID      string `json:"operator_id"`
 	DispersalSocket string `json:"dispersal_socket"`
 	RetrievalSocket string `json:"retrieval_socket"`
 	DispersalOnline bool   `json:"dispersal_online"`
@@ -511,13 +512,17 @@ func (n *Node) checkNodeReachability() {
 		}
 
 		var responseObject OperatorReachabilityResponse
-		json.Unmarshal(data, &responseObject)
+		err = json.Unmarshal(data, &responseObject)
+		if err != nil {
+			n.Logger.Error("Reachability check failed to unmarshal json response", err)
+			continue
+		}
+
 		if responseObject.DispersalOnline {
 			n.Logger.Info("Reachability check - dispersal socket is ONLINE", "socket", responseObject.DispersalSocket)
 		} else {
 			n.Logger.Error("Reachability check - dispersal socket is UNREACHABLE", "socket", responseObject.DispersalSocket)
 		}
-
 		if responseObject.RetrievalOnline {
 			n.Logger.Info("Reachability check - retrieval socket is ONLINE", "socket", responseObject.RetrievalSocket)
 		} else {


### PR DESCRIPTION
Default check interval is 5min
Minimum check interval is 10sec
Operators can disable by setting `NODE_REACHABILITY_POLL_INTERVAL` to 0

For backwards compatibility, the reachability check loop is disabled if the `NODE_DATAAPI_URL` is undefined (ie operator did not update their .env)

See also https://github.com/Layr-Labs/eigenda-operator-setup/pull/123

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(
