### PR TITLE
Fix fft_fr.IsPowerOfTwo(). (#83)

### DIFF
--- a/encoding/fft/fft_fr.go
+++ b/encoding/fft/fft_fr.go
@@ -132,7 +132,7 @@ func (fs *FFTSettings) InplaceFFT(vals []fr.Element, out []fr.Element, inv bool)
 	}
 }
 
-// Returns true if the provided integer v is a power of 2.
+// IsPowerOfTwo Returns true if the provided integer v is a power of 2.
 func IsPowerOfTwo(v uint64) bool {
 	return (v&(v-1) == 0) && (v != 0)
 }

--- a/encoding/fft/fft_fr.go
+++ b/encoding/fft/fft_fr.go
@@ -109,9 +109,9 @@ func (fs *FFTSettings) InplaceFFT(vals []fr.Element, out []fr.Element, inv bool)
 	}
 	if inv {
 		var invLen fr.Element
-		
+
 		invLen.SetInt64(int64(n))
-		
+
 		invLen.Inverse(&invLen)
 		rootz := fs.ReverseRootsOfUnity[:fs.MaxWidth]
 		stride := fs.MaxWidth / n
@@ -132,6 +132,7 @@ func (fs *FFTSettings) InplaceFFT(vals []fr.Element, out []fr.Element, inv bool)
 	}
 }
 
+// Returns true if the provided integer v is a power of 2.
 func IsPowerOfTwo(v uint64) bool {
-	return v&(v-1) == 0
+	return (v&(v-1) == 0) && (v != 0)
 }

--- a/encoding/fft/fft_fr.go
+++ b/encoding/fft/fft_fr.go
@@ -132,7 +132,7 @@ func (fs *FFTSettings) InplaceFFT(vals []fr.Element, out []fr.Element, inv bool)
 	}
 }
 
-// IsPowerOfTwo Returns true if the provided integer v is a power of 2.
+// IsPowerOfTwo returns true if the provided integer v is a power of 2.
 func IsPowerOfTwo(v uint64) bool {
 	return (v&(v-1) == 0) && (v != 0)
 }

--- a/encoding/fft/fft_fr_test.go
+++ b/encoding/fft/fft_fr_test.go
@@ -24,6 +24,7 @@
 package fft
 
 import (
+	"math"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
@@ -98,5 +99,25 @@ func TestInvFFT(t *testing.T) {
 
 	for i := range res {
 		assert.True(t, res[i].Equal(&expected[i]))
+	}
+}
+
+func TestIsPowerOfTwo(t *testing.T) {
+	var i uint64
+	for i = 0; i <= 1024; i++ {
+		result := IsPowerOfTwo(i)
+
+		var expectedResult bool
+		if i == 0 {
+			// Special case: math.Log2() is undefined for 0
+			expectedResult = false
+		} else {
+			// If a number is not a power of two then the log base 2 of that number will not be a whole integer.
+			logBase2 := math.Log2(float64(i))
+			truncatedLogBase2 := float64(uint64(logBase2))
+			expectedResult = logBase2 == truncatedLogBase2
+		}
+
+		assert.Equal(t, expectedResult, result, "IsPowerOfTwo(%d) returned unexpected result '%t'.", i, result)
 	}
 }


### PR DESCRIPTION
## Why are these changes needed?

This change fixes https://github.com/Layr-Labs/eigenda/issues/87

The function `fft_fr.IsPowerOfTwo()` did not return the correct response for `0`.

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
