### PR TITLE
[node] Refactor blob expiration key

### DIFF
--- a/node/store.go
+++ b/node/store.go
@@ -458,17 +458,6 @@ func (s *Store) StoreBlobs(ctx context.Context, blobs []*core.BlobMessage, blobs
 	values := make([][]byte, 0)
 
 	expirationTime := s.expirationTime()
-	expirationKey := EncodeBlobExpirationKey(expirationTime)
-	// expirationValue is a list of blob header hashes that are expired.
-	expirationValue := make([]byte, 0)
-	var err error
-	// If there is already an expiration key in the store, we need to get the value and append to it.
-	if s.HasKey(ctx, expirationKey) {
-		expirationValue, err = s.db.Get(expirationKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get the expiration value: %w", err)
-		}
-	}
 
 	// Generate key/value pairs for all blob headers and blob chunks .
 	size := int64(0)
@@ -479,11 +468,17 @@ func (s *Store) StoreBlobs(ctx context.Context, blobs []*core.BlobMessage, blobs
 			return nil, fmt.Errorf("internal error: the number of bundles in parsed blob (%d) must be the same as in raw blob (%d)", len(rawBlob.GetBundles()), len(blob.Bundles))
 		}
 
-		// blob header
 		blobHeaderHash, err := blob.BlobHeader.GetBlobHeaderHash()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get blob header hash: %w", err)
 		}
+
+		// expiration key
+		expirationKey := EncodeBlobExpirationKey(expirationTime, blobHeaderHash)
+		keys = append(keys, expirationKey)
+		values = append(values, blobHeaderHash[:])
+
+		// blob header
 		blobHeaderKey := EncodeBlobHeaderKeyByHash(blobHeaderHash)
 		if s.HasKey(ctx, blobHeaderKey) {
 			s.logger.Warn("Blob already exists", "blobHeaderHash", hexutil.Encode(blobHeaderHash[:]))
@@ -496,7 +491,6 @@ func (s *Store) StoreBlobs(ctx context.Context, blobs []*core.BlobMessage, blobs
 		}
 		keys = append(keys, blobHeaderKey)
 		values = append(values, blobHeaderBytes)
-		expirationValue = append(expirationValue, blobHeaderHash[:]...)
 
 		// Get raw chunks
 		start := time.Now()
@@ -559,12 +553,9 @@ func (s *Store) StoreBlobs(ctx context.Context, blobs []*core.BlobMessage, blobs
 		encodingDuration += time.Since(start)
 	}
 
-	keys = append(keys, expirationKey)
-	values = append(values, expirationValue)
-
 	start := time.Now()
 	// Write all the key/value pairs to the local database atomically.
-	err = s.db.WriteBatch(keys, values)
+	err := s.db.WriteBatch(keys, values)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write the batch into local database: %w", err)
 	}


### PR DESCRIPTION
## Why are these changes needed?
Instead of representing blob expiration value as a slice of blob header hashes, make each expiration key encode blob header hash so it represents expiration for a single blob.
Context: https://github.com/Layr-Labs/eigenda/pull/676#discussion_r1711801426

To be merged on top of https://github.com/Layr-Labs/eigenda/pull/676
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
