### PR TITLE
Fix GitVersion regex to properly identify versioned tags when building in detached HEAD mode

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -7,8 +7,7 @@ branches:
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
     regex: ^master$|^main$
-    source-branches:
-    - release
+    source-branches: []
     tracks-release-branches: true
     is-release-branch: false
     is-mainline: true
@@ -19,10 +18,8 @@ branches:
     increment: None
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
-    regex: ^v\d+\.\d+\.\d+$|^releases?[/-]
-    source-branches:
-    - main
-    - release
+    regex: ^tags/v\d+\.\d+\.\d+(-[a-z]+\.\d+)?|^releases?[/-]
+    source-branches: []
     tracks-release-branches: false
     is-release-branch: true
     is-mainline: false


### PR DESCRIPTION
Previously if you created a tag `v0.7.4-pre.1` it would resolve semver as `0.7.4-tags-v0-7-4-pre-1.1` as opposed to `0.7.4-pre.1`

I discovered this when I tagged a pre-release multi-platform build [v0.7.4-pre.1](https://github.com/Layr-Labs/eigenda/pkgs/container/eigenda%2Fopr-node/230340641?tag=0.7.4-tags-v0-7-4-pre-1.1)

Official releases are not impacted because they live in a release branch using `release/X.Y.Z` format and gitversion is able to identify the correct semver.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
