### PR TITLE
[2/N][zero serialization] Make Batcher operate on chunks without ser/deser

### DIFF
--- a/api/clients/mock/node_client.go
+++ b/api/clients/mock/node_client.go
@@ -54,9 +54,18 @@ func (c *MockNodeClient) GetChunks(
 ) {
 	args := c.Called(opID, opInfo, batchHeaderHash, blobIndex)
 	encodedBlob := (args.Get(0)).(core.EncodedBlob)
+	chunks, err := encodedBlob.EncodedBundlesByOperator[opID][quorumID].ToFrames()
+	if err != nil {
+		chunksChan <- clients.RetrievedChunks{
+			OperatorID: opID,
+			Err:        err,
+			Chunks:     nil,
+		}
+
+	}
 	chunksChan <- clients.RetrievedChunks{
 		OperatorID: opID,
 		Err:        nil,
-		Chunks:     encodedBlob.BundlesByOperator[opID][quorumID],
+		Chunks:     chunks,
 	}
 }

--- a/api/clients/retrieval_client_test.go
+++ b/api/clients/retrieval_client_test.go
@@ -60,8 +60,8 @@ var (
 	retrievalClient   clients.RetrievalClient
 	blobHeader        *core.BlobHeader
 	encodedBlob       core.EncodedBlob = core.EncodedBlob{
-		BlobHeader:        nil,
-		BundlesByOperator: make(map[core.OperatorID]core.Bundles),
+		BlobHeader:               nil,
+		EncodedBundlesByOperator: make(map[core.OperatorID]core.EncodedBundles),
 	}
 	batchHeaderHash        [32]byte
 	batchRoot              [32]byte
@@ -198,7 +198,11 @@ func setup(t *testing.T) {
 		bundles := make(map[core.QuorumID]core.Bundle, len(blobHeader.QuorumInfos))
 		bundles[quorumID] = chunks[assignment.StartIndex : assignment.StartIndex+assignment.NumChunks]
 		encodedBlob.BlobHeader = blobHeader
-		encodedBlob.BundlesByOperator[id] = bundles
+		eb, err := core.Bundles(bundles).ToEncodedBundles()
+		if err != nil {
+			t.Fatal(err)
+		}
+		encodedBlob.EncodedBundlesByOperator[id] = eb
 	}
 
 }

--- a/core/data.go
+++ b/core/data.go
@@ -267,7 +267,7 @@ type EncodedBlob struct {
 	BlobHeader        *BlobHeader
 	BundlesByOperator map[OperatorID]Bundles
 	// EncodedBundlesByOperator is bundles in encoded format (not deserialized)
-	EncodedBundlesByOperator map[OperatorID]map[QuorumID]*ChunksData
+	EncodedBundlesByOperator map[OperatorID]EncodedBundles
 }
 
 // A Bundle is the collection of chunks associated with a single blob, for a single operator and a single quorum.
@@ -275,6 +275,9 @@ type Bundle []*encoding.Frame
 
 // Bundles is the collection of bundles associated with a single blob and a single operator.
 type Bundles map[QuorumID]Bundle
