### PR TITLE
fix dataapi docker build

### DIFF
--- a/disperser/cmd/dataapi/Dockerfile
+++ b/disperser/cmd/dataapi/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache make musl-dev linux-headers gcc git jq bash
 
 # build data api server with local monorepo go modules
 COPY ./disperser /app/disperser
+COPY operators/ejector /app/operators/ejector
 COPY common /app/common
 COPY contracts /app/contracts
 COPY core /app/core


### PR DESCRIPTION
## Why are these changes needed?
Ejector has been pulled out of `dataapi` and into `operators` package. Making the corresponding changes in dockerfile 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
