### PR TITLE
[blobstore] Filter out expired blobs from query

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -154,13 +154,24 @@ func (b *Batcher) RecoverState(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get blobs in dispersing state: %w", err)
 	}
+	expired := 0
+	processing := 0
 	for _, meta := range metas {
-		err = b.Queue.MarkBlobProcessing(ctx, meta.GetBlobKey())
-		if err != nil {
-			return fmt.Errorf("failed to mark blob (%s) as processing: %w", meta.GetBlobKey(), err)
+		if meta.Expiry == 0 || meta.Expiry < uint64(time.Now().Unix()) {
+			err = b.Queue.MarkBlobFailed(ctx, meta.GetBlobKey())
+			if err != nil {
+				return fmt.Errorf("failed to mark blob (%s) as failed: %w", meta.GetBlobKey(), err)
+			}
+			expired += 1
+		} else {
+			err = b.Queue.MarkBlobProcessing(ctx, meta.GetBlobKey())
+			if err != nil {
+				return fmt.Errorf("failed to mark blob (%s) as processing: %w", meta.GetBlobKey(), err)
+			}
+			processing += 1
 		}
 	}
-	b.logger.Info("Recovering state took", "duration", time.Since(start), "numBlobs", len(metas))
+	b.logger.Info("Recovering state took", "duration", time.Since(start), "numBlobs", len(metas), "expired", expired, "processing", processing)
 	return nil
 }
 

