### PR TITLE
Use auto rate interval for blob thoughput metrics

### DIFF
--- a/disperser/dataapi/metrics_handlers.go
+++ b/disperser/dataapi/metrics_handlers.go
@@ -79,7 +79,7 @@ func (s *server) getMetric(ctx context.Context, startTime int64, endTime int64) 
 }
 
 func (s *server) getThroughput(ctx context.Context, start int64, end int64) ([]*Throughput, error) {
-	result, err := s.promClient.QueryDisperserAvgThroughputBlobSizeBytes(ctx, time.Unix(start, 0), time.Unix(end, 0), avgThroughputWindowSize)
+	result, err := s.promClient.QueryDisperserAvgThroughputBlobSizeBytes(ctx, time.Unix(start, 0), time.Unix(end, 0))
 	if err != nil {
 		return nil, err
 	}

--- a/disperser/dataapi/prometheus_client.go
+++ b/disperser/dataapi/prometheus_client.go
@@ -11,14 +11,13 @@ import (
 
 const (
 	// maxNumOfDataPoints is the maximum number of data points that can be queried from Prometheus based on latency that this API can provide
-	maxNumOfDataPoints        = 3500
-	throughputRateWindowInSec = 60
+	maxNumOfDataPoints = 3500
 )
 
 type (
 	PrometheusClient interface {
 		QueryDisperserBlobSizeBytesPerSecond(ctx context.Context, start time.Time, end time.Time) (*PrometheusResult, error)
-		QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, windowSizeInSec uint8) (*PrometheusResult, error)
+		QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time) (*PrometheusResult, error)
 	}
 
 	PrometheusResultValues struct {
@@ -47,12 +46,8 @@ func (pc *prometheusClient) QueryDisperserBlobSizeBytesPerSecond(ctx context.Con
 	return pc.queryRange(ctx, query, start, end)
 }
 
-func (pc *prometheusClient) QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, windowSizeInSec uint8) (*PrometheusResult, error) {
-	if windowSizeInSec < throughputRateWindowInSec {
-		windowSizeInSec = throughputRateWindowInSec
-	}
-
-	query := fmt.Sprintf("sum by (job) (rate(eigenda_batcher_blobs_total{state=\"confirmed\",data=\"size\",cluster=\"%s\"}[%ds]))", pc.cluster, windowSizeInSec)
+func (pc *prometheusClient) QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time) (*PrometheusResult, error) {
+	query := fmt.Sprintf("sum by (job) (rate(eigenda_batcher_blobs_total{state=\"confirmed\",data=\"size\",cluster=\"%s\"}[$$__rate_interval]))", pc.cluster)
 	return pc.queryRange(ctx, query, start, end)
 }
 

--- a/disperser/dataapi/prometheus_client.go
+++ b/disperser/dataapi/prometheus_client.go
@@ -48,6 +48,7 @@ func (pc *prometheusClient) QueryDisperserBlobSizeBytesPerSecond(ctx context.Con
 
 func (pc *prometheusClient) QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time) (*PrometheusResult, error) {
 	query := fmt.Sprintf("sum by (job) (rate(eigenda_batcher_blobs_total{state=\"confirmed\",data=\"size\",cluster=\"%s\"}[$$__rate_interval]))", pc.cluster)
+	fmt.Printf("Query: %s\n", query)
 	return pc.queryRange(ctx, query, start, end)
 }
 


### PR DESCRIPTION
DA internal dashboard blob throughput does not match blob explorer throughput graphs because dataapi query uses `120s` rate interval and DA dashboard uses auto `$__rateInterval`. This change converts dataAPI metrics to use the auto `$__rateInterval`.

See https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/

Comparison of using different rate intervals 
<img width="2170" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/bb4d4eb4-1aad-4e1b-8fca-6d2b51421db9">

The time series gets really funky at 24hrs without auto `$__rateInterval`
<img width="2178" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/86b18ee4-b888-485c-a3b3-8e93bbafdbdc">



## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
