### PR TITLE
Average blob throughput over 9m window

### DIFF
--- a/disperser/dataapi/prometheus_client.go
+++ b/disperser/dataapi/prometheus_client.go
@@ -47,7 +47,7 @@ func (pc *prometheusClient) QueryDisperserBlobSizeBytesPerSecond(ctx context.Con
 }
 
 func (pc *prometheusClient) QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, throughputRateSecs uint16) (*PrometheusResult, error) {
-	query := fmt.Sprintf("sum by (job) (rate(eigenda_batcher_blobs_total{state=\"confirmed\",data=\"size\",cluster=\"%s\"}[%ds]))", pc.cluster, throughputRateSecs)
+	query := fmt.Sprintf("avg_over_time( sum by (job) (rate(eigenda_batcher_blobs_total{state=\"confirmed\",data=\"size\",cluster=\"%s\"}[%ds])) [9m:])", pc.cluster, throughputRateSecs)
 	return pc.queryRange(ctx, query, start, end)
 }
 


### PR DESCRIPTION
9m seems like the best window to use between 10min->30d time ranges for smoothing out the 10m batch interval spikes See https://eigenda.grafana.net/d/bdssk3vbvt69sd/blob-explorer-query?orgId=1&from=1721922790524&to=1721965990524

raw rate vs 9m
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/b50981e8-e690-43df-902f-ca049262b8c0">

9m vs 10m
<img width="1521" alt="image" src="https://github.com/user-attachments/assets/67e2555d-578f-43dc-ae3d-b2fe98bda818">

24hr
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/4686744f-eddd-4fc0-ada0-d02db66a00ab">

1hr
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/84d8789c-d248-4fa3-aec0-f29f8b1e48b8">

1hr (9m vs 10m)
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/a779491a-ab85-4a1d-954a-10be198aab50">


## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
