### PR TITLE
Filter empty quorums when confirming batch

### DIFF
--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -34,13 +34,12 @@ type SigningMessage struct {
 }
 
 // QuorumAttestation contains the results of aggregating signatures from a set of operators by quorums
+// It also returns map of all signers across all quorums
 type QuorumAttestation struct {
 	// QuorumAggPubKeys contains the aggregated public keys for all of the operators each quorum,
 	// including those that did not sign
 	QuorumAggPubKey map[QuorumID]*G1Point
-	// SignersAggPubKey is the aggregated public key for all of the operators that signed the message for each quorum,
-	// further aggregated across the quorums; operators signing for multiple quorums will be included in
-	// the aggregation multiple times
+	// SignersAggPubKey is the aggregated public key for all of the operators that signed the message by each quorum
 	SignersAggPubKey map[QuorumID]*G2Point
 	// AggSignature is the aggregated signature for all of the operators that signed the message for each quorum, mirroring the
 	// SignersAggPubKey.

--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
@@ -32,13 +33,31 @@ type SigningMessage struct {
 	Err                  error
 }
 
-// SignatureAggregation contains the results of aggregating signatures from a set of operators
+// QuorumAttestation contains the results of aggregating signatures from a set of operators by quorums
+type QuorumAttestation struct {
+	// QuorumAggPubKeys contains the aggregated public keys for all of the operators each quorum,
+	// including those that did not sign
+	QuorumAggPubKey map[QuorumID]*G1Point
+	// SignersAggPubKey is the aggregated public key for all of the operators that signed the message for each quorum,
+	// further aggregated across the quorums; operators signing for multiple quorums will be included in
+	// the aggregation multiple times
+	SignersAggPubKey map[QuorumID]*G2Point
+	// AggSignature is the aggregated signature for all of the operators that signed the message for each quorum, mirroring the
+	// SignersAggPubKey.
+	AggSignature map[QuorumID]*Signature
+	// QuorumResults contains the quorum ID and the amount signed for each quorum
+	QuorumResults map[QuorumID]*QuorumResult
+	// SignerMap contains the operator IDs that signed the message
+	SignerMap map[OperatorID]bool
+}
+
+// SignatureAggregation contains the results of aggregating signatures from a set of operators across multiple quorums
 type SignatureAggregation struct {
 	// NonSigners contains the public keys of the operators that did not sign the message
 	NonSigners []*G1Point
 	// QuorumAggPubKeys contains the aggregated public keys for all of the operators each quorum,
 	// Including those that did not sign
-	QuorumAggPubKeys []*G1Point
+	QuorumAggPubKeys map[QuorumID]*G1Point
 	// AggPubKey is the aggregated public key for all of the operators that signed the message,
 	// further aggregated across the quorums; operators signing for multiple quorums will be included in
 	// the aggregation multiple times
@@ -48,16 +67,15 @@ type SignatureAggregation struct {
 	AggSignature *Signature
 	// QuorumResults contains the quorum ID and the amount signed for each quorum
 	QuorumResults map[QuorumID]*QuorumResult
-	// SignerMap contains the operator IDs that signed the message
-	SignerMap map[OperatorID]bool
 }
 
 // SignatureAggregator is an interface for aggregating the signatures returned by DA nodes so that they can be verified by the DA contract
 type SignatureAggregator interface {
-
-	// AggregateSignatures blocks until it receives a response for each operator in the operator state via messageChan, and then returns the aggregated signature.
+	// ReceiveSignatures blocks until it receives a response for each operator in the operator state via messageChan, and then returns the attestation result by quorum.
+	ReceiveSignatures(ctx context.Context, state *IndexedOperatorState, message [32]byte, messageChan chan SigningMessage) (*QuorumAttestation, error)
+	// AggregateSignatures takes attestation result by quorum and aggregates the signatures across them.
 	// If the aggregated signature is invalid, an error is returned.
-	AggregateSignatures(ctx context.Context, state *IndexedOperatorState, quorumIDs []QuorumID, message [32]byte, messageChan chan SigningMessage) (*SignatureAggregation, error)
+	AggregateSignatures(ctx context.Context, ics IndexedChainState, referenceBlockNumber uint, quorumAttestation *QuorumAttestation, quorumIDs []QuorumID) (*SignatureAggregation, error)
 }
 
 type StdSignatureAggregator struct {
@@ -82,8 +100,12 @@ func NewStdSignatureAggregator(logger logging.Logger, transactor Transactor) (*S
 
 var _ SignatureAggregator = (*StdSignatureAggregator)(nil)
 
-func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state *IndexedOperatorState, quorumIDs []QuorumID, message [32]byte, messageChan chan SigningMessage) (*SignatureAggregation, error) {
-	// TODO: Add logging
+func (a *StdSignatureAggregator) ReceiveSignatures(ctx context.Context, state *IndexedOperatorState, message [32]byte, messageChan chan SigningMessage) (*QuorumAttestation, error) {
+	quorumIDs := make([]QuorumID, 0, len(state.AggKeys))
+	for quorumID := range state.Operators {
+		quorumIDs = append(quorumIDs, quorumID)
+	}
+	slices.Sort(quorumIDs)
 
 	if len(quorumIDs) == 0 {
 		return nil, errors.New("the number of quorums must be greater than zero")
@@ -97,13 +119,12 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 		}
 	}
 
-	stakeSigned := make([]*big.Int, len(quorumIDs))
-	for ind := range quorumIDs {
-		stakeSigned[ind] = big.NewInt(0)
+	stakeSigned := make(map[QuorumID]*big.Int, len(quorumIDs))
+	for _, quorumID := range quorumIDs {
+		stakeSigned[quorumID] = big.NewInt(0)
 	}
-	aggSigs := make([]*Signature, len(quorumIDs))
-	aggPubKeys := make([]*G2Point, len(quorumIDs))
-
+	aggSigs := make(map[QuorumID]*Signature, len(quorumIDs))
+	aggPubKeys := make(map[QuorumID]*G2Point, len(quorumIDs))
 	signerMap := make(map[OperatorID]bool)
 
 	// Aggregate Signatures
@@ -151,7 +172,7 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 		}
 
 		operatorQuorums := make([]uint8, 0, len(quorumIDs))
-		for ind, quorumID := range quorumIDs {
+		for _, quorumID := range quorumIDs {
 			// Get stake amounts for operator
 			ops := state.Operators[quorumID]
 			opInfo, ok := ops[r.Operator]
@@ -164,15 +185,15 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 			signerMap[r.Operator] = true
 
 			// Add to stake signed
-			stakeSigned[ind].Add(stakeSigned[ind], opInfo.Stake)
+			stakeSigned[quorumID].Add(stakeSigned[quorumID], opInfo.Stake)
 
 			// Add to agg signature
-			if aggSigs[ind] == nil {
-				aggSigs[ind] = &Signature{sig.Clone()}
-				aggPubKeys[ind] = op.PubkeyG2.Clone()
+			if aggSigs[quorumID] == nil {
+				aggSigs[quorumID] = &Signature{sig.Clone()}
+				aggPubKeys[quorumID] = op.PubkeyG2.Clone()
 			} else {
-				aggSigs[ind].Add(sig.G1Point)
-				aggPubKeys[ind].Add(op.PubkeyG2)
+				aggSigs[quorumID].Add(sig.G1Point)
+				aggPubKeys[quorumID].Add(op.PubkeyG2)
 			}
 		}
 		a.Logger.Info("received signature from operator", "operatorID", operatorIDHex, "operatorAddress", operatorAddr, "socket", socket, "quorumIDs", fmt.Sprint(operatorQuorums), "batchHeaderHash", batchHeaderHashHex, "attestationLatencyMs", r.AttestationLatencyMs)
@@ -190,14 +211,14 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 		}
 	}
 
-	quorumAggPubKeys := make([]*G1Point, len(quorumIDs))
+	quorumAggPubKeys := make(map[QuorumID]*G1Point, len(quorumIDs))
 
 	// Validate the amount signed and aggregate signatures for each quorum
 	quorumResults := make(map[QuorumID]*QuorumResult)
 
-	for ind, quorumID := range quorumIDs {
+	for _, quorumID := range quorumIDs {
 		// Check that quorum has sufficient stake
-		percent := GetSignedPercentage(state.OperatorState, quorumID, stakeSigned[ind])
+		percent := GetSignedPercentage(state.OperatorState, quorumID, stakeSigned[quorumID])
 		quorumResults[quorumID] = &QuorumResult{
 			QuorumID:      quorumID,
 			PercentSigned: percent,
@@ -205,7 +226,7 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 
 		// Verify that the aggregated public key for the quorum matches the on-chain quorum aggregate public key sans non-signers of the quorum
 		quorumAggKey := state.AggKeys[quorumID]
-		quorumAggPubKeys[ind] = quorumAggKey
+		quorumAggPubKeys[quorumID] = quorumAggKey
 
 		signersAggKey := quorumAggKey.Clone()
 		for opInd, nsk := range nonSignerKeys {
@@ -215,11 +236,11 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 			}
 		}
 
-		if aggPubKeys[ind] == nil {
+		if aggPubKeys[quorumID] == nil {
 			return nil, ErrAggSigNotValid
 		}
 
-		ok, err := signersAggKey.VerifyEquivalence(aggPubKeys[ind])
+		ok, err := signersAggKey.VerifyEquivalence(aggPubKeys[quorumID])
 		if err != nil {
 			return nil, err
 		}
@@ -228,20 +249,54 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 		}
 
 		// Verify the aggregated signature for the quorum
-		ok = aggSigs[ind].Verify(aggPubKeys[ind], message)
+		ok = aggSigs[quorumID].Verify(aggPubKeys[quorumID], message)
 		if !ok {
 			return nil, ErrAggSigNotValid
 		}
 	}
 
+	return &QuorumAttestation{
+		QuorumAggPubKey:  quorumAggPubKeys,
+		SignersAggPubKey: aggPubKeys,
+		AggSignature:     aggSigs,
+		QuorumResults:    quorumResults,
+		SignerMap:        signerMap,
+	}, nil
+}
+
+func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, ics IndexedChainState, referenceBlockNumber uint, quorumAttestation *QuorumAttestation, quorumIDs []QuorumID) (*SignatureAggregation, error) {
 	// Aggregate the aggregated signatures. We reuse the first aggregated signature as the accumulator
-	for i := 1; i < len(aggSigs); i++ {
-		aggSigs[0].Add(aggSigs[i].G1Point)
+	var aggSig *Signature
+	for _, quorumID := range quorumIDs {
+		sig := quorumAttestation.AggSignature[quorumID]
+		if aggSig == nil {
+			aggSig = &Signature{sig.G1Point.Clone()}
+		} else {
+			aggSig.Add(sig.G1Point)
+		}
 	}
 
 	// Aggregate the aggregated public keys. We reuse the first aggregated public key as the accumulator
-	for i := 1; i < len(aggPubKeys); i++ {
-		aggPubKeys[0].Add(aggPubKeys[i])
+	var aggPubKey *G2Point
+	for _, quorumID := range quorumIDs {
+		apk := quorumAttestation.SignersAggPubKey[quorumID]
+		if aggPubKey == nil {
+			aggPubKey = apk.Clone()
+		} else {
+			aggPubKey.Add(apk)
+		}
+	}
+
+	nonSignerKeys := make([]*G1Point, 0)
+	indexedOperatorState, err := ics.GetIndexedOperatorState(ctx, referenceBlockNumber, quorumIDs)
+	if err != nil {
+		return nil, err
+	}
+	for id, op := range indexedOperatorState.IndexedOperators {
+		_, found := quorumAttestation.SignerMap[id]
+		if !found {
+			nonSignerKeys = append(nonSignerKeys, op.PubkeyG1)
+		}
 	}
 
 	// sort non signer keys according to how it's checked onchain
@@ -253,13 +308,22 @@ func (a *StdSignatureAggregator) AggregateSignatures(ctx context.Context, state 
 		return bytes.Compare(hash1[:], hash2[:]) == -1
 	})
 
+	quorumAggKeys := make(map[QuorumID]*G1Point, len(quorumIDs))
+	for _, quorumID := range quorumIDs {
+		quorumAggKeys[quorumID] = quorumAttestation.QuorumAggPubKey[quorumID]
+	}
+
+	quorumResults := make(map[QuorumID]*QuorumResult, len(quorumIDs))
+	for _, quorumID := range quorumIDs {
+		quorumResults[quorumID] = quorumAttestation.QuorumResults[quorumID]
+	}
+
 	return &SignatureAggregation{
 		NonSigners:       nonSignerKeys,
-		QuorumAggPubKeys: quorumAggPubKeys,
-		AggPubKey:        aggPubKeys[0],
-		AggSignature:     aggSigs[0],
+		QuorumAggPubKeys: quorumAggKeys,
+		AggPubKey:        aggPubKey,
+		AggSignature:     aggSig,
 		QuorumResults:    quorumResults,
-		SignerMap:        signerMap,
 	}, nil
 
 }

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -190,6 +190,7 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 		BlockNumber: blockNumber,
 	}
 
+	filteredIndexedOperators := make(map[core.OperatorID]*core.IndexedOperatorInfo, 0)
 	for quorumID, operatorsByID := range storedOperators {
 		for opID := range operatorsByID {
 			if aggPubKeys[quorumID] == nil {
@@ -198,12 +199,13 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 			} else {
 				aggPubKeys[quorumID].Add(privateOperators[opID].KeyPair.GetPubKeyG1())
 			}
+			filteredIndexedOperators[opID] = indexedOperators[opID]
 		}
 	}
 
 	indexedState := &core.IndexedOperatorState{
 		OperatorState:    operatorState,
-		IndexedOperators: indexedOperators,
+		IndexedOperators: filteredIndexedOperators,
 		AggKeys:          make(map[core.QuorumID]*core.G1Point),
 	}
 	for quorumID, apk := range aggPubKeys {

--- a/core/mock/tx.go
+++ b/core/mock/tx.go
@@ -90,7 +90,7 @@ func (t *MockTransactor) GetOperatorStakesForQuorums(ctx context.Context, quorum
 }
 
 func (t *MockTransactor) BuildConfirmBatchTxn(ctx context.Context, batchHeader *core.BatchHeader, quorums map[core.QuorumID]*core.QuorumResult, signatureAggregation *core.SignatureAggregation) (*types.Transaction, error) {
-	args := t.Called()
+	args := t.Called(ctx, batchHeader, quorums, signatureAggregation)
 	result := args.Get(0)
 	return result.(*types.Transaction), args.Error(1)
 }

--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -596,7 +596,9 @@ func (b *Batcher) getBatchID(ctx context.Context, txReceipt *types.Receipt) (uin
 	return batchID, nil
 }
 
-// numBlobsAttestedByQuorum returns the number of blobs that have been successfully attested by the given quorums
+// numBlobsAttestedByQuorum returns two values:
+// 1. the number of blobs that have been successfully attested by all quorums
+// 2. map[QuorumID]int mapping a quorum to the number of blobs that have been successfully attested by the quorum
 func numBlobsAttestedByQuorum(signedQuorums map[core.QuorumID]*core.QuorumResult, headers []*core.BlobHeader) (int, map[core.QuorumID]int) {
 	numPassed := 0
 	quorumCounts := make(map[core.QuorumID]int)

--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"slices"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
@@ -441,21 +440,12 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	// Aggregate the signatures
 	log.Debug("Aggregating signatures...")
 
-	// construct quorumParams
-	quorumIDs := make([]core.QuorumID, 0, len(batch.State.AggKeys))
-	for quorumID := range batch.State.Operators {
-		quorumIDs = append(quorumIDs, quorumID)
-	}
-	slices.Sort(quorumIDs)
-
 	stageTimer = time.Now()
-	aggSig, err := b.Aggregator.AggregateSignatures(ctx, batch.State, quorumIDs, headerHash, update)
+	quorumAttestation, err := b.Aggregator.ReceiveSignatures(ctx, batch.State, headerHash, update)
 	if err != nil {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailAggregateSignatures)
-		return fmt.Errorf("HandleSingleBatch: error aggregating signatures: %w", err)
+		return fmt.Errorf("HandleSingleBatch: error receiving and validating signatures: %w", err)
 	}
-	log.Debug("AggregateSignatures took", "duration", time.Since(stageTimer))
-	b.Metrics.ObserveLatency("AggregateSignatures", float64(time.Since(stageTimer).Milliseconds()))
 	operatorCount := make(map[core.QuorumID]int)
 	signerCount := make(map[core.QuorumID]int)
 	for quorumID, opState := range batch.State.Operators {
@@ -464,22 +454,40 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 			signerCount[quorumID] = 0
 		}
 		for opID := range opState {
-			if _, ok := aggSig.SignerMap[opID]; ok {
+			if _, ok := quorumAttestation.SignerMap[opID]; ok {
 				signerCount[quorumID]++
 			}
 		}
 	}
-	b.Metrics.UpdateAttestation(operatorCount, signerCount, aggSig.QuorumResults)
-	for _, quorumResult := range aggSig.QuorumResults {
+	b.Metrics.UpdateAttestation(operatorCount, signerCount, quorumAttestation.QuorumResults)
+	for _, quorumResult := range quorumAttestation.QuorumResults {
 		log.Info("Aggregated quorum result", "quorumID", quorumResult.QuorumID, "percentSigned", quorumResult.PercentSigned)
 	}
 
-	numPassed := numBlobsAttested(aggSig.QuorumResults, batch.BlobHeaders)
+	numPassed, numPassedByQuorum := numBlobsAttestedByQuorum(quorumAttestation.QuorumResults, batch.BlobHeaders)
 	// TODO(mooselumph): Determine whether to confirm the batch based on the number of successes
 	if numPassed == 0 {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailNoSignatures)
 		return errors.New("HandleSingleBatch: no blobs received sufficient signatures")
 	}
+
+	nonEmptyQuorums := []core.QuorumID{}
+	for quorumID, count := range numPassedByQuorum {
+		log.Info("Blobs attested by quorum", "quorumID", quorumID, "count", count)
+		if count > 0 {
+			nonEmptyQuorums = append(nonEmptyQuorums, quorumID)
+		}
+	}
+
+	// Aggregate the signatures across only the non-empty quorums. Excluding empty quorums reduces the gas cost.
+	aggSig, err := b.Aggregator.AggregateSignatures(ctx, b.ChainState, batch.BatchHeader.ReferenceBlockNumber, quorumAttestation, nonEmptyQuorums)
+	if err != nil {
+		_ = b.handleFailure(ctx, batch.BlobMetadata, FailAggregateSignatures)
+		return fmt.Errorf("HandleSingleBatch: error aggregating signatures: %w", err)
+	}
+
+	log.Debug("AggregateSignatures took", "duration", time.Since(stageTimer))
+	b.Metrics.ObserveLatency("AggregateSignatures", float64(time.Since(stageTimer).Milliseconds()))
 
 	// Confirm the batch
 	log.Debug("Confirming batch...")
@@ -588,15 +596,17 @@ func (b *Batcher) getBatchID(ctx context.Context, txReceipt *types.Receipt) (uin
 	return batchID, nil
 }
 
-// numBlobsAttested returns the number of blobs that have been successfully attested by the given quorums
-func numBlobsAttested(signedQuorums map[core.QuorumID]*core.QuorumResult, headers []*core.BlobHeader) int {
+// numBlobsAttestedByQuorum returns the number of blobs that have been successfully attested by the given quorums
+func numBlobsAttestedByQuorum(signedQuorums map[core.QuorumID]*core.QuorumResult, headers []*core.BlobHeader) (int, map[core.QuorumID]int) {
 	numPassed := 0
+	quorumCounts := make(map[core.QuorumID]int)
 	for _, blob := range headers {
 		thisPassed := true
 		for _, quorum := range blob.QuorumInfos {
 			if signedQuorums[quorum.QuorumID].PercentSigned < quorum.ConfirmationThreshold {
 				thisPassed = false
-				break
+			} else {
+				quorumCounts[quorum.QuorumID]++
 			}
 		}
 		if thisPassed {
@@ -604,7 +614,7 @@ func numBlobsAttested(signedQuorums map[core.QuorumID]*core.QuorumResult, header
 		}
 	}
 
-	return numPassed
+	return numPassed, quorumCounts
 }
 
 func isBlobAttested(signedQuorums map[core.QuorumID]*core.QuorumResult, header *core.BlobHeader) bool {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 var (
@@ -402,7 +403,7 @@ func TestDispersalAndRetrieval(t *testing.T) {
 	dis.batcher.EncodingStreamer.Pool.StopWait()
 
 	txn := types.NewTransaction(0, gethcommon.Address{}, big.NewInt(0), 0, big.NewInt(0), nil)
-	dis.transactor.On("BuildConfirmBatchTxn").Return(txn, nil)
+	dis.transactor.On("BuildConfirmBatchTxn", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(txn, nil)
 	dis.txnManager.On("ProcessTransaction").Return(nil)
 
 	err = dis.batcher.HandleSingleBatch(ctx)


### PR DESCRIPTION
## Why are these changes needed?
With additional (custom) quorums, blobs may fail to get attested by some quorums and the current implementation would still post the batch including all the non-signers in the failed quorums. 
This PR makes batcher inspect the quorum results and filter out empty quorums when submitting the batch confirmation transaction onchain. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
