### PR TITLE
[node] Make `GetBlobHeader` compatible with minibatches

### DIFF
--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -489,7 +489,7 @@ func (s *Server) GetBlobHeader(ctx context.Context, in *pb.GetBlobHeaderRequest)
 func (s *Server) rebuildMerkleTree(batchHeaderHash [32]byte) (*merkletree.MerkleTree, error) {
 	batchHeaderBytes, err := s.node.Store.GetBatchHeader(context.Background(), batchHeaderHash)
 	if err != nil {
-		return nil, errors.New("failed to get the batch header from Store")
+		return nil, err
 	}
 
 	batchHeader, err := new(core.BatchHeader).Deserialize(batchHeaderBytes)
@@ -547,7 +547,7 @@ func (s *Server) getBlobHeader(ctx context.Context, batchHeaderHash [32]byte, bl
 
 	blobHeaderBytes, err := s.node.Store.GetBlobHeader(ctx, batchHeaderHash, blobIndex)
 	if err != nil {
-		return nil, nil, errors.New("failed to get the blob header from Store")
+		return nil, nil, fmt.Errorf("failed to get the blob header from Store: %w", err)
 	}
 
 	var protoBlobHeader pb.BlobHeader

--- a/node/grpc/server_test.go
+++ b/node/grpc/server_test.go
@@ -422,7 +422,8 @@ func TestAttestBatch(t *testing.T) {
 		Blobs:                reqToCopy.Blobs,
 		ReferenceBlockNumber: 1,
 	}
-	reply, err := server.StoreBlobs(context.Background(), req)
+	ctx := context.Background()
+	reply, err := server.StoreBlobs(ctx, req)
 	assert.NoError(t, err)
 	assert.NotNil(t, reply.GetSignatures())
 
@@ -444,7 +445,7 @@ func TestAttestBatch(t *testing.T) {
 		},
 		BlobHeaderHashes: [][]byte{bhh0[:], bhh1[:]},
 	}
-	attestReply, err := server.AttestBatch(context.Background(), attestReq)
+	attestReply, err := server.AttestBatch(ctx, attestReq)
 	assert.NotNil(t, reply)
 	assert.NoError(t, err)
 	sig := attestReply.GetSignature()
@@ -456,6 +457,52 @@ func TestAttestBatch(t *testing.T) {
 	s := &core.Signature{G1Point: point}
 	ok := s.Verify(keyPair.GetPubKeyG2(), batchHeaderHash)
 	assert.True(t, ok)
+
+	// Get blob headers
+	blobHeaderReply, err := server.GetBlobHeader(ctx, &pb.GetBlobHeaderRequest{
+		BatchHeaderHash: batchHeaderHash[:],
+		BlobIndex:       0,
+		QuorumId:        0,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, blobHeaderReply)
+	blobHeader, err := node.GetBlobHeaderFromProto(blobHeaderReply.GetBlobHeader())
+	assert.NoError(t, err)
+	assert.Equal(t, blobHeader, blobHeaders[0])
+	proof := &merkletree.Proof{
+		Hashes: blobHeaderReply.GetProof().GetHashes(),
+		Index:  uint64(blobHeaderReply.GetProof().GetIndex()),
+	}
+	ok, err = merkletree.VerifyProofUsing(bhh0[:], false, proof, [][]byte{batchHeader.BatchRoot[:]}, keccak256.New())
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	blobHeaderReply, err = server.GetBlobHeader(ctx, &pb.GetBlobHeaderRequest{
+		BatchHeaderHash: batchHeaderHash[:],
+		BlobIndex:       1,
+		QuorumId:        0,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, blobHeaderReply)
+	blobHeader, err = node.GetBlobHeaderFromProto(blobHeaderReply.GetBlobHeader())
+	assert.NoError(t, err)
+	assert.Equal(t, blobHeader, blobHeaders[1])
+	proof = &merkletree.Proof{
+		Hashes: blobHeaderReply.GetProof().GetHashes(),
+		Index:  uint64(blobHeaderReply.GetProof().GetIndex()),
+	}
+	ok, err = merkletree.VerifyProofUsing(bhh1[:], false, proof, [][]byte{batchHeader.BatchRoot[:]}, keccak256.New())
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	// non-existent blob index
+	_, err = server.GetBlobHeader(ctx, &pb.GetBlobHeaderRequest{
+		BatchHeaderHash: batchHeaderHash[:],
+		BlobIndex:       2,
+		QuorumId:        0,
+	})
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "commit not found in db"))
 }
 
 func TestRetrieveChunks(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
`GetBlobHeader` attempts to find blob header using the existing schema. If it doesn't find one, it uses the new schema (`blobIndexKey` to fetch the blob header hash and then `blobHeaderKey` to fetch the blob header).
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
