### PR TITLE
[finalizer] Update confirmation block number in finalizer

### DIFF
--- a/disperser/batcher/finalizer.go
+++ b/disperser/batcher/finalizer.go
@@ -193,12 +193,22 @@ func (f *finalizer) updateBlobs(ctx context.Context, metadatas []*disperser.Blob
 			continue
 		}
 
+		if confirmationBlockNumber != uint64(confirmationMetadata.ConfirmationInfo.ConfirmationBlockNumber) {
+			// Confirmation block number has changed due to reorg. Update the confirmation block number in the metadata
+			err := f.blobStore.UpdateConfirmationBlockNumber(ctx, m, uint32(confirmationBlockNumber))
+			if err != nil {
+				f.logger.Error("error updating confirmation block number", "blobKey", blobKey.String(), "err", err)
+				f.metrics.IncrementNumBlobs("failed")
+				continue
+			}
+		}
+
 		// Leave as confirmed if the reorged confirmation block is after the latest finalized block (not yet finalized)
 		if uint64(confirmationBlockNumber) > lastFinalBlock {
 			continue
 		}
 
-		_, err = f.blobStore.MarkBlobFinalized(ctx, confirmationMetadata, confirmationBlockNumber)
+		err = f.blobStore.MarkBlobFinalized(ctx, blobKey)
 		if err != nil {
 			f.logger.Error("error marking blob as finalized", "blobKey", blobKey.String(), "err", err)
 			f.metrics.IncrementNumBlobs("failed")

--- a/disperser/batcher/finalizer.go
+++ b/disperser/batcher/finalizer.go
@@ -198,8 +198,7 @@ func (f *finalizer) updateBlobs(ctx context.Context, metadatas []*disperser.Blob
 			continue
 		}
 
-		confirmationMetadata.ConfirmationInfo.ConfirmationBlockNumber = uint32(confirmationBlockNumber)
-		err = f.blobStore.MarkBlobFinalized(ctx, blobKey)
+		_, err = f.blobStore.MarkBlobFinalized(ctx, confirmationMetadata, confirmationBlockNumber)
 		if err != nil {
 			f.logger.Error("error marking blob as finalized", "blobKey", blobKey.String(), "err", err)
 			f.metrics.IncrementNumBlobs("failed")

--- a/disperser/common/blobstore/shared_storage.go
+++ b/disperser/common/blobstore/shared_storage.go
@@ -172,17 +172,8 @@ func (s *SharedBlobStore) MarkBlobInsufficientSignatures(ctx context.Context, ex
 	return &newMetadata, s.blobMetadataStore.UpdateBlobMetadata(ctx, existingMetadata.GetBlobKey(), &newMetadata)
 }
 
-func (s *SharedBlobStore) MarkBlobFinalized(ctx context.Context, existingMetadata *disperser.BlobMetadata, confirmationBlockNumber uint64) (*disperser.BlobMetadata, error) {
-	if existingMetadata == nil {
-		return nil, errors.New("metadata is nil")
-	}
-	newMetadata := *existingMetadata
-	newMetadata.BlobStatus = disperser.Finalized
-	if confirmationBlockNumber > 0 {
-		newMetadata.ConfirmationInfo.ConfirmationBlockNumber = uint32(confirmationBlockNumber)
-	}
-
-	return &newMetadata, s.blobMetadataStore.UpdateBlobMetadata(ctx, existingMetadata.GetBlobKey(), &newMetadata)
+func (s *SharedBlobStore) MarkBlobFinalized(ctx context.Context, blobKey disperser.BlobKey) error {
+	return s.blobMetadataStore.SetBlobStatus(ctx, blobKey, disperser.Finalized)
 }
 
 func (s *SharedBlobStore) MarkBlobProcessing(ctx context.Context, metadataKey disperser.BlobKey) error {
@@ -197,6 +188,10 @@ func (s *SharedBlobStore) MarkBlobFailed(ctx context.Context, metadataKey disper
 
 func (s *SharedBlobStore) IncrementBlobRetryCount(ctx context.Context, existingMetadata *disperser.BlobMetadata) error {
 	return s.blobMetadataStore.IncrementNumRetries(ctx, existingMetadata)
+}
+
+func (s *SharedBlobStore) UpdateConfirmationBlockNumber(ctx context.Context, existingMetadata *disperser.BlobMetadata, confirmationBlockNumber uint32) error {
+	return s.blobMetadataStore.UpdateConfirmationBlockNumber(ctx, existingMetadata, confirmationBlockNumber)
 }
 
 func (s *SharedBlobStore) GetBlobsByMetadata(ctx context.Context, metadata []*disperser.BlobMetadata) (map[disperser.BlobKey]*core.Blob, error) {

--- a/disperser/common/blobstore/shared_storage_test.go
+++ b/disperser/common/blobstore/shared_storage_test.go
@@ -102,8 +102,10 @@ func TestSharedBlobStore(t *testing.T) {
 	assert.Nil(t, err)
 	assertMetadata(t, blobKey, blobSize, requestedAt, disperser.Confirmed, metadata1)
 
-	err = sharedStorage.MarkBlobFinalized(ctx, blobKey)
+	updatedMetadata, err = sharedStorage.MarkBlobFinalized(ctx, metadata1, 151)
 	assert.Nil(t, err)
+	assert.Equal(t, disperser.Finalized, updatedMetadata.BlobStatus)
+	assert.Equal(t, uint32(151), updatedMetadata.ConfirmationInfo.ConfirmationBlockNumber)
 
 	metadata1, err = sharedStorage.GetBlobMetadata(ctx, blobKey)
 	assert.Nil(t, err)

--- a/disperser/common/blobstore/shared_storage_test.go
+++ b/disperser/common/blobstore/shared_storage_test.go
@@ -102,10 +102,17 @@ func TestSharedBlobStore(t *testing.T) {
 	assert.Nil(t, err)
 	assertMetadata(t, blobKey, blobSize, requestedAt, disperser.Confirmed, metadata1)
 
-	updatedMetadata, err = sharedStorage.MarkBlobFinalized(ctx, metadata1, 151)
+	err = sharedStorage.UpdateConfirmationBlockNumber(ctx, metadata1, 151)
 	assert.Nil(t, err)
-	assert.Equal(t, disperser.Finalized, updatedMetadata.BlobStatus)
-	assert.Equal(t, uint32(151), updatedMetadata.ConfirmationInfo.ConfirmationBlockNumber)
+	metadata1, err = sharedStorage.GetBlobMetadata(ctx, blobKey)
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(151), metadata1.ConfirmationInfo.ConfirmationBlockNumber)
+
+	err = sharedStorage.MarkBlobFinalized(ctx, blobKey)
+	assert.Nil(t, err)
+	metadata1, err = sharedStorage.GetBlobMetadata(ctx, blobKey)
+	assert.Nil(t, err)
+	assert.Equal(t, disperser.Finalized, metadata1.BlobStatus)
 
 	metadata1, err = sharedStorage.GetBlobMetadata(ctx, blobKey)
 	assert.Nil(t, err)

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"strconv"
 	"sync"
@@ -123,19 +124,15 @@ func (q *BlobStore) MarkBlobInsufficientSignatures(ctx context.Context, existing
 	return &newMetadata, nil
 }
 
-func (q *BlobStore) MarkBlobFinalized(ctx context.Context, existingMetadata *disperser.BlobMetadata, confirmationBlockNumber uint64) (*disperser.BlobMetadata, error) {
+func (q *BlobStore) MarkBlobFinalized(ctx context.Context, blobKey disperser.BlobKey) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	blobKey := existingMetadata.GetBlobKey()
 	if _, ok := q.Metadata[blobKey]; !ok {
-		return nil, disperser.ErrBlobNotFound
+		return disperser.ErrBlobNotFound
 	}
 
-	newMetadata := *existingMetadata
-	newMetadata.BlobStatus = disperser.Finalized
-	newMetadata.ConfirmationInfo.ConfirmationBlockNumber = uint32(confirmationBlockNumber)
-	q.Metadata[blobKey] = &newMetadata
-	return &newMetadata, nil
+	q.Metadata[blobKey].BlobStatus = disperser.Finalized
+	return nil
 }
 
 func (q *BlobStore) MarkBlobProcessing(ctx context.Context, blobKey disperser.BlobKey) error {
@@ -168,6 +165,21 @@ func (q *BlobStore) IncrementBlobRetryCount(ctx context.Context, existingMetadat
 	}
 
 	q.Metadata[existingMetadata.GetBlobKey()].NumRetries++
+	return nil
+}
+
+func (q *BlobStore) UpdateConfirmationBlockNumber(ctx context.Context, existingMetadata *disperser.BlobMetadata, confirmationBlockNumber uint32) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if _, ok := q.Metadata[existingMetadata.GetBlobKey()]; !ok {
+		return disperser.ErrBlobNotFound
+	}
+
+	if q.Metadata[existingMetadata.GetBlobKey()].ConfirmationInfo == nil {
+		return fmt.Errorf("cannot update confirmation block number for blob without confirmation info: %s", existingMetadata.GetBlobKey().String())
+	}
+
+	q.Metadata[existingMetadata.GetBlobKey()].ConfirmationInfo.ConfirmationBlockNumber = confirmationBlockNumber
 	return nil
 }
 

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -123,15 +123,19 @@ func (q *BlobStore) MarkBlobInsufficientSignatures(ctx context.Context, existing
 	return &newMetadata, nil
 }
 
-func (q *BlobStore) MarkBlobFinalized(ctx context.Context, blobKey disperser.BlobKey) error {
+func (q *BlobStore) MarkBlobFinalized(ctx context.Context, existingMetadata *disperser.BlobMetadata, confirmationBlockNumber uint64) (*disperser.BlobMetadata, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	blobKey := existingMetadata.GetBlobKey()
 	if _, ok := q.Metadata[blobKey]; !ok {
-		return disperser.ErrBlobNotFound
+		return nil, disperser.ErrBlobNotFound
 	}
 
-	q.Metadata[blobKey].BlobStatus = disperser.Finalized
-	return nil
+	newMetadata := *existingMetadata
+	newMetadata.BlobStatus = disperser.Finalized
+	newMetadata.ConfirmationInfo.ConfirmationBlockNumber = uint32(confirmationBlockNumber)
+	q.Metadata[blobKey] = &newMetadata
+	return &newMetadata, nil
 }
 
 func (q *BlobStore) MarkBlobProcessing(ctx context.Context, blobKey disperser.BlobKey) error {

--- a/disperser/common/inmem/store_test.go
+++ b/disperser/common/inmem/store_test.go
@@ -96,9 +96,14 @@ func TestBlobStore(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, disperser.Confirmed, updated.BlobStatus)
 
+	err = bs.UpdateConfirmationBlockNumber(ctx, updated, 151)
+	assert.Nil(t, err)
+
 	meta2, err = bs.GetBlobMetadata(ctx, blobKey2)
 	assert.Nil(t, err)
 	assert.Equal(t, meta2.BlobStatus, disperser.Confirmed)
+	assert.Equal(t, uint32(151), meta2.ConfirmationInfo.ConfirmationBlockNumber)
+
 	meta1, err = bs.GetBlobMetadata(ctx, blobKey1)
 	assert.Nil(t, err)
 	assert.Equal(t, meta1.BlobStatus, disperser.Processing)

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -148,7 +148,7 @@ type BlobStore interface {
 	// Returns the updated metadata and error
 	MarkBlobInsufficientSignatures(ctx context.Context, existingMetadata *BlobMetadata, confirmationInfo *ConfirmationInfo) (*BlobMetadata, error)
 	// MarkBlobFinalized marks a blob as finalized
-	MarkBlobFinalized(ctx context.Context, blobKey BlobKey) error
+	MarkBlobFinalized(ctx context.Context, existingMetadata *BlobMetadata, confirmationBlockNumber uint64) (*BlobMetadata, error)
 	// MarkBlobProcessing marks a blob as processing
 	MarkBlobProcessing(ctx context.Context, blobKey BlobKey) error
 	// MarkBlobFailed marks a blob as failed

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -148,13 +148,15 @@ type BlobStore interface {
 	// Returns the updated metadata and error
 	MarkBlobInsufficientSignatures(ctx context.Context, existingMetadata *BlobMetadata, confirmationInfo *ConfirmationInfo) (*BlobMetadata, error)
 	// MarkBlobFinalized marks a blob as finalized
-	MarkBlobFinalized(ctx context.Context, existingMetadata *BlobMetadata, confirmationBlockNumber uint64) (*BlobMetadata, error)
+	MarkBlobFinalized(ctx context.Context, blobKey BlobKey) error
 	// MarkBlobProcessing marks a blob as processing
 	MarkBlobProcessing(ctx context.Context, blobKey BlobKey) error
 	// MarkBlobFailed marks a blob as failed
 	MarkBlobFailed(ctx context.Context, blobKey BlobKey) error
 	// IncrementBlobRetryCount increments the retry count of a blob
 	IncrementBlobRetryCount(ctx context.Context, existingMetadata *BlobMetadata) error
+	// UpdateConfirmationBlockNumber updates the confirmation block number of a blob
+	UpdateConfirmationBlockNumber(ctx context.Context, existingMetadata *BlobMetadata, confirmationBlockNumber uint32) error
 	// GetBlobsByMetadata retrieves a list of blobs given a list of metadata
 	GetBlobsByMetadata(ctx context.Context, metadata []*BlobMetadata) (map[BlobKey]*core.Blob, error)
 	// GetBlobMetadataByStatus returns a list of blob metadata for blobs with the given status


### PR DESCRIPTION
## Why are these changes needed?
The `confirmationBlockNumber` [retrieved](https://github.com/ian-shim/eigenda/blob/master/disperser/batcher/finalizer.go#L93) from the confirmation transaction may have been updated due to chain reorg. 
This PR makes the finalizer update the `confirmationBlockNumber` to keep the metadata in sync. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
