### PR TITLE
Refactor dispatcher timeout

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -417,7 +417,7 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	// Dispatch encoded batch
 	log.Debug("Dispatching encoded batch...")
 	stageTimer = time.Now()
-	update := b.Dispatcher.DisperseBatch(ctx, batch.State, batch.EncodedBlobs, batch.BatchHeader)
+	update := b.Dispatcher.DisperseBatch(ctx, batch.State, batch.EncodedBlobs, batch.BatchHeader, b.AttestationTimeout)
 	log.Debug("DisperseBatch took", "duration", time.Since(stageTimer))
 	h, err := batch.State.OperatorState.Hash()
 	if err != nil {

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -98,9 +98,7 @@ func RunBatcher(ctx *cli.Context) error {
 
 	metrics := batcher.NewMetrics(config.MetricsConfig.HTTPPort, logger)
 
-	dispatcher := dispatcher.NewDispatcher(&dispatcher.Config{
-		Timeout: config.TimeoutConfig.AttestationTimeout,
-	}, logger, metrics.DispatcherMetrics)
+	dispatcher := dispatcher.NewDispatcher(logger, metrics.DispatcherMetrics)
 	asgn := &core.StdAssignmentCoordinator{}
 
 	var wallet walletsdk.Wallet

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
@@ -176,7 +177,12 @@ type BlobStore interface {
 }
 
 type Dispatcher interface {
-	DisperseBatch(context.Context, *core.IndexedOperatorState, []core.EncodedBlob, *core.BatchHeader) chan core.SigningMessage
+	// DisperseBatch sends the blobs to the operators in the state and returns a channel to receive the signing messages
+	// Attestation timeout needs to be configured in the parameter to set the correct timeout for each dispersal request
+	DisperseBatch(context.Context, *core.IndexedOperatorState, []core.EncodedBlob, *core.BatchHeader, time.Duration) chan core.SigningMessage
+	// SendChunksToOperator sends the blobs to the operator and returns the signature and error
+	// It uses the context in the parameter to send the dispersal requests
+	SendChunksToOperator(ctx context.Context, blobs []*core.BlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) (*core.Signature, error)
 }
 
 // GenerateReverseIndexKey returns the key used to store the blob key in the reverse index

--- a/disperser/mock/dispatcher.go
+++ b/disperser/mock/dispatcher.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/Layr-Labs/eigenda/core"
 	coremock "github.com/Layr-Labs/eigenda/core/mock"
@@ -23,7 +24,7 @@ func NewDispatcher(state *coremock.PrivateOperatorState) *Dispatcher {
 	}
 }
 
-func (d *Dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOperatorState, blobs []core.EncodedBlob, header *core.BatchHeader) chan core.SigningMessage {
+func (d *Dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOperatorState, blobs []core.EncodedBlob, header *core.BatchHeader, timeout time.Duration) chan core.SigningMessage {
 	args := d.Called()
 	var nonSigners map[core.OperatorID]struct{}
 	if args.Get(0) != nil {
@@ -63,4 +64,9 @@ func (d *Dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOpera
 	}()
 
 	return update
+}
+
+func (c *Dispatcher) SendChunksToOperator(ctx context.Context, blobs []*core.BlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) (*core.Signature, error) {
+	args := c.Called(ctx, blobs, batchHeader, op)
+	return args.Get(0).(*core.Signature), args.Error(1)
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -129,11 +129,8 @@ type TestDisperser struct {
 }
 
 func mustMakeDisperser(t *testing.T, cst core.IndexedChainState, store disperser.BlobStore, logger logging.Logger) TestDisperser {
-	dispatcherConfig := &dispatcher.Config{
-		Timeout: time.Second,
-	}
 	batcherMetrics := batcher.NewMetrics("9100", logger)
-	dispatcher := dispatcher.NewDispatcher(dispatcherConfig, logger, batcherMetrics.DispatcherMetrics)
+	dispatcher := dispatcher.NewDispatcher(logger, batcherMetrics.DispatcherMetrics)
 
 	transactor := &coremock.MockTransactor{}
 	transactor.On("OperatorIDToAddress").Return(gethcommon.Address{}, nil)


### PR DESCRIPTION
## Why are these changes needed?
Currently, the dispatcher `DisperseBatch` method takes context in the parameter but uses the fixed timeout specified in its config. 
This doesn't allow the caller to use variable timeouts for different requests which is necessary for minibatcher. 
This PR makes two changes:
- It removes the fixed timeout in dispatcher config, and adds a `timeout` parameter for explicitly setting the timeout for each call
- It makes `sendChunks` a public method
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
