### PR TITLE
[1/N][zero serialization] Create data structure for passing encode chunks

### DIFF
--- a/core/data.go
+++ b/core/data.go
@@ -30,6 +30,7 @@ type SecurityParam struct {
 	QuorumRate common.RateParam
 }
 
+type ChunkEncodingFormat = uint8
 type BundleEncodingFormat = uint8
 
 const (
@@ -52,7 +53,110 @@ const (
 	// in protobuf, UNKNOWN as 0 is a convention).
 	GobBundleEncodingFormat   BundleEncodingFormat = 0
 	GnarkBundleEncodingFormat BundleEncodingFormat = 1
+
+	// Similar to bundle encoding format, this describes the encoding format of chunks.
+	// The difference is ChunkEncodingFormat is just about chunks, whereas BundleEncodingFormat
+	// is also about how multiple chunks of the same bundle are packed into a single byte array.
+	GobChunkEncodingFormat   ChunkEncodingFormat = 0
+	GnarkChunkEncodingFormat ChunkEncodingFormat = 1
 )
+
+type ChunksData struct {
+	// Chunks is the encoded bytes of the chunks.
+	// Each chunk are of same size.
+	Chunks [][]byte
+	// Format describes how the bytes of the chunks are encoded.
+	Format ChunkEncodingFormat
+}
+
+func (cd *ChunksData) Size() uint64 {
+	if len(cd.Chunks) == 0 {
+		return 0
+	}
+	return uint64(len(cd.Chunks)) * uint64(len(cd.Chunks[0]))
+}
+
+func (cd *ChunksData) ChunkLength() int {
+	if len(cd.Chunks) == 0 {
+		return 0
+	}
+	return len(cd.Chunks[0]) / encoding.BYTES_PER_SYMBOL
+}
+
+func (cd *ChunksData) FlattenToBundle() ([]byte, error) {
+	var format BundleEncodingFormat
+	switch cd.Format {
+	case GobChunkEncodingFormat:
+		format = GobBundleEncodingFormat
+	case GnarkChunkEncodingFormat:
+		format = GnarkBundleEncodingFormat
+	default:
+		return nil, fmt.Errorf("unsupported chunk encoding format: %v", cd.Format)
+	}
+	result := make([]byte, cd.Size()+8)
+	buf := result
+	metadata := (uint64(format) << (NumBundleHeaderBits - NumBundleEncodingFormatBits)) | uint64(cd.ChunkLength())
+	binary.LittleEndian.PutUint64(buf, metadata)
+	buf = buf[8:]
+	for _, c := range cd.Chunks {
+		if len(c) != len(cd.Chunks[0]) {
+			return nil, errors.New("all chunks must be of same size")
+		}
+		copy(buf, c)
+		buf = buf[len(c):]
+	}
+	return result, nil
+}
+
+func (cd *ChunksData) ToGobFormat() (*ChunksData, error) {
+	if cd.Format == GobChunkEncodingFormat {
+		return cd, nil
+	}
+	if cd.Format != GnarkChunkEncodingFormat {
+		return nil, fmt.Errorf("unsupported chunk encoding format: %d", cd.Format)
+	}
+	gobChunks := make([][]byte, 0, len(cd.Chunks))
+	for _, chunk := range cd.Chunks {
+		c, err := new(encoding.Frame).DeserializeGnark(chunk)
+		if err != nil {
+			return nil, err
+		}
+		gob, err := c.Serialize()
+		if err != nil {
+			return nil, err
+		}
+		gobChunks = append(gobChunks, gob)
+	}
+	return &ChunksData{
+		Chunks: gobChunks,
+		Format: GobChunkEncodingFormat,
+	}, nil
+}
+
+func (cd *ChunksData) ToGnarkFormat() (*ChunksData, error) {
+	if cd.Format == GnarkChunkEncodingFormat {
+		return cd, nil
+	}
+	if cd.Format != GobChunkEncodingFormat {
+		return nil, fmt.Errorf("unsupported chunk encoding format: %d", cd.Format)
+	}
+	gnarkChunks := make([][]byte, 0, len(cd.Chunks))
+	for _, chunk := range cd.Chunks {
+		c, err := new(encoding.Frame).Deserialize(chunk)
+		if err != nil {
+			return nil, err
+		}
+		gnark, err := c.SerializeGnark()
+		if err != nil {
+			return nil, err
+		}
+		gnarkChunks = append(gnarkChunks, gnark)
+	}
+	return &ChunksData{
+		Chunks: gnarkChunks,
+		Format: GnarkChunkEncodingFormat,
+	}, nil
+}
 
 func (s *SecurityParam) String() string {
 	return fmt.Sprintf("QuorumID: %d, AdversaryThreshold: %d, ConfirmationThreshold: %d", s.QuorumID, s.AdversaryThreshold, s.ConfirmationThreshold)


### PR DESCRIPTION
## Why are these changes needed?
Create a `ChunksData` data structure for the encoded chunks data. This will be used to pass chunks around Encoder/Batcher/Dispatcher and eventually used to create dispersal requests to operator nodes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
