### PR TITLE
Log request protobuf msg size

### DIFF
--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -14,6 +14,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
 )
 
 type Config struct {
@@ -130,7 +131,7 @@ func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.BlobMessage, 
 	}
 
 	opt := grpc.MaxCallSendMsgSize(60 * 1024 * 1024 * 1024)
-	c.logger.Debug("sending chunks to operator", "operator", op.Socket, "size", totalSize)
+	c.logger.Debug("sending chunks to operator", "operator", op.Socket, "size", totalSize, "request message size", proto.Size(request))
 	reply, err := gc.StoreChunks(ctx, request, opt)
 
 	if err != nil {

--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -200,6 +200,8 @@ func (s *Server) validateStoreChunkRequest(in *pb.StoreChunksRequest) error {
 func (s *Server) StoreChunks(ctx context.Context, in *pb.StoreChunksRequest) (*pb.StoreChunksReply, error) {
 	start := time.Now()
 
+	s.node.Logger.Info("StoreChunks RPC request recieved", "request message size", proto.Size(in))
+
 	// Validate the request.
 	if err := s.validateStoreChunkRequest(in); err != nil {
 		return nil, err


### PR DESCRIPTION
## Why are these changes needed?
The serialized protobuf message is the actual amount of data to be transmitted. And it could be quite different than the accounting in golang.

Example:
`2024-05-23 16:14:12.845 | {"time":"2024-05-23T23:14:12.845549648Z","level":"DEBUG","source":{"function":"github.com/Layr-Labs/eigenda/disperser/batcher/grpc.(*dispatcher).sendChunks","file":"/app/disperser/batcher/grpc/dispatcher.go","line":134},"msg":"sending chunks to operator","component":"Dispatcher","operator":"18.218.243.40:32005;32004","size":2689920,"request message size":10682225}`




<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
