### PR TITLE
Improved reachability check 404 handling

### DIFF
--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -169,8 +169,8 @@ func ValidOperatorIP(address string, logger logging.Logger) bool {
 func (s *server) probeOperatorPorts(ctx context.Context, operatorId string) (*OperatorPortCheckResponse, error) {
 	operatorInfo, err := s.subgraphClient.QueryOperatorInfoByOperatorId(context.Background(), operatorId)
 	if err != nil {
-		s.logger.Warn("failed to fetch operator info", "operator_id", operatorId, "error", err)
-		return &OperatorPortCheckResponse{}, errors.New("operator info not found.")
+		s.logger.Warn("failed to fetch operator info", "operatorId", operatorId, "error", err)
+		return &OperatorPortCheckResponse{}, errors.New("operator info not found")
 	}
 
 	operatorSocket := core.OperatorSocket(operatorInfo.Socket)

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -169,8 +169,8 @@ func ValidOperatorIP(address string, logger logging.Logger) bool {
 func (s *server) probeOperatorPorts(ctx context.Context, operatorId string) (*OperatorPortCheckResponse, error) {
 	operatorInfo, err := s.subgraphClient.QueryOperatorInfoByOperatorId(context.Background(), operatorId)
 	if err != nil {
-		s.logger.Warn("failed to fetch operator info", "error", err)
-		return &OperatorPortCheckResponse{}, errors.New("not found")
+		s.logger.Warn("failed to fetch operator info", "operator_id", operatorId, "error", err)
+		return &OperatorPortCheckResponse{}, errors.New("operator info not found.")
 	}
 
 	operatorSocket := core.OperatorSocket(operatorInfo.Socket)
@@ -190,7 +190,7 @@ func (s *server) probeOperatorPorts(ctx context.Context, operatorId string) (*Op
 	}
 
 	// Log the online status
-	s.logger.Info("operator port check response", portCheckResponse)
+	s.logger.Info("operator port check response", "response", portCheckResponse)
 
 	// Send the metadata to the results channel
 	return portCheckResponse, nil


### PR DESCRIPTION
## Why are these changes needed?

It's possible to get different 404 from dataapi. This change makes it clear that the operator info was not found vs the client made a bad api request.

If operator id is not found, caller gets a JSON response `{"error":"operator info not found"}`
If caller sends a request to non-existient  API it returns text/plain `404 page not found`

Also adds `operator_id` to Warning message for debugging context

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(