--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -40,7 +40,7 @@ var (
 type batcherComponents struct {
 	transactor       *coremock.MockTransactor
 	txnManager       *batchermock.MockTxnManager
-	blobStore        disperser.BlobStore
+	blobStore        *inmem.BlobStore
 	encoderClient    *disperser.LocalEncoderClient
 	encodingStreamer *bat.EncodingStreamer
 	ethClient        *cmock.MockEthClient
@@ -101,7 +101,10 @@ func makeBatcher(t *testing.T) (*batcherComponents, *bat.Batcher, func() []time.
 
 	// Disperser Components
 	dispatcher := dmock.NewDispatcher(state)
-	blobStore := inmem.NewBlobStore()
+	blobStore := &inmem.BlobStore{
+		Blobs:    make(map[disperser.BlobHash]*inmem.BlobHolder),
+		Metadata: make(map[disperser.BlobKey]*disperser.BlobMetadata),
+	}
 
 	pullInterval := 100 * time.Millisecond
 	config := bat.Config{
@@ -779,31 +782,57 @@ func TestBatcherRecoverState(t *testing.T) {
 		},
 	})
 
+	blob2 := makeTestBlob([]*core.SecurityParam{
+		{
+			QuorumID:              0,
+			AdversaryThreshold:    80,
+			ConfirmationThreshold: 100,
+		},
+		{
+			QuorumID:              2,
+			AdversaryThreshold:    80,
+			ConfirmationThreshold: 100,
+		},
+	})
+
 	components, batcher, _ := makeBatcher(t)
 
 	blobStore := components.blobStore
 	ctx := context.Background()
-	_, key1 := queueBlob(t, ctx, &blob0, blobStore)
-	_, _ = queueBlob(t, ctx, &blob1, blobStore)
+	_, key0 := queueBlob(t, ctx, &blob0, blobStore)
+	_, key1 := queueBlob(t, ctx, &blob1, blobStore)
+	_, key2 := queueBlob(t, ctx, &blob2, blobStore)
+	components.blobStore.Metadata[key2].Expiry = uint64(time.Now().Add(time.Hour * (-24)).Unix())
 
-	err := blobStore.MarkBlobDispersing(ctx, key1)
+	err := blobStore.MarkBlobDispersing(ctx, key0)
 	assert.NoError(t, err)
-	processingBlobs, err := blobStore.GetBlobMetadataByStatus(ctx, disperser.Processing)
+	err = blobStore.MarkBlobDispersing(ctx, key2)
 	assert.NoError(t, err)
-	assert.Len(t, processingBlobs, 1)
 
-	dispersingBlobs, err := blobStore.GetBlobMetadataByStatus(ctx, disperser.Dispersing)
+	b0, err := blobStore.GetBlobMetadata(ctx, key0)
 	assert.NoError(t, err)
-	assert.Len(t, dispersingBlobs, 1)
+	assert.Equal(t, b0.BlobStatus, disperser.Dispersing)
+
+	b1, err := blobStore.GetBlobMetadata(ctx, key1)
+	assert.NoError(t, err)
+	assert.Equal(t, b1.BlobStatus, disperser.Processing)
+
+	b2, err := blobStore.GetBlobMetadata(ctx, key2)
+	assert.NoError(t, err)
+	assert.Equal(t, b2.BlobStatus, disperser.Dispersing)
 
 	err = batcher.RecoverState(context.Background())
 	assert.NoError(t, err)
 
-	processingBlobs, err = blobStore.GetBlobMetadataByStatus(ctx, disperser.Processing)
+	b0, err = blobStore.GetBlobMetadata(ctx, key0)
 	assert.NoError(t, err)
-	assert.Len(t, processingBlobs, 2)
+	assert.Equal(t, b0.BlobStatus, disperser.Processing)
 
-	dispersingBlobs, err = blobStore.GetBlobMetadataByStatus(ctx, disperser.Dispersing)
+	b1, err = blobStore.GetBlobMetadata(ctx, key1)
 	assert.NoError(t, err)
-	assert.Len(t, dispersingBlobs, 0)
+	assert.Equal(t, b1.BlobStatus, disperser.Processing)
+
+	b2, err = blobStore.GetBlobMetadata(ctx, key2)
+	assert.NoError(t, err)
+	assert.Equal(t, b2.BlobStatus, disperser.Failed)
 }

--- a/disperser/batcher/finalizer_test.go
+++ b/disperser/batcher/finalizer_test.go
@@ -56,6 +56,7 @@ func TestFinalizedBlob(t *testing.T) {
 	blobIndex := uint32(10)
 	sigRecordHash := [32]byte{0}
 	inclusionProof := []byte{1, 2, 3, 4, 5}
+	expiry := uint64(time.Now().Add(time.Hour).Unix())
 	confirmationInfo := &disperser.ConfirmationInfo{
 		BatchHeaderHash:         batchHeaderHash,
 		BlobIndex:               blobIndex,
@@ -73,7 +74,7 @@ func TestFinalizedBlob(t *testing.T) {
 		BlobHash:     metadataKey1.BlobHash,
 		MetadataHash: metadataKey1.MetadataHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       expiry,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: core.BlobRequestHeader{
@@ -86,7 +87,7 @@ func TestFinalizedBlob(t *testing.T) {
 		BlobHash:     metadataKey2.BlobHash,
 		MetadataHash: metadataKey2.MetadataHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       expiry + 1,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: core.BlobRequestHeader{
@@ -164,11 +165,12 @@ func TestUnfinalizedBlob(t *testing.T) {
 		ConfirmationBlockNumber: uint32(150),
 		Fee:                     []byte{0},
 	}
+	expiry := uint64(time.Now().Add(100000).Unix())
 	metadata := &disperser.BlobMetadata{
 		BlobHash:     metadataKey.BlobHash,
 		MetadataHash: metadataKey.MetadataHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       expiry,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: core.BlobRequestHeader{
@@ -234,11 +236,12 @@ func TestNoReceipt(t *testing.T) {
 		ConfirmationBlockNumber: uint32(150),
 		Fee:                     []byte{0},
 	}
+	expiry := uint64(time.Now().Add(100000).Unix())
 	metadata := &disperser.BlobMetadata{
 		BlobHash:     metadataKey.BlobHash,
 		MetadataHash: metadataKey.MetadataHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       expiry,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: core.BlobRequestHeader{

--- a/disperser/common/blobstore/blob_metadata_store_test.go
+++ b/disperser/common/blobstore/blob_metadata_store_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	commondynamodb "github.com/Layr-Labs/eigenda/common/aws/dynamodb"
-	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -22,16 +21,17 @@ func TestBlobMetadataStoreOperations(t *testing.T) {
 		BlobHash:     blobHash,
 		MetadataHash: "hash",
 	}
+	now := time.Now()
 	metadata1 := &disperser.BlobMetadata{
 		MetadataHash: blobKey1.MetadataHash,
 		BlobHash:     blobHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       uint64(now.Add(time.Hour).Unix()),
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
 			BlobSize:          blobSize,
-			RequestedAt:       123,
+			RequestedAt:       uint64(now.Unix()),
 		},
 	}
 	blobKey2 := disperser.BlobKey{
@@ -42,12 +42,12 @@ func TestBlobMetadataStoreOperations(t *testing.T) {
 		MetadataHash: blobKey2.MetadataHash,
 		BlobHash:     blobKey2.BlobHash,
 		BlobStatus:   disperser.Finalized,
-		Expiry:       0,
+		Expiry:       uint64(now.Add(time.Hour).Unix()),
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
 			BlobSize:          blobSize,
-			RequestedAt:       123,
+			RequestedAt:       uint64(now.Unix()),
 		},
 		ConfirmationInfo: &disperser.ConfirmationInfo{},
 	}
@@ -73,7 +73,7 @@ func TestBlobMetadataStoreOperations(t *testing.T) {
 	assert.Len(t, processing, 1)
 	assert.Equal(t, metadata1, processing[0])
 
-	processingCount, err := blobMetadataStore.GetBlobMetadataByStatusCount(ctx, disperser.Processing)
+	processingCount, err := blobMetadataStore.GetBlobMetadataCountByStatus(ctx, disperser.Processing)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(1), processingCount)
 
@@ -89,11 +89,11 @@ func TestBlobMetadataStoreOperations(t *testing.T) {
 	assert.Len(t, finalized, 1)
 	assert.Equal(t, metadata2, finalized[0])
 
-	finalizedCount, err := blobMetadataStore.GetBlobMetadataByStatusCount(ctx, disperser.Finalized)
+	finalizedCount, err := blobMetadataStore.GetBlobMetadataCountByStatus(ctx, disperser.Finalized)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(1), finalizedCount)
 
-	confirmedMetadata := getConfirmedMetadata(t, blobKey1, 1)
+	confirmedMetadata := getConfirmedMetadata(t, metadata1, 1)
 	err = blobMetadataStore.UpdateBlobMetadata(ctx, blobKey1, confirmedMetadata)
 	assert.NoError(t, err)
 
@@ -101,7 +101,7 @@ func TestBlobMetadataStoreOperations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, metadata, confirmedMetadata)
 
-	confirmedCount, err := blobMetadataStore.GetBlobMetadataByStatusCount(ctx, disperser.Confirmed)
+	confirmedCount, err := blobMetadataStore.GetBlobMetadataCountByStatus(ctx, disperser.Confirmed)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(1), confirmedCount)
 
@@ -123,16 +123,17 @@ func TestBlobMetadataStoreOperationsWithPagination(t *testing.T) {
 		BlobHash:     blobHash,
 		MetadataHash: "hash",
 	}
+	now := time.Now()
 	metadata1 := &disperser.BlobMetadata{
 		MetadataHash: blobKey1.MetadataHash,
 		BlobHash:     blobHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       uint64(now.Add(time.Hour).Unix()),
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
 			BlobSize:          blobSize,
-			RequestedAt:       123,
+			RequestedAt:       uint64(now.Unix()),
 		},
 	}
 	blobKey2 := disperser.BlobKey{
@@ -143,12 +144,12 @@ func TestBlobMetadataStoreOperationsWithPagination(t *testing.T) {
 		MetadataHash: blobKey2.MetadataHash,
 		BlobHash:     blobKey2.BlobHash,
 		BlobStatus:   disperser.Finalized,
-		Expiry:       0,
+		Expiry:       uint64(now.Add(time.Hour).Unix()),
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
 			BlobSize:          blobSize,
-			RequestedAt:       123,
+			RequestedAt:       uint64(now.Unix()),
 		},
 		ConfirmationInfo: &disperser.ConfirmationInfo{},
 	}
@@ -199,11 +200,12 @@ func TestGetAllBlobMetadataByBatchWithPagination(t *testing.T) {
 		BlobHash:     blobHash,
 		MetadataHash: "hash",
 	}
+	expiry := uint64(time.Now().Add(time.Hour).Unix())
 	metadata1 := &disperser.BlobMetadata{
 		MetadataHash: blobKey1.MetadataHash,
 		BlobHash:     blobHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       expiry,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
@@ -219,7 +221,7 @@ func TestGetAllBlobMetadataByBatchWithPagination(t *testing.T) {
 		MetadataHash: blobKey2.MetadataHash,
 		BlobHash:     blobKey2.BlobHash,
 		BlobStatus:   disperser.Finalized,
-		Expiry:       0,
+		Expiry:       expiry,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
@@ -233,11 +235,11 @@ func TestGetAllBlobMetadataByBatchWithPagination(t *testing.T) {
 	err = blobMetadataStore.QueueNewBlobMetadata(ctx, metadata2)
 	assert.NoError(t, err)
 
-	confirmedMetadata1 := getConfirmedMetadata(t, blobKey1, 1)
+	confirmedMetadata1 := getConfirmedMetadata(t, metadata1, 1)
 	err = blobMetadataStore.UpdateBlobMetadata(ctx, blobKey1, confirmedMetadata1)
 	assert.NoError(t, err)
 
-	confirmedMetadata2 := getConfirmedMetadata(t, blobKey2, 2)
+	confirmedMetadata2 := getConfirmedMetadata(t, metadata2, 2)
 	err = blobMetadataStore.UpdateBlobMetadata(ctx, blobKey2, confirmedMetadata2)
 	assert.NoError(t, err)
 
@@ -306,11 +308,12 @@ func TestShadowWriteBlobMetadata(t *testing.T) {
 		BlobHash:     "shadowblob",
 		MetadataHash: "shadowhash",
 	}
+	expiry := uint64(time.Now().Add(time.Hour).Unix())
 	metadata := &disperser.BlobMetadata{
 		MetadataHash: blobKey.MetadataHash,
 		BlobHash:     blobKey.BlobHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       expiry,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
@@ -321,7 +324,6 @@ func TestShadowWriteBlobMetadata(t *testing.T) {
 	}
 
 	err := shadowBlobMetadataStore.QueueNewBlobMetadata(ctx, metadata)
-	assert.NoError(t, err)
 	assert.NoError(t, err)
 	err = blobMetadataStore.SetBlobStatus(context.Background(), blobKey, disperser.Dispersing)
 	assert.NoError(t, err)
@@ -351,14 +353,58 @@ func TestShadowWriteBlobMetadata(t *testing.T) {
 	})
 }
 
+func TestFilterOutExpiredBlobMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	blobKey := disperser.BlobKey{
+		BlobHash:     "blob1",
+		MetadataHash: "hash1",
+	}
+	now := time.Now()
+	metadata := &disperser.BlobMetadata{
+		MetadataHash: blobKey.MetadataHash,
+		BlobHash:     blobKey.BlobHash,
+		BlobStatus:   disperser.Processing,
+		Expiry:       uint64(now.Add(-1).Unix()),
+		NumRetries:   0,
+		RequestMetadata: &disperser.RequestMetadata{
+			BlobRequestHeader: blob.RequestHeader,
+			BlobSize:          blobSize,
+			RequestedAt:       uint64(now.Add(-1000).Unix()),
+		},
+		ConfirmationInfo: &disperser.ConfirmationInfo{},
+	}
+
+	err := blobMetadataStore.QueueNewBlobMetadata(ctx, metadata)
+	assert.NoError(t, err)
+
+	processing, err := blobMetadataStore.GetBlobMetadataByStatus(ctx, disperser.Processing)
+	assert.NoError(t, err)
+	assert.Len(t, processing, 0)
+
+	processingCount, err := blobMetadataStore.GetBlobMetadataCountByStatus(ctx, disperser.Processing)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(0), processingCount)
+
+	processing, _, err = blobMetadataStore.GetBlobMetadataByStatusWithPagination(ctx, disperser.Processing, 10, nil)
+	assert.NoError(t, err)
+	assert.Len(t, processing, 0)
+
+	deleteItems(t, []commondynamodb.Key{
+		{
+			"MetadataHash": &types.AttributeValueMemberS{Value: blobKey.MetadataHash},
+			"BlobHash":     &types.AttributeValueMemberS{Value: blobKey.BlobHash},
+		},
+	})
+}
+
 func deleteItems(t *testing.T, keys []commondynamodb.Key) {
 	_, err := dynamoClient.DeleteItems(context.Background(), metadataTableName, keys)
 	assert.NoError(t, err)
 }
 
-func getConfirmedMetadata(t *testing.T, metadataKey disperser.BlobKey, blobIndex uint32) *disperser.BlobMetadata {
+func getConfirmedMetadata(t *testing.T, metadata *disperser.BlobMetadata, blobIndex uint32) *disperser.BlobMetadata {
 	batchHeaderHash := [32]byte{1, 2, 3}
-	requestedAt := uint64(time.Now().Nanosecond())
 	var commitX, commitY fp.Element
 	_, err := commitX.SetString("21661178944771197726808973281966770251114553549453983978976194544185382599016")
 	assert.NoError(t, err)
@@ -376,34 +422,23 @@ func getConfirmedMetadata(t *testing.T, metadataKey disperser.BlobKey, blobIndex
 	sigRecordHash := [32]byte{0}
 	fee := []byte{0}
 	inclusionProof := []byte{1, 2, 3, 4, 5}
-	return &disperser.BlobMetadata{
-		BlobHash:     metadataKey.BlobHash,
-		MetadataHash: metadataKey.MetadataHash,
-		BlobStatus:   disperser.Confirmed,
-		Expiry:       0,
-		NumRetries:   0,
-		RequestMetadata: &disperser.RequestMetadata{
-			BlobRequestHeader: core.BlobRequestHeader{
-				SecurityParams: securityParams,
-			},
-			RequestedAt: requestedAt,
-			BlobSize:    blobSize,
+	confirmationInfo := &disperser.ConfirmationInfo{
+		BatchHeaderHash:      batchHeaderHash,
+		BlobIndex:            blobIndex,
+		SignatoryRecordHash:  sigRecordHash,
+		ReferenceBlockNumber: referenceBlockNumber,
+		BatchRoot:            batchRoot,
+		BlobInclusionProof:   inclusionProof,
+		BlobCommitment: &encoding.BlobCommitments{
+			Commitment: commitment,
+			Length:     uint(dataLength),
 		},
-		ConfirmationInfo: &disperser.ConfirmationInfo{
-			BatchHeaderHash:      batchHeaderHash,
-			BlobIndex:            blobIndex,
-			SignatoryRecordHash:  sigRecordHash,
-			ReferenceBlockNumber: referenceBlockNumber,
-			BatchRoot:            batchRoot,
-			BlobInclusionProof:   inclusionProof,
-			BlobCommitment: &encoding.BlobCommitments{
-				Commitment: commitment,
-				Length:     uint(dataLength),
-			},
-			BatchID:                 batchID,
-			ConfirmationTxnHash:     common.HexToHash("0x123"),
-			ConfirmationBlockNumber: confirmationBlockNumber,
-			Fee:                     fee,
-		},
+		BatchID:                 batchID,
+		ConfirmationTxnHash:     common.HexToHash("0x123"),
+		ConfirmationBlockNumber: confirmationBlockNumber,
+		Fee:                     fee,
 	}
+	metadata.BlobStatus = disperser.Confirmed
+	metadata.ConfirmationInfo = confirmationInfo
+	return metadata
 }

--- a/disperser/common/blobstore/shared_storage_test.go
+++ b/disperser/common/blobstore/shared_storage_test.go
@@ -56,14 +56,12 @@ func TestSharedBlobStore(t *testing.T) {
 	err = sharedStorage.IncrementBlobRetryCount(ctx, metadata1)
 	assert.Nil(t, err)
 	metadata1, err = sharedStorage.GetBlobMetadata(ctx, blobKey)
-	fmt.Println("Num Retries", metadata1.NumRetries)
 	assert.Nil(t, err)
 	assert.Equal(t, uint(1), metadata1.NumRetries)
 
 	err = sharedStorage.IncrementBlobRetryCount(ctx, metadata1)
 	assert.Nil(t, err)
 	metadata1, err = sharedStorage.GetBlobMetadata(ctx, blobKey)
-	fmt.Println("Num Retries", metadata1.NumRetries)
 	assert.Nil(t, err)
 	assert.Equal(t, uint(2), metadata1.NumRetries)
 
@@ -198,11 +196,12 @@ func TestSharedBlobStoreBlobMetadataStoreOperationsWithPagination(t *testing.T) 
 		BlobHash:     blobHash,
 		MetadataHash: "hash",
 	}
+	expiry := uint64(time.Now().Add(time.Hour).Unix())
 	metadata1 := &disperser.BlobMetadata{
 		MetadataHash: blobKey1.MetadataHash,
 		BlobHash:     blobHash,
 		BlobStatus:   disperser.Processing,
-		Expiry:       0,
+		Expiry:       expiry,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,
@@ -218,7 +217,7 @@ func TestSharedBlobStoreBlobMetadataStoreOperationsWithPagination(t *testing.T) 
 		MetadataHash: blobKey2.MetadataHash,
 		BlobHash:     blobKey2.BlobHash,
 		BlobStatus:   disperser.Finalized,
-		Expiry:       0,
+		Expiry:       expiry,
 		NumRetries:   0,
 		RequestMetadata: &disperser.RequestMetadata{
 			BlobRequestHeader: blob.RequestHeader,

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -128,7 +128,7 @@ func (collector *DynamoDBCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *DynamoDBCollector) Collect(ch chan<- prometheus.Metric) {
-	count, err := collector.blobMetadataStore.GetBlobMetadataByStatusCount(context.Background(), disperser.Processing)
+	count, err := collector.blobMetadataStore.GetBlobMetadataCountByStatus(context.Background(), disperser.Processing)
 	if err != nil {
 		collector.logger.Error("failed to get count of blob metadata by status", "err", err)
 		return

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -132,7 +132,7 @@ type BlobStoreExclusiveStartKey struct {
 	BlobHash     BlobHash
 	MetadataHash MetadataHash
 	BlobStatus   int32 // BlobStatus is an integer
-	RequestedAt  int64 //  RequestedAt is epoch time in seconds
+	Expiry       int64 // Expiry is epoch time in seconds
 }
 
 type BatchIndexExclusiveStartKey struct {


### PR DESCRIPTION
## Why are these changes needed?
Updates `GetBlobMetadataByStatusXXX` methods so that it doesn't fetch any expired blobs (determined by filtering on `RequestedAt > Now - TTL`). 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
