### PR TITLE
Fix the stake percentage rounding error in nonsigning api

### DIFF
--- a/disperser/dataapi/nonsigner_handler.go
+++ b/disperser/dataapi/nonsigner_handler.go
@@ -99,8 +99,10 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTi
 				const multipler = 10000
 				stakePercentage := float64(0)
 				if stake, ok := state.Operators[q][opID]; ok {
-					p, _ := new(big.Int).Div(new(big.Int).Mul(stake.Stake, big.NewInt(multipler)), state.Totals[q].Stake).Float64()
-					stakePercentage = p / multipler
+					totalStake := new(big.Float).SetInt(state.Totals[q].Stake)
+					stakePercentage, _ = new(big.Float).Quo(
+						new(big.Float).SetInt(stake.Stake),
+						totalStake).Float64()
 				} else if liveOnly {
 					// Operator "opID" isn't live at "endBlock", skip it.
 					continue


### PR DESCRIPTION
## Why are these changes needed?
Small operator's stake percentage was rounded to zero.

Before:
`{"meta":{"size":17},"data":[{"operator_id":"0x01794506c08001068676e50939147f9b94c528bd8e9e3427bd713255d3ac7afd","operator_address":"0xa33f68239d35e32e2aaa544e5ff4591227704357","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0x2ff81250b5063eefd6fbea4c530683546a9bf1607d7c34838de72d1cabc3e151","operator_address":"0x0713cd9686cd160bbe2f4376c5adee44d0e2ed18","quorum_id":0,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0x399be69e9565dcbe0dd89b3f3ef4b36c8c2677e44f8cf90e7f1ff2c54b33cd70","operator_address":"0x229a629ee1452abd1c4b29fef5d9eab4f41c8876","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0x3ceb264831fd0409c2be704857d44726a904ffb020c199cc0e965c076104d170","operator_address":"0xbf76d0ed9f1cb11c97f3292f16f7aea21c2dc7c3","quorum_id":0,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0x567f5cd99014498aee2e719ee1a87c7120a16205b724e4ac1b20e90864474174","operator_address":"0x3ca973165bc7d1dcd7adff778ae1892b15914552","quorum_id":0,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.01},{"operator_id":"0x567f5cd99014498aee2e719ee1a87c7120a16205b724e4ac1b20e90864474174","operator_address":"0x3ca973165bc7d1dcd7adff778ae1892b15914552","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.06999999999999999},{"operator_id":"0x6bae71cc967af786983140c507f69acc6ec6420ddaebbc77d60a05d77b2b48ea","operator_address":"0x6345d277ae9df69d16a43b2e52d3817abeb79c42","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0x6c53232d4448361202491e2feeba957b9fd270624a47cf51883c42c589397b16","operator_address":"0x2e0df822f3248124dea0e2cea40cf8de0f8b9dd6","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0x9f80a535ab06889e44d4d1efd4c06f5fbbef89051cd4151fcf434edc755f9ffc","operator_address":"0x9631af6a712d296fedb800132edcf08e493b12cd","quorum_id":0,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.01},{"operator_id":"0x9f80a535ab06889e44d4d1efd4c06f5fbbef89051cd4151fcf434edc755f9ffc","operator_address":"0x9631af6a712d296fedb800132edcf08e493b12cd","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.11},{"operator_id":"0xa675d3a7e990dc5c3a9fb4b27b84e8f346638f33eb797cb8bf316807530cb62b","operator_address":"0xcec63830c7ec8c7a36959ccf487ba0a055fba58b","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0xc3deb96eb578dcd3863108f0e8d30f6c3debce3e51161571699167159d75ac6e","operator_address":"0x99d81d73fdb63fc8ee9f8b51dbaf238b222d69b6","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0xc96ec180dbc9dffac5b43e3eab686d4b3da3dbb5c38523ad85ca02a142c7a126","operator_address":"0x065a1ac0262711d5fd90494dbc986601f77004cc","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0xd73845965604521fd298449295beb96a00639811beabdf8caf12b6b3e7778dde","operator_address":"0xb0a7aec1e6491b060db403f4574420e5ba5f4e97","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0xd769a89b590fd49868c55baf9a6245399e8b9610fe2e028e6b52f15d3adaf123","operator_address":"0xf609700812d92dd008bbe265d0a7c93c8f61f776","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0xf74392f551ec241d2222048fb1486d39320f20bc9d80777cd277012751babc05","operator_address":"0x853355e9d8efacde6b214ac02991d489e75d0b0f","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0},{"operator_id":"0xfa9261794eefda654f0dc9c25f3cbdadd56b2c0397d88b95c3a2f223cf2203cd","operator_address":"0x42d61874ea21bea75170029ea422f44211399a4b","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0}]}`

After:
`{"meta":{"size":17},"data":[{"operator_id":"0x01794506c08001068676e50939147f9b94c528bd8e9e3427bd713255d3ac7afd","operator_address":"0xa33f68239d35e32e2aaa544e5ff4591227704357","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.0002326483299534158},{"operator_id":"0x2ff81250b5063eefd6fbea4c530683546a9bf1607d7c34838de72d1cabc3e151","operator_address":"0x0713cd9686cd160bbe2f4376c5adee44d0e2ed18","quorum_id":0,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.007262513350138357},{"operator_id":"0x399be69e9565dcbe0dd89b3f3ef4b36c8c2677e44f8cf90e7f1ff2c54b33cd70","operator_address":"0x229a629ee1452abd1c4b29fef5d9eab4f41c8876","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.0020446660487706634},{"operator_id":"0x3ceb264831fd0409c2be704857d44726a904ffb020c199cc0e965c076104d170","operator_address":"0xbf76d0ed9f1cb11c97f3292f16f7aea21c2dc7c3","quorum_id":0,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.005212138350146632},{"operator_id":"0x567f5cd99014498aee2e719ee1a87c7120a16205b724e4ac1b20e90864474174","operator_address":"0x3ca973165bc7d1dcd7adff778ae1892b15914552","quorum_id":0,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.015230833856771302},{"operator_id":"0x567f5cd99014498aee2e719ee1a87c7120a16205b724e4ac1b20e90864474174","operator_address":"0x3ca973165bc7d1dcd7adff778ae1892b15914552","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.07439393286951007},{"operator_id":"0x6bae71cc967af786983140c507f69acc6ec6420ddaebbc77d60a05d77b2b48ea","operator_address":"0x6345d277ae9df69d16a43b2e52d3817abeb79c42","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.0002446473329578314},{"operator_id":"0x6c53232d4448361202491e2feeba957b9fd270624a47cf51883c42c589397b16","operator_address":"0x2e0df822f3248124dea0e2cea40cf8de0f8b9dd6","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.00022251390125037967},{"operator_id":"0x9f80a535ab06889e44d4d1efd4c06f5fbbef89051cd4151fcf434edc755f9ffc","operator_address":"0x9631af6a712d296fedb800132edcf08e493b12cd","quorum_id":0,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.015551824404838184},{"operator_id":"0x9f80a535ab06889e44d4d1efd4c06f5fbbef89051cd4151fcf434edc755f9ffc","operator_address":"0x9631af6a712d296fedb800132edcf08e493b12cd","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.11422466856296472},{"operator_id":"0xa675d3a7e990dc5c3a9fb4b27b84e8f346638f33eb797cb8bf316807530cb62b","operator_address":"0xcec63830c7ec8c7a36959ccf487ba0a055fba58b","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.00030637517658810146},{"operator_id":"0xc3deb96eb578dcd3863108f0e8d30f6c3debce3e51161571699167159d75ac6e","operator_address":"0x99d81d73fdb63fc8ee9f8b51dbaf238b222d69b6","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.002771884887777933},{"operator_id":"0xc96ec180dbc9dffac5b43e3eab686d4b3da3dbb5c38523ad85ca02a142c7a126","operator_address":"0x065a1ac0262711d5fd90494dbc986601f77004cc","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.00022455531318845654},{"operator_id":"0xd73845965604521fd298449295beb96a00639811beabdf8caf12b6b3e7778dde","operator_address":"0xb0a7aec1e6491b060db403f4574420e5ba5f4e97","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.00022588223094820653},{"operator_id":"0xd769a89b590fd49868c55baf9a6245399e8b9610fe2e028e6b52f15d3adaf123","operator_address":"0xf609700812d92dd008bbe265d0a7c93c8f61f776","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.00022455531318845654},{"operator_id":"0xf74392f551ec241d2222048fb1486d39320f20bc9d80777cd277012751babc05","operator_address":"0x853355e9d8efacde6b214ac02991d489e75d0b0f","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.000655893109450214},{"operator_id":"0xfa9261794eefda654f0dc9c25f3cbdadd56b2c0397d88b95c3a2f223cf2203cd","operator_address":"0x42d61874ea21bea75170029ea422f44211399a4b","quorum_id":1,"total_unsigned_batches":6,"total_batches":6,"percentage":100,"stake_percentage":0.00022455531318845654}]}`


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
