### PR TITLE
Add operatorId in attestation latency

### DIFF
--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -88,7 +88,7 @@ func (c *dispatcher) sendAllChunks(ctx context.Context, state *core.IndexedOpera
 					BatchHeaderHash:      batchHeaderHash,
 					AttestationLatencyMs: latencyMs,
 				}
-				c.metrics.ObserveLatency(false, latencyMs)
+				c.metrics.ObserveLatency(id.Hex(), false, latencyMs)
 			} else {
 				update <- core.SigningMessage{
 					Signature:            sig,
@@ -97,7 +97,7 @@ func (c *dispatcher) sendAllChunks(ctx context.Context, state *core.IndexedOpera
 					AttestationLatencyMs: latencyMs,
 					Err:                  nil,
 				}
-				c.metrics.ObserveLatency(true, latencyMs)
+				c.metrics.ObserveLatency(id.Hex(), true, latencyMs)
 			}
 
 		}(core.IndexedOperatorInfo{

--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -164,7 +164,7 @@ func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
 				Help:       "attestation latency summary in milliseconds",
 				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			},
-			[]string{"status"},
+			[]string{"operator_id", "status"},
 		),
 	}
 
@@ -252,12 +252,12 @@ func (g *Metrics) UpdateAttestation(operatorCount map[core.QuorumID]int, signerC
 	}
 }
 
-func (t *DispatcherMetrics) ObserveLatency(success bool, latencyMS float64) {
+func (t *DispatcherMetrics) ObserveLatency(operatorId string, success bool, latencyMS float64) {
 	label := "success"
 	if !success {
 		label = "failure"
 	}
-	t.Latency.WithLabelValues(label).Observe(latencyMS)
+	t.Latency.WithLabelValues(operatorId, label).Observe(latencyMS)
 }
 
 // UpdateCompletedBlob increments the number and updates size of processed blobs.


### PR DESCRIPTION
## Why are these changes needed?
To gain visibility into operator's attestation performance.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
