### PR TITLE
Simplify the bytes decoding of chunks

### DIFF
--- a/node/store.go
+++ b/node/store.go
@@ -334,7 +334,7 @@ func (s *Store) GetChunks(ctx context.Context, batchHeaderHash [32]byte, blobInd
 	}
 	log.Debug("Retrieved chunk", "blobKey", hexutil.Encode(blobKey), "length", len(data))
 
-	chunks, err := decodeChunks(data)
+	chunks, err := DecodeChunks(data)
 	if err != nil {
 		return nil, false
 	}
@@ -377,8 +377,8 @@ func EncodeChunks(chunks [][]byte) ([]byte, error) {
 // Converts a flattened array of chunks into an array of its constituent chunks,
 // throwing an error in case the chunks were not serialized correctly
 //
-// decodeChunks((len(chunks[0]), chunks[0], len(chunks[1]), chunks[1], ...)) = chunks
-func decodeChunks(data []byte) ([][]byte, error) {
+// DecodeChunks((len(chunks[0]), chunks[0], len(chunks[1]), chunks[1], ...)) = chunks
+func DecodeChunks(data []byte) ([][]byte, error) {
 	chunks := make([][]byte, 0)
 	buf := data
 	for len(buf) > 0 {

--- a/node/store_test.go
+++ b/node/store_test.go
@@ -286,3 +286,25 @@ func BenchmarkEncodeChunks(b *testing.B) {
 		_, _ = node.EncodeChunks(sampleChunks[i%numSamples])
 	}
 }
+
+func BenchmarkDecocodeChunks(b *testing.B) {
+	numSamples := 32
+	numChunks := 10
+	chunkSize := 2 * 1024
+	sampleChunks := make([][]byte, numSamples)
+	for n := 0; n < numSamples; n++ {
+		chunks := make([][]byte, numChunks)
+		for i := 0; i < numChunks; i++ {
+			chunk := make([]byte, chunkSize)
+			_, _ = cryptorand.Read(chunk)
+			chunks[i] = chunk
+		}
+		encoded, _ := node.EncodeChunks(chunks)
+		sampleChunks[n] = encoded
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = node.DecodeChunks(sampleChunks[i%numSamples])
+	}
+}

--- a/node/store_test.go
+++ b/node/store_test.go
@@ -197,8 +197,10 @@ func TestEncodeDecodeChunks(t *testing.T) {
 			_, _ = cryptorand.Read(chunk)
 			chunks[i] = chunk
 		}
-		encoded, _ := node.EncodeChunks(chunks)
-		decoded, _ := node.DecodeChunks(encoded)
+		encoded, err := node.EncodeChunks(chunks)
+		assert.Nil(t, err)
+		decoded, err := node.DecodeChunks(encoded)
+		assert.Nil(t, err)
 		for i := 0; i < numChunks; i++ {
 			assert.True(t, bytes.Equal(decoded[i], chunks[i]))
 		}

--- a/node/store_test.go
+++ b/node/store_test.go
@@ -186,6 +186,25 @@ func CreateBatch(t *testing.T) (*core.BatchHeader, []*core.BlobMessage, []*pb.Bl
 	return &batchHeader, blobMessage, blobs
 }
 
+func TestEncodeDecodeChunks(t *testing.T) {
+	numSamples := 32
+	numChunks := 10
+	chunkSize := 2 * 1024
+	for n := 0; n < numSamples; n++ {
+		chunks := make([][]byte, numChunks)
+		for i := 0; i < numChunks; i++ {
+			chunk := make([]byte, chunkSize)
+			_, _ = cryptorand.Read(chunk)
+			chunks[i] = chunk
+		}
+		encoded, _ := node.EncodeChunks(chunks)
+		decoded, _ := node.DecodeChunks(encoded)
+		for i := 0; i < numChunks; i++ {
+			assert.True(t, bytes.Equal(decoded[i], chunks[i]))
+		}
+	}
+}
+
 func TestStoringBlob(t *testing.T) {
 	staleMeasure := uint32(1)
 	storeDuration := uint32(1)


### PR DESCRIPTION
## Why are these changes needed?
Simplicity is better than complicatedness

This PR also makes it 15x faster to decode the chunks (BenchmarkDecocodeChunksOld is before this PR, BenchmarkDecocodeChunks is after this PR)
```
goos: linux
goarch: amd64
pkg: github.com/Layr-Labs/eigenda/node
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
BenchmarkEncodeChunks-8        	  198956	      5647 ns/op
BenchmarkEncodeChunks-8        	  206421	      5404 ns/op
BenchmarkEncodeChunks-8        	  223056	      5520 ns/op
BenchmarkEncodeChunks-8        	  203401	      5757 ns/op
BenchmarkDecocodeChunksOld-8   	  122836	      9562 ns/op
BenchmarkDecocodeChunksOld-8   	  127582	      9511 ns/op
BenchmarkDecocodeChunksOld-8   	  126115	      9490 ns/op
BenchmarkDecocodeChunksOld-8   	  126057	      9575 ns/op
BenchmarkDecocodeChunks-8      	 1974146	       604.8 ns/op
BenchmarkDecocodeChunks-8      	 1996282	       604.3 ns/op
BenchmarkDecocodeChunks-8      	 1978239	       606.9 ns/op
BenchmarkDecocodeChunks-8      	 1981912	       604.5 ns/op
PASS
ok  	github.com/Layr-Labs/eigenda/node	17.480s
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
