### PR TITLE
Use variable rate interval for blob thoughput metrics based on time interval

### DIFF
--- a/disperser/dataapi/prometheus_client.go
+++ b/disperser/dataapi/prometheus_client.go
@@ -11,14 +11,13 @@ import (
 
 const (
 	// maxNumOfDataPoints is the maximum number of data points that can be queried from Prometheus based on latency that this API can provide
-	maxNumOfDataPoints        = 3500
-	throughputRateWindowInSec = 60
+	maxNumOfDataPoints = 3500
 )
 
 type (
 	PrometheusClient interface {
 		QueryDisperserBlobSizeBytesPerSecond(ctx context.Context, start time.Time, end time.Time) (*PrometheusResult, error)
-		QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, windowSizeInSec uint8) (*PrometheusResult, error)
+		QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, windowSizeInSec uint16) (*PrometheusResult, error)
 	}
 
 	PrometheusResultValues struct {
@@ -47,12 +46,8 @@ func (pc *prometheusClient) QueryDisperserBlobSizeBytesPerSecond(ctx context.Con
 	return pc.queryRange(ctx, query, start, end)
 }
 
-func (pc *prometheusClient) QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, windowSizeInSec uint8) (*PrometheusResult, error) {
-	if windowSizeInSec < throughputRateWindowInSec {
-		windowSizeInSec = throughputRateWindowInSec
-	}
-
-	query := fmt.Sprintf("sum by (job) (rate(eigenda_batcher_blobs_total{state=\"confirmed\",data=\"size\",cluster=\"%s\"}[%ds]))", pc.cluster, windowSizeInSec)
+func (pc *prometheusClient) QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, throughputRateSecs uint16) (*PrometheusResult, error) {
+	query := fmt.Sprintf("sum by (job) (rate(eigenda_batcher_blobs_total{state=\"confirmed\",data=\"size\",cluster=\"%s\"}[%ds]))", pc.cluster, throughputRateSecs)
 	return pc.queryRange(ctx, query, start, end)
 }
 

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -323,10 +323,10 @@ func TestFetchMetricsThroughputHandler(t *testing.T) {
 	}
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
-	assert.Equal(t, 3481, len(response))
-	assert.Equal(t, float64(11666.666666666666), response[0].Throughput)
-	assert.Equal(t, uint64(1701292800), response[0].Timestamp)
-	assert.Equal(t, float64(3.599722666666646e+07), totalThroughput)
+	assert.Equal(t, 3361, len(response))
+	assert.Equal(t, float64(12000), response[0].Throughput)
+	assert.Equal(t, uint64(1701292920), response[0].Timestamp)
+	assert.Equal(t, float64(3.503022666666651e+07), totalThroughput)
 }
 
 func TestEjectOperatorHandler(t *testing.T) {


### PR DESCRIPTION
DA internal dashboard blob throughput does not match blob explorer throughput graphs because dataapi query uses 2m rate interval and DA dashboard uses auto `$__rate_interval`

Blob explorer show 5MiB spikes, whereas DA dashboard show 1.5MiB throughput.
<img width="1588" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/24a4e8c9-f5c8-4b78-af23-e36f1ee56f81">
<img width="1276" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/67d7ac78-05df-44e6-a0df-07eb4ee9bd5f">
Comparison overlay of 5MiB `2m` rate vs 1.5MiB `4m` rate aka `$__rate_interval`
<img width="1242" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/70a2b850-4751-44cf-819b-53c1f492e9b0">

Blob explorer throughput breaks when you expand to 24h & 7d because of the 2m rate used.
<img width="1585" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/febf26a0-b849-4872-8dc2-6950c2993e64">
<img width="1581" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/64cb08b8-17f3-417b-ab38-e40c9ef1e71d">

See https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/

The problem is that `$__rate_interval` is a grafana only feature and can not be used for raw prometheus queries. This change converts dataAPI metrics to use the auto variable rate based on query interval length and changes the default rate from 2m to 4m to match what `$__rate_interval` does under the covers.

Use `4m` for < 7d time interval
Use `11m` for >= 7d time interval

10m (note `$__rate_interval` matches 4m perfectly)
<img width="1247" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/9c790f5f-5da6-4069-b2f2-f23c50b0edd4">
30m (note `$__rate_interval` matches 4m perfectly)
<img width="1250" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/43d99ebd-8c58-41d9-9b94-4857a4dd48c3">
1h (note `$__rate_interval` matches 4m perfectly)
<img width="1242" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/70a2b850-4751-44cf-819b-53c1f492e9b0">
12h (note `$__rate_interval` matches 4m perfectly)
<img width="1242" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/464647f5-5f54-4148-9b40-814aa7014259">
24h (note `$__rate_interval` matches 4m perfectly)
<img width="1243" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/79441af3-f071-4164-bbf3-25e5c4c7a5e4">
7d (note `$__rate_interval` matches 11m perfectly)
<img width="1241" alt="image" src="https://github.com/Layr-Labs/eigenda/assets/354473/c34f9b69-c0c4-408d-85ae-3116083e51a0">

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
