### PR TITLE
Disperser client signer nil check

### DIFF
--- a/clients/disperser_client.go
+++ b/clients/disperser_client.go
@@ -106,7 +106,9 @@ func (c *disperserClient) DisperseBlob(ctx context.Context, data []byte, quorums
 }
 
 func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []byte, quorums []uint8) (*disperser.BlobStatus, []byte, error) {
-
+	if c.signer == nil {
+		return nil, nil, errors.New("signer is nil in an authenticated request")
+	}
 	addr := fmt.Sprintf("%v:%v", c.config.Hostname, c.config.Port)
 
 	dialOptions := c.getDialOptions()


### PR DESCRIPTION
## Why are these changes needed?
`signer` should not be nil in `DisperseBlobAuthenticated`
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
