### PR TITLE
[2/N] Chunk encoding optimization: bench mark the gnark based encoding

### DIFF
--- a/encoding/serialization_test.go
+++ b/encoding/serialization_test.go
@@ -1,6 +1,7 @@
 package encoding_test
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/Layr-Labs/eigenda/encoding"
@@ -43,5 +44,76 @@ func TestSerDeserGnark(t *testing.T) {
 	assert.Equal(t, len(f.Coeffs), len(c.Coeffs))
 	for i := 0; i < len(f.Coeffs); i++ {
 		assert.True(t, f.Coeffs[i].Equal(&c.Coeffs[i]))
+	}
+}
+
+func createFrames(b *testing.B, numFrames int) []encoding.Frame {
+	var XCoord, YCoord fp.Element
+	_, err := XCoord.SetString("21661178944771197726808973281966770251114553549453983978976194544185382599016")
+	assert.NoError(b, err)
+	_, err = YCoord.SetString("9207254729396071334325696286939045899948985698134704137261649190717970615186")
+	assert.NoError(b, err)
+	r := rand.New(rand.NewSource(2024))
+	numCoeffs := 64
+	frames := make([]encoding.Frame, numFrames)
+	for n := 0; n < numFrames; n++ {
+		frames[n].Proof = encoding.Proof{
+			X: XCoord,
+			Y: YCoord,
+		}
+		for i := 0; i < numCoeffs; i++ {
+			frames[n].Coeffs = append(frames[n].Coeffs, fr.NewElement(r.Uint64()))
+		}
+	}
+	return frames
+}
+
+func BenchmarkFrameGobSerialization(b *testing.B) {
+	numSamples := 64
+	frames := createFrames(b, numSamples)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = frames[i%numSamples].Serialize()
+	}
+}
+
+func BenchmarkFrameGnarkSerialization(b *testing.B) {
+	numSamples := 64
+	frames := createFrames(b, numSamples)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = frames[i%numSamples].SerializeGnark()
+	}
+}
+
+func BenchmarkFrameGobDeserialization(b *testing.B) {
+	numSamples := 64
+	frames := createFrames(b, numSamples)
+	bytes := make([][]byte, numSamples)
+	for n := 0; n < numSamples; n++ {
+		gob, _ := frames[n].Serialize()
+		bytes[n] = gob
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = new(encoding.Frame).Deserialize(bytes[i%numSamples])
+	}
+}
+
+func BenchmarkFrameGnarkDeserialization(b *testing.B) {
+	numSamples := 64
+	frames := createFrames(b, numSamples)
+	bytes := make([][]byte, numSamples)
+	for n := 0; n < numSamples; n++ {
+		gnark, _ := frames[n].SerializeGnark()
+		bytes[n] = gnark
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = new(encoding.Frame).DeserializeGnark(bytes[i%numSamples])
 	}
 }


### PR DESCRIPTION
## Why are these changes needed?
To understand the performance of new chunk serialization and deserialization compared to existing approach.

Encoding (BenchmarkFrameGnarkSerialization) is 7x faster, decoding (BenchmarkFrameGnarkDeserialization) is 3.6x faster.

```
goos: linux
goarch: amd64
pkg: github.com/Layr-Labs/eigenda/encoding
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
BenchmarkFrameGobSerialization-8       	   71583	     16657 ns/op
BenchmarkFrameGobSerialization-8       	   71329	     16743 ns/op
BenchmarkFrameGobSerialization-8       	   70735	     16912 ns/op
BenchmarkFrameGnarkSerialization-8     	  478899	      2402 ns/op
BenchmarkFrameGnarkSerialization-8     	  467806	      2390 ns/op
BenchmarkFrameGnarkSerialization-8     	  467905	      2402 ns/op
BenchmarkFrameGobDeserialization-8     	   32188	     34923 ns/op
BenchmarkFrameGobDeserialization-8     	   34275	     34864 ns/op
BenchmarkFrameGobDeserialization-8     	   33954	     34775 ns/op
BenchmarkFrameGnarkDeserialization-8   	  121190	      9715 ns/op
BenchmarkFrameGnarkDeserialization-8   	  122356	      9832 ns/op
BenchmarkFrameGnarkDeserialization-8   	  120322	      9718 ns/op
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
