### PR TITLE
Add `BlobMinibatchMapping` in minibatch store

### DIFF
--- a/disperser/batcher/batchstore/minibatch_store_test.go
+++ b/disperser/batcher/batchstore/minibatch_store_test.go
@@ -11,10 +11,14 @@ import (
 	"github.com/Layr-Labs/eigenda/common/aws/dynamodb"
 	test_utils "github.com/Layr-Labs/eigenda/common/aws/dynamodb/utils"
 	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/disperser/batcher"
 	"github.com/Layr-Labs/eigenda/disperser/batcher/batchstore"
+	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	gcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
 	"github.com/ory/dockertest/v3"
@@ -370,4 +374,98 @@ func TestDispersalStatus(t *testing.T) {
 	dispersed, err = minibatchStore.BatchDispersed(ctx, id)
 	assert.NoError(t, err)
 	assert.True(t, dispersed)
+}
+
+func TestGetBlobMinibatchMappings(t *testing.T) {
+	ctx := context.Background()
+	batchID, err := uuid.NewV7()
+	assert.NoError(t, err)
+	blobKey := disperser.BlobKey{
+		BlobHash:     "blob-hash",
+		MetadataHash: "metadata-hash",
+	}
+	var commitX, commitY, lengthX, lengthY fp.Element
+	_, err = commitX.SetString("21661178944771197726808973281966770251114553549453983978976194544185382599016")
+	assert.NoError(t, err)
+	_, err = commitY.SetString("9207254729396071334325696286939045899948985698134704137261649190717970615186")
+	assert.NoError(t, err)
+	commitment := &encoding.G1Commitment{
+		X: commitX,
+		Y: commitY,
+	}
+	_, err = lengthX.SetString("18730744272503541936633286178165146673834730535090946570310418711896464442549")
+	assert.NoError(t, err)
+	_, err = lengthY.SetString("15356431458378126778840641829778151778222945686256112821552210070627093656047")
+	assert.NoError(t, err)
+	var lengthXA0, lengthXA1, lengthYA0, lengthYA1 fp.Element
+	_, err = lengthXA0.SetString("10857046999023057135944570762232829481370756359578518086990519993285655852781")
+	assert.NoError(t, err)
+	_, err = lengthXA1.SetString("11559732032986387107991004021392285783925812861821192530917403151452391805634")
+	assert.NoError(t, err)
+	_, err = lengthYA0.SetString("8495653923123431417604973247489272438418190587263600148770280649306958101930")
+	assert.NoError(t, err)
+	_, err = lengthYA1.SetString("4082367875863433681332203403145435568316851327593401208105741076214120093531")
+	assert.NoError(t, err)
+
+	var lengthProof, lengthCommitment bn254.G2Affine
+	lengthProof.X.A0 = lengthXA0
+	lengthProof.X.A1 = lengthXA1
+	lengthProof.Y.A0 = lengthYA0
+	lengthProof.Y.A1 = lengthYA1
+
+	lengthCommitment = lengthProof
+	expectedDataLength := 111
+	expectedChunkLength := uint(222)
+	err = minibatchStore.PutBlobMinibatchMappings(ctx, []*batcher.BlobMinibatchMapping{
+		{
+			BlobKey:        &blobKey,
+			BatchID:        batchID,
+			MinibatchIndex: 11,
+			BlobIndex:      22,
+			BlobCommitments: encoding.BlobCommitments{
+				Commitment:       commitment,
+				LengthCommitment: (*encoding.G2Commitment)(&lengthCommitment),
+				Length:           uint(expectedDataLength),
+				LengthProof:      (*encoding.LengthProof)(&lengthProof),
+			},
+			BlobQuorumInfos: []*core.BlobQuorumInfo{
+				{
+					ChunkLength: expectedChunkLength,
+					SecurityParam: core.SecurityParam{
+						QuorumID:              1,
+						ConfirmationThreshold: 55,
+						AdversaryThreshold:    33,
+						QuorumRate:            123,
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	mapping, err := minibatchStore.GetBlobMinibatchMappings(ctx, blobKey)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mapping))
+	assert.Equal(t, &blobKey, mapping[0].BlobKey)
+	assert.Equal(t, batchID, mapping[0].BatchID)
+	assert.Equal(t, uint(11), mapping[0].MinibatchIndex)
+	assert.Equal(t, uint(22), mapping[0].BlobIndex)
+	assert.Equal(t, commitment, mapping[0].BlobCommitments.Commitment)
+	lengthCommitmentBytes, err := mapping[0].BlobCommitments.LengthCommitment.Serialize()
+	assert.NoError(t, err)
+	expectedLengthCommitmentBytes := lengthCommitment.Bytes()
+	assert.Equal(t, expectedLengthCommitmentBytes[:], lengthCommitmentBytes[:])
+	assert.Equal(t, expectedDataLength, int(mapping[0].BlobCommitments.Length))
+	lengthProofBytes, err := mapping[0].BlobCommitments.LengthProof.Serialize()
+	assert.NoError(t, err)
+	expectedLengthProofBytes := lengthProof.Bytes()
+	assert.Equal(t, expectedLengthProofBytes[:], lengthProofBytes[:])
+	assert.Len(t, mapping[0].BlobQuorumInfos, 1)
+	assert.Equal(t, expectedChunkLength, mapping[0].BlobQuorumInfos[0].ChunkLength)
+	assert.Equal(t, core.SecurityParam{
+		QuorumID:              1,
+		ConfirmationThreshold: 55,
+		AdversaryThreshold:    33,
+		QuorumRate:            123,
+	}, mapping[0].BlobQuorumInfos[0].SecurityParam)
 }

--- a/disperser/batcher/inmem/minibatch_store_test.go
+++ b/disperser/batcher/inmem/minibatch_store_test.go
@@ -6,8 +6,12 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/disperser/batcher"
 	"github.com/Layr-Labs/eigenda/disperser/batcher/inmem"
+	"github.com/Layr-Labs/eigenda/encoding"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	gcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -156,4 +160,99 @@ func TestPutDispersalResponse(t *testing.T) {
 	resp, err = s.GetDispersalResponse(ctx, id, minibatchIndex, resp2.OperatorID)
 	assert.NoError(t, err)
 	assert.Equal(t, resp2, resp)
+}
+
+func TestPutBlobMinibatchMappings(t *testing.T) {
+	s := newMinibatchStore()
+	ctx := context.Background()
+	batchID, err := uuid.NewV7()
+	assert.NoError(t, err)
+	blobKey := disperser.BlobKey{
+		BlobHash:     "blob-hash",
+		MetadataHash: "metadata-hash",
+	}
+	var commitX, commitY, lengthX, lengthY fp.Element
+	_, err = commitX.SetString("21661178944771197726808973281966770251114553549453983978976194544185382599016")
+	assert.NoError(t, err)
+	_, err = commitY.SetString("9207254729396071334325696286939045899948985698134704137261649190717970615186")
+	assert.NoError(t, err)
+	commitment := &encoding.G1Commitment{
+		X: commitX,
+		Y: commitY,
+	}
+	_, err = lengthX.SetString("18730744272503541936633286178165146673834730535090946570310418711896464442549")
+	assert.NoError(t, err)
+	_, err = lengthY.SetString("15356431458378126778840641829778151778222945686256112821552210070627093656047")
+	assert.NoError(t, err)
+	var lengthXA0, lengthXA1, lengthYA0, lengthYA1 fp.Element
+	_, err = lengthXA0.SetString("10857046999023057135944570762232829481370756359578518086990519993285655852781")
+	assert.NoError(t, err)
+	_, err = lengthXA1.SetString("11559732032986387107991004021392285783925812861821192530917403151452391805634")
+	assert.NoError(t, err)
+	_, err = lengthYA0.SetString("8495653923123431417604973247489272438418190587263600148770280649306958101930")
+	assert.NoError(t, err)
+	_, err = lengthYA1.SetString("4082367875863433681332203403145435568316851327593401208105741076214120093531")
+	assert.NoError(t, err)
+
+	var lengthProof, lengthCommitment bn254.G2Affine
+	lengthProof.X.A0 = lengthXA0
+	lengthProof.X.A1 = lengthXA1
+	lengthProof.Y.A0 = lengthYA0
+	lengthProof.Y.A1 = lengthYA1
+
+	lengthCommitment = lengthProof
+	expectedDataLength := 111
+	expectedChunkLength := uint(222)
+	err = s.PutBlobMinibatchMappings(ctx, []*batcher.BlobMinibatchMapping{
+		{
+			BlobKey:        &blobKey,
+			BatchID:        batchID,
+			MinibatchIndex: 11,
+			BlobIndex:      22,
+			BlobCommitments: encoding.BlobCommitments{
+				Commitment:       commitment,
+				LengthCommitment: (*encoding.G2Commitment)(&lengthCommitment),
+				Length:           uint(expectedDataLength),
+				LengthProof:      (*encoding.LengthProof)(&lengthProof),
+			},
+			BlobQuorumInfos: []*core.BlobQuorumInfo{
+				{
+					ChunkLength: expectedChunkLength,
+					SecurityParam: core.SecurityParam{
+						QuorumID:              1,
+						ConfirmationThreshold: 55,
+						AdversaryThreshold:    33,
+						QuorumRate:            123,
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	mapping, err := s.GetBlobMinibatchMappings(ctx, blobKey)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mapping))
+	assert.Equal(t, &blobKey, mapping[0].BlobKey)
+	assert.Equal(t, batchID, mapping[0].BatchID)
+	assert.Equal(t, uint(11), mapping[0].MinibatchIndex)
+	assert.Equal(t, uint(22), mapping[0].BlobIndex)
+	assert.Equal(t, commitment, mapping[0].BlobCommitments.Commitment)
+	lengthCommitmentBytes, err := mapping[0].BlobCommitments.LengthCommitment.Serialize()
+	assert.NoError(t, err)
+	expectedLengthCommitmentBytes := lengthCommitment.Bytes()
+	assert.Equal(t, expectedLengthCommitmentBytes[:], lengthCommitmentBytes[:])
+	assert.Equal(t, expectedDataLength, int(mapping[0].BlobCommitments.Length))
+	lengthProofBytes, err := mapping[0].BlobCommitments.LengthProof.Serialize()
+	assert.NoError(t, err)
+	expectedLengthProofBytes := lengthProof.Bytes()
+	assert.Equal(t, expectedLengthProofBytes[:], lengthProofBytes[:])
+	assert.Len(t, mapping[0].BlobQuorumInfos, 1)
+	assert.Equal(t, expectedChunkLength, mapping[0].BlobQuorumInfos[0].ChunkLength)
+	assert.Equal(t, core.SecurityParam{
+		QuorumID:              1,
+		ConfirmationThreshold: 55,
+		AdversaryThreshold:    33,
+		QuorumRate:            123,
+	}, mapping[0].BlobQuorumInfos[0].SecurityParam)
 }

--- a/disperser/batcher/minibatch_store.go
+++ b/disperser/batcher/minibatch_store.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/disperser"
+	"github.com/Layr-Labs/eigenda/encoding"
 	gcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
 )
@@ -20,7 +22,8 @@ type BatchStatus uint
 // The batch lifecycle is as follows:
 // Pending -> Formed -> Attested
 // \              /
-//  \-> Failed <-/
+//
+//	\-> Failed <-/
 const (
 	BatchStatusPending BatchStatus = iota
 	BatchStatusFormed
@@ -65,6 +68,15 @@ type DispersalResponse struct {
 	Error       error
 }
 
+type BlobMinibatchMapping struct {
+	BlobKey        *disperser.BlobKey `dynamodbav:"-"`
+	BatchID        uuid.UUID          `dynamodbav:"-"`
+	MinibatchIndex uint
+	BlobIndex      uint
+	encoding.BlobCommitments
+	BlobQuorumInfos []*core.BlobQuorumInfo
+}
+
 type MinibatchStore interface {
 	PutBatch(ctx context.Context, batch *BatchRecord) error
 	GetBatch(ctx context.Context, batchID uuid.UUID) (*BatchRecord, error)
@@ -79,7 +91,8 @@ type MinibatchStore interface {
 	PutDispersalResponse(ctx context.Context, response *DispersalResponse) error
 	GetDispersalResponse(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*DispersalResponse, error)
 	GetMinibatchDispersalResponses(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*DispersalResponse, error)
-
+	GetBlobMinibatchMappings(ctx context.Context, blobKey disperser.BlobKey) ([]*BlobMinibatchMapping, error)
+	PutBlobMinibatchMappings(ctx context.Context, blobMinibatchMappings []*BlobMinibatchMapping) error
 	// GetLatestFormedBatch returns the latest batch that has been formed.
 	// If there is no formed batch, it returns nil.
 	// It also returns the minibatches that belong to the batch in the ascending order of minibatch index.


### PR DESCRIPTION
## Why are these changes needed?
`BlobMinibatchMapping` maps blob key to minibatches it's part of. 
This will be used to
1) fetch blob metadata + commitment/quorum infos necessary to process full batches in `BatchConfirmer`
2) link blob key to minibatches to generate preconfs for specific blob
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
