### PR TITLE
[1/N] Chunk encoding optimization: Support encoding format with gnark

### DIFF
--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -24,7 +24,7 @@ func (c *Frame) Deserialize(data []byte) (*Frame, error) {
 }
 
 func (c *Frame) SerializeGnark() ([]byte, error) {
-	coded := make([]byte, 0)
+	coded := make([]byte, 0, 32*(1+len(c.Coeffs)))
 	// This is compressed format with just 32 bytes.
 	proofBytes := c.Proof.Bytes()
 	coded = append(coded, proofBytes[:]...)

--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -24,7 +24,7 @@ func (c *Frame) Deserialize(data []byte) (*Frame, error) {
 }
 
 func (c *Frame) SerializeGnark() ([]byte, error) {
-	coded := make([]byte, 0, 32*(1+len(c.Coeffs)))
+	coded := make([]byte, 0, bn254.SizeOfG1AffineCompressed+BYTES_PER_SYMBOL*len(c.Coeffs))
 	// This is compressed format with just 32 bytes.
 	proofBytes := c.Proof.Bytes()
 	coded = append(coded, proofBytes[:]...)
@@ -37,23 +37,23 @@ func (c *Frame) SerializeGnark() ([]byte, error) {
 func (c *Frame) DeserializeGnark(data []byte) (*Frame, error) {
 	var f Frame
 	buf := data
-	err := f.Proof.Unmarshal(buf[:32])
+	err := f.Proof.Unmarshal(buf[:bn254.SizeOfG1AffineCompressed])
 	if err != nil {
 		return nil, err
 	}
-	buf = buf[32:]
-	if len(buf)%32 != 0 {
+	buf = buf[bn254.SizeOfG1AffineCompressed:]
+	if len(buf)%BYTES_PER_SYMBOL != 0 {
 		return nil, errors.New("invalid chunk length")
 	}
-	f.Coeffs = make([]Symbol, len(buf)/32)
+	f.Coeffs = make([]Symbol, len(buf)/BYTES_PER_SYMBOL)
 	i := 0
 	for len(buf) > 0 {
-		if len(buf) < 32 {
+		if len(buf) < BYTES_PER_SYMBOL {
 			return nil, errors.New("invalid chunk length")
 		}
-		f.Coeffs[i].Unmarshal(buf[:32])
+		f.Coeffs[i].Unmarshal(buf[:BYTES_PER_SYMBOL])
 		i++
-		buf = buf[32:]
+		buf = buf[BYTES_PER_SYMBOL:]
 	}
 	return &f, nil
 }

--- a/encoding/serialization_test.go
+++ b/encoding/serialization_test.go
@@ -16,23 +16,25 @@ func TestSerDeserGnark(t *testing.T) {
 	_, err = YCoord.SetString("9207254729396071334325696286939045899948985698134704137261649190717970615186")
 	assert.NoError(t, err)
 
+	numCoeffs := 64
 	var f encoding.Frame
 	f.Proof = encoding.Proof{
 		X: XCoord,
 		Y: YCoord,
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < numCoeffs; i++ {
 		f.Coeffs = append(f.Coeffs, fr.NewElement(uint64(i)))
 	}
 
 	gnark, err := f.SerializeGnark()
 	assert.Nil(t, err)
-	// The gob encoding via f.Serialize() will generate 318 bytes
-	// whereas gnark only 128 bytes
-	assert.Equal(t, 128, len(gnark))
+	// The gnark encoding via f.Serialize() will generate less bytes
+	// than gob.
+	assert.Equal(t, 32*(1+numCoeffs), len(gnark))
 	gob, err := f.Serialize()
 	assert.Nil(t, err)
-	assert.Equal(t, 318, len(gob))
+	// 2080 with gnark v.s. 2574 with gob
+	assert.Equal(t, 2574, len(gob))
 
 	// Verify the deserialization can get back original data
 	c, err := new(encoding.Frame).DeserializeGnark(gnark)

--- a/encoding/serialization_test.go
+++ b/encoding/serialization_test.go
@@ -1,0 +1,45 @@
+package encoding_test
+
+import (
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/encoding"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSerDeserGnark(t *testing.T) {
+	var XCoord, YCoord fp.Element
+	_, err := XCoord.SetString("21661178944771197726808973281966770251114553549453983978976194544185382599016")
+	assert.NoError(t, err)
+	_, err = YCoord.SetString("9207254729396071334325696286939045899948985698134704137261649190717970615186")
+	assert.NoError(t, err)
+
+	var f encoding.Frame
+	f.Proof = encoding.Proof{
+		X: XCoord,
+		Y: YCoord,
+	}
+	for i := 0; i < 3; i++ {
+		f.Coeffs = append(f.Coeffs, fr.NewElement(uint64(i)))
+	}
+
+	gnark, err := f.SerializeGnark()
+	assert.Nil(t, err)
+	// The gob encoding via f.Serialize() will generate 318 bytes
+	// whereas gnark only 128 bytes
+	assert.Equal(t, 128, len(gnark))
+	gob, err := f.Serialize()
+	assert.Nil(t, err)
+	assert.Equal(t, 318, len(gob))
+
+	// Verify the deserialization can get back original data
+	c, err := new(encoding.Frame).DeserializeGnark(gnark)
+	assert.Nil(t, err)
+	assert.True(t, f.Proof.Equal(&c.Proof))
+	assert.Equal(t, len(f.Coeffs), len(c.Coeffs))
+	for i := 0; i < len(f.Coeffs); i++ {
+		assert.True(t, f.Coeffs[i].Equal(&c.Coeffs[i]))
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?
There are inefficiency in chunk encoding, which causes more than data to transmit over network and store to db than necessary.

This PR adds the encoding with gnark. The followup PR will integrate it (compatibly).

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
