### PR TITLE
Add BatchConfirmer

### DIFF
--- a/core/serialization.go
+++ b/core/serialization.go
@@ -57,6 +57,20 @@ func (h *BatchHeader) SetBatchRoot(blobHeaders []*BlobHeader) (*merkletree.Merkl
 	return tree, nil
 }
 
+func (h *BatchHeader) SetBatchRootFromBlobHeaderHashes(blobHeaderHashes [][32]byte) (*merkletree.MerkleTree, error) {
+	leafs := make([][]byte, len(blobHeaderHashes))
+	for i, hash := range blobHeaderHashes {
+		leafs[i] = hash[:]
+	}
+	tree, err := merkletree.NewTree(merkletree.WithData(leafs), merkletree.WithHashType(keccak256.New()))
+	if err != nil {
+		return nil, err
+	}
+
+	copy(h.BatchRoot[:], tree.Root())
+	return tree, nil
+}
+
 func (h *BatchHeader) Encode() ([]byte, error) {
 	// The order here has to match the field ordering of ReducedBatchHeader defined in IEigenDAServiceManager.sol
 	// ref: https://github.com/Layr-Labs/eigenda/blob/master/contracts/src/interfaces/IEigenDAServiceManager.sol#L43

--- a/disperser/batcher/batch_confirmer.go
+++ b/disperser/batcher/batch_confirmer.go
@@ -1,0 +1,532 @@
+package batcher
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"time"
+
+	"github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/disperser"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hashicorp/go-multierror"
+)
+
+type BatchConfirmerConfig struct {
+	PullInterval                 time.Duration
+	DispersalTimeout             time.Duration
+	DispersalStatusCheckInterval time.Duration
+	AttestationTimeout           time.Duration
+	SRSOrder                     int
+	NumConnections               int
+	MaxNumRetriesPerBlob         uint
+}
+
+type BatchConfirmer struct {
+	BatchConfirmerConfig
+
+	BlobStore      disperser.BlobStore
+	MinibatchStore MinibatchStore
+	Dispatcher     disperser.Dispatcher
+	EncoderClient  disperser.EncoderClient
+
+	ChainState         core.IndexedChainState
+	EncodingStreamer   *EncodingStreamer
+	Aggregator         core.SignatureAggregator
+	Transactor         core.Transactor
+	TransactionManager TxnManager
+	Minibatcher        *Minibatcher
+
+	ethClient common.EthClient
+	logger    logging.Logger
+}
+
+func NewBatchConfirmer(
+	config BatchConfirmerConfig,
+	blobStore disperser.BlobStore,
+	minibatchStore MinibatchStore,
+	dispatcher disperser.Dispatcher,
+	chainState core.IndexedChainState,
+	assignmentCoordinator core.AssignmentCoordinator,
+	encodingStreamer *EncodingStreamer,
+	aggregator core.SignatureAggregator,
+	ethClient common.EthClient,
+	transactor core.Transactor,
+	txnManager TxnManager,
+	minibatcher *Minibatcher,
+	logger logging.Logger,
+) (*BatchConfirmer, error) {
+	return &BatchConfirmer{
+		BatchConfirmerConfig: config,
+
+		BlobStore:        blobStore,
+		MinibatchStore:   minibatchStore,
+		Dispatcher:       dispatcher,
+		EncodingStreamer: encodingStreamer,
+
+		ChainState:         chainState,
+		Aggregator:         aggregator,
+		Transactor:         transactor,
+		TransactionManager: txnManager,
+		Minibatcher:        minibatcher,
+
+		ethClient: ethClient,
+		logger:    logger.With("component", "BatchConfirmer"),
+	}, nil
+}
+
+func (b *BatchConfirmer) Start(ctx context.Context) error {
+	err := b.ChainState.Start(ctx)
+	if err != nil {
+		return err
+	}
+	// Wait for few seconds for indexer to index blockchain
+	// This won't be needed when we switch to using Graph node
+	time.Sleep(indexerWarmupDelay)
+
+	go func() {
+		receiptChan := b.TransactionManager.ReceiptChan()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case receiptOrErr := <-receiptChan:
+				b.logger.Info("received response from transaction manager", "receipt", receiptOrErr.Receipt, "err", receiptOrErr.Err)
+				err := b.ProcessConfirmedBatch(ctx, receiptOrErr)
+				if err != nil {
+					b.logger.Error("failed to process confirmed batch", "err", err)
+				}
+			}
+		}
+	}()
+	b.TransactionManager.Start(ctx)
+
+	go func() {
+		ticker := time.NewTicker(b.PullInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := b.HandleSingleBatch(ctx); err != nil {
+					b.logger.Error("failed to process a batch", "err", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// updateConfirmationInfo updates the confirmation info for each blob in the batch and returns failed blobs to retry.
+func (b *BatchConfirmer) updateConfirmationInfo(
+	ctx context.Context,
+	batchData confirmationMetadata,
+	txnReceipt *types.Receipt,
+) ([]*disperser.BlobMetadata, error) {
+	if txnReceipt.BlockNumber == nil {
+		return nil, errors.New("error getting transaction receipt block number")
+	}
+	if len(batchData.blobs) == 0 {
+		return nil, errors.New("failed to process confirmed batch: no blobs from transaction manager metadata")
+	}
+	if batchData.batchHeader == nil {
+		return nil, errors.New("failed to process confirmed batch: batch header from transaction manager metadata is nil")
+	}
+	if len(batchData.blobHeaders) == 0 {
+		return nil, errors.New("failed to process confirmed batch: no blob headers from transaction manager metadata")
+	}
+	if batchData.merkleTree == nil {
+		return nil, errors.New("failed to process confirmed batch: merkle tree from transaction manager metadata is nil")
+	}
+	if batchData.aggSig == nil {
+		return nil, errors.New("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
+	}
+	headerHash, err := batchData.batchHeader.GetBatchHeaderHash()
+	if err != nil {
+		return nil, fmt.Errorf("error getting batch header hash: %w", err)
+	}
+	batchID, err := b.getBatchID(ctx, txnReceipt)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching batch ID: %w", err)
+	}
+
+	blobsToRetry := make([]*disperser.BlobMetadata, 0)
+	var updateConfirmationInfoErr error
+
+	for blobIndex, metadata := range batchData.blobs {
+		// Mark the blob failed if it didn't get enough signatures.
+		status := disperser.InsufficientSignatures
+
+		var proof []byte
+		if isBlobAttested(batchData.aggSig.QuorumResults, batchData.blobHeaders[blobIndex]) {
+			status = disperser.Confirmed
+			// generate inclusion proof
+			blobHeader := batchData.blobHeaders[blobIndex]
+
+			blobHeaderHash, err := blobHeader.GetBlobHeaderHash()
+			if err != nil {
+				b.logger.Error("failed to get blob header hash", "err", err)
+				blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
+				continue
+			}
+			merkleProof, err := batchData.merkleTree.GenerateProof(blobHeaderHash[:], 0)
+			if err != nil {
+				b.logger.Error("failed to generate blob header inclusion proof", "err", err)
+				blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
+				continue
+			}
+			proof = serializeProof(merkleProof)
+		}
+
+		confirmationInfo := &disperser.ConfirmationInfo{
+			BatchHeaderHash:         headerHash,
+			BlobIndex:               uint32(blobIndex),
+			SignatoryRecordHash:     core.ComputeSignatoryRecordHash(uint32(batchData.batchHeader.ReferenceBlockNumber), batchData.aggSig.NonSigners),
+			ReferenceBlockNumber:    uint32(batchData.batchHeader.ReferenceBlockNumber),
+			BatchRoot:               batchData.batchHeader.BatchRoot[:],
+			BlobInclusionProof:      proof,
+			BlobCommitment:          &batchData.blobHeaders[blobIndex].BlobCommitments,
+			BatchID:                 uint32(batchID),
+			ConfirmationTxnHash:     txnReceipt.TxHash,
+			ConfirmationBlockNumber: uint32(txnReceipt.BlockNumber.Uint64()),
+			Fee:                     []byte{0}, // No fee
+			QuorumResults:           batchData.aggSig.QuorumResults,
+			BlobQuorumInfos:         batchData.blobHeaders[blobIndex].QuorumInfos,
+		}
+
+		if status == disperser.Confirmed {
+			// TODO: add metrics for confirmed blobs
+			if _, updateConfirmationInfoErr = b.BlobStore.MarkBlobConfirmed(ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
+				b.logger.Debug("blob confirmed", "blobKey", metadata.GetBlobKey())
+				// b.Metrics.UpdateCompletedBlob(int(metadata.RequestMetadata.BlobSize), disperser.Confirmed)
+			}
+		} else if status == disperser.InsufficientSignatures {
+			if _, updateConfirmationInfoErr = b.BlobStore.MarkBlobInsufficientSignatures(ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
+				b.logger.Debug("blob marked as insufficient signatures", "blobKey", metadata.GetBlobKey())
+				// b.Metrics.UpdateCompletedBlob(int(metadata.RequestMetadata.BlobSize), disperser.InsufficientSignatures)
+			}
+		} else {
+			updateConfirmationInfoErr = fmt.Errorf("trying to update confirmation info for blob in status other than confirmed or insufficient signatures: %s", status.String())
+		}
+		if updateConfirmationInfoErr != nil {
+			b.logger.Error("error updating blob confirmed metadata", "err", updateConfirmationInfoErr)
+			blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
+		}
+	}
+
+	return blobsToRetry, nil
+}
+
+func (b *BatchConfirmer) ProcessConfirmedBatch(ctx context.Context, receiptOrErr *ReceiptOrErr) error {
+	if receiptOrErr.Metadata == nil {
+		return errors.New("failed to process confirmed batch: no metadata from transaction manager response")
+	}
+	confirmationMetadata := receiptOrErr.Metadata.(confirmationMetadata)
+	blobs := confirmationMetadata.blobs
+	if len(blobs) == 0 {
+		return errors.New("failed to process confirmed batch: no blobs from transaction manager metadata")
+	}
+	if receiptOrErr.Err != nil {
+		_ = b.handleFailure(ctx, blobs, FailConfirmBatch)
+		return fmt.Errorf("failed to confirm batch onchain: %w", receiptOrErr.Err)
+	}
+	if confirmationMetadata.aggSig == nil {
+		_ = b.handleFailure(ctx, blobs, FailNoAggregatedSignature)
+		return errors.New("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
+	}
+	b.logger.Info("received ConfirmBatch transaction receipt", "blockNumber", receiptOrErr.Receipt.BlockNumber, "txnHash", receiptOrErr.Receipt.TxHash.Hex())
+
+	// Mark the blobs as complete
+	stageTimer := time.Now()
+	blobsToRetry, err := b.updateConfirmationInfo(ctx, confirmationMetadata, receiptOrErr.Receipt)
+	if err != nil {
+		_ = b.handleFailure(ctx, blobs, FailUpdateConfirmationInfo)
+		return fmt.Errorf("failed to update confirmation info: %w", err)
+	}
+	if len(blobsToRetry) > 0 {
+		b.logger.Error("failed to update confirmation info", "failed", len(blobsToRetry), "total", len(blobs))
+		_ = b.handleFailure(ctx, blobsToRetry, FailUpdateConfirmationInfo)
+	}
+	b.logger.Debug("Update confirmation info took", "duration", time.Since(stageTimer).String())
+	batchSize := int64(0)
+	for _, blobMeta := range blobs {
+		batchSize += int64(blobMeta.RequestMetadata.BlobSize)
+	}
+
+	return nil
+}
+
+func (b *BatchConfirmer) handleFailure(ctx context.Context, blobMetadatas []*disperser.BlobMetadata, reason FailReason) error {
+	var result *multierror.Error
+	numPermanentFailures := 0
+	for _, metadata := range blobMetadatas {
+		retry, err := b.BlobStore.HandleBlobFailure(ctx, metadata, b.MaxNumRetriesPerBlob)
+		if err != nil {
+			b.logger.Error("HandleSingleBatch: error handling blob failure", "err", err)
+			// Append the error
+			result = multierror.Append(result, err)
+		}
+
+		if retry {
+			continue
+		}
+
+		numPermanentFailures++
+	}
+
+	// Return the error(s)
+	return result.ErrorOrNil()
+}
+
+func (b *BatchConfirmer) HandleSingleBatch(ctx context.Context) error {
+	currentBlock, err := b.ethClient.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting current block number: %w", err)
+	}
+
+	err = b.EncodingStreamer.UpdateReferenceBlock(uint(currentBlock))
+	if err != nil {
+		return fmt.Errorf("error updating reference block number: %w", err)
+	}
+
+	// Get the pending batch
+	b.logger.Debug("Getting latest formed batch...")
+	stateUpdateTicker := time.NewTicker(b.DispersalStatusCheckInterval)
+	var batch *BatchRecord
+	var minibatches []*MinibatchRecord
+	for batch == nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-stateUpdateTicker.C:
+			batch, minibatches, err = b.MinibatchStore.GetLatestFormedBatch(ctx)
+			if err != nil {
+				b.logger.Error("error getting latest formed batch", "err", err)
+			}
+		}
+	}
+
+	if len(minibatches) == 0 {
+		return fmt.Errorf("no minibatches in the batch %s", batch.ID)
+	}
+
+	// Make sure all minibatches in the batch have been dispersed
+	batchDispersed := false
+	stateUpdateTicker.Reset(b.DispersalStatusCheckInterval)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, b.DispersalTimeout)
+	defer cancel()
+	for !batchDispersed {
+		select {
+		case <-ctxWithTimeout.Done():
+			return ctxWithTimeout.Err()
+		case <-stateUpdateTicker.C:
+			batchDispersed, err = b.MinibatchStore.BatchDispersed(ctx, batch.ID)
+			if err != nil {
+				b.logger.Error("error checking if batch is dispersed", "err", err)
+			}
+		}
+	}
+
+	if !batchDispersed {
+		return errors.New("batch not dispersed")
+	}
+
+	// Get batch state
+	batchState := b.Minibatcher.PopBatchState(batch.ID)
+	if batchState == nil {
+		return fmt.Errorf("no batch state found for batch %s", batch.ID)
+	}
+
+	// Construct batch header
+	b.logger.Debug("Constructing batch header...")
+	batchHeader := &core.BatchHeader{
+		ReferenceBlockNumber: batch.ReferenceBlockNumber,
+		BatchRoot:            [32]byte{},
+	}
+	blobHeaderHashes := make([][32]byte, 0)
+	for _, minibatch := range minibatches {
+		blobHeaderHashes = append(blobHeaderHashes, minibatch.BlobHeaderHashes...)
+	}
+	merkleTree, err := batchHeader.SetBatchRootFromBlobHeaderHashes(blobHeaderHashes)
+	if err != nil {
+		return fmt.Errorf("error setting batch root from blob header hashes: %w", err)
+	}
+	batchHeaderHash, err := batchHeader.GetBatchHeaderHash()
+	if err != nil {
+		return fmt.Errorf("error getting batch header hash: %w", err)
+	}
+
+	// Make AttestBatch call
+	b.logger.Debug("Attesting batch...")
+	quorumIDsMap := make(map[core.QuorumID]struct{})
+	for _, blobHeader := range batchState.BlobHeaders {
+		for _, q := range blobHeader.QuorumInfos {
+			if _, ok := quorumIDsMap[q.QuorumID]; !ok {
+				quorumIDsMap[q.QuorumID] = struct{}{}
+			}
+		}
+	}
+	quorumIDs := make([]core.QuorumID, len(quorumIDsMap))
+	i := 0
+	for q := range quorumIDsMap {
+		quorumIDs[i] = q
+		i++
+	}
+
+	replyChan, err := b.Dispatcher.AttestBatch(ctx, batchState.OperatorState, blobHeaderHashes, batchHeader)
+	if err != nil {
+		return fmt.Errorf("error making attesting batch request: %w", err)
+	}
+
+	// Aggregate the signatures
+	b.logger.Debug("Aggregating signatures...")
+
+	quorumAttestation, err := b.Aggregator.ReceiveSignatures(ctx, batchState.OperatorState, batchHeaderHash, replyChan)
+	if err != nil {
+		_ = b.handleFailure(ctx, batchState.BlobMetadata, FailAggregateSignatures)
+		return fmt.Errorf("error receiving and validating signatures: %w", err)
+	}
+	operatorCount := make(map[core.QuorumID]int)
+	signerCount := make(map[core.QuorumID]int)
+	for quorumID, opState := range batchState.OperatorState.Operators {
+		operatorCount[quorumID] = len(opState)
+		if _, ok := signerCount[quorumID]; !ok {
+			signerCount[quorumID] = 0
+		}
+		for opID := range opState {
+			if _, ok := quorumAttestation.SignerMap[opID]; ok {
+				signerCount[quorumID]++
+			}
+		}
+	}
+	b.logger.Debug("received signatures", "signerCount", signerCount, "operatorCount", operatorCount)
+	for _, quorumResult := range quorumAttestation.QuorumResults {
+		b.logger.Info("aggregated quorum result", "quorumID", quorumResult.QuorumID, "percentSigned", quorumResult.PercentSigned)
+	}
+
+	numPassed, passedQuorums := numBlobsAttestedByQuorum(quorumAttestation.QuorumResults, batchState.BlobHeaders)
+	// TODO(mooselumph): Determine whether to confirm the batch based on the number of successes
+	if numPassed == 0 {
+		_ = b.handleFailure(ctx, batchState.BlobMetadata, FailNoSignatures)
+		return errors.New("no blobs received sufficient signatures")
+	}
+
+	nonEmptyQuorums := []core.QuorumID{}
+	for quorumID := range passedQuorums {
+		b.logger.Info("Quorums successfully attested", "quorumID", quorumID)
+		nonEmptyQuorums = append(nonEmptyQuorums, quorumID)
+	}
+
+	// Aggregate the signatures across only the non-empty quorums. Excluding empty quorums reduces the gas cost.
+	aggSig, err := b.Aggregator.AggregateSignatures(ctx, b.ChainState, batchHeader.ReferenceBlockNumber, quorumAttestation, nonEmptyQuorums)
+	if err != nil {
+		_ = b.handleFailure(ctx, batchState.BlobMetadata, FailAggregateSignatures)
+		return fmt.Errorf("error aggregating signatures: %w", err)
+	}
+
+	b.logger.Debug("Confirming batch...")
+
+	txn, err := b.Transactor.BuildConfirmBatchTxn(ctx, batchHeader, aggSig.QuorumResults, aggSig)
+	if err != nil {
+		_ = b.handleFailure(ctx, batchState.BlobMetadata, FailConfirmBatch)
+		return fmt.Errorf("error building confirmBatch transaction: %w", err)
+	}
+	err = b.TransactionManager.ProcessTransaction(ctx, NewTxnRequest(txn, "confirmBatch", big.NewInt(0), confirmationMetadata{
+		batchHeader: batchHeader,
+		blobs:       batchState.BlobMetadata,
+		blobHeaders: batchState.BlobHeaders,
+		merkleTree:  merkleTree,
+		aggSig:      aggSig,
+	}))
+	if err != nil {
+		_ = b.handleFailure(ctx, batchState.BlobMetadata, FailConfirmBatch)
+		return fmt.Errorf("error sending confirmBatch transaction: %w", err)
+	}
+
+	return nil
+}
+
+func (b *BatchConfirmer) parseBatchIDFromReceipt(txReceipt *types.Receipt) (uint32, error) {
+	if len(txReceipt.Logs) == 0 {
+		return 0, errors.New("failed to get transaction receipt with logs")
+	}
+	for _, log := range txReceipt.Logs {
+		if len(log.Topics) == 0 {
+			b.logger.Debug("transaction receipt has no topics")
+			continue
+		}
+		b.logger.Debug("[getBatchIDFromReceipt] ", "sigHash", log.Topics[0].Hex())
+
+		if log.Topics[0] == common.BatchConfirmedEventSigHash {
+			smAbi, err := abi.JSON(bytes.NewReader(common.ServiceManagerAbi))
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse ServiceManager ABI: %w", err)
+			}
+			eventAbi, err := smAbi.EventByID(common.BatchConfirmedEventSigHash)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse BatchConfirmed event ABI: %w", err)
+			}
+			unpackedData, err := eventAbi.Inputs.Unpack(log.Data)
+			if err != nil {
+				return 0, fmt.Errorf("failed to unpack BatchConfirmed log data: %w", err)
+			}
+
+			// There should be exactly one input in the data field, batchId.
+			// Labs/eigenda/blob/master/contracts/src/interfaces/IEigenDAServiceManager.sol#L17
+			if len(unpackedData) != 1 {
+				return 0, fmt.Errorf("BatchConfirmed log should contain exactly 1 inputs. Found %d", len(unpackedData))
+			}
+			return unpackedData[0].(uint32), nil
+		}
+	}
+	return 0, errors.New("failed to find BatchConfirmed log from the transaction")
+}
+
+func (b *BatchConfirmer) getBatchID(ctx context.Context, txReceipt *types.Receipt) (uint32, error) {
+	const (
+		maxRetries = 4
+		baseDelay  = 1 * time.Second
+	)
+	var (
+		batchID uint32
+		err     error
+	)
+
+	batchID, err = b.parseBatchIDFromReceipt(txReceipt)
+	if err == nil {
+		return batchID, nil
+	}
+
+	txHash := txReceipt.TxHash
+	for i := 0; i < maxRetries; i++ {
+		retrySec := math.Pow(2, float64(i))
+		b.logger.Warn("failed to get transaction receipt, retrying...", "retryIn", retrySec, "err", err)
+		time.Sleep(time.Duration(retrySec) * baseDelay)
+
+		txReceipt, err = b.ethClient.TransactionReceipt(ctx, txHash)
+		if err != nil {
+			continue
+		}
+
+		batchID, err = b.parseBatchIDFromReceipt(txReceipt)
+		if err == nil {
+			return batchID, nil
+		}
+	}
+
+	if err != nil {
+		b.logger.Warn("failed to get transaction receipt after retries", "numRetries", maxRetries, "err", err)
+		return 0, err
+	}
+
+	return batchID, nil
+}

