### PR TITLE
Optimize the bytes encoding at node

### DIFF
--- a/node/store.go
+++ b/node/store.go
@@ -360,7 +360,11 @@ func (s *Store) DeleteKeys(ctx context.Context, keys *[][]byte) error {
 //
 // encodeChunks(chunks) = (len(chunks[0]), chunks[0], len(chunks[1]), chunks[1], ...)
 func encodeChunks(chunks [][]byte) ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
+	totalSize := 0
+	for _, chunk := range chunks {
+		totalSize += len(chunk) + 8 // Add size of uint64 for length
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, totalSize))
 	for _, chunk := range chunks {
 		if err := binary.Write(buf, binary.LittleEndian, uint64(len(chunk))); err != nil {
 			return nil, err

--- a/node/store.go
+++ b/node/store.go
@@ -368,7 +368,7 @@ func EncodeChunks(chunks [][]byte) ([]byte, error) {
 	buf := result
 	for _, chunk := range chunks {
 		binary.LittleEndian.PutUint64(buf, uint64(len(chunk)))
-		buf = buf[4:]
+		buf = buf[8:]
 		copy(buf, chunk)
 		buf = buf[len(chunk):]
 	}

--- a/node/store.go
+++ b/node/store.go
@@ -364,16 +364,14 @@ func encodeChunks(chunks [][]byte) ([]byte, error) {
 	for _, chunk := range chunks {
 		totalSize += len(chunk) + 8 // Add size of uint64 for length
 	}
-	buf := bytes.NewBuffer(make([]byte, 0, totalSize))
+	buf := make([]byte, totalSize)
 	for _, chunk := range chunks {
-		if err := binary.Write(buf, binary.LittleEndian, uint64(len(chunk))); err != nil {
-			return nil, err
-		}
-		if _, err := buf.Write(chunk); err != nil {
-			return nil, err
-		}
+		binary.LittleEndian.PutUint64(buf, uint64(len(chunk)))
+		buf = buf[4:]
+		copy(buf, chunk)
+		buf = buf[len(chunk):]
 	}
-	return buf.Bytes(), nil
+	return buf, nil
 }
 
 // Converts a flattened array of chunks into an array of its constituent chunks,

--- a/node/store.go
+++ b/node/store.go
@@ -267,7 +267,7 @@ func (s *Store) StoreBatch(ctx context.Context, header *core.BatchHeader, blobs 
 			for i := 0; i < len(bundle); i++ {
 				bundleRaw[i] = rawChunks[quorumID][i]
 			}
-			chunkBytes, err := encodeChunks(bundleRaw)
+			chunkBytes, err := EncodeChunks(bundleRaw)
 			if err != nil {
 				return nil, err
 			}
@@ -358,8 +358,8 @@ func (s *Store) DeleteKeys(ctx context.Context, keys *[][]byte) error {
 
 // Flattens an array of byte arrays (chunks) into a single byte array
 //
-// encodeChunks(chunks) = (len(chunks[0]), chunks[0], len(chunks[1]), chunks[1], ...)
-func encodeChunks(chunks [][]byte) ([]byte, error) {
+// EncodeChunks(chunks) = (len(chunks[0]), chunks[0], len(chunks[1]), chunks[1], ...)
+func EncodeChunks(chunks [][]byte) ([]byte, error) {
 	totalSize := 0
 	for _, chunk := range chunks {
 		totalSize += len(chunk) + 8 // Add size of uint64 for length

--- a/node/store.go
+++ b/node/store.go
@@ -364,14 +364,15 @@ func EncodeChunks(chunks [][]byte) ([]byte, error) {
 	for _, chunk := range chunks {
 		totalSize += len(chunk) + 8 // Add size of uint64 for length
 	}
-	buf := make([]byte, totalSize)
+	result := make([]byte, totalSize)
+	buf := result
 	for _, chunk := range chunks {
 		binary.LittleEndian.PutUint64(buf, uint64(len(chunk)))
 		buf = buf[4:]
 		copy(buf, chunk)
 		buf = buf[len(chunk):]
 	}
-	return buf, nil
+	return result, nil
 }
 
 // Converts a flattened array of chunks into an array of its constituent chunks,

--- a/node/store_test.go
+++ b/node/store_test.go
@@ -3,6 +3,7 @@ package node_test
 import (
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
 	"testing"
 	"time"
 
@@ -263,4 +264,25 @@ func TestStoringBlob(t *testing.T) {
 	assert.False(t, s.HasKey(ctx, blobHeaderKey2))
 	assert.False(t, s.HasKey(ctx, blobKey1))
 	assert.False(t, s.HasKey(ctx, blobKey2))
+}
+
+func BenchmarkEncodeChunks(b *testing.B) {
+	numSamples := 32
+	numChunks := 10
+	chunkSize := 2 * 1024
+	sampleChunks := make([][][]byte, numSamples)
+	for n := 0; n < numSamples; n++ {
+		chunks := make([][]byte, numChunks)
+		for i := 0; i < numChunks; i++ {
+			chunk := make([]byte, chunkSize)
+			_, _ = cryptorand.Read(chunk)
+			chunks[i] = chunk
+		}
+		sampleChunks[n] = chunks
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = node.EncodeChunks(sampleChunks[i%numSamples])
+	}
 }


### PR DESCRIPTION
## Why are these changes needed?
When workload is high, the bytes encoding can be quite large (about 50% of actual DB write latency).
This PR avoids unnecessary memory movement when dealing with multiple chunks (on large operators). In addition, this re-implements the encoding in more efficient way.

Benchmark result shows near 4x improvement of performance (the BenchmarkEncodeChunksOld is before this PR, BenchmarkEncodeChunks is this PR):
```
goos: linux
goarch: amd64
pkg: github.com/Layr-Labs/eigenda/node
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
BenchmarkEncodeChunksOld-8   	   53523	     21934 ns/op
BenchmarkEncodeChunksOld-8   	   52783	     21848 ns/op
BenchmarkEncodeChunksOld-8   	   52980	     22338 ns/op
BenchmarkEncodeChunksOld-8   	   53157	     22530 ns/op
BenchmarkEncodeChunks-8      	  200438	      5840 ns/op
BenchmarkEncodeChunks-8      	  204920	      5691 ns/op
BenchmarkEncodeChunks-8      	  191730	      5836 ns/op
BenchmarkEncodeChunks-8      	  196705	      5789 ns/op
```
PASS
ok  	github.com/Layr-Labs/eigenda/node	10.581s


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
