### PR TITLE
Pull `ejector` out of `dataapi`

### DIFF
--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Layr-Labs/eigenda/disperser/dataapi"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi/prometheus"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi/subgraph"
+	"github.com/Layr-Labs/eigenda/operators/ejector"
 	walletsdk "github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/signerv2"
@@ -124,7 +125,7 @@ func RunDataApi(ctx *cli.Context) error {
 			subgraphClient,
 			tx,
 			chainState,
-			dataapi.NewEjector(wallet, client, logger, tx, metrics, config.TxnTimeout, config.NonsigningRateThreshold),
+			ejector.NewEjector(wallet, client, logger, tx, metrics.EjectorMetrics, config.TxnTimeout, config.NonsigningRateThreshold),
 			logger,
 			metrics,
 			nil,

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
+	"github.com/Layr-Labs/eigenda/operators/ejector"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"google.golang.org/grpc/codes"
 )
 
 type MetricsConfig struct {
@@ -23,14 +23,9 @@ type MetricsConfig struct {
 type Metrics struct {
 	registry *prometheus.Registry
 
-	NumRequests *prometheus.CounterVec
-	Latency     *prometheus.SummaryVec
-
-	PeriodicEjectionRequests *prometheus.CounterVec
-	UrgentEjectionRequests   *prometheus.CounterVec
-	OperatorsToEject         *prometheus.CounterVec
-	StakeShareToEject        *prometheus.GaugeVec
-	EjectionGasUsed          prometheus.Gauge
+	NumRequests    *prometheus.CounterVec
+	Latency        *prometheus.SummaryVec
+	EjectorMetrics *ejector.Metrics
 
 	httpPort string
 	logger   logging.Logger
@@ -60,58 +55,10 @@ func NewMetrics(blobMetadataStore *blobstore.BlobMetadataStore, httpPort string,
 			},
 			[]string{"method"},
 		),
-		// PeriodicEjectionRequests is a more detailed metric than NumRequests, specifically for
-		// tracking the ejection calls that are periodically initiated according to the SLA
-		// evaluation time window.
-		PeriodicEjectionRequests: promauto.With(reg).NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "periodic_ejection_requests_total",
-				Help:      "the total number of periodic ejection requests",
-			},
-			[]string{"status"},
-		),
-		// UrgentEjectionRequests is a more detailed metric than NumRequests, specifically for
-		// tracking the ejection calls that are urgently initiated due to bad network health
-		// condition.
-		UrgentEjectionRequests: promauto.With(reg).NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "urgent_ejection_requests_total",
-				Help:      "the total number of urgent ejection requests",
-			},
-			[]string{"status"},
-		),
-		// The number of operators requested to eject. Note this may be different than the
-		// actual number of operators ejected as EjectionManager contract may perform rate
-		// limiting.
-		OperatorsToEject: promauto.With(reg).NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "operators_to_eject",
-				Help:      "the total number of operators requested to eject",
-			}, []string{"quorum"},
-		),
-		// The total stake share requested to eject. Note this may be different than the
-		// actual stake share ejected as EjectionManager contract may perform rate limiting.
-		StakeShareToEject: promauto.With(reg).NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: namespace,
-				Name:      "stake_share_to_eject",
-				Help:      "the total stake share requested to eject",
-			}, []string{"quorum"},
-		),
-		// The gas used by EjectionManager contract for operator ejection.
-		EjectionGasUsed: promauto.With(reg).NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: namespace,
-				Name:      "ejection_gas_used",
-				Help:      "Gas used for operator ejection",
-			},
-		),
-		registry: reg,
-		httpPort: httpPort,
-		logger:   logger.With("component", "DataAPIMetrics"),
+		EjectorMetrics: ejector.NewMetrics(reg, logger),
+		registry:       reg,
+		httpPort:       httpPort,
+		logger:         logger.With("component", "DataAPIMetrics"),
 	}
 	return metrics
 }
@@ -135,38 +82,6 @@ func (g *Metrics) IncrementFailedRequestNum(method string) {
 		"status": "failed",
 		"method": method,
 	}).Inc()
-}
-
-func (g *Metrics) IncrementEjectionRequest(mode string, status codes.Code) {
-	switch mode {
-	case "periodic":
-		g.PeriodicEjectionRequests.With(prometheus.Labels{
-			"status": status.String(),
-		}).Inc()
-	case "urgent":
-		g.UrgentEjectionRequests.With(prometheus.Labels{
-			"status": status.String(),
-		}).Inc()
-	}
-}
-
-func (g *Metrics) UpdateRequestedOperatorMetric(numOperatorsByQuorum map[uint8]int, stakeShareByQuorum map[uint8]float64) {
-	for q, count := range numOperatorsByQuorum {
-		for i := 0; i < count; i++ {
-			g.OperatorsToEject.With(prometheus.Labels{
-				"quorum": fmt.Sprintf("%d", q),
-			}).Inc()
-		}
-	}
-	for q, stakeShare := range stakeShareByQuorum {
-		g.StakeShareToEject.With(prometheus.Labels{
-			"quorum": fmt.Sprintf("%d", q),
-		}).Set(stakeShare)
-	}
-}
-
-func (g *Metrics) UpdateEjectionGasUsed(gasUsed uint64) {
-	g.EjectionGasUsed.Set(float64(gasUsed))
 }
 
 // IncrementNotFoundRequestNum increments the number of not found requests

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Layr-Labs/eigenda/disperser/dataapi/subgraph"
 	subgraphmock "github.com/Layr-Labs/eigenda/disperser/dataapi/subgraph/mock"
 	"github.com/Layr-Labs/eigenda/encoding"