--- a/disperser/batcher/batch_confirmer_test.go
+++ b/disperser/batcher/batch_confirmer_test.go
@@ -1,0 +1,477 @@
+package batcher_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	cmock "github.com/Layr-Labs/eigenda/common/mock"
+	"github.com/Layr-Labs/eigenda/core"
+	coremock "github.com/Layr-Labs/eigenda/core/mock"
+	"github.com/Layr-Labs/eigenda/disperser"
+	bat "github.com/Layr-Labs/eigenda/disperser/batcher"
+	batcherinmem "github.com/Layr-Labs/eigenda/disperser/batcher/inmem"
+	batchermock "github.com/Layr-Labs/eigenda/disperser/batcher/mock"
+	batmock "github.com/Layr-Labs/eigenda/disperser/batcher/mock"
+	"github.com/Layr-Labs/eigenda/disperser/common/inmem"
+	dmock "github.com/Layr-Labs/eigenda/disperser/mock"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/gammazero/workerpool"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type batchConfirmerComponents struct {
+	batchConfirmer   *bat.BatchConfirmer
+	blobStore        disperser.BlobStore
+	minibatchStore   bat.MinibatchStore
+	minibatcher      *bat.Minibatcher
+	dispatcher       *dmock.Dispatcher
+	chainData        *coremock.ChainDataMock
+	transactor       *coremock.MockTransactor
+	txnManager       *batchermock.MockTxnManager
+	encodingStreamer *bat.EncodingStreamer
+	ethClient        *cmock.MockEthClient
+}
+
+func makeBatchConfirmer(t *testing.T) *batchConfirmerComponents {
+	logger := logging.NewNoopLogger()
+	asgn := &core.StdAssignmentCoordinator{}
+	transactor := &coremock.MockTransactor{}
+	agg, err := core.NewStdSignatureAggregator(logger, transactor)
+	assert.NoError(t, err)
+	state := mockChainState.GetTotalOperatorState(context.Background(), 0)
+	dispatcher := dmock.NewDispatcher(state)
+	blobStore := inmem.NewBlobStore()
+	ethClient := &cmock.MockEthClient{}
+	txnManager := batmock.NewTxnManager()
+	minibatchStore := batcherinmem.NewMinibatchStore(logger)
+	encodingWorkerPool := workerpool.New(10)
+	p, err := makeTestProver()
+	assert.NoError(t, err)
+	encoderClient := disperser.NewLocalEncoderClient(p)
+	metrics := bat.NewMetrics("9100", logger)
+	trigger := bat.NewEncodedSizeNotifier(
+		make(chan struct{}, 1),
+		10*1024*1024,
+	)
+	encodingStreamer, err := bat.NewEncodingStreamer(streamerConfig, blobStore, mockChainState, encoderClient, asgn, trigger, encodingWorkerPool, metrics.EncodingStreamerMetrics, logger)
+	assert.NoError(t, err)
+	pool := workerpool.New(int(10))
+	minibatcher, err := bat.NewMinibatcher(bat.MinibatcherConfig{
+		PullInterval:              100 * time.Millisecond,
+		MaxNumConnections:         10,
+		MaxNumRetriesPerBlob:      2,
+		MaxNumRetriesPerDispersal: 1,
+	}, blobStore, minibatchStore, dispatcher, mockChainState, asgn, encodingStreamer, ethClient, pool, logger)
+	assert.NoError(t, err)
+
+	config := bat.BatchConfirmerConfig{
+		PullInterval:                 100 * time.Millisecond,
+		DispersalTimeout:             1 * time.Second,
+		DispersalStatusCheckInterval: 100 * time.Millisecond,
+		AttestationTimeout:           1 * time.Second,
+		NumConnections:               1,
+		SRSOrder:                     3000,
+		MaxNumRetriesPerBlob:         2,
+	}
+	b, err := bat.NewBatchConfirmer(config, blobStore, minibatchStore, dispatcher, mockChainState, asgn, encodingStreamer, agg, ethClient, transactor, txnManager, minibatcher, logger)
+	assert.NoError(t, err)
+
+	ethClient.On("BlockNumber").Return(uint64(initialBlock), nil)
+
+	return &batchConfirmerComponents{
+		batchConfirmer:   b,
+		blobStore:        blobStore,
+		minibatchStore:   minibatchStore,
+		minibatcher:      minibatcher,
+		dispatcher:       dispatcher,
+		chainData:        mockChainState,
+		transactor:       transactor,
+		txnManager:       txnManager,
+		encodingStreamer: b.EncodingStreamer,
+		ethClient:        ethClient,
+	}
+}
+
+func TestBatchConfirmerIteration(t *testing.T) {
+	components := makeBatchConfirmer(t)
+	b := components.batchConfirmer
+	batchID, err := uuid.NewV7()
+	assert.NoError(t, err)
+	batch := &bat.BatchRecord{
+		ID:                   batchID,
+		CreatedAt:            time.Now(),
+		ReferenceBlockNumber: uint(initialBlock),
+		Status:               bat.BatchStatusFormed,
+		HeaderHash:           [32]byte{},
+		AggregatePubKey:      &core.G2Point{},
+		AggregateSignature:   &core.Signature{},
+	}
+	err = b.MinibatchStore.PutBatch(context.Background(), batch)
+	assert.NoError(t, err)
+	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
+		BatchID:              batchID,
+		MinibatchIndex:       0,
+		BlobHeaderHashes:     [][32]byte{{1}, {2}},
+		BatchSize:            0,
+		ReferenceBlockNumber: uint(initialBlock),
+	})
+	assert.NoError(t, err)
+	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
+		BatchID:              batchID,
+		MinibatchIndex:       1,
+		BlobHeaderHashes:     [][32]byte{{3}, {4}},
+		BatchSize:            0,
+		ReferenceBlockNumber: uint(initialBlock),
+	})
+	assert.NoError(t, err)
+	operatorState := components.chainData.GetTotalOperatorState(context.Background(), 0)
+
+	for opID, opInfo := range operatorState.PrivateOperators {
+		req0 := &bat.DispersalRequest{
+			BatchID:        batchID,
+			MinibatchIndex: 0,
+			OperatorID:     opID,
+			Socket:         opInfo.DispersalPort,
+			NumBlobs:       2,
+			RequestedAt:    time.Now(),
+			BlobHash:       "0",
+			MetadataHash:   "0",
+		}
+		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req0)
+		assert.NoError(t, err)
+		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
+			DispersalRequest: *req0,
+			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
+			RespondedAt:      time.Now(),
+			Error:            nil,
+		})
+		assert.NoError(t, err)
+
+		req1 := &bat.DispersalRequest{
+			BatchID:        batchID,
+			MinibatchIndex: 1,
+			OperatorID:     opID,
+			Socket:         opInfo.DispersalPort,
+			NumBlobs:       2,
+			RequestedAt:    time.Now(),
+			BlobHash:       "1",
+			MetadataHash:   "1",
+		}
+		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req1)
+		assert.NoError(t, err)
+		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
+			DispersalRequest: *req1,
+			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{1})},
+			RespondedAt:      time.Now(),
+			Error:            nil,
+		})
+		assert.NoError(t, err)
+	}
+
+	b.Minibatcher.Batches[batchID] = &bat.BatchState{
+		BatchID:              batchID,
+		ReferenceBlockNumber: uint(initialBlock),
+		BlobHeaders: []*core.BlobHeader{
+			{
+				AccountID: "0",
+				QuorumInfos: []*core.BlobQuorumInfo{
+					{
+						SecurityParam: core.SecurityParam{
+							QuorumID:              0,
+							AdversaryThreshold:    30,
+							ConfirmationThreshold: 80,
+						},
+					},
+					{
+						SecurityParam: core.SecurityParam{
+							QuorumID:              1,
+							AdversaryThreshold:    30,
+							ConfirmationThreshold: 80,
+						},
+					},
+				},
+			},
+			{
+				AccountID: "1",
+				QuorumInfos: []*core.BlobQuorumInfo{
+					{
+						SecurityParam: core.SecurityParam{
+							QuorumID:              0,
+							AdversaryThreshold:    30,
+							ConfirmationThreshold: 80,
+						},
+					},
+					{
+						SecurityParam: core.SecurityParam{
+							QuorumID:              1,
+							AdversaryThreshold:    30,
+							ConfirmationThreshold: 80,
+						},
+					},
+				},
+			},
+		},
+		BlobMetadata:   []*disperser.BlobMetadata{},
+		OperatorState:  operatorState.IndexedOperatorState,
+		NumMinibatches: 2,
+	}
+
+	signChan := make(chan core.SigningMessage, 4)
+	batchHeaderHash := [32]byte{93, 156, 41, 17, 3, 78, 159, 243, 222, 111, 54, 107, 237, 48, 243, 176, 224, 151, 96, 151, 159, 99, 118, 186, 53, 192, 72, 59, 160, 73, 7, 213}
+	for opID, opInfo := range operatorState.PrivateOperators {
+		signChan <- core.SigningMessage{
+			Signature:       opInfo.KeyPair.SignMessage(batchHeaderHash),
+			Operator:        opID,
+			BatchHeaderHash: batchHeaderHash,
+			Err:             nil,
+		}
+	}
+	components.dispatcher.On("AttestBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(signChan, nil)
+	txn := types.NewTransaction(0, gethcommon.Address{}, big.NewInt(0), 0, big.NewInt(0), nil)
+	components.transactor.On("OperatorIDToAddress").Return(gethcommon.Address{}, nil)
+	components.transactor.On("BuildConfirmBatchTxn", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(
+		func(args mock.Arguments) {
+			assert.Equal(t, args.Get(1).(*core.BatchHeader).ReferenceBlockNumber, uint(initialBlock))
+			assert.NotNil(t, args.Get(1).(*core.BatchHeader).BatchRoot)
+			assert.Equal(t, args.Get(2).(map[uint8]*core.QuorumResult)[0].PercentSigned, uint8(100))
+			assert.Equal(t, args.Get(2).(map[uint8]*core.QuorumResult)[1].PercentSigned, uint8(100))
+		},
+	).Return(txn, nil)
+	components.txnManager.On("ProcessTransaction").Return(nil)
+	err = b.HandleSingleBatch(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestBatchConfirmerIterationFailure(t *testing.T) {
+	// If dispersal responses are not received for all dispersal requests, the batch should not be confirmed
+	components := makeBatchConfirmer(t)
+	b := components.batchConfirmer
+	batchID, err := uuid.NewV7()
+	assert.NoError(t, err)
+	batch := &bat.BatchRecord{
+		ID:                   batchID,
+		CreatedAt:            time.Now(),
+		ReferenceBlockNumber: uint(initialBlock),
+		Status:               bat.BatchStatusFormed,
+		HeaderHash:           [32]byte{},
+		AggregatePubKey:      &core.G2Point{},
+		AggregateSignature:   &core.Signature{},
+	}
+	err = b.MinibatchStore.PutBatch(context.Background(), batch)
+	assert.NoError(t, err)
+	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
+		BatchID:              batchID,
+		MinibatchIndex:       0,
+		BlobHeaderHashes:     [][32]byte{{1}, {2}},
+		BatchSize:            0,
+		ReferenceBlockNumber: uint(initialBlock),
+	})
+	assert.NoError(t, err)
+	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
+		BatchID:              batchID,
+		MinibatchIndex:       1,
+		BlobHeaderHashes:     [][32]byte{{3}, {4}},
+		BatchSize:            0,
+		ReferenceBlockNumber: uint(initialBlock),
+	})
+	assert.NoError(t, err)
+	operatorState := components.chainData.GetTotalOperatorState(context.Background(), 0)
+
+	for opID, opInfo := range operatorState.PrivateOperators {
+		req0 := &bat.DispersalRequest{
+			BatchID:        batchID,
+			MinibatchIndex: 0,
+			OperatorID:     opID,
+			Socket:         opInfo.DispersalPort,
+			NumBlobs:       2,
+			RequestedAt:    time.Now(),
+			BlobHash:       "0",
+			MetadataHash:   "0",
+		}
+		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req0)
+		assert.NoError(t, err)
+		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
+			DispersalRequest: *req0,
+			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
+			RespondedAt:      time.Now(),
+			Error:            nil,
+		})
+		assert.NoError(t, err)
+
+		req1 := &bat.DispersalRequest{
+			BatchID:        batchID,
+			MinibatchIndex: 1,
+			OperatorID:     opID,
+			Socket:         opInfo.DispersalPort,
+			NumBlobs:       2,
+			RequestedAt:    time.Now(),
+			BlobHash:       "1",
+			MetadataHash:   "1",
+		}
+		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req1)
+		assert.NoError(t, err)
+		// Missing RespondedAt
+		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
+			DispersalRequest: *req1,
+		})
+		assert.NoError(t, err)
+	}
+
+	err = b.HandleSingleBatch(context.Background())
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestBatchConfirmerInsufficientSignatures(t *testing.T) {
+	components := makeBatchConfirmer(t)
+	b := components.batchConfirmer
+	batchID, err := uuid.NewV7()
+	assert.NoError(t, err)
+	batch := &bat.BatchRecord{
+		ID:                   batchID,
+		CreatedAt:            time.Now(),
+		ReferenceBlockNumber: uint(initialBlock),
+		Status:               bat.BatchStatusFormed,
+		HeaderHash:           [32]byte{},
+		AggregatePubKey:      &core.G2Point{},
+		AggregateSignature:   &core.Signature{},
+	}
+	err = b.MinibatchStore.PutBatch(context.Background(), batch)
+	assert.NoError(t, err)
+	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
+		BatchID:              batchID,
+		MinibatchIndex:       0,
+		BlobHeaderHashes:     [][32]byte{{1}, {2}},
+		BatchSize:            0,
+		ReferenceBlockNumber: uint(initialBlock),
+	})
+	assert.NoError(t, err)
+	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
+		BatchID:              batchID,
+		MinibatchIndex:       1,
+		BlobHeaderHashes:     [][32]byte{{3}, {4}},
+		BatchSize:            0,
+		ReferenceBlockNumber: uint(initialBlock),
+	})
+	assert.NoError(t, err)
+	operatorState := components.chainData.GetTotalOperatorState(context.Background(), 0)
+
+	for opID, opInfo := range operatorState.PrivateOperators {
+		req0 := &bat.DispersalRequest{
+			BatchID:        batchID,
+			MinibatchIndex: 0,
+			OperatorID:     opID,
+			Socket:         opInfo.DispersalPort,
+			NumBlobs:       2,
+			RequestedAt:    time.Now(),
+			BlobHash:       "0",
+			MetadataHash:   "0",
+		}
+		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req0)
+		assert.NoError(t, err)
+		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
+			DispersalRequest: *req0,
+			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
+			RespondedAt:      time.Now(),
+			Error:            nil,
+		})
+		assert.NoError(t, err)
+
+		req1 := &bat.DispersalRequest{
+			BatchID:        batchID,
+			MinibatchIndex: 1,
+			OperatorID:     opID,
+			Socket:         opInfo.DispersalPort,
+			NumBlobs:       2,
+			RequestedAt:    time.Now(),
+			BlobHash:       "1",
+			MetadataHash:   "1",
+		}
+		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req1)
+		assert.NoError(t, err)
+		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
+			DispersalRequest: *req1,
+			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{1})},
+			RespondedAt:      time.Now(),
+			Error:            nil,
+		})
+		assert.NoError(t, err)
+	}
+
+	b.Minibatcher.Batches[batchID] = &bat.BatchState{
+		BatchID:              batchID,
+		ReferenceBlockNumber: uint(initialBlock),
+		BlobHeaders: []*core.BlobHeader{
+			{
+				AccountID: "0",
+				QuorumInfos: []*core.BlobQuorumInfo{
+					{
+						SecurityParam: core.SecurityParam{
+							QuorumID:              0,
+							AdversaryThreshold:    30,
+							ConfirmationThreshold: 80,
+						},
+					},
+					{
+						SecurityParam: core.SecurityParam{
+							QuorumID:              1,
+							AdversaryThreshold:    30,
+							ConfirmationThreshold: 80,
+						},
+					},
+				},
+			},
+			{
+				AccountID: "1",
+				QuorumInfos: []*core.BlobQuorumInfo{
+					{
+						SecurityParam: core.SecurityParam{
+							QuorumID:              0,
+							AdversaryThreshold:    30,
+							ConfirmationThreshold: 80,
+						},
+					},
+					{
+						SecurityParam: core.SecurityParam{
+							QuorumID:              1,
+							AdversaryThreshold:    30,
+							ConfirmationThreshold: 80,
+						},
+					},
+				},
+			},
+		},
+		BlobMetadata:   []*disperser.BlobMetadata{},
+		OperatorState:  operatorState.IndexedOperatorState,
+		NumMinibatches: 2,
+	}
+
+	signChan := make(chan core.SigningMessage, 4)
+	batchHeaderHash := [32]byte{93, 156, 41, 17, 3, 78, 159, 243, 222, 111, 54, 107, 237, 48, 243, 176, 224, 151, 96, 151, 159, 99, 118, 186, 53, 192, 72, 59, 160, 73, 7, 213}
+	for opID, opInfo := range operatorState.PrivateOperators {
+		if opID == opId0 {
+			signChan <- core.SigningMessage{
+				Signature:       opInfo.KeyPair.SignMessage(batchHeaderHash),
+				Operator:        opID,
+				BatchHeaderHash: batchHeaderHash,
+				Err:             nil,
+			}
+		} else {
+			signChan <- core.SigningMessage{
+				Signature:       nil,
+				Operator:        opID,
+				BatchHeaderHash: batchHeaderHash,
+				Err:             context.DeadlineExceeded,
+			}
+		}
+	}
+	components.dispatcher.On("AttestBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(signChan, nil)
+	components.transactor.On("OperatorIDToAddress").Return(gethcommon.Address{}, nil)
+	err = b.HandleSingleBatch(context.Background())
+	assert.ErrorContains(t, err, "no blobs received sufficient signatures")
+}

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -422,7 +422,7 @@ func (e *EncodingStreamer) ProcessEncodedBlobs(ctx context.Context, result Encod
 	return nil
 }
 
