### PR TITLE
Add `GetBulkBlobMetadata` method in `BlobMetadataStore`

### DIFF
--- a/common/aws/dynamodb/client.go
+++ b/common/aws/dynamodb/client.go
@@ -165,6 +165,8 @@ func (c *Client) GetItem(ctx context.Context, tableName string, key Key) (Item, 
 	return resp.Item, nil
 }
 
+// GetItems returns the items for the given keys
+// Note: ordering of items is not guaranteed
 func (c *Client) GetItems(ctx context.Context, tableName string, keys []Key) ([]Item, error) {
 	items, err := c.readItems(ctx, tableName, keys)
 	if err != nil {

--- a/disperser/common/blobstore/blob_metadata_store_test.go
+++ b/disperser/common/blobstore/blob_metadata_store_test.go
@@ -63,6 +63,11 @@ func TestBlobMetadataStoreOperations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, metadata2, fetchedMetadata)
 
+	fetchBulk, err := blobMetadataStore.GetBulkBlobMetadata(ctx, []disperser.BlobKey{blobKey1, blobKey2})
+	assert.NoError(t, err)
+	assert.Equal(t, metadata1, fetchBulk[0])
+	assert.Equal(t, metadata2, fetchBulk[1])
+
 	processing, err := blobMetadataStore.GetBlobMetadataByStatus(ctx, disperser.Processing)
 	assert.NoError(t, err)
 	assert.Len(t, processing, 1)

--- a/disperser/common/blobstore/shared_storage.go
+++ b/disperser/common/blobstore/shared_storage.go
@@ -251,6 +251,10 @@ func (s *SharedBlobStore) GetBlobMetadata(ctx context.Context, metadataKey dispe
 	return s.blobMetadataStore.GetBlobMetadata(ctx, metadataKey)
 }
 
+func (s *SharedBlobStore) GetBulkBlobMetadata(ctx context.Context, blobKeys []disperser.BlobKey) ([]*disperser.BlobMetadata, error) {
+	return s.blobMetadataStore.GetBulkBlobMetadata(ctx, blobKeys)
+}
+
 func (s *SharedBlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) (bool, error) {
 	if metadata.NumRetries < maxRetry {
 		if err := s.MarkBlobProcessing(ctx, metadata.GetBlobKey()); err != nil {

--- a/disperser/common/inmem/store.go
+++ b/disperser/common/inmem/store.go
@@ -328,6 +328,18 @@ func (q *BlobStore) GetBlobMetadata(ctx context.Context, blobKey disperser.BlobK
 	return nil, disperser.ErrBlobNotFound
 }
 
+func (q *BlobStore) GetBulkBlobMetadata(ctx context.Context, blobKeys []disperser.BlobKey) ([]*disperser.BlobMetadata, error) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	metas := make([]*disperser.BlobMetadata, len(blobKeys))
+	for i, key := range blobKeys {
+		if meta, ok := q.Metadata[key]; ok {
+			metas[i] = meta
+		}
+	}
+	return metas, nil
+}
+
 func (q *BlobStore) HandleBlobFailure(ctx context.Context, metadata *disperser.BlobMetadata, maxRetry uint) (bool, error) {
 	if metadata.NumRetries < maxRetry {
 		if err := q.MarkBlobProcessing(ctx, metadata.GetBlobKey()); err != nil {

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -180,6 +180,8 @@ type BlobStore interface {
 	GetAllBlobMetadataByBatchWithPagination(ctx context.Context, batchHeaderHash [32]byte, limit int32, exclusiveStartKey *BatchIndexExclusiveStartKey) ([]*BlobMetadata, *BatchIndexExclusiveStartKey, error)
 	// GetBlobMetadata returns a blob metadata given a metadata key
 	GetBlobMetadata(ctx context.Context, blobKey BlobKey) (*BlobMetadata, error)
+	// GetBulkBlobMetadata returns a list of blob metadata given a list of blob keys
+	GetBulkBlobMetadata(ctx context.Context, blobKeys []BlobKey) ([]*BlobMetadata, error)
 	// HandleBlobFailure handles a blob failure by either incrementing the retry count or marking the blob as failed
 	// Returns a boolean indicating whether the blob should be retried and an error
 	HandleBlobFailure(ctx context.Context, metadata *BlobMetadata, maxRetry uint) (bool, error)


### PR DESCRIPTION
## Why are these changes needed?
This method allows querying multiple blob metadata in one query
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