+	"github.com/Layr-Labs/eigenda/operators/ejector"
 	sdkmock "github.com/Layr-Labs/eigensdk-go/chainio/clients/mocks"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
@@ -386,7 +387,7 @@ func TestEjectOperatorHandler(t *testing.T) {
 	data, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)
 
-	var response dataapi.EjectionResponse
+	var response ejector.EjectionResponse
 	err = json.Unmarshal(data, &response)
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
@@ -455,14 +456,14 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 type ejectorComponents struct {
 	wallet    *sdkmock.MockWallet
 	ethClient *commonmock.MockEthClient
-	ejector   *dataapi.Ejector
+	ejector   *ejector.Ejector
 }
 
 func getEjector(t *testing.T) *ejectorComponents {
 	ctrl := gomock.NewController(t)
 	w := sdkmock.NewMockWallet(ctrl)
 	ethClient := &commonmock.MockEthClient{}
-	ejector := dataapi.NewEjector(w, ethClient, mockLogger, mockTx, metrics, 100*time.Millisecond, -1)
+	ejector := ejector.NewEjector(w, ethClient, mockLogger, mockTx, metrics.EjectorMetrics, 100*time.Millisecond, -1)
 	return &ejectorComponents{
 		wallet:    w,
 		ethClient: ethClient,

--- a/operators/ejector/metrics.go
+++ b/operators/ejector/metrics.go
@@ -1,0 +1,106 @@
+package ejector
+
+import (
+	"fmt"
+
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc/codes"
+)
+
+type Metrics struct {
+	PeriodicEjectionRequests *prometheus.CounterVec
+	UrgentEjectionRequests   *prometheus.CounterVec
+	OperatorsToEject         *prometheus.CounterVec
+	StakeShareToEject        *prometheus.GaugeVec
+	EjectionGasUsed          prometheus.Gauge
+}
+
+func NewMetrics(reg *prometheus.Registry, logger logging.Logger) *Metrics {
+	namespace := "eigenda_ejector"
+	metrics := &Metrics{
+		// PeriodicEjectionRequests is a more detailed metric than NumRequests, specifically for
+		// tracking the ejection calls that are periodically initiated according to the SLA
+		// evaluation time window.
+		PeriodicEjectionRequests: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "periodic_ejection_requests_total",
+				Help:      "the total number of periodic ejection requests",
+			},
+			[]string{"status"},
+		),
+		// UrgentEjectionRequests is a more detailed metric than NumRequests, specifically for
+		// tracking the ejection calls that are urgently initiated due to bad network health
+		// condition.
+		UrgentEjectionRequests: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "urgent_ejection_requests_total",
+				Help:      "the total number of urgent ejection requests",
+			},
+			[]string{"status"},
+		),
+		// The number of operators requested to eject. Note this may be different than the
+		// actual number of operators ejected as EjectionManager contract may perform rate
+		// limiting.
+		OperatorsToEject: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "operators_to_eject",
+				Help:      "the total number of operators requested to eject",
+			}, []string{"quorum"},
+		),
+		// The total stake share requested to eject. Note this may be different than the
+		// actual stake share ejected as EjectionManager contract may perform rate limiting.
+		StakeShareToEject: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "stake_share_to_eject",
+				Help:      "the total stake share requested to eject",
+			}, []string{"quorum"},
+		),
+		// The gas used by EjectionManager contract for operator ejection.
+		EjectionGasUsed: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "ejection_gas_used",
+				Help:      "Gas used for operator ejection",
+			},
+		),
+	}
+	return metrics
+}
+
+func (g *Metrics) IncrementEjectionRequest(mode Mode, status codes.Code) {
+	switch mode {
+	case PeriodicMode:
+		g.PeriodicEjectionRequests.With(prometheus.Labels{
+			"status": status.String(),
+		}).Inc()
+	case UrgentMode:
+		g.UrgentEjectionRequests.With(prometheus.Labels{
+			"status": status.String(),
+		}).Inc()
+	}
+}
+
+func (g *Metrics) UpdateEjectionGasUsed(gasUsed uint64) {
+	g.EjectionGasUsed.Set(float64(gasUsed))
+}
+
+func (g *Metrics) UpdateRequestedOperatorMetric(numOperatorsByQuorum map[uint8]int, stakeShareByQuorum map[uint8]float64) {
+	for q, count := range numOperatorsByQuorum {
+		for i := 0; i < count; i++ {
+			g.OperatorsToEject.With(prometheus.Labels{
+				"quorum": fmt.Sprintf("%d", q),
+			}).Inc()
+		}
+	}
+	for q, stakeShare := range stakeShareByQuorum {
+		g.StakeShareToEject.With(prometheus.Labels{
+			"quorum": fmt.Sprintf("%d", q),
+		}).Set(stakeShare)
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?
This refactor pulls `ejector` out of `dataapi` so it can be imported as a library. 
The existing ejection API behavior in `dataapi` should remain the same. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
