### PR TITLE
Enable shadow PutItem blob metadata requests to separate dynamo table for minibatch preprod testing

### DIFF
--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -44,11 +44,12 @@ var (
 	queue           disperser.BlobStore
 	dispersalServer *apiserver.DispersalServer
 
-	dockertestPool     *dockertest.Pool
-	dockertestResource *dockertest.Resource
-	UUID               = uuid.New()
-	metadataTableName  = fmt.Sprintf("test-BlobMetadata-%v", UUID)
-	bucketTableName    = fmt.Sprintf("test-BucketStore-%v", UUID)
+	dockertestPool          *dockertest.Pool
+	dockertestResource      *dockertest.Resource
+	UUID                    = uuid.New()
+	metadataTableName       = fmt.Sprintf("test-BlobMetadata-%v", UUID)
+	shadowMetadataTableName = fmt.Sprintf("test-BlobMetadata-Shadow-%v", UUID)
+	bucketTableName         = fmt.Sprintf("test-BucketStore-%v", UUID)
 
 	deployLocalStack bool
 	localStackPort   = "4568"
@@ -585,7 +586,7 @@ func setup() {
 
 	}
 
-	err = deploy.DeployResources(dockertestPool, localStackPort, metadataTableName, bucketTableName)
+	err = deploy.DeployResources(dockertestPool, localStackPort, metadataTableName, shadowMetadataTableName, bucketTableName)
 	if err != nil {
 		teardown()
 		panic("failed to deploy AWS resources")
@@ -631,7 +632,7 @@ func newTestServer(transactor core.Transactor) *apiserver.DispersalServer {
 	if err != nil {
 		panic("failed to create dynamoDB client")
 	}
-	blobMetadataStore := blobstore.NewBlobMetadataStore(dynamoClient, logger, metadataTableName, time.Hour)
+	blobMetadataStore := blobstore.NewBlobMetadataStore(dynamoClient, logger, metadataTableName, shadowMetadataTableName, time.Hour)
 
 	globalParams := common.GlobalRateParams{
 		CountFailed: false,

--- a/disperser/cmd/apiserver/config.go
+++ b/disperser/cmd/apiserver/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	RateConfig        apiserver.RateConfig
 	EnableRatelimiter bool
 	BucketTableName   string
+	ShadowTableName   string
 	BucketStoreSize   int
 	EthClientConfig   geth.EthClientConfig
 
@@ -53,8 +54,9 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			GrpcTimeout: ctx.GlobalDuration(flags.GrpcTimeoutFlag.Name),
 		},
 		BlobstoreConfig: blobstore.Config{
-			BucketName: ctx.GlobalString(flags.S3BucketNameFlag.Name),
-			TableName:  ctx.GlobalString(flags.DynamoDBTableNameFlag.Name),
+			BucketName:      ctx.GlobalString(flags.S3BucketNameFlag.Name),
+			TableName:       ctx.GlobalString(flags.DynamoDBTableNameFlag.Name),
+			ShadowTableName: ctx.GlobalString(flags.ShadowTableNameFlag.Name),
 		},
 		LoggerConfig: *loggerConfig,
 		MetricsConfig: disperser.MetricsConfig{

--- a/disperser/cmd/apiserver/flags/flags.go
+++ b/disperser/cmd/apiserver/flags/flags.go
@@ -111,6 +111,7 @@ var optionalFlags = []cli.Flag{
 	EnableRatelimiter,
 	BucketStoreSize,
 	GrpcTimeoutFlag,
+	ShadowTableNameFlag,
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/disperser/cmd/apiserver/flags/flags.go
+++ b/disperser/cmd/apiserver/flags/flags.go
@@ -30,6 +30,13 @@ var (
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "DYNAMODB_TABLE_NAME"),
 	}
+	ShadowTableNameFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "shadow-table-name"),
+		Usage:    "Name of the dynamodb table to shadow write blob metadata",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "SHADOW_TABLE_NAME"),
+		Value:    "",
+	}
 	GrpcPortFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "grpc-port"),
 		Usage:    "Port at which disperser listens for grpc calls",

