### PR TITLE
chore: add new `help` target to Makefile to display the usage of all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: compile-el compile-dl clean protoc lint build unit-tests integration-tests-churner integration-tests-indexer integration-tests-inabox integration-tests-inabox-nochurner integration-tests-graph-indexer
+# Make sure the help command stays first, so that it's printed by default when `make` is called without arguments
+.PHONY: help compile-el compile-dl clean protoc lint build unit-tests integration-tests-churner integration-tests-indexer integration-tests-inabox integration-tests-inabox-nochurner integration-tests-graph-indexer
 
 ifeq ($(wildcard .git/*),)
 $(warning semver disabled - building from release zip)
@@ -22,19 +23,22 @@ PROTOS_DISPERSER := ./disperser/api/proto
 PROTO_GEN := ./api/grpc
 PROTO_GEN_DISPERSER_PATH = ./disperser/api/grpc
 
-compile-el:
+help: ## prints this help message
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+compile-el: ## compiles Ethereum contracts for the el environment
 	cd contracts && ./compile.sh compile-el
 
-compile-dl:
+compile-dl: ## compiles distributed ledger contracts
 	cd contracts && ./compile.sh compile-dl
 
-clean:
+clean: ## cleans up generated files
 	find $(PROTO_GEN) -name "*.pb.go" -type f | xargs rm -rf
 	mkdir -p $(PROTO_GEN)
 	find $(PROTO_GEN_DISPERSER_PATH) -name "*.pb.go" -type f | xargs rm -rf
 	mkdir -p $(PROTO_GEN_DISPERSER_PATH)
 
-protoc: clean
+protoc: clean ## generates protobuf files
 	protoc -I $(PROTOS) \
 	--go_out=$(PROTO_GEN) \
 	--go_opt=paths=source_relative \
@@ -49,12 +53,12 @@ protoc: clean
 	--go-grpc_opt=paths=source_relative \
 	$(PROTOS_DISPERSER)/**/*.proto
 
-lint:
+lint: ## runs all linters
 	golint -set_exit_status ./...
 	go tool fix ./..
 	golangci-lint run
 
-build:
+build: ## builds all components
 	cd operators/churner && make build
 	cd disperser && make build
 	cd node && make build
@@ -62,39 +66,39 @@ build:
 	cd tools/traffic && make build
 	cd tools/kzgpad && make build
 
-dataapi-build:
+dataapi-build: ## builds dataapi cli
 	cd disperser && go build -o ./bin/dataapi ./cmd/dataapi
 
-unit-tests:
+unit-tests: ## runs unit tests
 	./test.sh
 
-integration-tests-churner:
+integration-tests-churner: ## runs integration tests for churner
 	go test -v ./churner/tests
 
-integration-tests-indexer:
+integration-tests-indexer: ## runs integration tests for indexer
 	go test -v ./core/indexer
 
-integration-tests-node-plugin:
+integration-tests-node-plugin: ## runs integration tests for the node plugin
 	go test -v ./node/plugin/tests
 
-integration-tests-inabox:
+integration-tests-inabox: ## runs all integration tests in a boxed environment
 	make build
 	cd inabox && make run-e2e
 
-integration-tests-inabox-nochurner:
+integration-tests-inabox-nochurner: ## runs all integration tests in a boxed environment without churner
 	make build
 	cd inabox && make run-e2e-nochurner
 
-integration-tests-graph-indexer:
+integration-tests-graph-indexer: ## runs integration tests for the graph indexer
 	make build
 	go test -v ./core/thegraph
 
-integration-tests-dataapi:
+integration-tests-dataapi: ## runs integration tests for the dataapi
 	make dataapi-build
 	go test -v ./disperser/dataapi
 
-docker-release-build:
+docker-release-build: ## builds docker images for release
 	RELEASE_TAG=${SEMVER} docker compose -f docker-compose-release.yaml build --build-arg SEMVER=${SEMVER} --build-arg GITCOMMIT=${GITCOMMIT} --build-arg GITDATE=${GITDATE} ${PUSH_FLAG}
 
-semver:
+semver: ## displays the current semantic version
 	echo "${SEMVER}"


### PR DESCRIPTION
## Why are these changes needed?

This PR adds a new target `help` to display commonly used targets in this project Makefile. This is useful for new developers begin to contribute and get a helpful tool for building


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