-func (e *EncodingStreamer) UpdateReferenecBlock(currentBlockNumber uint) error {
+func (e *EncodingStreamer) UpdateReferenceBlock(currentBlockNumber uint) error {
 	blockNumber := currentBlockNumber
 	if blockNumber > e.FinalizationBlockDelay {
 		blockNumber -= e.FinalizationBlockDelay

--- a/disperser/batcher/encoding_streamer_test.go
+++ b/disperser/batcher/encoding_streamer_test.go
@@ -828,7 +828,7 @@ func TestCreateMinibatch(t *testing.T) {
 	assert.Nil(t, res)
 	assert.ErrorContains(t, err, "GetEncodedBlob: no such key")
 
-	err = encodingStreamer.UpdateReferenecBlock(15)
+	err = encodingStreamer.UpdateReferenceBlock(15)
 	assert.Nil(t, err)
 	assert.Equal(t, encodingStreamer.ReferenceBlockNumber, uint(15))
 

--- a/disperser/batcher/minibatch_store.go
+++ b/disperser/batcher/minibatch_store.go
@@ -20,7 +20,8 @@ type BatchStatus uint
 // The batch lifecycle is as follows:
 // Pending -> Formed -> Attested
 // \              /
-//  \-> Failed <-/
+//
+//	\-> Failed <-/
 const (
 	BatchStatusPending BatchStatus = iota
 	BatchStatusFormed

--- a/disperser/batcher/minibatcher_test.go
+++ b/disperser/batcher/minibatcher_test.go
@@ -41,6 +41,9 @@ var (
 		MaxNumConnections:         3,
 		MaxNumRetriesPerDispersal: 3,
 	}
+)
+
+const (
 	initialBlock = uint(10)
 )
 
@@ -213,7 +216,7 @@ func TestDisperseMinibatch(t *testing.T) {
 	_, _ = queueBlob(t, ctx, &blob1, c.blobStore)
 	_, _ = queueBlob(t, ctx, &blob2, c.blobStore)
 
-	err = c.encodingStreamer.UpdateReferenecBlock(initialBlock + 10)
+	err = c.encodingStreamer.UpdateReferenceBlock(initialBlock + 10)
 	assert.NoError(t, err)
 	err = c.encodingStreamer.RequestEncoding(ctx, out)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Why are these changes needed?
BatchConfirmer will take the `MinibatchResponse`s and confirm the full batch by getting & aggregating the nodes' signatures for the full batch. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
