### PR TITLE
Upgrade actions to versions with node20

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -22,10 +22,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checkout wiki
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{github.repository}}.wiki
         token: ${{ github.token }}

--- a/.github/workflows/docker-publish-opr-node-images.yaml
+++ b/.github/workflows/docker-publish-opr-node-images.yaml
@@ -30,7 +30,7 @@ jobs:
       packages: write
     steps:
     - name: Checkout repository at specified commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.commit_sha }}
     - name: Get Commit Date

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -19,7 +19,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,16 +12,16 @@ jobs:
     name: Linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21' # The Go version to download (if necessary) and use.
       - run: go version
 
       - name: Checkout EigenDA
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.54
           args: --timeout 3m --verbose

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,13 +26,13 @@ jobs:
           aws configure --profile test-profile set region us-east-1
           aws configure --profile test-profile set source_profile default
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21' # The Go version to download (if necessary) and use.
       - run: go version
 
       - name: Checkout EigenDA
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Update Submodule Commits
         run: |

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -17,7 +17,7 @@ jobs:
     name: Foundry Project
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,13 +26,13 @@ jobs:
           aws configure --profile test-profile set region us-east-1
           aws configure --profile test-profile set source_profile default
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21' # The Go version to download (if necessary) and use.
       - run: go version
 
       - name: Checkout EigenDA
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: make build
@@ -51,7 +51,7 @@ jobs:
     needs: unit-tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Update coverage badge
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Node 16 has reached end of life
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Remove warnings like this
https://github.com/Layr-Labs/eigenda/actions/runs/9084687605