### PR TITLE
Allow decimal basis points for stake share

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -231,8 +231,12 @@ func (g *Metrics) collectOnchainMetrics() {
 		}
 		for q, operators := range state.Operators {
 			operatorStakeShares := make([]*OperatorStakeShare, 0)
+			totalStake := new(big.Float).SetInt(state.Totals[q].Stake)
 			for opId, opInfo := range operators {
-				share, _ := new(big.Int).Div(new(big.Int).Mul(opInfo.Stake, big.NewInt(10000)), state.Totals[q].Stake).Float64()
+				opStake := new(big.Float).SetInt(opInfo.Stake)
+				share, _ := new(big.Float).Quo(
+					new(big.Float).Mul(opStake, big.NewFloat(100000)),
+					totalStake).Float64()
 				operatorStakeShares = append(operatorStakeShares, &OperatorStakeShare{operatorId: opId, stakeShare: share})
 			}
 			// Descending order by stake share in the quorum.


### PR DESCRIPTION
## Why are these changes needed?
Small operators' stake share in basis point may be rounded to zero, if using integers

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