--- a/disperser/cmd/apiserver/main.go
+++ b/disperser/cmd/apiserver/main.go
@@ -89,7 +89,7 @@ func RunDisperserServer(ctx *cli.Context) error {
 
 	bucketName := config.BlobstoreConfig.BucketName
 	logger.Info("Creating blob store", "bucket", bucketName)
-	blobMetadataStore := blobstore.NewBlobMetadataStore(dynamoClient, logger, config.BlobstoreConfig.TableName, time.Duration((storeDurationBlocks+blockStaleMeasure)*12)*time.Second)
+	blobMetadataStore := blobstore.NewBlobMetadataStore(dynamoClient, logger, config.BlobstoreConfig.TableName, config.BlobstoreConfig.ShadowTableName, time.Duration((storeDurationBlocks+blockStaleMeasure)*12)*time.Second)
 	blobStore := blobstore.NewSharedStorage(bucketName, s3Client, blobMetadataStore, logger)
 
 	reg := prometheus.NewRegistry()

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -192,7 +192,7 @@ func RunBatcher(ctx *cli.Context) error {
 	if err != nil || storeDurationBlocks == 0 {
 		return fmt.Errorf("failed to get STORE_DURATION_BLOCKS: %w", err)
 	}
-	blobMetadataStore := blobstore.NewBlobMetadataStore(dynamoClient, logger, config.BlobstoreConfig.TableName, time.Duration((storeDurationBlocks+blockStaleMeasure)*12)*time.Second)
+	blobMetadataStore := blobstore.NewBlobMetadataStore(dynamoClient, logger, config.BlobstoreConfig.TableName, config.BlobstoreConfig.ShadowTableName, time.Duration((storeDurationBlocks+blockStaleMeasure)*12)*time.Second)
 	queue := blobstore.NewSharedStorage(bucketName, s3Client, blobMetadataStore, logger)
 
 	cs := coreeth.NewChainState(tx, client)

--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -89,7 +89,7 @@ func RunDataApi(ctx *cli.Context) error {
 
 	var (
 		promClient        = dataapi.NewPrometheusClient(promApi, config.PrometheusConfig.Cluster)
-		blobMetadataStore = blobstore.NewBlobMetadataStore(dynamoClient, logger, config.BlobstoreConfig.TableName, 0)
+		blobMetadataStore = blobstore.NewBlobMetadataStore(dynamoClient, logger, config.BlobstoreConfig.TableName, config.BlobstoreConfig.ShadowTableName, 0)
 		sharedStorage     = blobstore.NewSharedStorage(config.BlobstoreConfig.BucketName, s3Client, blobMetadataStore, logger)
 		subgraphApi       = subgraph.NewApi(config.SubgraphApiBatchMetadataAddr, config.SubgraphApiOperatorStateAddr)
 		subgraphClient    = dataapi.NewSubgraphClient(subgraphApi, logger)

--- a/disperser/common/blobstore/blobstore_test.go
+++ b/disperser/common/blobstore/blobstore_test.go
@@ -45,9 +45,10 @@ var (
 	deployLocalStack bool
 	localStackPort   = "4569"
 
-	dynamoClient      *dynamodb.Client
-	blobMetadataStore *blobstore.BlobMetadataStore
-	sharedStorage     *blobstore.SharedBlobStore
+	dynamoClient            *dynamodb.Client
+	blobMetadataStore       *blobstore.BlobMetadataStore
+	shadowBlobMetadataStore *blobstore.BlobMetadataStore
+	sharedStorage           *blobstore.SharedBlobStore
 
 	UUID                    = uuid.New()
 	metadataTableName       = fmt.Sprintf("test-BlobMetadata-%v", UUID)
@@ -105,7 +106,8 @@ func setup(m *testing.M) {
 		panic("failed to create dynamodb client: " + err.Error())
 	}
 
-	blobMetadataStore = blobstore.NewBlobMetadataStore(dynamoClient, logger, metadataTableName, shadowMetadataTableName, time.Hour)
+	blobMetadataStore = blobstore.NewBlobMetadataStore(dynamoClient, logger, metadataTableName, metadataTableName, time.Hour)
+	shadowBlobMetadataStore = blobstore.NewBlobMetadataStore(dynamoClient, logger, metadataTableName, shadowMetadataTableName, time.Hour)
 	sharedStorage = blobstore.NewSharedStorage(bucketName, s3Client, blobMetadataStore, logger)
 }
 

--- a/disperser/common/blobstore/shared_storage.go
+++ b/disperser/common/blobstore/shared_storage.go
@@ -46,8 +46,9 @@ type SharedBlobStore struct {
 }
 
 type Config struct {
-	BucketName string
-	TableName  string
+	BucketName      string
+	TableName       string
+	ShadowTableName string
 }
 
 // This represents the s3 fetch result for a blob.

--- a/inabox/deploy/cmd/main.go
+++ b/inabox/deploy/cmd/main.go
@@ -16,8 +16,9 @@ var (
 	localstackFlagName      = "localstack-port"
 	deployResourcesFlagName = "deploy-resources"
 
-	metadataTableName = "test-BlobMetadata"
-	bucketTableName   = "test-BucketStore"
+	metadataTableName       = "test-BlobMetadata"
+	shadowMetadataTableName = "" // not used
+	bucketTableName         = "test-BucketStore"
 
 	chainCmdName      = "chain"
 	localstackCmdName = "localstack"
@@ -137,7 +138,7 @@ func localstack(ctx *cli.Context) error {
 	}
 
 	if ctx.Bool(deployResourcesFlagName) {
-		return deploy.DeployResources(pool, ctx.String(localstackFlagName), metadataTableName, bucketTableName)
+		return deploy.DeployResources(pool, ctx.String(localstackFlagName), metadataTableName, shadowMetadataTableName, bucketTableName)
 	}
 
 	return nil

--- a/inabox/deploy/localstack.go
+++ b/inabox/deploy/localstack.go
@@ -86,7 +86,7 @@ func StartDockertestWithLocalstackContainer(localStackPort string) (*dockertest.
 	return pool, resource, nil
 }
 
-func DeployResources(pool *dockertest.Pool, localStackPort, metadataTableName, bucketTableName string) error {
+func DeployResources(pool *dockertest.Pool, localStackPort, metadataTableName, shadowTableName, bucketTableName string) error {
 
 	if pool == nil {
 		var err error

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -39,15 +39,16 @@ var (
 	dockertestResource *dockertest.Resource
 	localStackPort     string
 
-	metadataTableName = "test-BlobMetadata"
-	bucketTableName   = "test-BucketStore"
-	logger            logging.Logger
-	ethClient         common.EthClient
-	rpcClient         common.RPCEthClient
-	mockRollup        *rollupbindings.ContractMockRollup
-	retrievalClient   clients.RetrievalClient
-	numConfirmations  int = 3
-	numRetries            = 0
+	metadataTableName       = "test-BlobMetadata"
+	shadowMetadataTableName = ""
+	bucketTableName         = "test-BucketStore"
+	logger                  logging.Logger
+	ethClient               common.EthClient
+	rpcClient               common.RPCEthClient
+	mockRollup              *rollupbindings.ContractMockRollup
+	retrievalClient         clients.RetrievalClient
+	numConfirmations        int = 3
+	numRetries                  = 0
 
 	cancel context.CancelFunc
 )
@@ -91,7 +92,7 @@ var _ = BeforeSuite(func() {
 			dockertestPool = pool
 			dockertestResource = resource
 
-			err = deploy.DeployResources(pool, localStackPort, metadataTableName, bucketTableName)
+			err = deploy.DeployResources(pool, localStackPort, metadataTableName, shadowMetadataTableName, bucketTableName)
 			Expect(err).To(BeNil())
 
 		} else {


### PR DESCRIPTION
## Why are these changes needed?
<img width="847" alt="image" src="https://github.com/user-attachments/assets/bb35e14e-66bd-4a33-aa23-912b8a189a79">

Adds shadow writes of putItem requests (only) to a separate dynamo table

Minibatcher (preprod) will be configured to use **BlobMetada-Shadow** as it's primary blob metadata store - isolating it from legacy Batcher.

Shadow writes are disabled by default and will not impact testnet/mainnet (unless we wanted to enable them there).

Shadow writes will dramatically simplify testing in preprod as we will not need to manage 2 dispersers + traffic generation for minibatch testing.

## Checks

- [x] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(
