### PR TITLE
chore(all): use `errors.New` to replace `fmt.Errorf` with no parameters

### DIFF
--- a/api/clients/codecs/default_blob_codec.go
+++ b/api/clients/codecs/default_blob_codec.go
@@ -3,6 +3,7 @@ package codecs
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
@@ -36,7 +37,7 @@ func (v DefaultBlobCodec) EncodeBlob(rawData []byte) ([]byte, error) {
 
 func (v DefaultBlobCodec) DecodeBlob(data []byte) ([]byte, error) {
 	if len(data) < 32 {
-		return nil, fmt.Errorf("blob does not contain 32 header bytes, meaning it is malformed")
+		return nil, errors.New("blob does not contain 32 header bytes, meaning it is malformed")
 	}
 
 	length := binary.BigEndian.Uint32(data[2:6])
@@ -52,7 +53,7 @@ func (v DefaultBlobCodec) DecodeBlob(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to copy unpadded data into final buffer, length: %d, bytes read: %d", length, n)
 	}
 	if uint32(n) != length {
-		return nil, fmt.Errorf("data length does not match length prefix")
+		return nil, errors.New("data length does not match length prefix")
 	}
 
 	return rawData, nil

--- a/api/clients/codecs/ifft_codec.go
+++ b/api/clients/codecs/ifft_codec.go
@@ -1,6 +1,9 @@
 package codecs
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type IFFTCodec struct {
 	writeCodec BlobCodec
@@ -26,7 +29,7 @@ func (v IFFTCodec) EncodeBlob(data []byte) ([]byte, error) {
 
 func (v IFFTCodec) DecodeBlob(data []byte) ([]byte, error) {
 	if len(data) == 0 {
-		return nil, fmt.Errorf("blob has length 0, meaning it is malformed")
+		return nil, errors.New("blob has length 0, meaning it is malformed")
 	}
 	var err error
 	data, err = FFT(data)

--- a/api/clients/config.go
+++ b/api/clients/config.go
@@ -1,7 +1,7 @@
 package clients
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
@@ -53,10 +53,10 @@ func (c *EigenDAClientConfig) CheckAndSetDefaults() error {
 		c.ResponseTimeout = 30 * time.Second
 	}
 	if len(c.SignerPrivateKeyHex) != 64 {
-		return fmt.Errorf("EigenDAClientConfig.SignerPrivateKeyHex should be 64 hex characters long, should not have 0x prefix")
+		return errors.New("EigenDAClientConfig.SignerPrivateKeyHex should be 64 hex characters long, should not have 0x prefix")
 	}
 	if len(c.RPC) == 0 {
-		return fmt.Errorf("EigenDAClientConfig.RPC not set")
+		return errors.New("EigenDAClientConfig.RPC not set")
 	}
 	return nil
 }

--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -82,7 +83,7 @@ func (m EigenDAClient) GetBlob(ctx context.Context, batchHeaderHash []byte, blob
 	}
 
 	if len(data) == 0 {
-		return nil, fmt.Errorf("blob has length zero")
+		return nil, errors.New("blob has length zero")
 	}
 
 	decodedData, err := m.Codec.DecodeBlob(data)
@@ -118,7 +119,7 @@ func (m EigenDAClient) putBlob(ctx context.Context, rawData []byte, resultChan c
 
 	// encode blob
 	if m.Codec == nil {
-		errChan <- fmt.Errorf("Codec cannot be nil")
+		errChan <- errors.New("Codec cannot be nil")
 		return
 	}
 

--- a/api/clients/eigenda_client_test.go
+++ b/api/clients/eigenda_client_test.go
@@ -2,7 +2,7 @@ package clients_test
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -224,7 +224,7 @@ func TestPutRetrieveBlobNoIFFTSuccess(t *testing.T) {
 func TestPutBlobFailDispersal(t *testing.T) {
 	disperserClient := clientsmock.NewMockDisperserClient()
 	(disperserClient.On("DisperseBlobAuthenticated", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, nil, fmt.Errorf("error dispersing")))
+		Return(nil, nil, errors.New("error dispersing")))
 	logger := log.NewLogger(log.DiscardHandler())
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,

--- a/common/fireblocks_config.go
+++ b/common/fireblocks_config.go
@@ -106,7 +106,7 @@ func ReadFireblocksCLIConfig(ctx *cli.Context, flagPrefix string) FireblocksConf
 func NewFireblocksWallet(config *FireblocksConfig, ethClient EthClient, logger logging.Logger) (walletsdk.Wallet, error) {
 	if config.Disable {
 		logger.Info("Fireblocks wallet disabled")
-		return nil, fmt.Errorf("fireblocks wallet is disabled")
+		return nil, errors.New("fireblocks wallet is disabled")
 	}
 
 	validConfigflag := len(config.APIKeyName) > 0 &&

--- a/core/assignment.go
+++ b/core/assignment.go
@@ -121,7 +121,7 @@ func (c *StdAssignmentCoordinator) GetAssignments(state *OperatorState, blobLeng
 
 		gammaChunkLength := big.NewInt(int64(info.ChunkLength) * int64((info.ConfirmationThreshold - info.AdversaryThreshold)))
 		if gammaChunkLength.Cmp(big.NewInt(0)) <= 0 {
-			return nil, AssignmentInfo{}, fmt.Errorf("gammaChunkLength must be greater than 0")
+			return nil, AssignmentInfo{}, errors.New("gammaChunkLength must be greater than 0")
 		}
 		if totalStakes.Cmp(big.NewInt(0)) == 0 {
 			return nil, AssignmentInfo{}, fmt.Errorf("total stake in quorum %d must be greater than 0", quorum)

--- a/core/serialization.go
+++ b/core/serialization.go
@@ -365,15 +365,15 @@ func (h *BlobHeader) Deserialize(data []byte) (*BlobHeader, error) {
 	err := decode(data, h)
 
 	if !(*bn254.G1Affine)(h.BlobCommitments.Commitment).IsInSubGroup() {
-		return nil, fmt.Errorf("in BlobHeader Commitment is not in the subgroup")
+		return nil, errors.New("in BlobHeader Commitment is not in the subgroup")
 	}
 
 	if !(*bn254.G2Affine)(h.BlobCommitments.LengthCommitment).IsInSubGroup() {
-		return nil, fmt.Errorf("in BlobHeader LengthCommitment is not in the subgroup")
+		return nil, errors.New("in BlobHeader LengthCommitment is not in the subgroup")
 	}
 
 	if !(*bn254.G2Affine)(h.BlobCommitments.LengthProof).IsInSubGroup() {
-		return nil, fmt.Errorf("in BlobHeader LengthProof is not in the subgroup")
+		return nil, errors.New("in BlobHeader LengthProof is not in the subgroup")
 	}
 
 	return h, err

--- a/core/validator.go
+++ b/core/validator.go
@@ -219,7 +219,7 @@ func validateBatchHeaderRoot(batchHeader *BatchHeader, blobs []*BlobMessage) err
 	}
 
 	if batchHeader.BatchRoot != derivedHeader.BatchRoot {
-		return fmt.Errorf("batch header root does not match computed root")
+		return errors.New("batch header root does not match computed root")
 	}
 
 	return nil

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -910,10 +910,10 @@ func (s *DispersalServer) validateRequestAndGetBlob(ctx context.Context, req *pb
 	blobSize := len(data)
 	// The blob size in bytes must be in range [1, maxBlobSize].
 	if blobSize > maxBlobSize {
-		return nil, fmt.Errorf("blob size cannot exceed 2 MiB")
+		return nil, errors.New("blob size cannot exceed 2 MiB")
 	}
 	if blobSize == 0 {
-		return nil, fmt.Errorf("blob size must be greater than 0")
+		return nil, errors.New("blob size must be greater than 0")
 	}
 
 	if len(req.GetCustomQuorumNumbers()) > 256 {
@@ -951,7 +951,7 @@ func (s *DispersalServer) validateRequestAndGetBlob(ctx context.Context, req *pb
 		}
 
 		if _, ok := seenQuorums[quorumID]; ok {
-			return nil, fmt.Errorf("custom_quorum_numbers must not contain duplicates")
+			return nil, errors.New("custom_quorum_numbers must not contain duplicates")
 		}
 		seenQuorums[quorumID] = struct{}{}
 
@@ -974,7 +974,7 @@ func (s *DispersalServer) validateRequestAndGetBlob(ctx context.Context, req *pb
 	}
 
 	if len(seenQuorums) == 0 {
-		return nil, fmt.Errorf("the blob must be sent to at least one quorum")
+		return nil, errors.New("the blob must be sent to at least one quorum")
 	}
 
 	params := make([]*core.SecurityParam, len(seenQuorums))

--- a/disperser/batcher/txn_manager.go
+++ b/disperser/batcher/txn_manager.go
@@ -264,7 +264,7 @@ func (t *txnManager) ensureAnyTransactionEvaled(ctx context.Context, txs []*tran
 		}
 
 		if len(txnsToQuery) == 0 {
-			return nil, fmt.Errorf("all transactions failed")
+			return nil, errors.New("all transactions failed")
 		}
 
 		// Wait for the next round.

--- a/disperser/dataapi/grpc_service_availability_handler.go
+++ b/disperser/dataapi/grpc_service_availability_handler.go
@@ -3,6 +3,7 @@ package dataapi
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -25,7 +26,7 @@ type EigenDAServiceAvailabilityCheck struct {
 
 func (s *server) getServiceAvailability(ctx context.Context, services []string) ([]*ServiceAvailability, error) {
 	if services == nil {
-		return nil, fmt.Errorf("services cannot be nil")
+		return nil, errors.New("services cannot be nil")
 	}
 
 	availabilityStatuses := make([]*ServiceAvailability, len(services))
@@ -118,13 +119,13 @@ func (sac *EigenDAServiceAvailabilityCheck) CheckHealth(ctx context.Context, ser
 	case "disperser":
 
 		if sac.disperserConn == nil {
-			return nil, fmt.Errorf("disperser connection is nil")
+			return nil, errors.New("disperser connection is nil")
 		}
 		client = grpc_health_v1.NewHealthClient(sac.disperserConn)
 	case "churner":
 
 		if sac.churnerConn == nil {
-			return nil, fmt.Errorf("churner connection is nil")
+			return nil, errors.New("churner connection is nil")
 		}
 		client = grpc_health_v1.NewHealthClient(sac.churnerConn)
 	default:

--- a/disperser/dataapi/nonsigner_utils.go
+++ b/disperser/dataapi/nonsigner_utils.go
@@ -1,6 +1,7 @@
 package dataapi
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 )
@@ -184,7 +185,7 @@ func validateQuorumEvents(added []*OperatorQuorum, removed []*OperatorQuorum, st
 				return fmt.Errorf("quorum events must be in range [%d, %d]", startBlock+1, endBlock)
 			}
 			if i > 0 && events[i].BlockNumber < events[i-1].BlockNumber {
-				return fmt.Errorf("quorum events must be in ascending order by block number")
+				return errors.New("quorum events must be in ascending order by block number")
 			}
 		}
 		return nil

--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -5,7 +5,6 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 )
@@ -17,7 +16,7 @@ func (c *Frame) Serialize() ([]byte, error) {
 func (c *Frame) Deserialize(data []byte) (*Frame, error) {
 	err := decode(data, c)
 	if !c.Proof.IsInSubGroup() {
-		return nil, fmt.Errorf("proof is in not the subgroup")
+		return nil, errors.New("proof is in not the subgroup")
 	}
 
 	return c, err
@@ -102,7 +101,7 @@ func (c *G1Commitment) UnmarshalJSON(data []byte) error {
 	c.Y = g1Point.Y
 
 	if !(*bn254.G1Affine)(c).IsInSubGroup() {
-		return fmt.Errorf("G1Commitment not in the subgroup")
+		return errors.New("G1Commitment not in the subgroup")
 	}
 
 	return nil
@@ -132,7 +131,7 @@ func (c *G2Commitment) UnmarshalJSON(data []byte) error {
 	c.Y = g2Point.Y
 
 	if !(*bn254.G2Affine)(c).IsInSubGroup() {
-		return fmt.Errorf("G2Commitment not in the subgroup")
+		return errors.New("G2Commitment not in the subgroup")
 	}
 	return nil
 }

--- a/encoding/utils/openCommitment/open_commitment.go
+++ b/encoding/utils/openCommitment/open_commitment.go
@@ -2,7 +2,6 @@ package openCommitment
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -18,10 +17,10 @@ func ComputeKzgProof(
 	rootOfUnities []fr.Element,
 ) (*bn254.G1Affine, *fr.Element, error) {
 	if len(evalFr) != len(rootOfUnities) {
-		return nil, nil, fmt.Errorf("inconsistent length between blob and root of unities")
+		return nil, nil, errors.New("inconsistent length between blob and root of unities")
 	}
 	if index < 0 || index >= len(evalFr) {
-		return nil, nil, fmt.Errorf("the function only opens points within a blob")
+		return nil, nil, errors.New("the function only opens points within a blob")
 	}
 
 	polyShift := make([]fr.Element, len(evalFr))

--- a/node/operator.go
+++ b/node/operator.go
@@ -113,7 +113,7 @@ func UpdateOperatorSocket(ctx context.Context, transactor core.Transactor, socke
 // getQuorumIdsToRegister returns the quorum ids that the operator is not registered in.
 func (c *Operator) getQuorumIdsToRegister(ctx context.Context, transactor core.Transactor) ([]core.QuorumID, error) {
 	if len(c.QuorumIDs) == 0 {
-		return nil, fmt.Errorf("an operator should be in at least one quorum to be useful")
+		return nil, errors.New("an operator should be in at least one quorum to be useful")
 	}
 
 	registeredQuorumIds, err := transactor.GetRegisteredQuorumIdsForOperator(ctx, c.OperatorId)

--- a/tools/srs-utils/verifier/verifier.go
+++ b/tools/srs-utils/verifier/verifier.go
@@ -1,6 +1,7 @@
 package verifier
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -172,7 +173,7 @@ func PairingCheck(a1 *bn254.G1Affine, a2 *bn254.G2Affine, b1 *bn254.G1Affine, b2
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("PairingCheck pairing not ok. SRS is invalid")
+		return errors.New("PairingCheck pairing not ok. SRS is invalid")
 	}
 
 	return nil


### PR DESCRIPTION
## Why are these changes needed?

It's better to use `errors.New` than `fmt.Errorf` when there is no parameter in error message

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
