### PR TITLE
Fix the operator stake share basis point calculation

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -245,7 +245,7 @@ func (g *Metrics) collectOnchainMetrics() {
 			for opId, opInfo := range operators {
 				opStake := new(big.Float).SetInt(opInfo.Stake)
 				share, _ := new(big.Float).Quo(
-					new(big.Float).Mul(opStake, big.NewFloat(100000)),
+					new(big.Float).Mul(opStake, big.NewFloat(10000)),
 					totalStake).Float64()
 				operatorStakeShares = append(operatorStakeShares, &OperatorStakeShare{operatorId: opId, stakeShare: share})
 			}


### PR DESCRIPTION
## Why are these changes needed?
The current `100000` is not providing basis point, but 0.1 basis point. It needs to be `10000`.

Otherwise, we will see `17351.099508447942` basis point for a large operator, which means more than 100% of stake (it should be just 17.35%)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
