### PR TITLE
Compress signatures in minibatch response

### DIFF
--- a/core/serialization_test.go
+++ b/core/serialization_test.go
@@ -210,3 +210,14 @@ func TestParseOperatorSocket(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "invalid socket address format: localhost1234;5678", err.Error())
 }
+
+func TestSignatureBytes(t *testing.T) {
+	sig := &core.Signature{
+		G1Point: core.NewG1Point(big.NewInt(1), big.NewInt(2)),
+	}
+	bytes := sig.Bytes()
+	recovered := new(bn254.G1Affine)
+	_, err := recovered.SetBytes(bytes[:])
+	assert.NoError(t, err)
+	assert.Equal(t, recovered, sig.G1Point.G1Affine)
+}

--- a/disperser/batcher/batch_confirmer_test.go
+++ b/disperser/batcher/batch_confirmer_test.go
@@ -199,7 +199,7 @@ func TestBatchConfirmerIteration(t *testing.T) {
 			NumBlobs:       1,
 			RequestedAt:    time.Now(),
 			DispersalResponse: bat.DispersalResponse{
-				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage(batchHeaderHash1)},
+				Signatures:  [][32]byte{opInfo.KeyPair.SignMessage(batchHeaderHash1).Bytes()},
 				RespondedAt: time.Now(),
 				Error:       nil,
 			},
@@ -215,7 +215,7 @@ func TestBatchConfirmerIteration(t *testing.T) {
 			NumBlobs:       1,
 			RequestedAt:    time.Now(),
 			DispersalResponse: bat.DispersalResponse{
-				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage(batchHeaderHash2)},
+				Signatures:  [][32]byte{opInfo.KeyPair.SignMessage(batchHeaderHash2).Bytes()},
 				RespondedAt: time.Now(),
 				Error:       nil,
 			},
@@ -359,7 +359,7 @@ func TestBatchConfirmerIterationFailure(t *testing.T) {
 			NumBlobs:       2,
 			RequestedAt:    time.Now(),
 			DispersalResponse: bat.DispersalResponse{
-				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
+				Signatures:  [][32]byte{opInfo.KeyPair.SignMessage([32]byte{0}).Bytes()},
 				RespondedAt: time.Now(),
 				Error:       nil,
 			},
@@ -434,7 +434,7 @@ func TestBatchConfirmerInsufficientSignatures(t *testing.T) {
 			NumBlobs:       2,
 			RequestedAt:    time.Now(),
 			DispersalResponse: bat.DispersalResponse{
-				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
+				Signatures:  [][32]byte{opInfo.KeyPair.SignMessage([32]byte{0}).Bytes()},
 				RespondedAt: time.Now(),
 				Error:       nil,
 			},
@@ -449,7 +449,7 @@ func TestBatchConfirmerInsufficientSignatures(t *testing.T) {
 			NumBlobs:       2,
 			RequestedAt:    time.Now(),
 			DispersalResponse: bat.DispersalResponse{
-				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{1})},
+				Signatures:  [][32]byte{opInfo.KeyPair.SignMessage([32]byte{1}).Bytes()},
 				RespondedAt: time.Now(),
 				Error:       nil,
 			},

--- a/disperser/batcher/minibatch_store.go
+++ b/disperser/batcher/minibatch_store.go
@@ -40,7 +40,10 @@ type BatchRecord struct {
 }
 
 type DispersalResponse struct {
-	Signatures  []*core.Signature
+	// Signatures is the signatures of the blobs that were dispersed to the operator
+	// The order of the signatures is the same as the order of the blobs in the minibatch
+	// The signatures are compressed using G1Affine.Bytes(), to be decompressed using G1Affine.SetBytes()
+	Signatures  [][32]byte
 	RespondedAt time.Time
 	Error       error
 }

--- a/disperser/batcher/minibatcher.go
+++ b/disperser/batcher/minibatcher.go
@@ -265,9 +265,13 @@ func (b *Minibatcher) DisperseBatch(ctx context.Context, state *core.IndexedOper
 			if err != nil {
 				b.logger.Errorf("failed to send blobs to operator %s: %v", opID.Hex(), err)
 			}
+			compressedSignatures := make([][32]byte, 0, len(signatures))
+			for _, signature := range signatures {
+				compressedSignatures = append(compressedSignatures, signature.Bytes())
+			}
 			// Update the minibatch state
 			err = b.MinibatchStore.UpdateDispersalResponse(ctx, req, &DispersalResponse{
-				Signatures:  signatures,
+				Signatures:  compressedSignatures,
 				RespondedAt: time.Now().UTC(),
 				Error:       err,
 			})


### PR DESCRIPTION
## Why are these changes needed?
Compress signatures stored in minibatch response (64 bytes -> 32 bytes)
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
