### PR TITLE
Support custom quorums in traffic generator

### DIFF
--- a/tools/traffic/flags/flags.go
+++ b/tools/traffic/flags/flags.go
@@ -72,6 +72,12 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "USE_SECURE_GRPC"),
 	}
+	CustomQuorumNumbersFlag = cli.IntSliceFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "custom-quorum-numbers"),
+		Usage:    "Custom quorum numbers to use for the traffic generator",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envPrefix, "CUSTOM_QUORUM_NUMBERS"),
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -87,6 +93,7 @@ var optionalFlags = []cli.Flag{
 	RandomizeBlobsFlag,
 	InstanceLaunchIntervalFlag,
 	UseSecureGrpcFlag,
+	CustomQuorumNumbersFlag,
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/tools/traffic/generator.go
+++ b/tools/traffic/generator.go
@@ -97,7 +97,7 @@ func (g *TrafficGenerator) StartTraffic(ctx context.Context) error {
 func (g *TrafficGenerator) sendRequest(ctx context.Context, data []byte) error {
 	ctxTimeout, cancel := context.WithTimeout(ctx, g.Config.Timeout)
 	defer cancel()
-	blobStatus, key, err := g.DisperserClient.DisperseBlob(ctxTimeout, data, []uint8{})
+	blobStatus, key, err := g.DisperserClient.DisperseBlob(ctxTimeout, data, g.Config.CustomQuorums)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why are these changes needed?
Allow specifying custom quorums in dispersal requests from traffic generator
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
