### PR TITLE
Revert "Refactor dispatcher timeout"

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -417,7 +417,7 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	// Dispatch encoded batch
 	log.Debug("Dispatching encoded batch...")
 	stageTimer = time.Now()
-	update := b.Dispatcher.DisperseBatch(ctx, batch.State, batch.EncodedBlobs, batch.BatchHeader, b.AttestationTimeout)
+	update := b.Dispatcher.DisperseBatch(ctx, batch.State, batch.EncodedBlobs, batch.BatchHeader)
 	log.Debug("DisperseBatch took", "duration", time.Since(stageTimer))
 	h, err := batch.State.OperatorState.Hash()
 	if err != nil {

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -98,7 +98,9 @@ func RunBatcher(ctx *cli.Context) error {
 
 	metrics := batcher.NewMetrics(config.MetricsConfig.HTTPPort, logger)
 
-	dispatcher := dispatcher.NewDispatcher(logger, metrics.DispatcherMetrics)
+	dispatcher := dispatcher.NewDispatcher(&dispatcher.Config{
+		Timeout: config.TimeoutConfig.AttestationTimeout,
+	}, logger, metrics.DispatcherMetrics)
 	asgn := &core.StdAssignmentCoordinator{}
 
 	var wallet walletsdk.Wallet

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
@@ -177,12 +176,7 @@ type BlobStore interface {
 }
 
 type Dispatcher interface {
-	// DisperseBatch sends the blobs to the operators in the state and returns a channel to receive the signing messages
-	// Attestation timeout needs to be configured in the parameter to set the correct timeout for each dispersal request
-	DisperseBatch(context.Context, *core.IndexedOperatorState, []core.EncodedBlob, *core.BatchHeader, time.Duration) chan core.SigningMessage
-	// SendChunksToOperator sends the blobs to the operator and returns the signature and error
-	// It uses the context in the parameter to send the dispersal requests
-	SendChunksToOperator(ctx context.Context, blobs []*core.BlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) (*core.Signature, error)
+	DisperseBatch(context.Context, *core.IndexedOperatorState, []core.EncodedBlob, *core.BatchHeader) chan core.SigningMessage
 }
 
 // GenerateReverseIndexKey returns the key used to store the blob key in the reverse index

--- a/disperser/mock/dispatcher.go
+++ b/disperser/mock/dispatcher.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/Layr-Labs/eigenda/core"
 	coremock "github.com/Layr-Labs/eigenda/core/mock"
@@ -24,7 +23,7 @@ func NewDispatcher(state *coremock.PrivateOperatorState) *Dispatcher {
 	}
 }
 
-func (d *Dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOperatorState, blobs []core.EncodedBlob, header *core.BatchHeader, timeout time.Duration) chan core.SigningMessage {
+func (d *Dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOperatorState, blobs []core.EncodedBlob, header *core.BatchHeader) chan core.SigningMessage {
 	args := d.Called()
 	var nonSigners map[core.OperatorID]struct{}
 	if args.Get(0) != nil {
@@ -64,9 +63,4 @@ func (d *Dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOpera
 	}()
 
 	return update
-}
-
-func (c *Dispatcher) SendChunksToOperator(ctx context.Context, blobs []*core.BlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) (*core.Signature, error) {
-	args := c.Called(ctx, blobs, batchHeader, op)
-	return args.Get(0).(*core.Signature), args.Error(1)
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -129,8 +129,11 @@ type TestDisperser struct {
 }
 
 func mustMakeDisperser(t *testing.T, cst core.IndexedChainState, store disperser.BlobStore, logger logging.Logger) TestDisperser {
+	dispatcherConfig := &dispatcher.Config{
+		Timeout: time.Second,
+	}
 	batcherMetrics := batcher.NewMetrics("9100", logger)
-	dispatcher := dispatcher.NewDispatcher(logger, batcherMetrics.DispatcherMetrics)
+	dispatcher := dispatcher.NewDispatcher(dispatcherConfig, logger, batcherMetrics.DispatcherMetrics)
 
 	transactor := &coremock.MockTransactor{}
 	transactor.On("OperatorIDToAddress").Return(gethcommon.Address{}, nil)


### PR DESCRIPTION
Reverts Layr-Labs/eigenda#641

#641 should be a no-op to the existing functionality but it does change the current logic. 
The use case needed for minibatch streaming can be added without modifying the existing dispatcher codebase at all. 
Thus reverting the PR to be safe.