### PR TITLE
Check attestation results from valid quorums only

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -619,6 +619,9 @@ func numBlobsAttestedByQuorum(signedQuorums map[core.QuorumID]*core.QuorumResult
 
 func isBlobAttested(signedQuorums map[core.QuorumID]*core.QuorumResult, header *core.BlobHeader) bool {
 	for _, quorum := range header.QuorumInfos {
+		if _, ok := signedQuorums[quorum.QuorumID]; !ok {
+			return false
+		}
 		if signedQuorums[quorum.QuorumID].PercentSigned < quorum.ConfirmationThreshold {
 			return false
 		}


### PR DESCRIPTION
## Why are these changes needed?
When checking if a blob has been attested, consider not attested if the quorum is not present in the quorum results as quorums with insufficient signatures have been filtered out.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
