### PR TITLE
Dispatcher method to disperse blobs to node via `StoreBlobs` endpoint

### DIFF
--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -177,6 +177,7 @@ type BlobStore interface {
 
 type Dispatcher interface {
 	DisperseBatch(context.Context, *core.IndexedOperatorState, []core.EncodedBlob, *core.BatchHeader) chan core.SigningMessage
+	SendBlobsToOperator(ctx context.Context, blobs []*core.BlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) ([]*core.Signature, error)
 }
 
 // GenerateReverseIndexKey returns the key used to store the blob key in the reverse index

--- a/disperser/mock/dispatcher.go
+++ b/disperser/mock/dispatcher.go
@@ -64,3 +64,11 @@ func (d *Dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOpera
 
 	return update
 }
+
+func (d *Dispatcher) SendBlobsToOperator(ctx context.Context, blobs []*core.BlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) ([]*core.Signature, error) {
+	args := d.Called(ctx, blobs, batchHeader, op)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*core.Signature), args.Error(1)
+}


### PR DESCRIPTION
## Why are these changes needed?
This method is the same as the existing `sendChunks` method, except that it disperses data via `StoreBlobs` endpoint not `StoreChunks` endpoint. 
It also returns a slice of signatures (vs. a single signature).

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
