### PR TITLE
Collect Node Info during reachability check if port scan was successful

### DIFF
--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -185,7 +185,7 @@ func (s *server) probeOperatorPorts(ctx context.Context, operatorId string) (*Op
 
 	if dispersalOnline {
 		// collect node info if online
-		getNodeInfo(dispersalSocket, operatorId, 3, s.logger)
+		getNodeInfo(ctx, dispersalSocket, operatorId, s.logger)
 	}
 
 	// Create the metadata regardless of online status
@@ -205,7 +205,7 @@ func (s *server) probeOperatorPorts(ctx context.Context, operatorId string) (*Op
 }
 
 // query operator host info endpoint if available
-func getNodeInfo(socket string, operatorId string, timeoutSecs int, logger logging.Logger) {
+func getNodeInfo(ctx context.Context, socket string, operatorId string, logger logging.Logger) {
 	conn, err := grpc.Dial(socket, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		logger.Error("Failed to dial grpc operator socket", "operatorId", operatorId, "socket", socket, "error", err)
@@ -213,8 +213,6 @@ func getNodeInfo(socket string, operatorId string, timeoutSecs int, logger loggi
 	}
 	defer conn.Close()
 	client := node.NewDispersalClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSecs)*time.Second)
-	defer cancel()
 	reply, err := client.NodeInfo(ctx, &node.NodeInfoRequest{})
 	if err != nil {
 		logger.Info("NodeInfo", "operatorId", operatorId, "semver", "unknown")

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -185,7 +185,7 @@ func (s *server) probeOperatorPorts(ctx context.Context, operatorId string) (*Op
 
 	if dispersalOnline {
 		// collect node info if online
-		getNodeInfo(dispersalSocket, operatorId, s.logger)
+		getNodeInfo(dispersalSocket, operatorId, 3, s.logger)
 	}
 
 	// Create the metadata regardless of online status
@@ -205,7 +205,7 @@ func (s *server) probeOperatorPorts(ctx context.Context, operatorId string) (*Op
 }
 
 // query operator host info endpoint if available
-func getNodeInfo(socket string, operatorId string, logger logging.Logger) {
+func getNodeInfo(socket string, operatorId string, timeoutSecs int, logger logging.Logger) {
 	conn, err := grpc.Dial(socket, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		logger.Error("Failed to dial grpc operator socket", "operatorId", operatorId, "socket", socket, "error", err)
@@ -213,7 +213,9 @@ func getNodeInfo(socket string, operatorId string, logger logging.Logger) {
 	}
 	defer conn.Close()
 	client := node.NewDispersalClient(conn)
-	reply, err := client.NodeInfo(context.Background(), &node.NodeInfoRequest{})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSecs)*time.Second)
+	defer cancel()
+	reply, err := client.NodeInfo(ctx, &node.NodeInfoRequest{})
 	if err != nil {
 		logger.Info("NodeInfo", "operatorId", operatorId, "semver", "unknown")
 		return


### PR DESCRIPTION
Allows us to track node versions when nodes request reachability checks

We only attempt a NodeInfo request if the dispersal socket was validated as open.

Log from node with NodeInfo resource collection (default behavior)
```
{"msg":"NodeInfo","component":"DataAPIServer","operatorId":"a96bfb4a7ca981ad365220f336dc5a3de0816ebd5130b79bbc85aca94bc9b6ab","semver":"0.7.5-pre.1","os":"linux","arch":"amd64","numCpu":8,"memBytes":33545670656}
```

Log from node with `NODE_ENABLE_NODE_INFO_RESOURCES=false` will only populate `semver`
```
{"msg":"NodeInfo","component":"DataAPIServer","operatorId":"a96bfb4a7ca981ad365220f336dc5a3de0816ebd5130b79bbc85aca94bc9b6ab","semver":"0.7.5pre.1","os":"","arch":"","numCpu":0,"memBytes":0}  
```
                                                                                                                                                                                                                                                           
Legacy operator nodes will be tracked with `semver: unknown`
```
{"msg":"NodeInfo","component":"DataAPIServer","operatorId":"a96bfb4a7ca981ad365220f336dc5a3de0816ebd5130b79bbc85aca94bc9b6ab","semver":"unknown"}                                                                                                                                                                                                       
```

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
