### PR TITLE
[node] Use URL builder to get reachability URL

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -139,3 +139,12 @@ func TestNodeStartOperatorIDDoesNotMatch(t *testing.T) {
 	err := c.node.Start(context.Background())
 	assert.ErrorContains(t, err, "operator ID mismatch")
 }
+
+func TestGetReachabilityURL(t *testing.T) {
+	url, err := node.GetReachabilityURL("https://dataapi.eigenda.xyz/", "123123123")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://dataapi.eigenda.xyz/api/v1/operators-info/port-check?operator_id=123123123", url)
+	url, err = node.GetReachabilityURL("https://dataapi.eigenda.xyz", "123123123")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://dataapi.eigenda.xyz/api/v1/operators-info/port-check?operator_id=123123123", url)
+}


### PR DESCRIPTION
## Why are these changes needed?
Instead of using `fmt.Sprintf`, use `net/url` library to build the URL. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
