### PR TITLE
[minibatcher] Fullbatch state management

### DIFF
--- a/disperser/batcher/inmem/minibatch_store_test.go
+++ b/disperser/batcher/inmem/minibatch_store_test.go
@@ -84,7 +84,7 @@ func TestPutDispersalRequest(t *testing.T) {
 	err = s.PutDispersalRequest(ctx, req2)
 	assert.NoError(t, err)
 
-	r, err := s.GetDispersalRequests(ctx, id, minibatchIndex)
+	r, err := s.GetMinibatchDispersalRequests(ctx, id, minibatchIndex)
 	assert.NoError(t, err)
 	assert.Len(t, r, 2)
 	assert.Equal(t, req1, r[0])
@@ -136,7 +136,7 @@ func TestPutDispersalResponse(t *testing.T) {
 	err = s.PutDispersalResponse(ctx, resp2)
 	assert.NoError(t, err)
 
-	r, err := s.GetDispersalResponses(ctx, id, minibatchIndex)
+	r, err := s.GetMinibatchDispersalResponses(ctx, id, minibatchIndex)
 	assert.NoError(t, err)
 	assert.Len(t, r, 2)
 

--- a/disperser/batcher/minibatch_store.go
+++ b/disperser/batcher/minibatch_store.go
@@ -9,10 +9,30 @@ import (
 	"github.com/google/uuid"
 )
 
+type BatchStatus uint
+
+// Pending: the batch has been created and minibatches are being added. There can be only one pending batch at a time.
+// Formed: the batch has been formed and no more minibatches can be added. Implies that all minibatch records and dispersal request records have been created.
+//
+// Attested: the batch has been attested.
+// Failed: the batch has failed.
+//
+// The batch lifecycle is as follows:
+// Pending -> Formed -> Attested
+// \              /
+//  \-> Failed <-/
+const (
+	BatchStatusPending BatchStatus = iota
+	BatchStatusFormed
+	BatchStatusAttested
+	BatchStatusFailed
+)
+
 type BatchRecord struct {
 	ID                   uuid.UUID
 	CreatedAt            time.Time
 	ReferenceBlockNumber uint
+	Status               BatchStatus
 	HeaderHash           [32]byte
 	AggregatePubKey      *core.G2Point
 	AggregateSignature   *core.Signature
@@ -46,13 +66,21 @@ type DispersalResponse struct {
 type MinibatchStore interface {
 	PutBatch(ctx context.Context, batch *BatchRecord) error
 	GetBatch(ctx context.Context, batchID uuid.UUID) (*BatchRecord, error)
+	GetBatchesByStatus(ctx context.Context, status BatchStatus) ([]*BatchRecord, error)
+	UpdateBatchStatus(ctx context.Context, batchID uuid.UUID, status BatchStatus) error
 	PutMinibatch(ctx context.Context, minibatch *MinibatchRecord) error
 	GetMinibatch(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) (*MinibatchRecord, error)
+	GetMinibatches(ctx context.Context, batchID uuid.UUID) ([]*MinibatchRecord, error)
 	PutDispersalRequest(ctx context.Context, request *DispersalRequest) error
 	GetDispersalRequest(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*DispersalRequest, error)
-	GetDispersalRequests(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*DispersalRequest, error)
+	GetMinibatchDispersalRequests(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*DispersalRequest, error)
 	PutDispersalResponse(ctx context.Context, response *DispersalResponse) error
 	GetDispersalResponse(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*DispersalResponse, error)
-	GetDispersalResponses(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*DispersalResponse, error)
-	GetPendingBatch(ctx context.Context) (*BatchRecord, error)
+	GetMinibatchDispersalResponses(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*DispersalResponse, error)
+
+	// GetLatestFormedBatch returns the latest batch that has been formed.
+	// If there is no formed batch, it returns nil.
+	// It also returns the minibatches that belong to the batch in the ascending order of minibatch index.
+	GetLatestFormedBatch(ctx context.Context) (batch *BatchRecord, minibatches []*MinibatchRecord, err error)
+	BatchDispersed(ctx context.Context, batchID uuid.UUID) (bool, error)
 }

--- a/disperser/batcher/minibatcher_test.go
+++ b/disperser/batcher/minibatcher_test.go
@@ -171,7 +171,7 @@ func TestDisperseMinibatch(t *testing.T) {
 
 	c.pool.StopWait()
 	c.dispatcher.AssertNumberOfCalls(t, "SendBlobsToOperator", 2)
-	dispersalRequests, err := c.minibatchStore.GetDispersalRequests(ctx, c.minibatcher.BatchID, 0)
+	dispersalRequests, err := c.minibatchStore.GetMinibatchDispersalRequests(ctx, c.minibatcher.BatchID, 0)
 	assert.NoError(t, err)
 	assert.Len(t, dispersalRequests, 2)
 	opIDs := make([]core.OperatorID, 2)
@@ -185,7 +185,7 @@ func TestDisperseMinibatch(t *testing.T) {
 	}
 	assert.ElementsMatch(t, opIDs, []core.OperatorID{opId0, opId1})
 
-	dispersalResponses, err := c.minibatchStore.GetDispersalResponses(ctx, c.minibatcher.BatchID, 0)
+	dispersalResponses, err := c.minibatchStore.GetMinibatchDispersalResponses(ctx, c.minibatcher.BatchID, 0)
 	assert.NoError(t, err)
 	assert.Len(t, dispersalResponses, 2)
 	for _, resp := range dispersalResponses {
@@ -262,7 +262,7 @@ func TestDisperseMinibatchFailure(t *testing.T) {
 
 	c.pool.StopWait()
 	c.dispatcher.AssertNumberOfCalls(t, "SendBlobsToOperator", 2)
-	dispersalRequests, err := c.minibatchStore.GetDispersalRequests(ctx, c.minibatcher.BatchID, 0)
+	dispersalRequests, err := c.minibatchStore.GetMinibatchDispersalRequests(ctx, c.minibatcher.BatchID, 0)
 	assert.NoError(t, err)
 	assert.Len(t, dispersalRequests, 2)
 	opIDs := make([]core.OperatorID, 2)
@@ -276,7 +276,7 @@ func TestDisperseMinibatchFailure(t *testing.T) {
 	}
 	assert.ElementsMatch(t, opIDs, []core.OperatorID{opId0, opId1})
 
-	dispersalResponses, err := c.minibatchStore.GetDispersalResponses(ctx, c.minibatcher.BatchID, 0)
+	dispersalResponses, err := c.minibatchStore.GetMinibatchDispersalResponses(ctx, c.minibatcher.BatchID, 0)
 	assert.NoError(t, err)
 	assert.Len(t, dispersalResponses, 2)
 	for _, resp := range dispersalResponses {


### PR DESCRIPTION
## Why are these changes needed?
- `MinibatchStore`: adds `BatchStatus` and auxiliary methods
- `Minibatcher`: updates batch status; creates dispersal requests before the dispersal go routine spins up
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
