### PR TITLE
[dataapi] Use ctx with timeout for txn receipt retrieval

### DIFF
--- a/disperser/dataapi/ejector.go
+++ b/disperser/dataapi/ejector.go
@@ -148,7 +148,7 @@ func (e *Ejector) Eject(ctx context.Context, nonsigningRate *OperatorsNonsigning
 	defer cancelCtx()
 	var receipt *types.Receipt
 	for {
-		receipt, err = e.wallet.GetTransactionReceipt(ctx, txID)
+		receipt, err = e.wallet.GetTransactionReceipt(ctxWithTimeout, txID)
 		if err == nil {
 			break
 		}
@@ -167,7 +167,7 @@ func (e *Ejector) Eject(ctx context.Context, nonsigningRate *OperatorsNonsigning
 
 		// Wait for the next round.
 		select {
-		case <-ctx.Done():
+		case <-ctxWithTimeout.Done():
 			return ctxWithTimeout.Err()
 		case <-queryTicker.C:
 		}


### PR DESCRIPTION
## Why are these changes needed?
`GetTransactionReceipt` should be using context with timeout 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
