### PR TITLE
Add an API to fetch blobs from a given batch header hash

### DIFF
--- a/disperser/common/blobstore/blob_metadata_store.go
+++ b/disperser/common/blobstore/blob_metadata_store.go
@@ -265,7 +265,6 @@ func (s *BlobMetadataStore) GetAllBlobMetadataByBatchWithPagination(
 	}
 
 	// Convert the last evaluated key to a disperser.BatchIndexExclusiveStartKey
-	s.logger.Info("Converting last evaluated key to exclusive start key", "lastEvaluatedKey", lastEvaluatedKey)
 	exclusiveStartKey, err = convertToExclusiveStartKeyBatchIndex(lastEvaluatedKey)
 	if err != nil {
 		return nil, nil, err

--- a/disperser/common/blobstore/shared_storage.go
+++ b/disperser/common/blobstore/shared_storage.go
@@ -242,6 +242,10 @@ func (s *SharedBlobStore) GetAllBlobMetadataByBatch(ctx context.Context, batchHe
 	return s.blobMetadataStore.GetAllBlobMetadataByBatch(ctx, batchHeaderHash)
 }
 
+func (s *SharedBlobStore) GetAllBlobMetadataByBatchWithPagination(ctx context.Context, batchHeaderHash [32]byte, limit int32, exclusiveStartKey *disperser.BatchIndexExclusiveStartKey) ([]*disperser.BlobMetadata, *disperser.BatchIndexExclusiveStartKey, error) {
+	return s.blobMetadataStore.GetAllBlobMetadataByBatchWithPagination(ctx, batchHeaderHash, limit, exclusiveStartKey)
+}
+
 // GetMetadata returns a blob metadata given a metadata key
 func (s *SharedBlobStore) GetBlobMetadata(ctx context.Context, metadataKey disperser.BlobKey) (*disperser.BlobMetadata, error) {
 	return s.blobMetadataStore.GetBlobMetadata(ctx, metadataKey)

--- a/disperser/common/blobstore/shared_storage_test.go
+++ b/disperser/common/blobstore/shared_storage_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	commondynamodb "github.com/Layr-Labs/eigenda/common/aws/dynamodb"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/encoding"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -174,6 +176,232 @@ func TestSharedBlobStore(t *testing.T) {
 	assert.NotNil(t, blob2Metadata)
 	assertMetadata(t, blobKey, blobSize, requestedAt, disperser.Finalized, blob1Metadata)
 	assertMetadata(t, blobKey2, blobSize2, requestedAt, disperser.InsufficientSignatures, blob2Metadata)
+
+	// Cleanup: Delete test items
+	t.Cleanup(func() {
+		deleteItems(t, []commondynamodb.Key{
+			{
+				"MetadataHash": &types.AttributeValueMemberS{Value: blobKey.MetadataHash},
+				"BlobHash":     &types.AttributeValueMemberS{Value: blobKey.BlobHash},
+			},
+			{
+				"MetadataHash": &types.AttributeValueMemberS{Value: blobKey2.MetadataHash},
+				"BlobHash":     &types.AttributeValueMemberS{Value: blobKey2.BlobHash},
+			},
+		})
+	})
+}
+
+func TestSharedBlobStoreBlobMetadataStoreOperationsWithPagination(t *testing.T) {
+	ctx := context.Background()
+	blobKey1 := disperser.BlobKey{
+		BlobHash:     blobHash,
+		MetadataHash: "hash",
+	}
+	metadata1 := &disperser.BlobMetadata{
+		MetadataHash: blobKey1.MetadataHash,
+		BlobHash:     blobHash,
+		BlobStatus:   disperser.Processing,
+		Expiry:       0,
+		NumRetries:   0,
+		RequestMetadata: &disperser.RequestMetadata{
+			BlobRequestHeader: blob.RequestHeader,
+			BlobSize:          blobSize,
+			RequestedAt:       123,
+		},
+	}
+	blobKey2 := disperser.BlobKey{
+		BlobHash:     "blob2",
+		MetadataHash: "hash2",
+	}
+	metadata2 := &disperser.BlobMetadata{
+		MetadataHash: blobKey2.MetadataHash,
+		BlobHash:     blobKey2.BlobHash,
+		BlobStatus:   disperser.Finalized,
+		Expiry:       0,
+		NumRetries:   0,
+		RequestMetadata: &disperser.RequestMetadata{
+			BlobRequestHeader: blob.RequestHeader,
+			BlobSize:          blobSize,
+			RequestedAt:       123,
+		},
+		ConfirmationInfo: &disperser.ConfirmationInfo{},
+	}
+
+	// Setup: Queue new blob metadata
+	err := blobMetadataStore.QueueNewBlobMetadata(ctx, metadata1)
+	assert.NoError(t, err)
+	err = blobMetadataStore.QueueNewBlobMetadata(ctx, metadata2)
+	assert.NoError(t, err)
+
+	// Test: Fetch individual blob metadata
+	fetchedMetadata, err := sharedStorage.GetBlobMetadata(ctx, blobKey1)
+	assert.NoError(t, err)
+	assert.Equal(t, metadata1, fetchedMetadata)
+	fetchedMetadata, err = sharedStorage.GetBlobMetadata(ctx, blobKey2)
+	assert.NoError(t, err)
+	assert.Equal(t, metadata2, fetchedMetadata)
+
+	// Test: Fetch blob metadata by status with pagination
+	t.Run("Fetch Processing Blobs", func(t *testing.T) {
+		processing, lastEvaluatedKey, err := sharedStorage.GetBlobMetadataByStatusWithPagination(ctx, disperser.Processing, 1, nil)
+		assert.NoError(t, err)
+		assert.Len(t, processing, 1)
+		assert.Equal(t, metadata1, processing[0])
+		assert.NotNil(t, lastEvaluatedKey)
+
+		// Fetch next page (should be empty)
+		nextProcessing, nextLastEvaluatedKey, err := sharedStorage.GetBlobMetadataByStatusWithPagination(ctx, disperser.Processing, 1, lastEvaluatedKey)
+		assert.NoError(t, err)
+		assert.Len(t, nextProcessing, 0)
+		assert.Nil(t, nextLastEvaluatedKey)
+	})
+
+	t.Run("Fetch Finalized Blobs", func(t *testing.T) {
+		finalized, lastEvaluatedKey, err := sharedStorage.GetBlobMetadataByStatusWithPagination(ctx, disperser.Finalized, 1, nil)
+		assert.NoError(t, err)
+		assert.Len(t, finalized, 1)
+		assert.Equal(t, metadata2, finalized[0])
+		assert.NotNil(t, lastEvaluatedKey)
+
+		// Fetch next page (should be empty)
+		nextFinalized, nextLastEvaluatedKey, err := sharedStorage.GetBlobMetadataByStatusWithPagination(ctx, disperser.Finalized, 1, lastEvaluatedKey)
+		assert.NoError(t, err)
+		assert.Len(t, nextFinalized, 0)
+		assert.Nil(t, nextLastEvaluatedKey)
+	})
+
+	// Cleanup: Delete test items
+	t.Cleanup(func() {
+		deleteItems(t, []commondynamodb.Key{
+			{
+				"MetadataHash": &types.AttributeValueMemberS{Value: blobKey1.MetadataHash},
+				"BlobHash":     &types.AttributeValueMemberS{Value: blobKey1.BlobHash},
+			},
+			{
+				"MetadataHash": &types.AttributeValueMemberS{Value: blobKey2.MetadataHash},
+				"BlobHash":     &types.AttributeValueMemberS{Value: blobKey2.BlobHash},
+			},
+		})
+	})
+}
+
+func TestSharedBlobStoreGetAllBlobMetadataByBatchWithPagination(t *testing.T) {
+	ctx := context.Background()
+	batchHeaderHash := [32]byte{1, 2, 3}
+
+	// Create and store multiple blob metadata for the same batch
+	numBlobs := 5
+	blobKeys := make([]disperser.BlobKey, numBlobs)
+	for i := 0; i < numBlobs; i++ {
+		blobKey := disperser.BlobKey{
+			BlobHash:     fmt.Sprintf("blob%d", i),
+			MetadataHash: fmt.Sprintf("hash%d", i),
+		}
+		blobKeys[i] = blobKey
+
+		metadata := &disperser.BlobMetadata{
+			BlobHash:     blobKey.BlobHash,
+			MetadataHash: blobKey.MetadataHash,
+			BlobStatus:   disperser.Confirmed,
+			RequestMetadata: &disperser.RequestMetadata{
+				BlobRequestHeader: blob.RequestHeader,
+				BlobSize:          blobSize,
+				RequestedAt:       uint64(time.Now().UnixNano()),
+			},
+			ConfirmationInfo: &disperser.ConfirmationInfo{
+				BatchHeaderHash: batchHeaderHash,
+				BlobIndex:       uint32(i),
+			},
+		}
+
+		err := blobMetadataStore.QueueNewBlobMetadata(ctx, metadata)
+		assert.NoError(t, err)
+	}
+
+	// Test pagination with a page size of 2
+	t.Run("Fetch All Blobs with Pagination", func(t *testing.T) {
+		var allFetchedMetadata []*disperser.BlobMetadata
+		var lastEvaluatedKey *disperser.BatchIndexExclusiveStartKey
+		pageSize := int32(2)
+
+		for {
+			fetchedMetadata, newLastEvaluatedKey, err := sharedStorage.GetAllBlobMetadataByBatchWithPagination(ctx, batchHeaderHash, pageSize, lastEvaluatedKey)
+			assert.NoError(t, err)
+
+			allFetchedMetadata = append(allFetchedMetadata, fetchedMetadata...)
+
+			if newLastEvaluatedKey == nil {
+				assert.Len(t, fetchedMetadata, numBlobs%int(pageSize))
+				break
+			} else {
+				assert.Len(t, fetchedMetadata, int(pageSize))
+			}
+			lastEvaluatedKey = newLastEvaluatedKey
+		}
+
+		assert.Len(t, allFetchedMetadata, numBlobs)
+
+		// Verify that all blob metadata is fetched and in the correct order
+		for i, metadata := range allFetchedMetadata {
+			assert.Equal(t, fmt.Sprintf("blob%d", i), metadata.BlobHash)
+			assert.Equal(t, fmt.Sprintf("hash%d", i), metadata.MetadataHash)
+			assert.Equal(t, uint32(i), metadata.ConfirmationInfo.BlobIndex)
+		}
+	})
+
+	// Test pagination with a page size of 10
+	t.Run("Fetch All Blobs with Pagination (Page Size > Num Blobs)", func(t *testing.T) {
+		var allFetchedMetadata []*disperser.BlobMetadata
+		var lastEvaluatedKey *disperser.BatchIndexExclusiveStartKey
+		pageSize := int32(10)
+
+		for {
+			fetchedMetadata, newLastEvaluatedKey, err := sharedStorage.GetAllBlobMetadataByBatchWithPagination(ctx, batchHeaderHash, pageSize, lastEvaluatedKey)
+			assert.NoError(t, err)
+
+			allFetchedMetadata = append(allFetchedMetadata, fetchedMetadata...)
+
+			if newLastEvaluatedKey == nil {
+				assert.Len(t, fetchedMetadata, numBlobs)
+				break
+			} else {
+				assert.Len(t, fetchedMetadata, int(pageSize))
+			}
+
+			lastEvaluatedKey = newLastEvaluatedKey
+		}
+
+		assert.Len(t, allFetchedMetadata, numBlobs)
+
+		// Verify that all blob metadata is fetched and in the correct order
+		for i, metadata := range allFetchedMetadata {
+			assert.Equal(t, fmt.Sprintf("blob%d", i), metadata.BlobHash)
+			assert.Equal(t, fmt.Sprintf("hash%d", i), metadata.MetadataHash)
+			assert.Equal(t, uint32(i), metadata.ConfirmationInfo.BlobIndex)
+		}
+	})
+
+	// Test invalid batch header hash
+	t.Run("Fetch All Blobs with Invalid Batch Header Hash", func(t *testing.T) {
+		invalidBatchHeaderHash := [32]byte{4, 5, 6}
+		allFetchedMetadata, lastEvaluatedKey, err := sharedStorage.GetAllBlobMetadataByBatchWithPagination(ctx, invalidBatchHeaderHash, 10, nil)
+		assert.NoError(t, err)
+		assert.Len(t, allFetchedMetadata, 0)
+		assert.Nil(t, lastEvaluatedKey)
+	})
+
+	// Cleanup: Delete test items
+	t.Cleanup(func() {
+		var keys []commondynamodb.Key
+		for _, blobKey := range blobKeys {
+			keys = append(keys, commondynamodb.Key{
+				"MetadataHash": &types.AttributeValueMemberS{Value: blobKey.MetadataHash},
+				"BlobHash":     &types.AttributeValueMemberS{Value: blobKey.BlobHash},
+			})
+		}
+		deleteItems(t, keys)
+	})
 }
 
 func assertMetadata(t *testing.T, blobKey disperser.BlobKey, expectedBlobSize uint, expectedRequestedAt uint64, expectedStatus disperser.BlobStatus, actualMetadata *disperser.BlobMetadata) {

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -302,7 +302,7 @@ func (q *BlobStore) GetAllBlobMetadataByBatchWithPagination(ctx context.Context,
 			if len(metas) == int(limit) {
 				return metas, &disperser.BatchIndexExclusiveStartKey{
 					BatchHeaderHash: meta.ConfirmationInfo.BatchHeaderHash[:],
-					BlobIndex:       int32(meta.ConfirmationInfo.BlobIndex),
+					BlobIndex:       meta.ConfirmationInfo.BlobIndex,
 				}, nil
 			}
 		} else if exclusiveStartKey != nil && meta.ConfirmationInfo.BlobIndex > uint32(exclusiveStartKey.BlobIndex) {
@@ -311,7 +311,7 @@ func (q *BlobStore) GetAllBlobMetadataByBatchWithPagination(ctx context.Context,
 			if len(metas) == int(limit) {
 				return metas, &disperser.BatchIndexExclusiveStartKey{
 					BatchHeaderHash: meta.ConfirmationInfo.BatchHeaderHash[:],
-					BlobIndex:       int32(meta.ConfirmationInfo.BlobIndex),
+					BlobIndex:       meta.ConfirmationInfo.BlobIndex,
 				}, nil
 			}
 		}

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -279,6 +279,48 @@ func (q *BlobStore) GetAllBlobMetadataByBatch(ctx context.Context, batchHeaderHa
 	return metas, nil
 }
 
+func (q *BlobStore) GetAllBlobMetadataByBatchWithPagination(ctx context.Context, batchHeaderHash [32]byte, limit int32, exclusiveStartKey *disperser.BatchIndexExclusiveStartKey) ([]*disperser.BlobMetadata, *disperser.BatchIndexExclusiveStartKey, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	metas := make([]*disperser.BlobMetadata, 0)
+	foundStart := exclusiveStartKey == nil
+
+	keys := make([]disperser.BlobKey, 0, len(q.Metadata))
+	for k, v := range q.Metadata {
+		if v.ConfirmationInfo != nil && v.ConfirmationInfo.BatchHeaderHash == batchHeaderHash {
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return q.Metadata[keys[i]].ConfirmationInfo.BlobIndex < q.Metadata[keys[j]].ConfirmationInfo.BlobIndex
+	})
+
+	for _, key := range keys {
+		meta := q.Metadata[key]
+		if foundStart {
+			metas = append(metas, meta)
+			if len(metas) == int(limit) {
+				return metas, &disperser.BatchIndexExclusiveStartKey{
+					BatchHeaderHash: meta.ConfirmationInfo.BatchHeaderHash[:],
+					BlobIndex:       int32(meta.ConfirmationInfo.BlobIndex),
+				}, nil
+			}
+		} else if exclusiveStartKey != nil && meta.ConfirmationInfo.BlobIndex > uint32(exclusiveStartKey.BlobIndex) {
+			foundStart = true
+			metas = append(metas, meta)
+			if len(metas) == int(limit) {
+				return metas, &disperser.BatchIndexExclusiveStartKey{
+					BatchHeaderHash: meta.ConfirmationInfo.BatchHeaderHash[:],
+					BlobIndex:       int32(meta.ConfirmationInfo.BlobIndex),
+				}, nil
+			}
+		}
+	}
+
+	// Return all the metas if limit is not reached
+	return metas, nil, nil
+}
+
 func (q *BlobStore) GetBlobMetadata(ctx context.Context, blobKey disperser.BlobKey) (*disperser.BlobMetadata, error) {
 	if meta, ok := q.Metadata[blobKey]; ok {
 		return meta, nil

--- a/disperser/dataapi/blobs_handlers.go
+++ b/disperser/dataapi/blobs_handlers.go
@@ -190,8 +190,8 @@ func (s *server) getBlobMetadataByBatchHeaderHashWithLimit(ctx context.Context, 
 	const maxLimit int32 = 1000
 	remainingLimit := min(limit, maxLimit)
 
+	s.logger.Debug("Getting blob metadata by batch header hash", "batchHeaderHash", batchHeaderHash, "remainingLimit", remainingLimit, "nextKey", nextKey)
 	for int32(len(allMetadata)) < remainingLimit {
-		s.logger.Debug("Getting blob metadata by batch header hash", "batchHeaderHash", batchHeaderHash, "remainingLimit", remainingLimit, "nextKey", nextKey)
 		metadatas, newNextKey, err := s.blobstore.GetAllBlobMetadataByBatchWithPagination(ctx, batchHeaderHash, remainingLimit-int32(len(allMetadata)), nextKey)
 		if err != nil {
 			s.logger.Error("Failed to get blob metadata", "error", err)

--- a/disperser/dataapi/blobs_handlers.go
+++ b/disperser/dataapi/blobs_handlers.go
@@ -35,6 +35,18 @@ func (s *server) getBlobs(ctx context.Context, limit int) ([]*BlobMetadataRespon
 	return s.convertBlobMetadatasToBlobMetadataResponse(ctx, blobMetadatas)
 }
 
+func (s *server) getBlobsFromBatchHeaderHash(ctx context.Context, batcherHeaderHash string, limit int) ([]*BlobMetadataResponse, error) {
+	blobMetadatas, err := s.getBlobMetadataByBatchHeaderHashWithLimit(ctx, batcherHeaderHash, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(blobMetadatas) == 0 {
+		return nil, errNotFound
+	}
+
+	return s.convertBlobMetadatasToBlobMetadataResponse(ctx, blobMetadatas)
+}
+
 func (s *server) convertBlobMetadatasToBlobMetadataResponse(ctx context.Context, metadatas []*disperser.BlobMetadata) ([]*BlobMetadataResponse, error) {
 	var (
 		err               error
@@ -95,4 +107,93 @@ func convertMetadataToBlobMetadataResponse(metadata *disperser.BlobMetadata) (*B
 		RequestAt:               ConvertNanosecondToSecond(metadata.RequestMetadata.RequestedAt),
 		BlobStatus:              metadata.BlobStatus,
 	}, nil
+}
+
+func (s *server) getBlobMetadataByBatchesWithLimit(ctx context.Context, limit int) ([]*Batch, []*disperser.BlobMetadata, error) {
+	var (
+		blobMetadatas   = make([]*disperser.BlobMetadata, 0)
+		batches         = make([]*Batch, 0)
+		blobKeyPresence = make(map[string]struct{})
+		batchPresence   = make(map[string]struct{})
+	)
+
+	for skip := 0; len(blobMetadatas) < limit && skip < limit; skip += maxQueryBatchesLimit {
+		batchesWithLimit, err := s.subgraphClient.QueryBatchesWithLimit(ctx, maxQueryBatchesLimit, skip)
+		if err != nil {
+			s.logger.Error("Failed to query batches", "error", err)
+			return nil, nil, err
+		}
+
+		if len(batchesWithLimit) == 0 {
+			break
+		}
+
+		for i := range batchesWithLimit {
+			s.logger.Debug("Getting blob metadata", "batchHeaderHash", batchesWithLimit[i].BatchHeaderHash)
+			var (
+				batch = batchesWithLimit[i]
+			)
+			if batch == nil {
+				continue
+			}
+			batchHeaderHash, err := ConvertHexadecimalToBytes(batch.BatchHeaderHash)
+			if err != nil {
+				s.logger.Error("Failed to convert batch header hash to hex string", "error", err)
+				continue
+			}
+			batchKey := string(batchHeaderHash[:])
+			if _, found := batchPresence[batchKey]; !found {
+				batchPresence[batchKey] = struct{}{}
+			} else {
+				// The batch has processed, skip it.
+				s.logger.Error("Getting duplicate batch from the graph", "batch header hash", batchKey)
+				continue
+			}
+
+			metadatas, err := s.blobstore.GetAllBlobMetadataByBatch(ctx, batchHeaderHash)
+			if err != nil {
+				s.logger.Error("Failed to get blob metadata", "error", err)
+				continue
+			}
+			for _, bm := range metadatas {
+				blobKey := bm.GetBlobKey().String()
+				if _, found := blobKeyPresence[blobKey]; !found {
+					blobKeyPresence[blobKey] = struct{}{}
+					blobMetadatas = append(blobMetadatas, bm)
+				} else {
+					s.logger.Error("Getting duplicate blob key from the blobstore", "blobkey", blobKey)
+				}
+			}
+			batches = append(batches, batch)
+			if len(blobMetadatas) >= limit {
+				break
+			}
+		}
+	}
+
+	if len(blobMetadatas) >= limit {
+		blobMetadatas = blobMetadatas[:limit]
+	}
+
+	return batches, blobMetadatas, nil
+}
+
+func (s *server) getBlobMetadataByBatchHeaderHashWithLimit(ctx context.Context, batchHeaderHash string, limit int) ([]*disperser.BlobMetadata, error) {
+	batchHeaderHashBytes, err := ConvertHexadecimalToBytes([]byte(batchHeaderHash))
+	if err != nil {
+		s.logger.Error("Failed to convert batch header hash to hex string", "error", err)
+		return nil, err
+	}
+
+	metadatas, err := s.blobstore.GetAllBlobMetadataByBatch(ctx, batchHeaderHashBytes)
+	if err != nil {
+		s.logger.Error("Failed to get blob metadata", "error", err)
+		return nil, err
+	}
+
+	if len(metadatas) >= limit {
+		metadatas = metadatas[:limit]
+	}
+
+	return metadatas, nil
 }

--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -37,13 +37,19 @@ const docTemplate = `{
                         "description": "Limit [default: 10]",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Next page token",
+                        "name": "next_token",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dataapi.BlobMetadataResponse"
+                            "$ref": "#/definitions/dataapi.BlobsResponse"
                         }
                     },
                     "400": {
@@ -708,6 +714,9 @@ const docTemplate = `{
         "dataapi.Meta": {
             "type": "object",
             "properties": {
+                "next_token": {
+                    "type": "string"
+                },
                 "size": {
                     "type": "integer"
                 }

--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -15,6 +15,58 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/feed/batches/{batch_header_hash}/blobs": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feed"
+                ],
+                "summary": "Fetch blob metadata by batch header hash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Batch Header Hash",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit [default: 10]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.BlobMetadataResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/feed/blobs": {
             "get": {
                 "produces": [

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -11,32 +11,27 @@
         "version": "1"
     },
     "paths": {
-        "/ejector/operators": {
-            "post": {
+        "/feed/batches/{batch_header_hash}/blobs": {
+            "get": {
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "Ejector"
+                    "Feed"
                 ],
-                "summary": "Eject operators who violate the SLAs during the given time interval",
+                "summary": "Fetch blob metadata by batch header hash",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "Lookback window for operator ejection [default: 86400]",
-                        "name": "interval",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "End time for evaluating operator ejection [default: now]",
-                        "name": "end",
-                        "in": "query"
-                    },
-                    {
                         "type": "string",
-                        "description": "Whether it's periodic or urgent ejection request [default: periodic]",
-                        "name": "mode",
+                        "description": "Batch Header Hash",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit [default: 10]",
+                        "name": "limit",
                         "in": "query"
                     }
                 ],
@@ -44,7 +39,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dataapi.EjectionResponse"
+                            "$ref": "#/definitions/dataapi.BlobMetadataResponse"
                         }
                     },
                     "400": {
@@ -695,14 +690,6 @@
                 },
                 "meta": {
                     "$ref": "#/definitions/dataapi.Meta"
-                }
-            }
-        },
-        "dataapi.EjectionResponse": {
-            "type": "object",
-            "properties": {
-                "transaction_hash": {
-                    "type": "string"
                 }
             }
         },

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -33,13 +33,19 @@
                         "description": "Limit [default: 10]",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Next page token",
+                        "name": "next_token",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dataapi.BlobMetadataResponse"
+                            "$ref": "#/definitions/dataapi.BlobsResponse"
                         }
                     },
                     "400": {
@@ -704,6 +710,9 @@
         "dataapi.Meta": {
             "type": "object",
             "properties": {
+                "next_token": {
+                    "type": "string"
+                },
                 "size": {
                     "type": "integer"
                 }

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -66,11 +66,6 @@ definitions:
       meta:
         $ref: '#/definitions/dataapi.Meta'
     type: object
-  dataapi.EjectionResponse:
-    properties:
-      transaction_hash:
-        type: string
-    type: object
   dataapi.ErrorResponse:
     properties:
       error:
@@ -245,29 +240,25 @@ info:
   title: EigenDA Data Access API
   version: "1"
 paths:
-  /ejector/operators:
-    post:
+  /feed/batches/{batch_header_hash}/blobs:
+    get:
       parameters:
-      - description: 'Lookback window for operator ejection [default: 86400]'
-        in: query
-        name: interval
-        type: integer
-      - description: 'End time for evaluating operator ejection [default: now]'
-        in: query
-        name: end
-        type: integer
-      - description: 'Whether it''s periodic or urgent ejection request [default:
-          periodic]'
-        in: query
-        name: mode
+      - description: Batch Header Hash
+        in: path
+        name: batch_header_hash
+        required: true
         type: string
+      - description: 'Limit [default: 10]'
+        in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dataapi.EjectionResponse'
+            $ref: '#/definitions/dataapi.BlobMetadataResponse'
         "400":
           description: 'error: Bad request'
           schema:
@@ -280,9 +271,9 @@ paths:
           description: 'error: Server error'
           schema:
             $ref: '#/definitions/dataapi.ErrorResponse'
-      summary: Eject operators who violate the SLAs during the given time interval
+      summary: Fetch blob metadata by batch header hash
       tags:
-      - Ejector
+      - Feed
   /feed/blobs:
     get:
       parameters:

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -73,6 +73,8 @@ definitions:
     type: object
   dataapi.Meta:
     properties:
+      next_token:
+        type: string
       size:
         type: integer
     type: object
@@ -252,13 +254,17 @@ paths:
         in: query
         name: limit
         type: integer
+      - description: Next page token
+        in: query
+        name: next_token
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dataapi.BlobMetadataResponse'
+            $ref: '#/definitions/dataapi.BlobsResponse'
         "400":
           description: 'error: Bad request'
           schema:

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -372,9 +372,9 @@ func (s *server) FetchBlobsFromBatchHeaderHash(c *gin.Context) {
 		errorResponse(c, fmt.Errorf("invalid limit parameter"))
 		return
 	}
-	if limit <= 0 {
+	if limit <= 0 || limit > 1000 {
 		s.metrics.IncrementFailedRequestNum("FetchBlobsFromBatchHeaderHash")
-		errorResponse(c, fmt.Errorf("limit must be greater than 0"))
+		errorResponse(c, fmt.Errorf("limit must be between 0 and 1000"))
 		return
 	}
 

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -366,7 +366,7 @@ func (s *server) FetchBlobsFromBatchHeaderHash(c *gin.Context) {
 		return
 	}
 
-	limit, err := strconv.Atoi(c.DefaultQuery("limit", "100"))
+	limit, err := strconv.Atoi(c.DefaultQuery("limit", "10"))
 	if err != nil {
 		s.metrics.IncrementFailedRequestNum("FetchBlobsFromBatchHeaderHash")
 		errorResponse(c, fmt.Errorf("invalid limit parameter"))

--- a/disperser/dataapi/utils.go
+++ b/disperser/dataapi/utils.go
@@ -23,7 +23,7 @@ func ConvertHexadecimalToBytes(byteHash []byte) ([32]byte, error) {
 
 	// We expect the resulting byte slice to have a length of 32 bytes.
 	if len(decodedBytes) != 32 {
-		return [32]byte{}, errors.New("error decoding hash")
+		return [32]byte{}, errors.New("error decoding hash, invalid length")
 	}
 
 	// Convert the byte slice to a [32]byte array

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -135,6 +135,13 @@ type BlobStoreExclusiveStartKey struct {
 	RequestedAt  int64 //  RequestedAt is epoch time in seconds
 }
 
+type BatchIndexExclusiveStartKey struct {
+	BlobHash        BlobHash
+	MetadataHash    MetadataHash
+	BatchHeaderHash []byte
+	BlobIndex       int32
+}
+
 type BlobStore interface {
 	// StoreBlob adds a blob to the queue and returns a key that can be used to retrieve the blob later
 	StoreBlob(ctx context.Context, blob *core.Blob, requestedAt uint64) (BlobKey, error)
@@ -169,6 +176,8 @@ type BlobStore interface {
 	GetBlobMetadataByStatusWithPagination(ctx context.Context, blobStatus BlobStatus, limit int32, exclusiveStartKey *BlobStoreExclusiveStartKey) ([]*BlobMetadata, *BlobStoreExclusiveStartKey, error)
 	// GetAllBlobMetadataByBatch returns the metadata of all the blobs in the batch.
 	GetAllBlobMetadataByBatch(ctx context.Context, batchHeaderHash [32]byte) ([]*BlobMetadata, error)
+	// GetAllBlobMetadataByBatchWithPagination returns all the blobs in the batch using pagination
+	GetAllBlobMetadataByBatchWithPagination(ctx context.Context, batchHeaderHash [32]byte, limit int32, exclusiveStartKey *BatchIndexExclusiveStartKey) ([]*BlobMetadata, *BatchIndexExclusiveStartKey, error)
 	// GetBlobMetadata returns a blob metadata given a metadata key
 	GetBlobMetadata(ctx context.Context, blobKey BlobKey) (*BlobMetadata, error)
 	// HandleBlobFailure handles a blob failure by either incrementing the retry count or marking the blob as failed

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -139,7 +139,7 @@ type BatchIndexExclusiveStartKey struct {
 	BlobHash        BlobHash
 	MetadataHash    MetadataHash
 	BatchHeaderHash []byte
-	BlobIndex       int32
+	BlobIndex       uint32
 }
 
 type BlobStore interface {


### PR DESCRIPTION
## Why are these changes needed?

Adds a new endpoint to the data api server to fetch blob metadata from a batch header hash. This API should enable others to build blob explorers on top of our data.

The endpoint is paginated and returns a `next_token` field which is a base64 encoded token of the last evaluated key in the page.

Example:
Sample query:
```
 curl -X 'GET' \
  'http://localhost:8080/api/v1/feed/batches/6E2EFA6EB7AE40CE7A65B465679DE5649F994296D18C075CF2C490564BBF7CA5/blobs?limit=1' \  
  -H 'accept: application/json
```

Sample response
```
{"meta":{"size":1,"next_token":"eyJCbG9iSGFzaCI6ImRkMjZjYTk3YmNlNzhhYTk2ZTAxMGUwMzNhY2ZjNDZmOWRhYTEwODVjZDVhMzg1MTRiNTAyNzUwZjU5YjlkMTMiLCJNZXRhZGF0YUhhc2giOiIzMTM3MzIzMjMzMzgzODM4MzkzMzMwMzkzNzMyMzMzMzM3MzczNjJmMzAyZjMzMzMyZjMxMmYzMzMzMmZlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1IiwiQmF0Y2hIZWFkZXJIYXNoIjoiYmk3NmJyZXVRTTU2WmJSbFo1M2xaSitaUXBiUmpBZGM4c1NRVmt1L2ZLVT0iLCJCbG9iSW5kZXgiOjB9"},"data":[{"blob_key":"dd26ca97bce78aa96e010e033acfc46f9daa1085cd5a38514b502750f59b9d13-313732323338383839333039373233333737362f302f33332f312f33332fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","batch_header_hash":"6e2efa6eb7ae40ce7a65b465679de5649f994296d18c075cf2c490564bbf7ca5","blob_index":0,"signatory_record_hash":"3dfc70eafe5215ca1051a74e3609bb1d160e1f99005fc13d8c86c539d9114f7b","reference_block_number":2035851,"batch_root":"d9a658a5646d8d41fcea70afd9339d8d8b9041050c1ad2b2f4abe36f45613d2a","blob_inclusion_proof":"64bcc95c806f5d656192872c558988e9ec83d22ec1e000c5a1f13e31e100c8aa700baf3003f5453f2dbf13a9d5d12024d2a55c705ea225c81693145c2cc13fd78216d5479cda9f844af7864a92a42c23333290122fbc811bd604d9f9a9784a66dcaf7c45e683d49118884ebbb397d59b01e2dee2fc97b902c33ad712a276cfb5003ab3aa93c3ae8ab3b4132e0be40d87fb4f58cc5e49d4186e8b8831c014a6e2618bd5f8fdbbb6bccc68df2c04e1db82e8be1fadde0450cfdaf1c34263b92c7fe11f108590db529ec088a0a7ed08f9b2edbb799c85da41654e2f28317411032644096cdc49dd590f3f89d99ade73cb7c2347feb09d49c9450dc26a2fdc37c713c17eab2130c9bc5f84734ea6ccca24ce6f0339017d2877661858f2808b41aca94c86b4810e9fad5f48deb82578e6c2caa165fa64d3c4e49875bd0d91096997987bc6c3d811864bf293dbb728f9f436c5db38eec6ee6008ed82801254eabd178816f60734844264a7f53675b60d0ed1872987854c4d98ec09b9facfe59239bdff495d297de4fdccf4cc0e6dba7772c2880feee533993c1defe1c3d39bce42534cdca435e988da10ec5384b3ba21d2863a9b8f701a9405b7fa631f817f3326d04f32d4f17265cd8c17fe4edf564f7d2818c5c97baf1b39f30316b3d2f3ee53d051","blob_commitment":{"commitment":{"X":"10654988599870587770787393200552110054687298615607967764937097592038258411754","Y":"18734666437462819052584172468786552309751381314655805698672660714753147273453"},"length_commitment":{"X":{"A0":"5061480280063149801552916064155196935940417917920806083877037326616821363934","A1":"14062936678877092061763909390797389513408830393357964905007718131886911533835"},"Y":{"A0":"5745003969301824632454161959921145214502865986519377269450276040077026980010","A1":"6074252507891203505580637063317121427461816738102068256590025258852140830928"}},"length_proof":{"X":{"A0":"21399264865984950761164626890540180632049418151916889200045365655764199070011","A1":"17196068782888244615236694895883064928167854490786996353102920417690165216790"},"Y":{"A0":"17448100457771843994069640177381667809841110272430530510830195951164391042871","A1":"10444118721190278594390330487379515821747120086963435285720236784527226967237"}},"length":54},"batch_id":27961,"confirmation_block_number":2036016,"confirmation_txn_hash":"0xdfa70b7fbcedb568a792b495f0c74ba84c89519399e31287c839fb0b36871337","fee":"00","security_params":[{"QuorumID":0,"AdversaryThreshold":33,"ConfirmationThreshold":55,"QuorumRate":3072},{"QuorumID":1,"AdversaryThreshold":33,"ConfirmationThreshold":55,"QuorumRate":3072}],"requested_at":1722388893,"blob_status":3}]}
``` 

next_token decoded:
```
{"BlobHash":"dd26ca97bce78aa96e010e033acfc46f9daa1085cd5a38514b502750f59b9d13","MetadataHash":"313732323338383839333039373233333737362f302f33332f312f33332fe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","BatchHeaderHash":"bi76breuQM56ZbRlZ53lZJ+ZQpbRjAdc8sSQVku/fKU=","BlobIndex":0}
```

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
