### PR TITLE
Log batch header hash in hex instead of bytes

### DIFF
--- a/node/operator.go
+++ b/node/operator.go
@@ -44,7 +44,7 @@ func RegisterOperator(ctx context.Context, operator *Operator, transactor core.T
 		return nil
 	}
 
-	logger.Info("Quorums to register for", "quorums", quorumsToRegister)
+	logger.Info("Quorums to register for", "quorums", fmt.Sprint(quorumsToRegister))
 
 	// register for quorums
 	shouldCallChurner := false


### PR DESCRIPTION
## Why are these changes needed?
Makes node logs more readable:
- logs batch header hash in hex instead of bytestring
- logs quorum IDs in string vs. base64 encoded
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