+
+// This is similar to Bundle, but track chunks in encoded format (i.e. not deserialized).
+type EncodedBundles map[QuorumID]*ChunksData
 
 // BlobMessage is the message that is sent to DA nodes. It contains the blob header and the associated chunk bundles.
 type BlobMessage struct {

--- a/core/data.go
+++ b/core/data.go
@@ -280,8 +280,6 @@ type Bundles map[QuorumID]Bundle
 type BlobMessage struct {
 	BlobHeader *BlobHeader
 	Bundles    Bundles
-	// EncodedBundles is bundles in encoded format (not deserialized)
-	EncodedBundles map[QuorumID]*ChunksData
 }
 
 // This is similar to BlobMessage, but keep the commitments and chunks in encoded format

--- a/core/data.go
+++ b/core/data.go
@@ -94,7 +94,7 @@ func (cd *ChunksData) FromFrames(fr []*encoding.Frame) (*ChunksData, error) {
 	var c ChunksData
 	c.Format = GnarkChunkEncodingFormat
 	c.ChunkLen = fr[0].Length()
-	c.Chunks = make([][]byte, len(fr))
+	c.Chunks = make([][]byte, 0, len(fr))
 	for _, f := range fr {
 		bytes, err := f.SerializeGnark()
 		if err != nil {

--- a/core/data.go
+++ b/core/data.go
@@ -171,8 +171,9 @@ func (cd *ChunksData) ToGobFormat() (*ChunksData, error) {
 		gobChunks = append(gobChunks, gob)
 	}
 	return &ChunksData{
-		Chunks: gobChunks,
-		Format: GobChunkEncodingFormat,
+		Chunks:   gobChunks,
+		Format:   GobChunkEncodingFormat,
+		ChunkLen: cd.ChunkLen,
 	}, nil
 }
 
@@ -196,8 +197,9 @@ func (cd *ChunksData) ToGnarkFormat() (*ChunksData, error) {
 		gnarkChunks = append(gnarkChunks, gnark)
 	}
 	return &ChunksData{
-		Chunks: gnarkChunks,
-		Format: GnarkChunkEncodingFormat,
+		Chunks:   gnarkChunks,
+		Format:   GnarkChunkEncodingFormat,
+		ChunkLen: cd.ChunkLen,
 	}, nil
 }
 

--- a/core/data.go
+++ b/core/data.go
@@ -284,6 +284,14 @@ type BlobMessage struct {
 	EncodedBundles map[QuorumID]*ChunksData
 }
 
+// This is similar to BlobMessage, but keep the commitments and chunks in encoded format
+// (i.e. not deserialized)
+type EncodedBlobMessage struct {
+	// TODO(jianoaix): Change the commitments to encoded format.
+	BlobHeader     *BlobHeader
+	EncodedBundles map[QuorumID]*ChunksData
+}
+
 func (b Bundle) Size() uint64 {
 	size := uint64(0)
 	for _, chunk := range b {

--- a/core/data.go
+++ b/core/data.go
@@ -307,8 +307,8 @@ type BatchHeader struct {
 
 // EncodedBlob contains the messages to be sent to a group of DA nodes corresponding to a single blob
 type EncodedBlob struct {
-	BlobHeader        *BlobHeader
-	BundlesByOperator map[OperatorID]Bundles
+	BlobHeader *BlobHeader
+	// BundlesByOperator map[OperatorID]Bundles
 	// EncodedBundlesByOperator is bundles in encoded format (not deserialized)
 	EncodedBundlesByOperator map[OperatorID]EncodedBundles
 }

--- a/core/data.go
+++ b/core/data.go
@@ -307,8 +307,8 @@ type BatchHeader struct {
 
 // EncodedBlob contains the messages to be sent to a group of DA nodes corresponding to a single blob
 type EncodedBlob struct {
-	BlobHeader *BlobHeader
-	// BundlesByOperator map[OperatorID]Bundles
+	BlobHeader        *BlobHeader
+	BundlesByOperator map[OperatorID]Bundles
 	// EncodedBundlesByOperator is bundles in encoded format (not deserialized)
 	EncodedBundlesByOperator map[OperatorID]EncodedBundles
 }

--- a/core/data.go
+++ b/core/data.go
@@ -106,7 +106,7 @@ func (cd *ChunksData) FromFrames(fr []*encoding.Frame) (*ChunksData, error) {
 }
 
 func (cd *ChunksData) ToFrames() ([]*encoding.Frame, error) {
-	frames := make([]*encoding.Frame, len(cd.Chunks))
+	frames := make([]*encoding.Frame, 0, len(cd.Chunks))
 	switch cd.Format {
 	case GobChunkEncodingFormat:
 		for _, data := range cd.Chunks {

--- a/core/data.go
+++ b/core/data.go
@@ -266,6 +266,8 @@ type BatchHeader struct {
 type EncodedBlob struct {
 	BlobHeader        *BlobHeader
 	BundlesByOperator map[OperatorID]Bundles
+	// EncodedBundlesByOperator is bundles in encoded format (not deserialized)
+	EncodedBundlesByOperator map[OperatorID]map[QuorumID]*ChunksData
 }
 
 // A Bundle is the collection of chunks associated with a single blob, for a single operator and a single quorum.
@@ -278,6 +280,8 @@ type Bundles map[QuorumID]Bundle
 type BlobMessage struct {
 	BlobHeader *BlobHeader
 	Bundles    Bundles
+	// EncodedBundles is bundles in encoded format (not deserialized)
+	EncodedBundles map[QuorumID]*ChunksData
 }
 
 func (b Bundle) Size() uint64 {

--- a/core/data_test.go
+++ b/core/data_test.go
@@ -136,6 +136,36 @@ func TestBundleEncoding(t *testing.T) {
 	}
 }
 
+func TestEncodedBundles(t *testing.T) {
+	numTrials := 16
+	for i := 0; i < numTrials; i++ {
+		bundles := core.Bundles(map[core.QuorumID]core.Bundle{
+			0: createBundle(t, 64, 64, i),
+			1: createBundle(t, 64, 64, i+numTrials),
+		})
+		// ToEncodedBundles
+		ec, err := bundles.ToEncodedBundles()
+		assert.Nil(t, err)
+		assert.Equal(t, len(ec), len(bundles))
+		for quorum, bundle := range bundles {
+			cd, ok := ec[quorum]
+			assert.True(t, ok)
+			fr, err := cd.ToFrames()
+			assert.Nil(t, err)
+			checkBundleEquivalence(t, fr, bundle)
+		}
+		// FromEncodedBundles
+		bundles2, err := new(core.Bundles).FromEncodedBundles(ec)
+		assert.Nil(t, err)
+		assert.Equal(t, len(bundles2), len(bundles))
+		for quorum, bundle := range bundles {
+			b, ok := bundles2[quorum]
+			assert.True(t, ok)
+			checkBundleEquivalence(t, b, bundle)
+		}
+	}
+}
+
 func TestChunksData(t *testing.T) {
 	numTrials := 16
 	for i := 0; i < numTrials; i++ {

--- a/core/data_test.go
+++ b/core/data_test.go
@@ -179,20 +179,14 @@ func TestChunksData(t *testing.T) {
 		assert.Equal(t, convertedGob, gob)
 		convertedGob, err = gnark.ToGobFormat()
 		assert.Nil(t, err)
-		assert.Equal(t, len(gob.Chunks), len(convertedGob.Chunks))
-		for i := 0; i < len(gob.Chunks); i++ {
-			assert.True(t, bytes.Equal(gob.Chunks[i], convertedGob.Chunks[i]))
-		}
+		checkChunksDataEquivalence(t, gob, convertedGob)
 		// ToGnarkFormat
 		convertedGnark, err := gnark.ToGnarkFormat()
 		assert.Nil(t, err)
 		assert.Equal(t, convertedGnark, gnark)
 		convertedGnark, err = gob.ToGnarkFormat()
 		assert.Nil(t, err)
-		assert.Equal(t, len(gnark.Chunks), len(convertedGnark.Chunks))
-		for i := 0; i < len(gnark.Chunks); i++ {
-			assert.True(t, bytes.Equal(gnark.Chunks[i], convertedGnark.Chunks[i]))
-		}
+		checkChunksDataEquivalence(t, gnark, convertedGnark)
 		// FlattenToBundle
 		bytesFromChunksData, err := gnark.FlattenToBundle()
 		assert.Nil(t, err)

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -113,8 +113,8 @@ func prepareBatch(t *testing.T, operatorCount uint, blobs []core.Blob, bn uint) 
 		blobHeaders[z] = blobHeader
 
 		encodedBlob := core.EncodedBlob{
-			BlobHeader:        blobHeader,
-			BundlesByOperator: make(map[core.OperatorID]core.Bundles),
+			BlobHeader:               blobHeader,
+			EncodedBundlesByOperator: make(map[core.OperatorID]core.EncodedBundles),
 		}
 		encodedBlobs[z] = encodedBlob
 
@@ -156,6 +156,12 @@ func prepareBatch(t *testing.T, operatorCount uint, blobs []core.Blob, bn uint) 
 			if err != nil {
 				t.Fatal(err)
 			}
+			bytes := make([][]byte, len(chunks))
+			for _, c := range chunks {
+				serialized, err := c.SerializeGnark()
+				t.Fatal(err)
+				bytes = append(bytes, serialized)
+			}
 
 			blobHeader.BlobCommitments = encoding.BlobCommitments{
 				Commitment:       commitments.Commitment,
@@ -167,13 +173,18 @@ func prepareBatch(t *testing.T, operatorCount uint, blobs []core.Blob, bn uint) 
 			blobHeader.QuorumInfos = append(blobHeader.QuorumInfos, quorumHeader)
 
 			for id, assignment := range assignments {
-				_, ok := encodedBlob.BundlesByOperator[id]
+				chunksData := &core.ChunksData{
+					Format:   core.GnarkChunkEncodingFormat,
+					ChunkLen: int(chunkLength),
+					Chunks:   bytes[assignment.StartIndex : assignment.StartIndex+assignment.NumChunks],
+				}
+				_, ok := encodedBlob.EncodedBundlesByOperator[id]
 				if !ok {
-					encodedBlob.BundlesByOperator[id] = map[core.QuorumID]core.Bundle{
-						quorumID: chunks[assignment.StartIndex : assignment.StartIndex+assignment.NumChunks],
+					encodedBlob.EncodedBundlesByOperator[id] = map[core.QuorumID]*core.ChunksData{
+						quorumID: chunksData,
 					}
 				} else {
-					encodedBlob.BundlesByOperator[id][quorumID] = chunks[assignment.StartIndex : assignment.StartIndex+assignment.NumChunks]
+					encodedBlob.EncodedBundlesByOperator[id][quorumID] = chunksData
 				}
 			}
 
@@ -207,9 +218,13 @@ func checkBatchByUniversalVerifier(cst core.IndexedChainState, encodedBlobs []co
 		val.UpdateOperatorID(id)
 		blobMessages := make([]*core.BlobMessage, numBlob)
 		for z, encodedBlob := range encodedBlobs {
+			bundles, err := new(core.Bundles).FromEncodedBundles(encodedBlob.EncodedBundlesByOperator[id])
+			if err != nil {
+				return err
+			}
 			blobMessages[z] = &core.BlobMessage{
 				BlobHeader: encodedBlob.BlobHeader,
-				Bundles:    encodedBlob.BundlesByOperator[id],
+				Bundles:    bundles,
 			}
 		}
 		err := val.ValidateBatch(&header, blobMessages, state.OperatorState, pool)

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -156,9 +156,9 @@ func prepareBatch(t *testing.T, operatorCount uint, blobs []core.Blob, bn uint) 
 			if err != nil {
 				t.Fatal(err)
 			}
-			bytes := make([][]byte, len(chunks))
+			bytes := make([][]byte, 0, len(chunks))
 			for _, c := range chunks {
-				serialized, err := c.SerializeGnark()
+				serialized, err := c.Serialize()
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -176,7 +176,7 @@ func prepareBatch(t *testing.T, operatorCount uint, blobs []core.Blob, bn uint) 
 
 			for id, assignment := range assignments {
 				chunksData := &core.ChunksData{
-					Format:   core.GnarkChunkEncodingFormat,
+					Format:   core.GobChunkEncodingFormat,
 					ChunkLen: int(chunkLength),
 					Chunks:   bytes[assignment.StartIndex : assignment.StartIndex+assignment.NumChunks],
 				}

--- a/core/test/core_test.go
+++ b/core/test/core_test.go
@@ -159,7 +159,9 @@ func prepareBatch(t *testing.T, operatorCount uint, blobs []core.Blob, bn uint) 
 			bytes := make([][]byte, len(chunks))
 			for _, c := range chunks {
 				serialized, err := c.SerializeGnark()
-				t.Fatal(err)
+				if err != nil {
+					t.Fatal(err)
+				}
 				bytes = append(bytes, serialized)
 			}
 

--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -227,7 +227,7 @@ func TestBatcherIterations(t *testing.T) {
 	assert.NoError(t, err)
 	count, size := components.encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, 2, count)
-	assert.Equal(t, uint64(24576), size) // Robert checks it
+	assert.Equal(t, uint64(27631), size) // Robert checks it
 
 	txn := types.NewTransaction(0, gethcommon.Address{}, big.NewInt(0), 0, big.NewInt(0), nil)
 	components.transactor.On("BuildConfirmBatchTxn", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {

--- a/disperser/batcher/batcher_test.go
+++ b/disperser/batcher/batcher_test.go
@@ -227,7 +227,7 @@ func TestBatcherIterations(t *testing.T) {
 	assert.NoError(t, err)
 	count, size := components.encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, 2, count)
-	assert.Equal(t, uint64(27631), size) // Robert checks it
+	assert.Equal(t, uint64(27631), size)
 
 	txn := types.NewTransaction(0, gethcommon.Address{}, big.NewInt(0), 0, big.NewInt(0), nil)
 	components.transactor.On("BuildConfirmBatchTxn", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {

--- a/disperser/batcher/encoded_blob_store.go
+++ b/disperser/batcher/encoded_blob_store.go
@@ -29,7 +29,7 @@ type EncodingResult struct {
 	ReferenceBlockNumber uint
 	BlobQuorumInfo       *core.BlobQuorumInfo
 	Commitment           *encoding.BlobCommitments
-	Chunks               []*encoding.Frame
+	ChunksData           *core.ChunksData
 	Assignments          map[core.OperatorID]core.Assignment
 }
 
@@ -197,5 +197,5 @@ func getRequestID(key disperser.BlobKey, quorumID core.QuorumID) requestID {
 
 // getChunksSize returns the total size of all the chunks in the encoded result in bytes
 func getChunksSize(result *EncodingResult) uint64 {
-	return core.Bundle(result.Chunks).Size()
+	return result.ChunksData.Size()
 }

--- a/disperser/batcher/encoded_blob_store.go
+++ b/disperser/batcher/encoded_blob_store.go
@@ -197,5 +197,8 @@ func getRequestID(key disperser.BlobKey, quorumID core.QuorumID) requestID {
 
 // getChunksSize returns the total size of all the chunks in the encoded result in bytes
 func getChunksSize(result *EncodingResult) uint64 {
+	if result.ChunksData == nil {
+		return 0
+	}
 	return result.ChunksData.Size()
 }

--- a/disperser/batcher/encoded_blob_store.go
+++ b/disperser/batcher/encoded_blob_store.go
@@ -197,7 +197,7 @@ func getRequestID(key disperser.BlobKey, quorumID core.QuorumID) requestID {
 
 // getChunksSize returns the total size of all the chunks in the encoded result in bytes
 func getChunksSize(result *EncodingResult) uint64 {
-	if result.ChunksData == nil {
+	if result == nil || result.ChunksData == nil {
 		return 0
 	}
 	return result.ChunksData.Size()

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -380,8 +380,6 @@ func (e *EncodingStreamer) RequestEncodingForBlob(ctx context.Context, metadata 
 				return
 			}
 
-			fmt.Println("XXX chunks format:", chunks.Format)
-
 			encoderChan <- EncodingResultOrStatus{
 				EncodingResult: EncodingResult{
 					BlobMetadata:         metadata,

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -482,8 +482,8 @@ func (e *EncodingStreamer) CreateMinibatch(ctx context.Context) (*batch, error) 
 			}
 			blobHeaderByKey[blobKey] = blobHeader
 			encodedBlobByKey[blobKey] = core.EncodedBlob{
-				BlobHeader:        blobHeader,
-				BundlesByOperator: make(map[core.OperatorID]core.Bundles),
+				BlobHeader:               blobHeader,
+				EncodedBundlesByOperator: make(map[core.OperatorID]map[core.QuorumID]*core.ChunksData),
 			}
 		}
 
@@ -633,8 +633,8 @@ func (e *EncodingStreamer) CreateBatch(ctx context.Context) (*batch, error) {
 			}
 			blobHeaderByKey[blobKey] = blobHeader
 			encodedBlobByKey[blobKey] = core.EncodedBlob{
-				BlobHeader:        blobHeader,
-				BundlesByOperator: make(map[core.OperatorID]core.Bundles),
+				BlobHeader:               blobHeader,
+				EncodedBundlesByOperator: make(map[core.OperatorID]map[core.QuorumID]*core.ChunksData),
 			}
 		}
 

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -483,7 +483,7 @@ func (e *EncodingStreamer) CreateMinibatch(ctx context.Context) (*batch, error) 
 			blobHeaderByKey[blobKey] = blobHeader
 			encodedBlobByKey[blobKey] = core.EncodedBlob{
 				BlobHeader:               blobHeader,
-				EncodedBundlesByOperator: make(map[core.OperatorID]map[core.QuorumID]*core.ChunksData),
+				EncodedBundlesByOperator: make(map[core.OperatorID]core.EncodedBundles),
 			}
 		}
 
@@ -491,7 +491,7 @@ func (e *EncodingStreamer) CreateMinibatch(ctx context.Context) (*batch, error) 
 		for opID, assignment := range result.Assignments {
 			bundles, ok := encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			if !ok {
-				encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID] = make(map[core.QuorumID]*core.ChunksData)
+				encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID] = make(core.EncodedBundles)
 				bundles = encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			}
 			bundles[result.BlobQuorumInfo.QuorumID].Format = result.ChunksData.Format
@@ -634,7 +634,7 @@ func (e *EncodingStreamer) CreateBatch(ctx context.Context) (*batch, error) {
 			blobHeaderByKey[blobKey] = blobHeader
 			encodedBlobByKey[blobKey] = core.EncodedBlob{
 				BlobHeader:               blobHeader,
-				EncodedBundlesByOperator: make(map[core.OperatorID]map[core.QuorumID]*core.ChunksData),
+				EncodedBundlesByOperator: make(map[core.OperatorID]core.EncodedBundles),
 			}
 		}
 
@@ -642,7 +642,7 @@ func (e *EncodingStreamer) CreateBatch(ctx context.Context) (*batch, error) {
 		for opID, assignment := range result.Assignments {
 			bundles, ok := encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			if !ok {
-				encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID] = make(map[core.QuorumID]*core.ChunksData)
+				encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID] = make(core.EncodedBundles)
 				bundles = encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			}
 			bundles[result.BlobQuorumInfo.QuorumID].Format = result.ChunksData.Format

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -380,6 +380,8 @@ func (e *EncodingStreamer) RequestEncodingForBlob(ctx context.Context, metadata 
 				return
 			}
 
+			fmt.Println("XXX chunks format:", chunks.Format)
+
 			encoderChan <- EncodingResultOrStatus{
 				EncodingResult: EncodingResult{
 					BlobMetadata:         metadata,
@@ -494,6 +496,7 @@ func (e *EncodingStreamer) CreateMinibatch(ctx context.Context) (*batch, error) 
 				encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID] = make(core.EncodedBundles)
 				bundles = encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			}
+			bundles[result.BlobQuorumInfo.QuorumID] = new(core.ChunksData)
 			bundles[result.BlobQuorumInfo.QuorumID].Format = result.ChunksData.Format
 			bundles[result.BlobQuorumInfo.QuorumID].Chunks = append(bundles[result.BlobQuorumInfo.QuorumID].Chunks, result.ChunksData.Chunks[assignment.StartIndex:assignment.StartIndex+assignment.NumChunks]...)
 			bundles[result.BlobQuorumInfo.QuorumID].ChunkLen = result.ChunksData.ChunkLen
@@ -645,6 +648,7 @@ func (e *EncodingStreamer) CreateBatch(ctx context.Context) (*batch, error) {
 				encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID] = make(core.EncodedBundles)
 				bundles = encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			}
+			bundles[result.BlobQuorumInfo.QuorumID] = new(core.ChunksData)
 			bundles[result.BlobQuorumInfo.QuorumID].Format = result.ChunksData.Format
 			bundles[result.BlobQuorumInfo.QuorumID].Chunks = append(bundles[result.BlobQuorumInfo.QuorumID].Chunks, result.ChunksData.Chunks[assignment.StartIndex:assignment.StartIndex+assignment.NumChunks]...)
 			bundles[result.BlobQuorumInfo.QuorumID].ChunkLen = result.ChunksData.ChunkLen

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -386,7 +386,7 @@ func (e *EncodingStreamer) RequestEncodingForBlob(ctx context.Context, metadata 
 					ReferenceBlockNumber: referenceBlockNumber,
 					BlobQuorumInfo:       res.BlobQuorumInfo,
 					Commitment:           commits,
-					Chunks:               chunks,
+					ChunksData:           chunks,
 					Assignments:          res.Assignments,
 				},
 				Err: nil,
@@ -489,12 +489,14 @@ func (e *EncodingStreamer) CreateMinibatch(ctx context.Context) (*batch, error) 
 
 		// Populate the assigned bundles
 		for opID, assignment := range result.Assignments {
-			bundles, ok := encodedBlobByKey[blobKey].BundlesByOperator[opID]
+			bundles, ok := encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			if !ok {
-				encodedBlobByKey[blobKey].BundlesByOperator[opID] = make(core.Bundles)
-				bundles = encodedBlobByKey[blobKey].BundlesByOperator[opID]
+				encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID] = make(map[core.QuorumID]*core.ChunksData)
+				bundles = encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			}
-			bundles[result.BlobQuorumInfo.QuorumID] = append(bundles[result.BlobQuorumInfo.QuorumID], result.Chunks[assignment.StartIndex:assignment.StartIndex+assignment.NumChunks]...)
+			bundles[result.BlobQuorumInfo.QuorumID].Format = result.ChunksData.Format
+			bundles[result.BlobQuorumInfo.QuorumID].Chunks = append(bundles[result.BlobQuorumInfo.QuorumID].Chunks, result.ChunksData.Chunks[assignment.StartIndex:assignment.StartIndex+assignment.NumChunks]...)
+			bundles[result.BlobQuorumInfo.QuorumID].ChunkLen = result.ChunksData.ChunkLen
 		}
 
 		blobQuorums[blobKey] = append(blobQuorums[blobKey], result.BlobQuorumInfo)
@@ -638,12 +640,14 @@ func (e *EncodingStreamer) CreateBatch(ctx context.Context) (*batch, error) {
 
 		// Populate the assigned bundles
 		for opID, assignment := range result.Assignments {
-			bundles, ok := encodedBlobByKey[blobKey].BundlesByOperator[opID]
+			bundles, ok := encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			if !ok {
-				encodedBlobByKey[blobKey].BundlesByOperator[opID] = make(core.Bundles)
-				bundles = encodedBlobByKey[blobKey].BundlesByOperator[opID]
+				encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID] = make(map[core.QuorumID]*core.ChunksData)
+				bundles = encodedBlobByKey[blobKey].EncodedBundlesByOperator[opID]
 			}
-			bundles[result.BlobQuorumInfo.QuorumID] = append(bundles[result.BlobQuorumInfo.QuorumID], result.Chunks[assignment.StartIndex:assignment.StartIndex+assignment.NumChunks]...)
+			bundles[result.BlobQuorumInfo.QuorumID].Format = result.ChunksData.Format
+			bundles[result.BlobQuorumInfo.QuorumID].Chunks = append(bundles[result.BlobQuorumInfo.QuorumID].Chunks, result.ChunksData.Chunks[assignment.StartIndex:assignment.StartIndex+assignment.NumChunks]...)
+			bundles[result.BlobQuorumInfo.QuorumID].ChunkLen = result.ChunksData.ChunkLen
 		}
 
 		blobQuorums[blobKey] = append(blobQuorums[blobKey], result.BlobQuorumInfo)

--- a/disperser/batcher/encoding_streamer_test.go
+++ b/disperser/batcher/encoding_streamer_test.go
@@ -445,7 +445,7 @@ func TestPartialBlob(t *testing.T) {
 
 	// Check EncodedBlobs
 	assert.Len(t, batch.EncodedBlobs, 1)
-	assert.Len(t, batch.EncodedBlobs[0].BundlesByOperator, numOperators)
+	assert.Len(t, batch.EncodedBlobs[0].EncodedBundlesByOperator, numOperators)
 
 	encodedBlob1 := batch.EncodedBlobs[0]
 	assert.NotNil(t, encodedBlob1)
@@ -465,10 +465,10 @@ func TestPartialBlob(t *testing.T) {
 	}})
 
 	assert.Contains(t, batch.BlobHeaders, encodedBlob1.BlobHeader)
-	assert.Len(t, encodedBlob1.BundlesByOperator, numOperators)
-	for _, bundles := range encodedBlob1.BundlesByOperator {
+	assert.Len(t, encodedBlob1.EncodedBundlesByOperator, numOperators)
+	for _, bundles := range encodedBlob1.EncodedBundlesByOperator {
 		assert.Len(t, bundles, 1)
-		assert.Greater(t, len(bundles[0]), 0)
+		assert.Greater(t, len(bundles[0].Chunks), 0)
 		break
 	}
 
@@ -674,7 +674,7 @@ func TestGetBatch(t *testing.T) {
 
 	// Check EncodedBlobs
 	assert.Len(t, batch.EncodedBlobs, 2)
-	assert.Len(t, batch.EncodedBlobs[0].BundlesByOperator, numOperators)
+	assert.Len(t, batch.EncodedBlobs[0].EncodedBundlesByOperator, numOperators)
 
 	var encodedBlob1 core.EncodedBlob
 	var encodedBlob2 core.EncodedBlob
@@ -718,10 +718,10 @@ func TestGetBatch(t *testing.T) {
 	})
 
 	assert.Contains(t, batch.BlobHeaders, encodedBlob1.BlobHeader)
-	for _, bundles := range encodedBlob1.BundlesByOperator {
+	for _, bundles := range encodedBlob1.EncodedBundlesByOperator {
 		assert.Len(t, bundles, 2)
-		assert.Greater(t, len(bundles[0]), 0)
-		assert.Greater(t, len(bundles[1]), 0)
+		assert.Greater(t, len(bundles[0].Chunks), 0)
+		assert.Greater(t, len(bundles[1].Chunks), 0)
 		break
 	}
 
@@ -739,9 +739,9 @@ func TestGetBatch(t *testing.T) {
 		},
 		ChunkLength: 8,
 	}})
-	for _, bundles := range encodedBlob2.BundlesByOperator {
+	for _, bundles := range encodedBlob2.EncodedBundlesByOperator {
 		assert.Len(t, bundles, 1)
-		assert.Greater(t, len(bundles[core.QuorumID(2)]), 0)
+		assert.Greater(t, len(bundles[core.QuorumID(2)].Chunks), 0)
 		break
 	}
 	assert.Len(t, batch.BlobHeaders, 2)
@@ -842,7 +842,7 @@ func TestCreateMinibatch(t *testing.T) {
 
 	// Check EncodedBlobs
 	assert.Len(t, batch.EncodedBlobs, 2)
-	assert.Len(t, batch.EncodedBlobs[0].BundlesByOperator, numOperators)
+	assert.Len(t, batch.EncodedBlobs[0].EncodedBundlesByOperator, numOperators)
 
 	var encodedBlob1 core.EncodedBlob
 	var encodedBlob2 core.EncodedBlob
@@ -886,10 +886,10 @@ func TestCreateMinibatch(t *testing.T) {
 	})
 
 	assert.Contains(t, batch.BlobHeaders, encodedBlob1.BlobHeader)
-	for _, bundles := range encodedBlob1.BundlesByOperator {
+	for _, bundles := range encodedBlob1.EncodedBundlesByOperator {
 		assert.Len(t, bundles, 2)
-		assert.Greater(t, len(bundles[0]), 0)
-		assert.Greater(t, len(bundles[1]), 0)
+		assert.Greater(t, len(bundles[0].Chunks), 0)
+		assert.Greater(t, len(bundles[1].Chunks), 0)
 		break
 	}
 
@@ -907,9 +907,9 @@ func TestCreateMinibatch(t *testing.T) {
 		},
 		ChunkLength: 8,
 	}})
-	for _, bundles := range encodedBlob2.BundlesByOperator {
+	for _, bundles := range encodedBlob2.EncodedBundlesByOperator {
 		assert.Len(t, bundles, 1)
-		assert.Greater(t, len(bundles[core.QuorumID(2)]), 0)
+		assert.Greater(t, len(bundles[core.QuorumID(2)].Chunks), 0)
 		break
 	}
 	assert.Len(t, batch.BlobHeaders, 2)

--- a/disperser/batcher/encoding_streamer_test.go
+++ b/disperser/batcher/encoding_streamer_test.go
@@ -142,7 +142,7 @@ func TestEncodingQueueLimit(t *testing.T) {
 }
 
 func TestBatchTrigger(t *testing.T) {
-	encodingStreamer, c := createEncodingStreamer(t, 10, 20_000, streamerConfig)
+	encodingStreamer, c := createEncodingStreamer(t, 10, 30_000, streamerConfig)
 
 	blob := makeTestBlob([]*core.SecurityParam{{
 		QuorumID:              0,
@@ -160,7 +160,7 @@ func TestBatchTrigger(t *testing.T) {
 	assert.Nil(t, err)
 	count, size := encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, count, 1)
-	assert.Equal(t, size, uint64(16384))
+	assert.Equal(t, size, uint64(26630))
 
 	// try encode the same blobs again at different block (this happens when the blob is retried)
 	encodingStreamer.ReferenceBlockNumber = 11
@@ -171,7 +171,7 @@ func TestBatchTrigger(t *testing.T) {
 
 	count, size = encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, count, 1)
-	assert.Equal(t, size, uint64(16384))
+	assert.Equal(t, size, uint64(26630))
 
 	// don't notify yet
 	select {
@@ -190,7 +190,7 @@ func TestBatchTrigger(t *testing.T) {
 
 	count, size = encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, count, 2)
-	assert.Equal(t, size, uint64(16384)*2)
+	assert.Equal(t, size, uint64(26630)*2)
 
 	// notify
 	select {

--- a/disperser/batcher/encoding_streamer_test.go
+++ b/disperser/batcher/encoding_streamer_test.go
@@ -246,12 +246,12 @@ func TestStreamingEncoding(t *testing.T) {
 	assert.NotNil(t, encodedResult.Commitment.LengthProof)
 	assert.Greater(t, encodedResult.Commitment.Length, uint(0))
 	assert.Len(t, encodedResult.Assignments, numOperators)
-	assert.Len(t, encodedResult.ChunksData, 32)
+	assert.Len(t, encodedResult.ChunksData.Chunks, 32)
 	isRequested = encodingStreamer.EncodedBlobstore.HasEncodingRequested(metadataKey, core.QuorumID(0), 10)
 	assert.True(t, isRequested)
 	count, size = encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, count, 1)
-	assert.Equal(t, size, uint64(16384))
+	assert.Equal(t, size, uint64(26630))
 
 	// Cancel previous blob so it doesn't get reencoded.
 	err = c.blobStore.MarkBlobFailed(ctx, metadataKey)
@@ -281,7 +281,7 @@ func TestStreamingEncoding(t *testing.T) {
 	assert.True(t, isRequested)
 	count, size = encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, count, 1)
-	assert.Equal(t, size, uint64(16384))
+	assert.Equal(t, size, uint64(26630))
 
 	// Request the same blob, which should be dedupped
 	_, err = c.blobStore.StoreBlob(ctx, &blob, requestedAt)
@@ -292,7 +292,7 @@ func TestStreamingEncoding(t *testing.T) {
 	// It should not have been added to the encoded blob store
 	count, size = encodingStreamer.EncodedBlobstore.GetEncodedResultSize()
 	assert.Equal(t, count, 1)
-	assert.Equal(t, size, uint64(16384))
+	assert.Equal(t, size, uint64(26630))
 }
 
 func TestEncodingFailure(t *testing.T) {

--- a/disperser/batcher/encoding_streamer_test.go
+++ b/disperser/batcher/encoding_streamer_test.go
@@ -246,7 +246,7 @@ func TestStreamingEncoding(t *testing.T) {
 	assert.NotNil(t, encodedResult.Commitment.LengthProof)
 	assert.Greater(t, encodedResult.Commitment.Length, uint(0))
 	assert.Len(t, encodedResult.Assignments, numOperators)
-	assert.Len(t, encodedResult.Chunks, 32)
+	assert.Len(t, encodedResult.ChunksData, 32)
 	isRequested = encodingStreamer.EncodedBlobstore.HasEncodingRequested(metadataKey, core.QuorumID(0), 10)
 	assert.True(t, isRequested)
 	count, size = encodingStreamer.EncodedBlobstore.GetEncodedResultSize()

--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -59,7 +59,7 @@ func (c *dispatcher) sendAllChunks(ctx context.Context, state *core.IndexedOpera
 				return
 			}
 			for _, blob := range blobs {
-				if _, ok := blob.BundlesByOperator[id]; ok {
+				if _, ok := blob.EncodedBundlesByOperator[id]; ok {
 					hasAnyBundles = true
 				}
 				blobMessages = append(blobMessages, &core.EncodedBlobMessage{

--- a/disperser/batcher/minibatcher.go
+++ b/disperser/batcher/minibatcher.go
@@ -317,7 +317,7 @@ func (b *Minibatcher) SendBlobsToOperatorWithRetries(
 	blobMessages := make([]*core.EncodedBlobMessage, 0)
 	hasAnyBundles := false
 	for _, blob := range blobs {
-		if _, ok := blob.BundlesByOperator[opID]; ok {
+		if _, ok := blob.EncodedBundlesByOperator[opID]; ok {
 			hasAnyBundles = true
 		}
 		blobMessages = append(blobMessages, &core.EncodedBlobMessage{

--- a/disperser/batcher/minibatcher.go
+++ b/disperser/batcher/minibatcher.go
@@ -314,16 +314,16 @@ func (b *Minibatcher) SendBlobsToOperatorWithRetries(
 	opID core.OperatorID,
 	maxNumRetries int,
 ) ([]*core.Signature, error) {
-	blobMessages := make([]*core.BlobMessage, 0)
+	blobMessages := make([]*core.EncodedBlobMessage, 0)
 	hasAnyBundles := false
 	for _, blob := range blobs {
 		if _, ok := blob.BundlesByOperator[opID]; ok {
 			hasAnyBundles = true
 		}
-		blobMessages = append(blobMessages, &core.BlobMessage{
+		blobMessages = append(blobMessages, &core.EncodedBlobMessage{
 			BlobHeader: blob.BlobHeader,
 			// Bundles will be empty if the operator is not in the quorums blob is dispersed on
-			Bundles: blob.BundlesByOperator[opID],
+			EncodedBundles: blob.EncodedBundlesByOperator[opID],
 		})
 	}
 	if !hasAnyBundles {

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -178,7 +178,7 @@ type BlobStore interface {
 
 type Dispatcher interface {
 	DisperseBatch(context.Context, *core.IndexedOperatorState, []core.EncodedBlob, *core.BatchHeader) chan core.SigningMessage
-	SendBlobsToOperator(ctx context.Context, blobs []*core.BlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) ([]*core.Signature, error)
+	SendBlobsToOperator(ctx context.Context, blobs []*core.EncodedBlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) ([]*core.Signature, error)
 	AttestBatch(ctx context.Context, state *core.IndexedOperatorState, blobHeaderHashes [][32]byte, batchHeader *core.BatchHeader) (chan core.SigningMessage, error)
 	SendAttestBatchRequest(ctx context.Context, nodeDispersalClient node.DispersalClient, blobHeaderHashes [][32]byte, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) (*core.Signature, error)
 }

--- a/disperser/encoder_client.go
+++ b/disperser/encoder_client.go
@@ -3,9 +3,10 @@ package disperser
 import (
 	"context"
 
+	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/encoding"
 )
 
 type EncoderClient interface {
-	EncodeBlob(ctx context.Context, data []byte, encodingParams encoding.EncodingParams) (*encoding.BlobCommitments, []*encoding.Frame, error)
+	EncodeBlob(ctx context.Context, data []byte, encodingParams encoding.EncodingParams) (*encoding.BlobCommitments, *core.ChunksData, error)
 }

--- a/disperser/local_encoder_client.go
+++ b/disperser/local_encoder_client.go
@@ -30,7 +30,7 @@ func (m *LocalEncoderClient) EncodeBlob(ctx context.Context, data []byte, encodi
 		return nil, nil, err
 	}
 
-	bytes := make([][]byte, len(chunks))
+	bytes := make([][]byte, 0, len(chunks))
 	for _, c := range chunks {
 		serialized, err := c.Serialize()
 		if err != nil {

--- a/disperser/local_encoder_client.go
+++ b/disperser/local_encoder_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/encoding"
 )
 
@@ -21,7 +22,7 @@ func NewLocalEncoderClient(prover encoding.Prover) *LocalEncoderClient {
 	}
 }
 
-func (m *LocalEncoderClient) EncodeBlob(ctx context.Context, data []byte, encodingParams encoding.EncodingParams) (*encoding.BlobCommitments, []*encoding.Frame, error) {
+func (m *LocalEncoderClient) EncodeBlob(ctx context.Context, data []byte, encodingParams encoding.EncodingParams) (*encoding.BlobCommitments, *core.ChunksData, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	commits, chunks, err := m.prover.EncodeAndProve(data, encodingParams)
@@ -29,5 +30,19 @@ func (m *LocalEncoderClient) EncodeBlob(ctx context.Context, data []byte, encodi
 		return nil, nil, err
 	}
 
-	return &commits, chunks, nil
+	bytes := make([][]byte, len(chunks))
+	for _, c := range chunks {
+		serialized, err := c.Serialize()
+		if err != nil {
+			return nil, nil, err
+		}
+		bytes = append(bytes, serialized)
+	}
+	chunksData := &core.ChunksData{
+		Chunks:   bytes,
+		Format:   core.GobChunkEncodingFormat,
+		ChunkLen: int(encodingParams.ChunkLength),
+	}
+
+	return &commits, chunksData, nil
 }

--- a/disperser/mock/dispatcher.go
+++ b/disperser/mock/dispatcher.go
@@ -66,7 +66,7 @@ func (d *Dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOpera
 	return update
 }
 
-func (d *Dispatcher) SendBlobsToOperator(ctx context.Context, blobs []*core.BlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) ([]*core.Signature, error) {
+func (d *Dispatcher) SendBlobsToOperator(ctx context.Context, blobs []*core.EncodedBlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) ([]*core.Signature, error) {
 	args := d.Called(ctx, blobs, batchHeader, op)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/disperser/mock/encoder.go
+++ b/disperser/mock/encoder.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 
+	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/stretchr/testify/mock"
@@ -18,15 +19,15 @@ func NewMockEncoderClient() *MockEncoderClient {
 	return &MockEncoderClient{}
 }
 
-func (m *MockEncoderClient) EncodeBlob(ctx context.Context, data []byte, encodingParams encoding.EncodingParams) (*encoding.BlobCommitments, []*encoding.Frame, error) {
+func (m *MockEncoderClient) EncodeBlob(ctx context.Context, data []byte, encodingParams encoding.EncodingParams) (*encoding.BlobCommitments, *core.ChunksData, error) {
 	args := m.Called(ctx, data, encodingParams)
 	var commitments *encoding.BlobCommitments
 	if args.Get(0) != nil {
 		commitments = args.Get(0).(*encoding.BlobCommitments)
 	}
-	var chunks []*encoding.Frame
+	var chunks *core.ChunksData
 	if args.Get(1) != nil {
-		chunks = args.Get(1).([]*encoding.Frame)
+		chunks = args.Get(1).(*core.ChunksData)
 	}
 	return commitments, chunks, args.Error(2)
 }

--- a/node/grpc/server_load_test.go
+++ b/node/grpc/server_load_test.go
@@ -84,7 +84,7 @@ func makeBatch(t *testing.T, blobSize int, numBlobs int, advThreshold, quorumThr
 		for opID, assignment := range quorumInfo.Assignments {
 			blobMessagesByOp[opID] = append(blobMessagesByOp[opID], &core.EncodedBlobMessage{
 				BlobHeader:     blobHeaders[i],
-				EncodedBundles: make(map[core.QuorumID]*core.ChunksData),
+				EncodedBundles: make(core.EncodedBundles),
 			})
 			blobMessagesByOp[opID][i].EncodedBundles[0].Format = core.GobChunkEncodingFormat
 			blobMessagesByOp[opID][i].EncodedBundles[0].ChunkLen = int(params.ChunkLength)

--- a/node/grpc/server_load_test.go
+++ b/node/grpc/server_load_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func makeBatch(t *testing.T, blobSize int, numBlobs int, advThreshold, quorumThreshold int, refBlockNumber uint) (*core.BatchHeader, map[core.OperatorID][]*core.BlobMessage) {
+func makeBatch(t *testing.T, blobSize int, numBlobs int, advThreshold, quorumThreshold int, refBlockNumber uint) (*core.BatchHeader, map[core.OperatorID][]*core.EncodedBlobMessage) {
 	p, _, err := makeTestComponents()
 	assert.NoError(t, err)
 	asn := &core.StdAssignmentCoordinator{}
 
 	blobHeaders := make([]*core.BlobHeader, numBlobs)
 	blobChunks := make([][]*encoding.Frame, numBlobs)
-	blobMessagesByOp := make(map[core.OperatorID][]*core.BlobMessage)
+	blobMessagesByOp := make(map[core.OperatorID][]*core.EncodedBlobMessage)
 	for i := 0; i < numBlobs; i++ {
 		// create data
 		ranData := make([]byte, blobSize)
@@ -67,6 +67,13 @@ func makeBatch(t *testing.T, blobSize int, numBlobs int, advThreshold, quorumThr
 		assert.NoError(t, err)
 		blobChunks[i] = chunks
 
+		chunkBytes := make([][]byte, len(chunks))
+		for _, c := range chunks {
+			serialized, err := c.Serialize()
+			assert.NotNil(t, err)
+			chunkBytes = append(chunkBytes, serialized)
+		}
+
 		// populate blob header
 		blobHeaders[i] = &core.BlobHeader{
 			BlobCommitments: commits,
@@ -75,11 +82,13 @@ func makeBatch(t *testing.T, blobSize int, numBlobs int, advThreshold, quorumThr
 
 		// populate blob messages
 		for opID, assignment := range quorumInfo.Assignments {
-			blobMessagesByOp[opID] = append(blobMessagesByOp[opID], &core.BlobMessage{
-				BlobHeader: blobHeaders[i],
-				Bundles:    make(core.Bundles),
+			blobMessagesByOp[opID] = append(blobMessagesByOp[opID], &core.EncodedBlobMessage{
+				BlobHeader:     blobHeaders[i],
+				EncodedBundles: make(map[core.QuorumID]*core.ChunksData),
 			})
-			blobMessagesByOp[opID][i].Bundles[0] = append(blobMessagesByOp[opID][i].Bundles[0], chunks[assignment.StartIndex:assignment.StartIndex+assignment.NumChunks]...)
+			blobMessagesByOp[opID][i].EncodedBundles[0].Format = core.GobChunkEncodingFormat
+			blobMessagesByOp[opID][i].EncodedBundles[0].ChunkLen = int(params.ChunkLength)
+			blobMessagesByOp[opID][i].EncodedBundles[0].Chunks = append(blobMessagesByOp[opID][i].EncodedBundles[0].Chunks, chunkBytes[assignment.StartIndex:assignment.StartIndex+assignment.NumChunks]...)
 		}
 	}
 
@@ -100,7 +109,7 @@ func TestStoreChunks(t *testing.T) {
 	batchHeader, blobMessagesByOp := makeBatch(t, 200*1024, 50, 80, 100, 1)
 	numTotalChunks := 0
 	for i := range blobMessagesByOp[opID] {
-		numTotalChunks += len(blobMessagesByOp[opID][i].Bundles[0])
+		numTotalChunks += len(blobMessagesByOp[opID][i].EncodedBundles[0].Chunks)
 	}
 	t.Logf("Batch numTotalChunks: %d", numTotalChunks)
 	req, totalSize, err := dispatcher.GetStoreChunksRequest(blobMessagesByOp[opID], batchHeader, false)


### PR DESCRIPTION
## Why are these changes needed?
This eliminates both the deserialization and serialization of chunks at the Batcher.

This matters because the cost on just the serialization of chunks can be significant: e.g. a large operator took 61s to serialize the dispersal request

Such perf/cost is on the critical path of E2E flow, so by eliminating them (as well as eliminating the cost to deserialize chunks from Encoder) will contribute directly the E2E perf.

![Screenshot 2024-08-13 at 2 58 56 PM](https://github.com/user-attachments/assets/fe4b3fdb-8a6c-4dae-a367-56efacf2805b)

### Testing
In addition to the unit test, also tested it in Preprod, with following setup
- Original chunks are in Gob
- The 3 Nodes are running with: 1) v0.7.4; 2) v0.8.0+ with Gnark disabled (i.e. using Gob); 3) v0.8.0+ with Gnark enabled

And the Batcher was tested in these two cases:
- Batcher shipping Gob chunks to Node: chunks will be shipped as it is
- Batcher shipping Gnark chunks to Node: chunks will be converted to Gnark (since they were in Gob) and then shipped to Nodes

This shows the compatibility/safety of:
1) interaction with the ongoing Gob->Gnark migration is correct
2) the migration of frames (deserialized) -> ChunksData (zero ser/deser) itself is correct

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
