### PR TITLE
Record args in mock transactor

### DIFF
--- a/core/mock/tx.go
+++ b/core/mock/tx.go
@@ -71,7 +71,7 @@ func (t *MockTransactor) UpdateOperatorSocket(ctx context.Context, socket string
 }
 
 func (t *MockTransactor) BuildEjectOperatorsTxn(ctx context.Context, operatorsByQuorum [][]core.OperatorID) (*types.Transaction, error) {
-	args := t.Called()
+	args := t.Called(ctx, operatorsByQuorum)
 	result := args.Get(0)
 	return result.(*types.Transaction), args.Error(1)
 }

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -342,7 +342,7 @@ func TestEjectOperatorHandler(t *testing.T) {
 	addr2 := gethcommon.HexToAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
 	mockTx.On("BatchOperatorIDToAddress").Return([]gethcommon.Address{addr1, addr2}, nil)
 	mockTx.On("GetQuorumBitmapForOperatorsAtBlockNumber").Return([]*big.Int{big.NewInt(3), big.NewInt(0)}, nil)
-	mockTx.On("BuildEjectOperatorsTxn").Return(types.NewTransaction(0, gethcommon.HexToAddress("0x1"), big.NewInt(0), 0, big.NewInt(0), []byte{}), nil)
+	mockTx.On("BuildEjectOperatorsTxn", mock.Anything, mock.Anything).Return(types.NewTransaction(0, gethcommon.HexToAddress("0x1"), big.NewInt(0), 0, big.NewInt(0), []byte{}), nil)
 	mockTx.On("EjectOperators").Return(&types.Receipt{
 		GasUsed: uint64(10),
 	}, nil)


### PR DESCRIPTION
## Why are these changes needed?
Record the arguments in mock transactor so arguments can be asserted 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
