### PR TITLE
Simplify minibatch data model

### DIFF
--- a/disperser/batcher/batch_confirmer_test.go
+++ b/disperser/batcher/batch_confirmer_test.go
@@ -148,15 +148,11 @@ func TestBatchConfirmerIteration(t *testing.T) {
 		AdversaryThreshold:    80,
 		ConfirmationThreshold: 100,
 	}})
-	blobHeaderHash1, err := blobHeader1.GetBlobHeaderHash()
-	assert.NoError(t, err)
 	blob2, blobHeader2 := generateBlobAndHeader(t, operatorState.OperatorState, []*core.SecurityParam{{
 		QuorumID:              1,
 		AdversaryThreshold:    70,
 		ConfirmationThreshold: 100,
 	}})
-	blobHeaderHash2, err := blobHeader2.GetBlobHeaderHash()
-	assert.NoError(t, err)
 	b := components.batchConfirmer
 	batchID, err := uuid.NewV7()
 	assert.NoError(t, err)
@@ -165,29 +161,11 @@ func TestBatchConfirmerIteration(t *testing.T) {
 		CreatedAt:            time.Now(),
 		ReferenceBlockNumber: uint(initialBlock),
 		Status:               bat.BatchStatusFormed,
-		HeaderHash:           [32]byte{},
-		AggregatePubKey:      &core.G2Point{},
-		AggregateSignature:   &core.Signature{},
+		NumMinibatches:       2,
 	}
 
-	// Set up batch and minibatch
+	// Set up batch
 	err = b.MinibatchStore.PutBatch(context.Background(), batch)
-	assert.NoError(t, err)
-	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
-		BatchID:              batchID,
-		MinibatchIndex:       0,
-		BlobHeaderHashes:     [][32]byte{blobHeaderHash1},
-		BatchSize:            1,
-		ReferenceBlockNumber: uint(initialBlock),
-	})
-	assert.NoError(t, err)
-	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
-		BatchID:              batchID,
-		MinibatchIndex:       1,
-		BlobHeaderHashes:     [][32]byte{blobHeaderHash2},
-		BatchSize:            1,
-		ReferenceBlockNumber: uint(initialBlock),
-	})
 	assert.NoError(t, err)
 	requestedAt1, blobKey1 := queueBlob(t, ctx, blob1, components.blobStore)
 	_, blobKey2 := queueBlob(t, ctx, blob2, components.blobStore)
@@ -211,46 +189,38 @@ func TestBatchConfirmerIteration(t *testing.T) {
 	assert.NoError(t, err)
 	batchHeaderHash2, err := batchHeader2.GetBatchHeaderHash()
 	assert.NoError(t, err)
-	// Set up dispersal requests and responses
+	// Set up dispersals
 	for opID, opInfo := range operatorState.PrivateOperators {
-		req0 := &bat.DispersalRequest{
+		req0 := &bat.MinibatchDispersal{
 			BatchID:        batchID,
 			MinibatchIndex: 0,
 			OperatorID:     opID,
 			Socket:         opInfo.DispersalPort,
 			NumBlobs:       1,
 			RequestedAt:    time.Now(),
-			BlobHash:       blobKey1.BlobHash,
-			MetadataHash:   blobKey1.MetadataHash,
+			DispersalResponse: bat.DispersalResponse{
+				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage(batchHeaderHash1)},
+				RespondedAt: time.Now(),
+				Error:       nil,
+			},
 		}
-		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req0)
-		assert.NoError(t, err)
-		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
-			DispersalRequest: *req0,
-			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage(batchHeaderHash1)},
-			RespondedAt:      time.Now(),
-			Error:            nil,
-		})
+		err = b.MinibatchStore.PutDispersal(context.Background(), req0)
 		assert.NoError(t, err)
 
-		req1 := &bat.DispersalRequest{
+		req1 := &bat.MinibatchDispersal{
 			BatchID:        batchID,
 			MinibatchIndex: 1,
 			OperatorID:     opID,
 			Socket:         opInfo.DispersalPort,
 			NumBlobs:       1,
 			RequestedAt:    time.Now(),
-			BlobHash:       blobKey2.BlobHash,
-			MetadataHash:   blobKey2.MetadataHash,
+			DispersalResponse: bat.DispersalResponse{
+				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage(batchHeaderHash2)},
+				RespondedAt: time.Now(),
+				Error:       nil,
+			},
 		}
-		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req1)
-		assert.NoError(t, err)
-		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
-			DispersalRequest: *req1,
-			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage(batchHeaderHash2)},
-			RespondedAt:      time.Now(),
-			Error:            nil,
-		})
+		err = b.MinibatchStore.PutDispersal(context.Background(), req1)
 		assert.NoError(t, err)
 	}
 
@@ -262,9 +232,8 @@ func TestBatchConfirmerIteration(t *testing.T) {
 			blobHeader1,
 			blobHeader2,
 		},
-		BlobMetadata:   []*disperser.BlobMetadata{meta1, meta2},
-		OperatorState:  operatorState.IndexedOperatorState,
-		NumMinibatches: 2,
+		BlobMetadata:  []*disperser.BlobMetadata{meta1, meta2},
+		OperatorState: operatorState.IndexedOperatorState,
 	}
 
 	// Receive signatures
@@ -376,67 +345,39 @@ func TestBatchConfirmerIterationFailure(t *testing.T) {
 		CreatedAt:            time.Now(),
 		ReferenceBlockNumber: uint(initialBlock),
 		Status:               bat.BatchStatusFormed,
-		HeaderHash:           [32]byte{},
-		AggregatePubKey:      &core.G2Point{},
-		AggregateSignature:   &core.Signature{},
 	}
 	err = b.MinibatchStore.PutBatch(context.Background(), batch)
-	assert.NoError(t, err)
-	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
-		BatchID:              batchID,
-		MinibatchIndex:       0,
-		BlobHeaderHashes:     [][32]byte{{1}, {2}},
-		BatchSize:            0,
-		ReferenceBlockNumber: uint(initialBlock),
-	})
-	assert.NoError(t, err)
-	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
-		BatchID:              batchID,
-		MinibatchIndex:       1,
-		BlobHeaderHashes:     [][32]byte{{3}, {4}},
-		BatchSize:            0,
-		ReferenceBlockNumber: uint(initialBlock),
-	})
 	assert.NoError(t, err)
 	operatorState := components.chainData.GetTotalOperatorState(context.Background(), 0)
 
 	for opID, opInfo := range operatorState.PrivateOperators {
-		req0 := &bat.DispersalRequest{
+		req0 := &bat.MinibatchDispersal{
 			BatchID:        batchID,
 			MinibatchIndex: 0,
 			OperatorID:     opID,
 			Socket:         opInfo.DispersalPort,
 			NumBlobs:       2,
 			RequestedAt:    time.Now(),
-			BlobHash:       "0",
-			MetadataHash:   "0",
+			DispersalResponse: bat.DispersalResponse{
+				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
+				RespondedAt: time.Now(),
+				Error:       nil,
+			},
 		}
-		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req0)
+		err = b.MinibatchStore.PutDispersal(context.Background(), req0)
 		assert.NoError(t, err)
-		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
-			DispersalRequest: *req0,
-			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
-			RespondedAt:      time.Now(),
-			Error:            nil,
-		})
-		assert.NoError(t, err)
-
-		req1 := &bat.DispersalRequest{
-			BatchID:        batchID,
-			MinibatchIndex: 1,
-			OperatorID:     opID,
-			Socket:         opInfo.DispersalPort,
-			NumBlobs:       2,
-			RequestedAt:    time.Now(),
-			BlobHash:       "1",
-			MetadataHash:   "1",
+		req1 := &bat.MinibatchDispersal{
+			BatchID:           batchID,
+			MinibatchIndex:    1,
+			OperatorID:        opID,
+			Socket:            opInfo.DispersalPort,
+			NumBlobs:          2,
+			RequestedAt:       time.Now(),
+			DispersalResponse: bat.DispersalResponse{
+				// Missing RespondedAt
+			},
 		}
-		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req1)
-		assert.NoError(t, err)
-		// Missing RespondedAt
-		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
-			DispersalRequest: *req1,
-		})
+		err = b.MinibatchStore.PutDispersal(context.Background(), req1)
 		assert.NoError(t, err)
 	}
 
@@ -454,69 +395,66 @@ func TestBatchConfirmerInsufficientSignatures(t *testing.T) {
 		CreatedAt:            time.Now(),
 		ReferenceBlockNumber: uint(initialBlock),
 		Status:               bat.BatchStatusFormed,
-		HeaderHash:           [32]byte{},
-		AggregatePubKey:      &core.G2Point{},
-		AggregateSignature:   &core.Signature{},
+		NumMinibatches:       2,
 	}
-	err = b.MinibatchStore.PutBatch(context.Background(), batch)
+	ctx := context.Background()
+	err = b.MinibatchStore.PutBatch(ctx, batch)
 	assert.NoError(t, err)
-	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
-		BatchID:              batchID,
-		MinibatchIndex:       0,
-		BlobHeaderHashes:     [][32]byte{{1}, {2}},
-		BatchSize:            0,
-		ReferenceBlockNumber: uint(initialBlock),
-	})
-	assert.NoError(t, err)
-	err = b.MinibatchStore.PutMinibatch(context.Background(), &bat.MinibatchRecord{
-		BatchID:              batchID,
-		MinibatchIndex:       1,
-		BlobHeaderHashes:     [][32]byte{{3}, {4}},
-		BatchSize:            0,
-		ReferenceBlockNumber: uint(initialBlock),
-	})
-	assert.NoError(t, err)
+
 	operatorState := components.chainData.GetTotalOperatorState(context.Background(), 0)
+	blob1, blobHeader1 := generateBlobAndHeader(t, operatorState.OperatorState, []*core.SecurityParam{{
+		QuorumID:              0,
+		AdversaryThreshold:    80,
+		ConfirmationThreshold: 100,
+	}})
+	blob2, blobHeader2 := generateBlobAndHeader(t, operatorState.OperatorState, []*core.SecurityParam{
+		{
+			QuorumID:              0,
+			AdversaryThreshold:    70,
+			ConfirmationThreshold: 100,
+		},
+		{
+			QuorumID:              1,
+			AdversaryThreshold:    70,
+			ConfirmationThreshold: 100,
+		}})
+	_, blobKey1 := queueBlob(t, ctx, blob1, components.blobStore)
+	_, blobKey2 := queueBlob(t, ctx, blob2, components.blobStore)
+	meta1, err := components.blobStore.GetBlobMetadata(ctx, blobKey1)
+	assert.NoError(t, err)
+	meta2, err := components.blobStore.GetBlobMetadata(ctx, blobKey2)
+	assert.NoError(t, err)
 
 	for opID, opInfo := range operatorState.PrivateOperators {
-		req0 := &bat.DispersalRequest{
+		req0 := &bat.MinibatchDispersal{
 			BatchID:        batchID,
 			MinibatchIndex: 0,
 			OperatorID:     opID,
 			Socket:         opInfo.DispersalPort,
 			NumBlobs:       2,
 			RequestedAt:    time.Now(),
-			BlobHash:       "0",
-			MetadataHash:   "0",
+			DispersalResponse: bat.DispersalResponse{
+				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
+				RespondedAt: time.Now(),
+				Error:       nil,
+			},
 		}
-		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req0)
+		err = b.MinibatchStore.PutDispersal(context.Background(), req0)
 		assert.NoError(t, err)
-		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
-			DispersalRequest: *req0,
-			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{0})},
-			RespondedAt:      time.Now(),
-			Error:            nil,
-		})
-		assert.NoError(t, err)
-
-		req1 := &bat.DispersalRequest{
+		req1 := &bat.MinibatchDispersal{
 			BatchID:        batchID,
 			MinibatchIndex: 1,
 			OperatorID:     opID,
 			Socket:         opInfo.DispersalPort,
 			NumBlobs:       2,
 			RequestedAt:    time.Now(),
-			BlobHash:       "1",
-			MetadataHash:   "1",
+			DispersalResponse: bat.DispersalResponse{
+				Signatures:  []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{1})},
+				RespondedAt: time.Now(),
+				Error:       nil,
+			},
 		}
-		err = b.MinibatchStore.PutDispersalRequest(context.Background(), req1)
-		assert.NoError(t, err)
-		err = b.MinibatchStore.PutDispersalResponse(context.Background(), &bat.DispersalResponse{
-			DispersalRequest: *req1,
-			Signatures:       []*core.Signature{opInfo.KeyPair.SignMessage([32]byte{1})},
-			RespondedAt:      time.Now(),
-			Error:            nil,
-		})
+		err = b.MinibatchStore.PutDispersal(context.Background(), req1)
 		assert.NoError(t, err)
 	}
 
@@ -524,52 +462,26 @@ func TestBatchConfirmerInsufficientSignatures(t *testing.T) {
 		BatchID:              batchID,
 		ReferenceBlockNumber: uint(initialBlock),
 		BlobHeaders: []*core.BlobHeader{
-			{
-				AccountID: "0",
-				QuorumInfos: []*core.BlobQuorumInfo{
-					{
-						SecurityParam: core.SecurityParam{
-							QuorumID:              0,
-							AdversaryThreshold:    30,
-							ConfirmationThreshold: 80,
-						},
-					},
-					{
-						SecurityParam: core.SecurityParam{
-							QuorumID:              1,
-							AdversaryThreshold:    30,
-							ConfirmationThreshold: 80,
-						},
-					},
-				},
-			},
-			{
-				AccountID: "1",
-				QuorumInfos: []*core.BlobQuorumInfo{
-					{
-						SecurityParam: core.SecurityParam{
-							QuorumID:              0,
-							AdversaryThreshold:    30,
-							ConfirmationThreshold: 80,
-						},
-					},
-					{
-						SecurityParam: core.SecurityParam{
-							QuorumID:              1,
-							AdversaryThreshold:    30,
-							ConfirmationThreshold: 80,
-						},
-					},
-				},
-			},
+			blobHeader1,
+			blobHeader2,
 		},
-		BlobMetadata:   []*disperser.BlobMetadata{},
-		OperatorState:  operatorState.IndexedOperatorState,
-		NumMinibatches: 2,
+		BlobMetadata:  []*disperser.BlobMetadata{meta1, meta2},
+		OperatorState: operatorState.IndexedOperatorState,
 	}
 
 	signChan := make(chan core.SigningMessage, 4)
-	batchHeaderHash := [32]byte{93, 156, 41, 17, 3, 78, 159, 243, 222, 111, 54, 107, 237, 48, 243, 176, 224, 151, 96, 151, 159, 99, 118, 186, 53, 192, 72, 59, 160, 73, 7, 213}
+	batchHeader := &core.BatchHeader{
+		ReferenceBlockNumber: uint(initialBlock),
+		BatchRoot:            [32]byte{},
+	}
+	bhh1, err := blobHeader1.GetBlobHeaderHash()
+	assert.NoError(t, err)
+	bhh2, err := blobHeader2.GetBlobHeaderHash()
+	assert.NoError(t, err)
+	_, err = batchHeader.SetBatchRootFromBlobHeaderHashes([][32]byte{bhh1, bhh2})
+	assert.NoError(t, err)
+	batchHeaderHash, err := batchHeader.GetBatchHeaderHash()
+	assert.NoError(t, err)
 	for opID, opInfo := range operatorState.PrivateOperators {
 		if opID == opId0 {
 			signChan <- core.SigningMessage{

--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -148,6 +148,8 @@ func NewBatcher(
 }
 
 func (b *Batcher) RecoverState(ctx context.Context) error {
+	b.logger.Info("Recovering state...")
+	start := time.Now()
 	metas, err := b.Queue.GetBlobMetadataByStatus(ctx, disperser.Dispersing)
 	if err != nil {
 		return fmt.Errorf("failed to get blobs in dispersing state: %w", err)
@@ -158,6 +160,7 @@ func (b *Batcher) RecoverState(ctx context.Context) error {
 			return fmt.Errorf("failed to mark blob (%s) as processing: %w", meta.GetBlobKey(), err)
 		}
 	}
+	b.logger.Info("Recovering state took", "duration", time.Since(start), "numBlobs", len(metas))
 	return nil
 }
 

--- a/disperser/batcher/batchstore/minibatch_store.go
+++ b/disperser/batcher/batchstore/minibatch_store.go
@@ -22,9 +22,7 @@ const (
 	batchStatusIndexName          = "BatchStatusIndex"
 	blobMinibatchMappingIndexName = "BlobMinibatchMappingIndex"
 	batchSKPrefix                 = "BATCH#"
-	minibatchSKPrefix             = "MINIBATCH#"
-	dispersalRequestSKPrefix      = "DISPERSAL_REQUEST#"
-	dispersalResponseSKPrefix     = "DISPERSAL_RESPONSE#"
+	dispersalSKPrefix             = "DISPERSAL#"
 	blobMinibatchMappingSKPrefix  = "BLOB_MINIBATCH_MAPPING#"
 )
 
@@ -142,25 +140,16 @@ func MarshalBatchRecord(batch *batcher.BatchRecord) (map[string]types.AttributeV
 	return fields, nil
 }
 
-func MarshalMinibatchRecord(minibatch *batcher.MinibatchRecord) (map[string]types.AttributeValue, error) {
-	fields, err := attributevalue.MarshalMap(*minibatch)
+func MarshalDispersal(response *batcher.MinibatchDispersal) (map[string]types.AttributeValue, error) {
+	fields, err := attributevalue.MarshalMap(*response)
 	if err != nil {
 		return nil, err
 	}
-	fields["BatchID"] = &types.AttributeValueMemberS{Value: minibatch.BatchID.String()}
-	fields["SK"] = &types.AttributeValueMemberS{Value: minibatchSKPrefix + fmt.Sprintf("%d", minibatch.MinibatchIndex)}
-	return fields, nil
-}
-
-func MarshalDispersalRequest(request *batcher.DispersalRequest) (map[string]types.AttributeValue, error) {
-	fields, err := attributevalue.MarshalMap(*request)
-	if err != nil {
-		return nil, err
-	}
-	fields["BatchID"] = &types.AttributeValueMemberS{Value: request.BatchID.String()}
-	fields["SK"] = &types.AttributeValueMemberS{Value: dispersalRequestSKPrefix + fmt.Sprintf("%d#%s", request.MinibatchIndex, request.OperatorID.Hex())}
-	fields["OperatorID"] = &types.AttributeValueMemberS{Value: request.OperatorID.Hex()}
-	fields["RequestedAt"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", request.RequestedAt.UTC().Unix())}
+	fields["BatchID"] = &types.AttributeValueMemberS{Value: response.BatchID.String()}
+	fields["SK"] = &types.AttributeValueMemberS{Value: dispersalSKPrefix + fmt.Sprintf("%d#%s", response.MinibatchIndex, response.OperatorID.Hex())}
+	fields["OperatorID"] = &types.AttributeValueMemberS{Value: response.OperatorID.Hex()}
+	fields["RespondedAt"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", response.RespondedAt.UTC().Unix())}
+	fields["RequestedAt"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", response.RequestedAt.UTC().Unix())}
 	return fields, nil
 }
 
@@ -169,11 +158,6 @@ func MarshalDispersalResponse(response *batcher.DispersalResponse) (map[string]t
 	if err != nil {
 		return nil, err
 	}
-	fields["BatchID"] = &types.AttributeValueMemberS{Value: response.BatchID.String()}
-	fields["SK"] = &types.AttributeValueMemberS{Value: dispersalResponseSKPrefix + fmt.Sprintf("%d#%s", response.MinibatchIndex, response.OperatorID.Hex())}
-	fields["OperatorID"] = &types.AttributeValueMemberS{Value: response.OperatorID.Hex()}
-	fields["RespondedAt"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", response.RespondedAt.UTC().Unix())}
-	fields["RequestedAt"] = &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", response.DispersalRequest.RequestedAt.UTC().Unix())}
 	return fields, nil
 }
 
@@ -254,47 +238,8 @@ func UnmarshalBatchRecord(item commondynamodb.Item) (*batcher.BatchRecord, error
 	return &batch, nil
 }
 
-func UnmarshalMinibatchRecord(item commondynamodb.Item) (*batcher.MinibatchRecord, error) {
-	minibatch := batcher.MinibatchRecord{}
-	err := attributevalue.UnmarshalMap(item, &minibatch)
-	if err != nil {
-		return nil, err
-	}
-
-	batchID, err := UnmarshalBatchID(item)
-	if err != nil {
-		return nil, err
-	}
-	minibatch.BatchID = *batchID
-
-	return &minibatch, nil
-}
-
-func UnmarshalDispersalRequest(item commondynamodb.Item) (*batcher.DispersalRequest, error) {
-	request := batcher.DispersalRequest{}
-	err := attributevalue.UnmarshalMap(item, &request)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal dispersal request from DynamoDB: %v", err)
-	}
-
-	batchID, err := UnmarshalBatchID(item)
-	if err != nil {
-		return nil, err
-	}
-	request.BatchID = *batchID
-
-	operatorID, err := UnmarshalOperatorID(item)
-	if err != nil {
-		return nil, err
-	}
-	request.OperatorID = *operatorID
-
-	request.RequestedAt = request.RequestedAt.UTC()
-	return &request, nil
-}
-
-func UnmarshalDispersalResponse(item commondynamodb.Item) (*batcher.DispersalResponse, error) {
-	response := batcher.DispersalResponse{}
+func UnmarshalDispersal(item commondynamodb.Item) (*batcher.MinibatchDispersal, error) {
+	response := batcher.MinibatchDispersal{}
 	err := attributevalue.UnmarshalMap(item, &response)
 	if err != nil {
 		return nil, err
@@ -313,7 +258,7 @@ func UnmarshalDispersalResponse(item commondynamodb.Item) (*batcher.DispersalRes
 	response.OperatorID = *operatorID
 
 	response.RespondedAt = response.RespondedAt.UTC()
-	response.DispersalRequest.RequestedAt = response.DispersalRequest.RequestedAt.UTC()
+	response.RequestedAt = response.RequestedAt.UTC()
 	return &response, nil
 }
 
@@ -348,8 +293,8 @@ func (m *MinibatchStore) PutBatch(ctx context.Context, batch *batcher.BatchRecor
 	return m.dynamoDBClient.PutItemWithCondition(ctx, m.tableName, item, constraint)
 }
 
-func (m *MinibatchStore) PutMinibatch(ctx context.Context, minibatch *batcher.MinibatchRecord) error {
-	item, err := MarshalMinibatchRecord(minibatch)
+func (m *MinibatchStore) PutDispersal(ctx context.Context, response *batcher.MinibatchDispersal) error {
+	item, err := MarshalDispersal(response)
 	if err != nil {
 		return err
 	}
@@ -357,22 +302,21 @@ func (m *MinibatchStore) PutMinibatch(ctx context.Context, minibatch *batcher.Mi
 	return m.dynamoDBClient.PutItem(ctx, m.tableName, item)
 }
 
-func (m *MinibatchStore) PutDispersalRequest(ctx context.Context, request *batcher.DispersalRequest) error {
-	item, err := MarshalDispersalRequest(request)
+func (m *MinibatchStore) UpdateDispersalResponse(ctx context.Context, dispersal *batcher.MinibatchDispersal, response *batcher.DispersalResponse) error {
+	marshaledResponse, err := MarshalDispersalResponse(response)
 	if err != nil {
 		return err
 	}
+	_, err = m.dynamoDBClient.UpdateItem(ctx, m.tableName, map[string]types.AttributeValue{
+		"BatchID": &types.AttributeValueMemberS{
+			Value: dispersal.BatchID.String(),
+		},
+		"SK": &types.AttributeValueMemberS{
+			Value: dispersalSKPrefix + fmt.Sprintf("%d#%s", dispersal.MinibatchIndex, dispersal.OperatorID.Hex()),
+		},
+	}, marshaledResponse)
 
-	return m.dynamoDBClient.PutItem(ctx, m.tableName, item)
-}
-
-func (m *MinibatchStore) PutDispersalResponse(ctx context.Context, response *batcher.DispersalResponse) error {
-	item, err := MarshalDispersalResponse(response)
-	if err != nil {
-		return err
-	}
-
-	return m.dynamoDBClient.PutItem(ctx, m.tableName, item)
+	return err
 }
 
 func (m *MinibatchStore) PutBlobMinibatchMappings(ctx context.Context, blobMinibatchMappings []*batcher.BlobMinibatchMapping) error {
@@ -422,24 +366,35 @@ func (m *MinibatchStore) GetBatch(ctx context.Context, batchID uuid.UUID) (*batc
 	return batch, nil
 }
 
-func (m *MinibatchStore) BatchDispersed(ctx context.Context, batchID uuid.UUID) (bool, error) {
-	dispersalRequests, err := m.GetDispersalRequests(ctx, batchID)
-	if err != nil {
-		return false, fmt.Errorf("failed to get dispersal requests for batch %s - %v", batchID.String(), err)
-
-	}
-	dispersalResponses, err := m.GetDispersalResponses(ctx, batchID)
+func (m *MinibatchStore) BatchDispersed(ctx context.Context, batchID uuid.UUID, numMinibatches uint) (bool, error) {
+	dispersals, err := m.GetDispersalsByBatchID(ctx, batchID)
 	if err != nil {
 		return false, fmt.Errorf("failed to get dispersal responses for batch %s - %v", batchID.String(), err)
 	}
-	if len(dispersalRequests) != len(dispersalResponses) {
-		m.logger.Info("number of minibatch dispersal requests does not match responses", "batchID", batchID, "numRequests", len(dispersalRequests), "numResponses", len(dispersalResponses))
+	if len(dispersals) == 0 {
+		m.logger.Info("no dispersals found", "batchID", batchID)
 		return false, nil
 	}
-	if len(dispersalRequests) == 0 || len(dispersalResponses) == 0 {
-		m.logger.Info("no dispersal requests or responses found", "batchID", batchID)
+
+	minibatchIndices := make(map[uint]struct{})
+	for _, dispersal := range dispersals {
+		minibatchIndices[dispersal.MinibatchIndex] = struct{}{}
+		if dispersal.RespondedAt.IsZero() || dispersal.Error != nil {
+			m.logger.Info("response pending", "batchID", batchID, "minibatchIndex", dispersal.MinibatchIndex, "operatorID", dispersal.OperatorID.Hex())
+			return false, nil
+		}
+	}
+	if len(minibatchIndices) != int(numMinibatches) {
+		m.logger.Info("number of minibatches does not match", "batchID", batchID, "numMinibatches", numMinibatches, "minibatchIndices", len(minibatchIndices))
 		return false, nil
 	}
+	for i := uint(0); i < numMinibatches; i++ {
+		if _, ok := minibatchIndices[i]; !ok {
+			m.logger.Info("number of minibatches does not match", "batchID", batchID, "minibatchIndex", i, "numMinibatches", numMinibatches)
+			return false, nil
+		}
+	}
+
 	return true, nil
 }
 
@@ -464,20 +419,30 @@ func (m *MinibatchStore) GetBatchesByStatus(ctx context.Context, status batcher.
 	return batches, nil
 }
 
-func (m *MinibatchStore) GetLatestFormedBatch(ctx context.Context) (batch *batcher.BatchRecord, minibatches []*batcher.MinibatchRecord, err error) {
+func (m *MinibatchStore) MarkBatchFormed(ctx context.Context, batchID uuid.UUID, numMinibatches uint) error {
+	_, err := m.dynamoDBClient.UpdateItem(ctx, m.tableName, map[string]types.AttributeValue{
+		"BatchID": &types.AttributeValueMemberS{Value: batchID.String()},
+		"SK":      &types.AttributeValueMemberS{Value: batchSKPrefix + batchID.String()},
+	}, commondynamodb.Item{
+		"NumMinibatches": &types.AttributeValueMemberN{
+			Value: strconv.Itoa(int(numMinibatches)),
+		},
+		"BatchStatus": &types.AttributeValueMemberN{
+			Value: strconv.Itoa(int(batcher.BatchStatusFormed)),
+		},
+	})
+	return err
+}
+
+func (m *MinibatchStore) GetLatestFormedBatch(ctx context.Context) (batch *batcher.BatchRecord, err error) {
 	formed, err := m.GetBatchesByStatus(ctx, batcher.BatchStatusFormed)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if len(formed) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
-	batch = formed[len(formed)-1]
-	minibatches, err = m.GetMinibatches(ctx, batch.ID)
-	if err != nil {
-		return nil, nil, err
-	}
-	return batch, minibatches, nil
+	return formed[len(formed)-1], nil
 }
 
 func (m *MinibatchStore) UpdateBatchStatus(ctx context.Context, batchID uuid.UUID, status batcher.BatchStatus) error {
@@ -500,144 +465,13 @@ func (m *MinibatchStore) UpdateBatchStatus(ctx context.Context, batchID uuid.UUI
 	return nil
 }
 
-func (m *MinibatchStore) GetMinibatch(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) (*batcher.MinibatchRecord, error) {
+func (m *MinibatchStore) GetDispersal(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*batcher.MinibatchDispersal, error) {
 	item, err := m.dynamoDBClient.GetItem(ctx, m.tableName, map[string]types.AttributeValue{
 		"BatchID": &types.AttributeValueMemberS{
 			Value: batchID.String(),
 		},
 		"SK": &types.AttributeValueMemberS{
-			Value: minibatchSKPrefix + fmt.Sprintf("%d", minibatchIndex),
-		},
-	})
-	if err != nil {
-		m.logger.Errorf("failed to get minibatch from DynamoDB: %v", err)
-		return nil, err
-	}
-
-	if item == nil {
-		return nil, nil
-	}
-
-	minibatch, err := UnmarshalMinibatchRecord(item)
-	if err != nil {
-		m.logger.Errorf("failed to unmarshal minibatch record from DynamoDB: %v", err)
-		return nil, err
-	}
-	return minibatch, nil
-}
-
-func (m *MinibatchStore) GetMinibatches(ctx context.Context, batchID uuid.UUID) ([]*batcher.MinibatchRecord, error) {
-	items, err := m.dynamoDBClient.Query(ctx, m.tableName, "BatchID = :batchID AND begins_with(SK, :prefix)", commondynamodb.ExpresseionValues{
-		":batchID": &types.AttributeValueMemberS{
-			Value: batchID.String(),
-		},
-		":prefix": &types.AttributeValueMemberS{
-			Value: minibatchSKPrefix,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	minibatches := make([]*batcher.MinibatchRecord, len(items))
-	for i, item := range items {
-		minibatches[i], err = UnmarshalMinibatchRecord(item)
-		if err != nil {
-			m.logger.Errorf("failed to unmarshal minibatch record at index %d: %v", i, err)
-			return nil, err
-		}
-	}
-
-	return minibatches, nil
-}
-
-func (m *MinibatchStore) GetDispersalRequest(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*batcher.DispersalRequest, error) {
-	item, err := m.dynamoDBClient.GetItem(ctx, m.tableName, map[string]types.AttributeValue{
-		"BatchID": &types.AttributeValueMemberS{
-			Value: batchID.String(),
-		},
-		"SK": &types.AttributeValueMemberS{
-			Value: dispersalRequestSKPrefix + fmt.Sprintf("%d#%s", minibatchIndex, opID.Hex()),
-		},
-	})
-	if err != nil {
-		m.logger.Errorf("failed to get dispersal request from DynamoDB: %v", err)
-		return nil, err
-	}
-
-	if item == nil {
-		return nil, nil
-	}
-
-	request, err := UnmarshalDispersalRequest(item)
-	if err != nil {
-		m.logger.Errorf("failed to unmarshal dispersal request from DynamoDB: %v", err)
-		return nil, err
-	}
-	return request, nil
-}
-
-func (m *MinibatchStore) GetDispersalRequests(ctx context.Context, batchID uuid.UUID) ([]*batcher.DispersalRequest, error) {
-	items, err := m.dynamoDBClient.Query(ctx, m.tableName, "BatchID = :batchID AND begins_with(SK, :prefix)", commondynamodb.ExpresseionValues{
-		":batchID": &types.AttributeValueMemberS{
-			Value: batchID.String(),
-		},
-		":prefix": &types.AttributeValueMemberS{
-			Value: dispersalRequestSKPrefix,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	requests := make([]*batcher.DispersalRequest, len(items))
-	for i, item := range items {
-		requests[i], err = UnmarshalDispersalRequest(item)
-		if err != nil {
-			m.logger.Errorf("failed to unmarshal dispersal requests at index %d: %v", i, err)
-			return nil, err
-		}
-	}
-
-	return requests, nil
-}
-
-func (m *MinibatchStore) GetMinibatchDispersalRequests(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*batcher.DispersalRequest, error) {
-	items, err := m.dynamoDBClient.Query(ctx, m.tableName, "BatchID = :batchID AND SK = :sk", commondynamodb.ExpresseionValues{
-		":batchID": &types.AttributeValueMemberS{
-			Value: batchID.String(),
-		},
-		":sk": &types.AttributeValueMemberS{
-			Value: dispersalRequestSKPrefix + fmt.Sprintf("%s#%d", batchID.String(), minibatchIndex),
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if len(items) == 0 {
-		return nil, fmt.Errorf("no dispersal requests found for BatchID %s MinibatchIndex %d", batchID, minibatchIndex)
-	}
-
-	requests := make([]*batcher.DispersalRequest, len(items))
-	for i, item := range items {
-		requests[i], err = UnmarshalDispersalRequest(item)
-		if err != nil {
-			m.logger.Errorf("failed to unmarshal dispersal requests at index %d: %v", i, err)
-			return nil, err
-		}
-	}
-
-	return requests, nil
-}
-
-func (m *MinibatchStore) GetDispersalResponse(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*batcher.DispersalResponse, error) {
-	item, err := m.dynamoDBClient.GetItem(ctx, m.tableName, map[string]types.AttributeValue{
-		"BatchID": &types.AttributeValueMemberS{
-			Value: batchID.String(),
-		},
-		"SK": &types.AttributeValueMemberS{
-			Value: dispersalResponseSKPrefix + fmt.Sprintf("%d#%s", minibatchIndex, opID.Hex()),
+			Value: dispersalSKPrefix + fmt.Sprintf("%d#%s", minibatchIndex, opID.Hex()),
 		},
 	})
 	if err != nil {
@@ -649,7 +483,7 @@ func (m *MinibatchStore) GetDispersalResponse(ctx context.Context, batchID uuid.
 		return nil, nil
 	}
 
-	response, err := UnmarshalDispersalResponse(item)
+	response, err := UnmarshalDispersal(item)
 	if err != nil {
 		m.logger.Errorf("failed to unmarshal dispersal response from DynamoDB: %v", err)
 		return nil, err
@@ -657,22 +491,22 @@ func (m *MinibatchStore) GetDispersalResponse(ctx context.Context, batchID uuid.
 	return response, nil
 }
 
-func (m *MinibatchStore) GetDispersalResponses(ctx context.Context, batchID uuid.UUID) ([]*batcher.DispersalResponse, error) {
+func (m *MinibatchStore) GetDispersalsByBatchID(ctx context.Context, batchID uuid.UUID) ([]*batcher.MinibatchDispersal, error) {
 	items, err := m.dynamoDBClient.Query(ctx, m.tableName, "BatchID = :batchID AND begins_with(SK, :prefix)", commondynamodb.ExpresseionValues{
 		":batchID": &types.AttributeValueMemberS{
 			Value: batchID.String(),
 		},
 		":prefix": &types.AttributeValueMemberS{
-			Value: dispersalResponseSKPrefix,
+			Value: dispersalSKPrefix,
 		},
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	responses := make([]*batcher.DispersalResponse, len(items))
+	responses := make([]*batcher.MinibatchDispersal, len(items))
 	for i, item := range items {
-		responses[i], err = UnmarshalDispersalResponse(item)
+		responses[i], err = UnmarshalDispersal(item)
 		if err != nil {
 			m.logger.Errorf("failed to unmarshal dispersal response at index %d: %v", i, err)
 			return nil, err
@@ -682,13 +516,13 @@ func (m *MinibatchStore) GetDispersalResponses(ctx context.Context, batchID uuid
 	return responses, nil
 }
 
-func (m *MinibatchStore) GetMinibatchDispersalResponses(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*batcher.DispersalResponse, error) {
+func (m *MinibatchStore) GetDispersalsByMinibatch(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*batcher.MinibatchDispersal, error) {
 	items, err := m.dynamoDBClient.Query(ctx, m.tableName, "BatchID = :batchID AND SK = :sk", commondynamodb.ExpresseionValues{
 		":batchID": &types.AttributeValueMemberS{
 			Value: batchID.String(),
 		},
 		":sk": &types.AttributeValueMemberS{
-			Value: dispersalResponseSKPrefix + fmt.Sprintf("%s#%d", batchID.String(), minibatchIndex),
+			Value: dispersalSKPrefix + fmt.Sprintf("%s#%d", batchID.String(), minibatchIndex),
 		},
 	})
 	if err != nil {
@@ -699,9 +533,9 @@ func (m *MinibatchStore) GetMinibatchDispersalResponses(ctx context.Context, bat
 		return nil, fmt.Errorf("no dispersal responses found for BatchID %s MinibatchIndex %d", batchID, minibatchIndex)
 	}
 
-	responses := make([]*batcher.DispersalResponse, len(items))
+	responses := make([]*batcher.MinibatchDispersal, len(items))
 	for i, item := range items {
-		responses[i], err = UnmarshalDispersalResponse(item)
+		responses[i], err = UnmarshalDispersal(item)
 		if err != nil {
 			m.logger.Errorf("failed to unmarshal dispersal response at index %d: %v", i, err)
 			return nil, err
@@ -718,6 +552,28 @@ func (m *MinibatchStore) GetBlobMinibatchMappings(ctx context.Context, blobKey d
 		},
 		":prefix": &types.AttributeValueMemberS{
 			Value: blobMinibatchMappingSKPrefix + blobKey.MetadataHash,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	blobMinibatchMappings := make([]*batcher.BlobMinibatchMapping, len(items))
+	for i, item := range items {
+		blobMinibatchMappings[i], err = UnmarshalBlobMinibatchMapping(item)
+		if err != nil {
+			m.logger.Errorf("failed to unmarshal blob minibatch mapping at index %d: %v", i, err)
+			return nil, err
+		}
+	}
+
+	return blobMinibatchMappings, nil
+}
+
+func (m *MinibatchStore) GetBlobMinibatchMappingsByBatchID(ctx context.Context, batchID uuid.UUID) ([]*batcher.BlobMinibatchMapping, error) {
+	items, err := m.dynamoDBClient.Query(ctx, m.tableName, "BatchID = :batchID", commondynamodb.ExpresseionValues{
+		":batchID": &types.AttributeValueMemberS{
+			Value: batchID.String(),
 		},
 	})
 	if err != nil {

--- a/disperser/batcher/inmem/minibatch_store.go
+++ b/disperser/batcher/inmem/minibatch_store.go
@@ -3,6 +3,7 @@ package inmem
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 
@@ -18,12 +19,7 @@ var BatchNotFound = errors.New("batch not found")
 type minibatchStore struct {
 	// BatchRecords maps batch IDs to batch records
 	BatchRecords map[uuid.UUID]*batcher.BatchRecord
-	// MinibatchRecords maps batch IDs to a map from minibatch indices to minibatch records
-	MinibatchRecords map[uuid.UUID]map[uint]*batcher.MinibatchRecord
-	// DispersalRequests maps batch IDs to a map from minibatch indices to dispersal requests
-	DispersalRequests map[uuid.UUID]map[uint][]*batcher.DispersalRequest
-	// DispersalResponses maps batch IDs to a map from minibatch indices to dispersal responses
-	DispersalResponses map[uuid.UUID]map[uint][]*batcher.DispersalResponse
+	Dispersals   map[uuid.UUID]map[uint][]*batcher.MinibatchDispersal
 	// BlobMinibatchMapping maps blob key to a map from batch ID to minibatch records
 	BlobMinibatchMapping map[string]map[uuid.UUID]*batcher.BlobMinibatchMapping
 
@@ -36,9 +32,7 @@ var _ batcher.MinibatchStore = (*minibatchStore)(nil)
 func NewMinibatchStore(logger logging.Logger) batcher.MinibatchStore {
 	return &minibatchStore{
 		BatchRecords:         make(map[uuid.UUID]*batcher.BatchRecord),
-		MinibatchRecords:     make(map[uuid.UUID]map[uint]*batcher.MinibatchRecord),
-		DispersalRequests:    make(map[uuid.UUID]map[uint][]*batcher.DispersalRequest),
-		DispersalResponses:   make(map[uuid.UUID]map[uint][]*batcher.DispersalResponse),
+		Dispersals:           make(map[uuid.UUID]map[uint][]*batcher.MinibatchDispersal),
 		BlobMinibatchMapping: make(map[string]map[uuid.UUID]*batcher.BlobMinibatchMapping),
 
 		logger: logger,
@@ -93,77 +87,69 @@ func (m *minibatchStore) UpdateBatchStatus(ctx context.Context, batchID uuid.UUI
 	return nil
 }
 
-func (m *minibatchStore) PutMinibatch(ctx context.Context, minibatch *batcher.MinibatchRecord) error {
+func (m *minibatchStore) MarkBatchFormed(ctx context.Context, batchID uuid.UUID, numMinibatches uint) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.MinibatchRecords[minibatch.BatchID]; !ok {
-		m.MinibatchRecords[minibatch.BatchID] = make(map[uint]*batcher.MinibatchRecord)
+	b, ok := m.BatchRecords[batchID]
+	if !ok {
+		return BatchNotFound
 	}
-	m.MinibatchRecords[minibatch.BatchID][minibatch.MinibatchIndex] = minibatch
-
+	b.NumMinibatches = numMinibatches
+	b.Status = batcher.BatchStatusFormed
 	return nil
 }
 
-func (m *minibatchStore) GetMinibatch(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) (*batcher.MinibatchRecord, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if _, ok := m.MinibatchRecords[batchID]; !ok {
-		return nil, BatchNotFound
-	}
-	return m.MinibatchRecords[batchID][minibatchIndex], nil
-}
-
-func (m *minibatchStore) GetMinibatches(ctx context.Context, batchID uuid.UUID) ([]*batcher.MinibatchRecord, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if _, ok := m.MinibatchRecords[batchID]; !ok {
-		return nil, nil
-	}
-
-	res := make([]*batcher.MinibatchRecord, 0, len(m.MinibatchRecords[batchID]))
-	for _, minibatch := range m.MinibatchRecords[batchID] {
-		res = append(res, minibatch)
-	}
-	sort.Slice(res, func(i, j int) bool {
-		return res[i].MinibatchIndex < res[j].MinibatchIndex
-	})
-
-	return res, nil
-}
-
-func (m *minibatchStore) PutDispersalRequest(ctx context.Context, request *batcher.DispersalRequest) error {
+func (m *minibatchStore) PutDispersal(ctx context.Context, dispersal *batcher.MinibatchDispersal) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.DispersalRequests[request.BatchID]; !ok {
-		m.DispersalRequests[request.BatchID] = make(map[uint][]*batcher.DispersalRequest)
+	if _, ok := m.Dispersals[dispersal.BatchID]; !ok {
+		m.Dispersals[dispersal.BatchID] = make(map[uint][]*batcher.MinibatchDispersal)
 	}
 
-	if _, ok := m.DispersalRequests[request.BatchID][request.MinibatchIndex]; !ok {
-		m.DispersalRequests[request.BatchID][request.MinibatchIndex] = make([]*batcher.DispersalRequest, 0)
+	if _, ok := m.Dispersals[dispersal.BatchID][dispersal.MinibatchIndex]; !ok {
+		m.Dispersals[dispersal.BatchID][dispersal.MinibatchIndex] = make([]*batcher.MinibatchDispersal, 0)
 	}
 
-	for _, r := range m.DispersalRequests[request.BatchID][request.MinibatchIndex] {
-		if r.OperatorID == request.OperatorID {
+	for _, r := range m.Dispersals[dispersal.BatchID][dispersal.MinibatchIndex] {
+		if r.OperatorID == dispersal.OperatorID {
 			// replace existing record
-			*r = *request
+			*r = *dispersal
 			return nil
 		}
 	}
 
-	m.DispersalRequests[request.BatchID][request.MinibatchIndex] = append(m.DispersalRequests[request.BatchID][request.MinibatchIndex], request)
+	m.Dispersals[dispersal.BatchID][dispersal.MinibatchIndex] = append(m.Dispersals[dispersal.BatchID][dispersal.MinibatchIndex], dispersal)
 
 	return nil
 }
 
-func (m *minibatchStore) GetDispersalRequest(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*batcher.DispersalRequest, error) {
+func (m *minibatchStore) UpdateDispersalResponse(ctx context.Context, dispersal *batcher.MinibatchDispersal, response *batcher.DispersalResponse) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.Dispersals[dispersal.BatchID][dispersal.MinibatchIndex]; !ok {
+		return fmt.Errorf("dispersal not found")
+	}
+
+	for _, r := range m.Dispersals[dispersal.BatchID][dispersal.MinibatchIndex] {
+		if r.OperatorID == dispersal.OperatorID {
+			r.Signatures = response.Signatures
+			r.RespondedAt = response.RespondedAt
+			r.Error = response.Error
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func (m *minibatchStore) GetDispersal(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*batcher.MinibatchDispersal, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	requests, err := m.GetMinibatchDispersalRequests(ctx, batchID, minibatchIndex)
+	requests, err := m.GetDispersalsByMinibatch(ctx, batchID, minibatchIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -175,67 +161,31 @@ func (m *minibatchStore) GetDispersalRequest(ctx context.Context, batchID uuid.U
 	return nil, nil
 }
 
-func (m *minibatchStore) GetMinibatchDispersalRequests(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*batcher.DispersalRequest, error) {
+func (m *minibatchStore) GetDispersalsByBatchID(ctx context.Context, batchID uuid.UUID) ([]*batcher.MinibatchDispersal, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, ok := m.DispersalRequests[batchID]; !ok {
+	if _, ok := m.Dispersals[batchID]; !ok {
 		return nil, BatchNotFound
 	}
 
-	return m.DispersalRequests[batchID][minibatchIndex], nil
+	res := make([]*batcher.MinibatchDispersal, 0)
+	for _, reqs := range m.Dispersals[batchID] {
+		res = append(res, reqs...)
+	}
+
+	return res, nil
 }
 
-func (m *minibatchStore) PutDispersalResponse(ctx context.Context, response *batcher.DispersalResponse) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if _, ok := m.DispersalResponses[response.BatchID]; !ok {
-		m.DispersalResponses[response.BatchID] = make(map[uint][]*batcher.DispersalResponse)
-	}
-
-	if _, ok := m.DispersalResponses[response.BatchID][response.MinibatchIndex]; !ok {
-		m.DispersalResponses[response.BatchID][response.MinibatchIndex] = make([]*batcher.DispersalResponse, 0)
-	}
-
-	for _, r := range m.DispersalResponses[response.BatchID][response.MinibatchIndex] {
-		if r.OperatorID == response.OperatorID {
-			// replace existing record
-			*r = *response
-			return nil
-		}
-	}
-
-	m.DispersalResponses[response.BatchID][response.MinibatchIndex] = append(m.DispersalResponses[response.BatchID][response.MinibatchIndex], response)
-
-	return nil
-}
-
-func (m *minibatchStore) GetDispersalResponse(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*batcher.DispersalResponse, error) {
+func (m *minibatchStore) GetDispersalsByMinibatch(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*batcher.MinibatchDispersal, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	responses, err := m.GetMinibatchDispersalResponses(ctx, batchID, minibatchIndex)
-	if err != nil {
-		return nil, err
-	}
-	for _, r := range responses {
-		if r.OperatorID == opID {
-			return r, nil
-		}
-	}
-	return nil, nil
-}
-
-func (m *minibatchStore) GetMinibatchDispersalResponses(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*batcher.DispersalResponse, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if _, ok := m.DispersalResponses[batchID]; !ok {
+	if _, ok := m.Dispersals[batchID]; !ok {
 		return nil, BatchNotFound
 	}
 
-	return m.DispersalResponses[batchID][minibatchIndex], nil
+	return m.Dispersals[batchID][minibatchIndex], nil
 }
 
 func (m *minibatchStore) GetBlobMinibatchMappings(ctx context.Context, blobKey disperser.BlobKey) ([]*batcher.BlobMinibatchMapping, error) {
@@ -251,6 +201,22 @@ func (m *minibatchStore) GetBlobMinibatchMappings(ctx context.Context, blobKey d
 		res = append(res, blobMinibatchMapping)
 	}
 
+	return res, nil
+}
+
+func (m *minibatchStore) GetBlobMinibatchMappingsByBatchID(ctx context.Context, batchID uuid.UUID) ([]*batcher.BlobMinibatchMapping, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	res := make([]*batcher.BlobMinibatchMapping, 0)
+
+	for _, batchToBlobMinibatchMapping := range m.BlobMinibatchMapping {
+		for bID, blobMinibatchMapping := range batchToBlobMinibatchMapping {
+			if bID == batchID {
+				res = append(res, blobMinibatchMapping)
+			}
+		}
+	}
 	return res, nil
 }
 
@@ -273,72 +239,50 @@ func (m *minibatchStore) PutBlobMinibatchMappings(ctx context.Context, blobMinib
 	return nil
 }
 
-func (m *minibatchStore) GetLatestFormedBatch(ctx context.Context) (batch *batcher.BatchRecord, minibatches []*batcher.MinibatchRecord, err error) {
+func (m *minibatchStore) GetLatestFormedBatch(ctx context.Context) (batch *batcher.BatchRecord, err error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	batches, err := m.GetBatchesByStatus(ctx, batcher.BatchStatusFormed)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if len(batches) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	batch = batches[0]
-	minibatches, err = m.GetMinibatches(ctx, batches[0].ID)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	return batch, minibatches, nil
+	return batch, nil
 }
 
-func (m *minibatchStore) getDispersals(ctx context.Context, batchID uuid.UUID) ([]*batcher.DispersalRequest, []*batcher.DispersalResponse, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if _, ok := m.DispersalRequests[batchID]; !ok {
-		return nil, nil, BatchNotFound
-	}
-
-	if _, ok := m.DispersalResponses[batchID]; !ok {
-		return nil, nil, BatchNotFound
-	}
-
-	requests := make([]*batcher.DispersalRequest, 0)
-	for _, reqs := range m.DispersalRequests[batchID] {
-		requests = append(requests, reqs...)
-	}
-
-	responses := make([]*batcher.DispersalResponse, 0)
-	for _, resp := range m.DispersalResponses[batchID] {
-		responses = append(responses, resp...)
-	}
-
-	return requests, responses, nil
-}
-
-func (m *minibatchStore) BatchDispersed(ctx context.Context, batchID uuid.UUID) (bool, error) {
+func (m *minibatchStore) BatchDispersed(ctx context.Context, batchID uuid.UUID, numMinibatches uint) (bool, error) {
 	dispersed := true
-	requests, responses, err := m.getDispersals(ctx, batchID)
+	dispersals, err := m.GetDispersalsByBatchID(ctx, batchID)
 	if err != nil {
 		return false, err
 	}
 
-	if len(requests) == 0 || len(responses) == 0 {
+	if len(dispersals) == 0 {
 		return false, nil
 	}
 
-	if len(requests) != len(responses) {
-		m.logger.Info("number of minibatch dispersal requests does not match the number of responses", "batchID", batchID, "numRequests", len(requests), "numResponses", len(responses))
-		return false, nil
-	}
-
-	for _, resp := range responses {
-		if resp.RespondedAt.IsZero() {
+	minibatchIndices := make(map[uint]struct{})
+	for _, resp := range dispersals {
+		minibatchIndices[resp.MinibatchIndex] = struct{}{}
+		if resp.RespondedAt.IsZero() || resp.Error != nil {
 			dispersed = false
 			m.logger.Info("response pending", "batchID", batchID, "minibatchIndex", resp.MinibatchIndex, "operatorID", resp.OperatorID.Hex())
+		}
+	}
+	if len(minibatchIndices) != int(numMinibatches) {
+		m.logger.Info("number of minibatches does not match", "batchID", batchID, "numMinibatches", numMinibatches, "minibatchIndices", len(minibatchIndices))
+		return false, nil
+	}
+	for i := uint(0); i < numMinibatches; i++ {
+		if _, ok := minibatchIndices[i]; !ok {
+			m.logger.Info("minibatch missing", "batchID", batchID, "minibatchIndex", i, "numMinibatches", numMinibatches)
+			return false, nil
 		}
 	}
 

--- a/disperser/batcher/inmem/minibatch_store_test.go
+++ b/disperser/batcher/inmem/minibatch_store_test.go
@@ -31,9 +31,6 @@ func TestPutBatch(t *testing.T) {
 		CreatedAt:            time.Now().UTC(),
 		ReferenceBlockNumber: 1,
 		Status:               1,
-		HeaderHash:           [32]byte{1},
-		AggregatePubKey:      nil,
-		AggregateSignature:   nil,
 	}
 	ctx := context.Background()
 	err = s.PutBatch(ctx, batch)
@@ -43,123 +40,56 @@ func TestPutBatch(t *testing.T) {
 	assert.Equal(t, batch, b)
 }
 
-func TestPutMiniBatch(t *testing.T) {
+func TestPutDispersal(t *testing.T) {
 	s := newMinibatchStore()
 	id, err := uuid.NewV7()
 	assert.NoError(t, err)
-	minibatch := &batcher.MinibatchRecord{
-		BatchID:              id,
-		MinibatchIndex:       12,
-		BlobHeaderHashes:     [][32]byte{{1}},
-		BatchSize:            1,
-		ReferenceBlockNumber: 1,
-	}
 	ctx := context.Background()
-	err = s.PutMinibatch(ctx, minibatch)
-	assert.NoError(t, err)
-	m, err := s.GetMinibatch(ctx, minibatch.BatchID, minibatch.MinibatchIndex)
-	assert.NoError(t, err)
-	assert.Equal(t, minibatch, m)
-}
-
-func TestPutDispersalRequest(t *testing.T) {
-	s := newMinibatchStore()
-	id, err := uuid.NewV7()
-	assert.NoError(t, err)
 	minibatchIndex := uint(0)
-	ctx := context.Background()
-	req1 := &batcher.DispersalRequest{
+	dispersal1 := &batcher.MinibatchDispersal{
+		DispersalResponse: batcher.DispersalResponse{
+			Signatures:  nil,
+			RespondedAt: time.Now().UTC(),
+			Error:       nil,
+		},
 		BatchID:         id,
 		MinibatchIndex:  minibatchIndex,
 		OperatorID:      core.OperatorID([32]byte{1}),
 		OperatorAddress: gcommon.HexToAddress("0x0"),
 		NumBlobs:        1,
 		RequestedAt:     time.Now().UTC(),
-		BlobHash:        "1a2b",
-		MetadataHash:    "3c4d",
 	}
-	err = s.PutDispersalRequest(ctx, req1)
-	assert.NoError(t, err)
-	req2 := &batcher.DispersalRequest{
+	dispersal2 := &batcher.MinibatchDispersal{
+		DispersalResponse: batcher.DispersalResponse{
+			Signatures:  nil,
+			RespondedAt: time.Now().UTC(),
+			Error:       nil,
+		},
 		BatchID:         id,
 		MinibatchIndex:  minibatchIndex,
 		OperatorID:      core.OperatorID([32]byte{2}),
 		OperatorAddress: gcommon.HexToAddress("0x0"),
 		NumBlobs:        1,
 		RequestedAt:     time.Now().UTC(),
-		BlobHash:        "1a2b",
-		MetadataHash:    "3c4d",
 	}
-	err = s.PutDispersalRequest(ctx, req2)
+	err = s.PutDispersal(ctx, dispersal1)
+	assert.NoError(t, err)
+	err = s.PutDispersal(ctx, dispersal2)
 	assert.NoError(t, err)
 
-	r, err := s.GetMinibatchDispersalRequests(ctx, id, minibatchIndex)
+	r, err := s.GetDispersalsByMinibatch(ctx, id, minibatchIndex)
 	assert.NoError(t, err)
 	assert.Len(t, r, 2)
-	assert.Equal(t, req1, r[0])
-	assert.Equal(t, req2, r[1])
+	assert.Equal(t, dispersal1, r[0])
+	assert.Equal(t, dispersal2, r[1])
 
-	req, err := s.GetDispersalRequest(ctx, id, minibatchIndex, req1.OperatorID)
+	resp, err := s.GetDispersal(ctx, id, minibatchIndex, dispersal1.OperatorID)
 	assert.NoError(t, err)
-	assert.Equal(t, req1, req)
+	assert.Equal(t, dispersal1, resp)
 
-	req, err = s.GetDispersalRequest(ctx, id, minibatchIndex, req2.OperatorID)
+	resp, err = s.GetDispersal(ctx, id, minibatchIndex, dispersal2.OperatorID)
 	assert.NoError(t, err)
-	assert.Equal(t, req2, req)
-}
-
-func TestPutDispersalResponse(t *testing.T) {
-	s := newMinibatchStore()
-	id, err := uuid.NewV7()
-	assert.NoError(t, err)
-	ctx := context.Background()
-	minibatchIndex := uint(0)
-	resp1 := &batcher.DispersalResponse{
-		DispersalRequest: batcher.DispersalRequest{
-			BatchID:         id,
-			MinibatchIndex:  minibatchIndex,
-			OperatorID:      core.OperatorID([32]byte{1}),
-			OperatorAddress: gcommon.HexToAddress("0x0"),
-			NumBlobs:        1,
-			RequestedAt:     time.Now().UTC(),
-			BlobHash:        "1a2b",
-			MetadataHash:    "3c4d",
-		},
-		Signatures:  nil,
-		RespondedAt: time.Now().UTC(),
-		Error:       nil,
-	}
-	resp2 := &batcher.DispersalResponse{
-		DispersalRequest: batcher.DispersalRequest{
-			BatchID:         id,
-			MinibatchIndex:  minibatchIndex,
-			OperatorID:      core.OperatorID([32]byte{2}),
-			OperatorAddress: gcommon.HexToAddress("0x0"),
-			NumBlobs:        1,
-			RequestedAt:     time.Now().UTC(),
-			BlobHash:        "0x0",
-			MetadataHash:    "0x0",
-		},
-		Signatures:  nil,
-		RespondedAt: time.Now().UTC(),
-		Error:       nil,
-	}
-	err = s.PutDispersalResponse(ctx, resp1)
-	assert.NoError(t, err)
-	err = s.PutDispersalResponse(ctx, resp2)
-	assert.NoError(t, err)
-
-	r, err := s.GetMinibatchDispersalResponses(ctx, id, minibatchIndex)
-	assert.NoError(t, err)
-	assert.Len(t, r, 2)
-
-	resp, err := s.GetDispersalResponse(ctx, id, minibatchIndex, resp1.OperatorID)
-	assert.NoError(t, err)
-	assert.Equal(t, resp1, resp)
-
-	resp, err = s.GetDispersalResponse(ctx, id, minibatchIndex, resp2.OperatorID)
-	assert.NoError(t, err)
-	assert.Equal(t, resp2, resp)
+	assert.Equal(t, dispersal2, resp)
 }
 
 func TestPutBlobMinibatchMappings(t *testing.T) {
@@ -209,22 +139,25 @@ func TestPutBlobMinibatchMappings(t *testing.T) {
 			BatchID:        batchID,
 			MinibatchIndex: 11,
 			BlobIndex:      22,
-			BlobCommitments: encoding.BlobCommitments{
-				Commitment:       commitment,
-				LengthCommitment: (*encoding.G2Commitment)(&lengthCommitment),
-				Length:           uint(expectedDataLength),
-				LengthProof:      (*encoding.LengthProof)(&lengthProof),
-			},
-			BlobQuorumInfos: []*core.BlobQuorumInfo{
-				{
-					ChunkLength: expectedChunkLength,
-					SecurityParam: core.SecurityParam{
-						QuorumID:              1,
-						ConfirmationThreshold: 55,
-						AdversaryThreshold:    33,
-						QuorumRate:            123,
+			BlobHeader: core.BlobHeader{
+				BlobCommitments: encoding.BlobCommitments{
+					Commitment:       commitment,
+					LengthCommitment: (*encoding.G2Commitment)(&lengthCommitment),
+					Length:           uint(expectedDataLength),
+					LengthProof:      (*encoding.LengthProof)(&lengthProof),
+				},
+				QuorumInfos: []*core.BlobQuorumInfo{
+					{
+						ChunkLength: expectedChunkLength,
+						SecurityParam: core.SecurityParam{
+							QuorumID:              1,
+							ConfirmationThreshold: 55,
+							AdversaryThreshold:    33,
+							QuorumRate:            123,
+						},
 					},
 				},
+				AccountID: "account-id",
 			},
 		},
 	})
@@ -247,12 +180,12 @@ func TestPutBlobMinibatchMappings(t *testing.T) {
 	assert.NoError(t, err)
 	expectedLengthProofBytes := lengthProof.Bytes()
 	assert.Equal(t, expectedLengthProofBytes[:], lengthProofBytes[:])
-	assert.Len(t, mapping[0].BlobQuorumInfos, 1)
-	assert.Equal(t, expectedChunkLength, mapping[0].BlobQuorumInfos[0].ChunkLength)
+	assert.Len(t, mapping[0].QuorumInfos, 1)
+	assert.Equal(t, expectedChunkLength, mapping[0].QuorumInfos[0].ChunkLength)
 	assert.Equal(t, core.SecurityParam{
 		QuorumID:              1,
 		ConfirmationThreshold: 55,
 		AdversaryThreshold:    33,
 		QuorumRate:            123,
-	}, mapping[0].BlobQuorumInfos[0].SecurityParam)
+	}, mapping[0].QuorumInfos[0].SecurityParam)
 }

--- a/disperser/batcher/minibatch_store.go
+++ b/disperser/batcher/minibatch_store.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
-	"github.com/Layr-Labs/eigenda/encoding"
 	gcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
 )
@@ -36,20 +35,17 @@ type BatchRecord struct {
 	CreatedAt            time.Time
 	ReferenceBlockNumber uint
 	Status               BatchStatus `dynamodbav:"BatchStatus"`
-	HeaderHash           [32]byte
-	AggregatePubKey      *core.G2Point
-	AggregateSignature   *core.Signature
+
+	NumMinibatches uint
 }
 
-type MinibatchRecord struct {
-	BatchID              uuid.UUID `dynamodbav:"-"`
-	MinibatchIndex       uint
-	BlobHeaderHashes     [][32]byte
-	BatchSize            uint64 // in bytes
-	ReferenceBlockNumber uint
+type DispersalResponse struct {
+	Signatures  []*core.Signature
+	RespondedAt time.Time
+	Error       error
 }
 
-type DispersalRequest struct {
+type MinibatchDispersal struct {
 	BatchID         uuid.UUID `dynamodbav:"-"`
 	MinibatchIndex  uint
 	core.OperatorID `dynamodbav:"-"`
@@ -57,15 +53,7 @@ type DispersalRequest struct {
 	Socket          string
 	NumBlobs        uint
 	RequestedAt     time.Time
-	BlobHash        string
-	MetadataHash    string
-}
-
-type DispersalResponse struct {
-	DispersalRequest
-	Signatures  []*core.Signature
-	RespondedAt time.Time
-	Error       error
+	DispersalResponse
 }
 
 type BlobMinibatchMapping struct {
@@ -73,29 +61,27 @@ type BlobMinibatchMapping struct {
 	BatchID        uuid.UUID          `dynamodbav:"-"`
 	MinibatchIndex uint
 	BlobIndex      uint
-	encoding.BlobCommitments
-	BlobQuorumInfos []*core.BlobQuorumInfo
+	BlobHeaderHash [32]byte
+	core.BlobHeader
 }
 
 type MinibatchStore interface {
 	PutBatch(ctx context.Context, batch *BatchRecord) error
 	GetBatch(ctx context.Context, batchID uuid.UUID) (*BatchRecord, error)
 	GetBatchesByStatus(ctx context.Context, status BatchStatus) ([]*BatchRecord, error)
+	MarkBatchFormed(ctx context.Context, batchID uuid.UUID, numMinibatches uint) error
 	UpdateBatchStatus(ctx context.Context, batchID uuid.UUID, status BatchStatus) error
-	PutMinibatch(ctx context.Context, minibatch *MinibatchRecord) error
-	GetMinibatch(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) (*MinibatchRecord, error)
-	GetMinibatches(ctx context.Context, batchID uuid.UUID) ([]*MinibatchRecord, error)
-	PutDispersalRequest(ctx context.Context, request *DispersalRequest) error
-	GetDispersalRequest(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*DispersalRequest, error)
-	GetMinibatchDispersalRequests(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*DispersalRequest, error)
-	PutDispersalResponse(ctx context.Context, response *DispersalResponse) error
-	GetDispersalResponse(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*DispersalResponse, error)
-	GetMinibatchDispersalResponses(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*DispersalResponse, error)
+	PutDispersal(ctx context.Context, dispersal *MinibatchDispersal) error
+	UpdateDispersalResponse(ctx context.Context, dispersal *MinibatchDispersal, response *DispersalResponse) error
+	GetDispersal(ctx context.Context, batchID uuid.UUID, minibatchIndex uint, opID core.OperatorID) (*MinibatchDispersal, error)
+	GetDispersalsByBatchID(ctx context.Context, batchID uuid.UUID) ([]*MinibatchDispersal, error)
+	GetDispersalsByMinibatch(ctx context.Context, batchID uuid.UUID, minibatchIndex uint) ([]*MinibatchDispersal, error)
 	GetBlobMinibatchMappings(ctx context.Context, blobKey disperser.BlobKey) ([]*BlobMinibatchMapping, error)
+	GetBlobMinibatchMappingsByBatchID(ctx context.Context, batchID uuid.UUID) ([]*BlobMinibatchMapping, error)
 	PutBlobMinibatchMappings(ctx context.Context, blobMinibatchMappings []*BlobMinibatchMapping) error
 	// GetLatestFormedBatch returns the latest batch that has been formed.
 	// If there is no formed batch, it returns nil.
 	// It also returns the minibatches that belong to the batch in the ascending order of minibatch index.
-	GetLatestFormedBatch(ctx context.Context) (batch *BatchRecord, minibatches []*MinibatchRecord, err error)
-	BatchDispersed(ctx context.Context, batchID uuid.UUID) (bool, error)
+	GetLatestFormedBatch(ctx context.Context) (batch *BatchRecord, err error)
+	BatchDispersed(ctx context.Context, batchID uuid.UUID, numMinibatches uint) (bool, error)
 }

--- a/disperser/batcher/minibatcher_test.go
+++ b/disperser/batcher/minibatcher_test.go
@@ -52,7 +52,7 @@ type minibatcherComponents struct {
 	blobStore             disperser.BlobStore
 	minibatchStore        batcher.MinibatchStore
 	dispatcher            *dmock.Dispatcher
-	chainState            *coremock.MockIndexedChainState
+	chainState            *core.IndexedOperatorState
 	assignmentCoordinator core.AssignmentCoordinator
 	encodingStreamer      *batcher.EncodingStreamer
 	pool                  *workerpool.WorkerPool
@@ -68,7 +68,6 @@ func newMinibatcher(t *testing.T, config batcher.MinibatcherConfig) *minibatcher
 	assert.NoError(t, err)
 	state := chainState.GetTotalOperatorState(context.Background(), 0)
 	dispatcher := dmock.NewDispatcher(state)
-	ics := &coremock.MockIndexedChainState{}
 	streamerConfig := batcher.StreamerConfig{
 		SRSOrder:                 3000,
 		EncodingRequestTimeout:   5 * time.Second,
@@ -94,6 +93,8 @@ func newMinibatcher(t *testing.T, config batcher.MinibatcherConfig) *minibatcher
 	ethClient := &cmock.MockEthClient{}
 	pool := workerpool.New(int(config.MaxNumConnections))
 	m, err := batcher.NewMinibatcher(config, blobStore, minibatchStore, dispatcher, chainState, asgn, encodingStreamer, ethClient, pool, logger)
+	assert.NoError(t, err)
+	ics, err := chainState.GetIndexedOperatorState(context.Background(), 0, []core.QuorumID{0, 1})
 	assert.NoError(t, err)
 	return &minibatcherComponents{
 		minibatcher:           m,
@@ -153,15 +154,37 @@ func TestDisperseMinibatch(t *testing.T) {
 
 	_, err = c.minibatcher.HandleSingleMinibatch(ctx)
 	assert.NoError(t, err)
+
+	// Check the minibatcher state
 	assert.NotNil(t, c.minibatcher.CurrentBatchID)
 	assert.Equal(t, c.minibatcher.MinibatchIndex, uint(1))
 	assert.Equal(t, c.minibatcher.ReferenceBlockNumber, initialBlock)
 	assert.Len(t, c.minibatcher.Batches, 1)
 	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BatchID, c.minibatcher.CurrentBatchID)
-	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].NumMinibatches, uint(1))
 	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].ReferenceBlockNumber, initialBlock)
 	assert.Len(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BlobHeaders, 2)
 	assert.ElementsMatch(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BlobMetadata, []*disperser.BlobMetadata{encoded1.BlobMetadata, encoded2.BlobMetadata})
+
+	// Check the dispersal records
+	dispersal, err := c.minibatchStore.GetDispersal(ctx, c.minibatcher.CurrentBatchID, 0, opId0)
+	assert.NoError(t, err)
+	assert.Equal(t, dispersal.BatchID, c.minibatcher.CurrentBatchID)
+	assert.Equal(t, dispersal.MinibatchIndex, uint(0))
+	assert.Equal(t, dispersal.OperatorID, opId0)
+	assert.Equal(t, dispersal.Socket, c.chainState.IndexedOperators[opId0].Socket)
+	assert.Equal(t, dispersal.NumBlobs, uint(2))
+	assert.NotNil(t, dispersal.RequestedAt)
+
+	dispersal, err = c.minibatchStore.GetDispersal(ctx, c.minibatcher.CurrentBatchID, 0, opId1)
+	assert.NoError(t, err)
+	assert.Equal(t, dispersal.BatchID, c.minibatcher.CurrentBatchID)
+	assert.Equal(t, dispersal.MinibatchIndex, uint(0))
+	assert.Equal(t, dispersal.OperatorID, opId1)
+	assert.Equal(t, dispersal.Socket, c.chainState.IndexedOperators[opId1].Socket)
+	assert.Equal(t, dispersal.NumBlobs, uint(2))
+	assert.NotNil(t, dispersal.RequestedAt)
+
+	// Check the blob minibatch mappings
 	blobKey1 := encoded1.BlobMetadata.GetBlobKey()
 	blobMinibatchMappings, err := c.minibatchStore.GetBlobMinibatchMappings(ctx, blobKey1)
 	assert.NoError(t, err)
@@ -170,7 +193,7 @@ func TestDisperseMinibatch(t *testing.T) {
 	assert.Equal(t, mapping1.BlobKey, &blobKey1)
 	assert.Equal(t, mapping1.BatchID, c.minibatcher.CurrentBatchID)
 	assert.Equal(t, mapping1.MinibatchIndex, uint(0))
-	assert.Equal(t, mapping1.BlobQuorumInfos, []*core.BlobQuorumInfo{encoded1.BlobQuorumInfo})
+	assert.Equal(t, mapping1.BlobHeader.QuorumInfos, []*core.BlobQuorumInfo{encoded1.BlobQuorumInfo})
 	serializedCommitment1, err := encoded1.Commitment.Commitment.Serialize()
 	assert.NoError(t, err)
 	expectedCommitment1, err := mapping1.Commitment.Serialize()
@@ -194,7 +217,7 @@ func TestDisperseMinibatch(t *testing.T) {
 	assert.Equal(t, mapping2.BlobKey, &blobKey2)
 	assert.Equal(t, mapping2.BatchID, c.minibatcher.CurrentBatchID)
 	assert.Equal(t, mapping2.MinibatchIndex, uint(0))
-	assert.Equal(t, mapping2.BlobQuorumInfos, []*core.BlobQuorumInfo{encoded1.BlobQuorumInfo})
+	assert.Equal(t, mapping2.BlobHeader.QuorumInfos, []*core.BlobQuorumInfo{encoded1.BlobQuorumInfo})
 	if mapping1.BlobIndex != 0 {
 		assert.Equal(t, mapping2.BlobIndex, uint(1))
 	} else if mapping1.BlobIndex != 1 {
@@ -237,7 +260,6 @@ func TestDisperseMinibatch(t *testing.T) {
 	assert.Equal(t, c.minibatcher.ReferenceBlockNumber, initialBlock)
 	assert.Len(t, c.minibatcher.Batches, 1)
 	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BatchID, c.minibatcher.CurrentBatchID)
-	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].NumMinibatches, uint(2))
 	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].ReferenceBlockNumber, initialBlock)
 	assert.Len(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BlobHeaders, 3)
 	assert.ElementsMatch(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BlobMetadata, []*disperser.BlobMetadata{encoded1.BlobMetadata, encoded2.BlobMetadata, encoded3.BlobMetadata})
@@ -249,22 +271,6 @@ func TestDisperseMinibatch(t *testing.T) {
 	assert.Equal(t, c.minibatcher.CurrentBatchID, b.ID)
 	assert.NotNil(t, b.CreatedAt)
 	assert.Equal(t, c.minibatcher.ReferenceBlockNumber, b.ReferenceBlockNumber)
-	mb, err := c.minibatchStore.GetMinibatch(ctx, c.minibatcher.CurrentBatchID, 0)
-	assert.NoError(t, err)
-	assert.NotNil(t, mb)
-	assert.Equal(t, c.minibatcher.CurrentBatchID, mb.BatchID)
-	assert.Equal(t, uint(0), mb.MinibatchIndex)
-	assert.Len(t, mb.BlobHeaderHashes, 2)
-	assert.Equal(t, uint64(12800), mb.BatchSize)
-	assert.Equal(t, c.minibatcher.ReferenceBlockNumber, mb.ReferenceBlockNumber)
-	mb, err = c.minibatchStore.GetMinibatch(ctx, c.minibatcher.CurrentBatchID, 1)
-	assert.NoError(t, err)
-	assert.NotNil(t, mb)
-	assert.Equal(t, c.minibatcher.CurrentBatchID, mb.BatchID)
-	assert.Equal(t, uint(1), mb.MinibatchIndex)
-	assert.Len(t, mb.BlobHeaderHashes, 1)
-	assert.Equal(t, uint64(7680), mb.BatchSize)
-	assert.Equal(t, c.minibatcher.ReferenceBlockNumber, mb.ReferenceBlockNumber)
 
 	blobKey3 := encoded3.BlobMetadata.GetBlobKey()
 	blobMinibatchMappings, err = c.minibatchStore.GetBlobMinibatchMappings(ctx, blobKey3)
@@ -309,7 +315,6 @@ func TestDisperseMinibatch(t *testing.T) {
 	assert.Equal(t, c.minibatcher.ReferenceBlockNumber, initialBlock+10)
 	assert.Len(t, c.minibatcher.Batches, 2)
 	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BatchID, c.minibatcher.CurrentBatchID)
-	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].NumMinibatches, uint(1))
 	assert.Equal(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].ReferenceBlockNumber, initialBlock+10)
 	assert.Len(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BlobHeaders, 2)
 	assert.ElementsMatch(t, c.minibatcher.Batches[c.minibatcher.CurrentBatchID].BlobMetadata, []*disperser.BlobMetadata{encoded4.BlobMetadata, encoded5.BlobMetadata})
@@ -326,7 +331,6 @@ func TestDisperseMinibatch(t *testing.T) {
 	assert.NotNil(t, batchState)
 	assert.Equal(t, batchState.BatchID, b.ID)
 	assert.Equal(t, batchState.ReferenceBlockNumber, initialBlock)
-	assert.Equal(t, batchState.NumMinibatches, uint(2))
 	assert.Len(t, batchState.BlobHeaders, 3)
 	assert.ElementsMatch(t, batchState.BlobMetadata, []*disperser.BlobMetadata{encoded1.BlobMetadata, encoded2.BlobMetadata, encoded3.BlobMetadata})
 	assert.NotNil(t, batchState.OperatorState)
@@ -334,30 +338,22 @@ func TestDisperseMinibatch(t *testing.T) {
 	assert.Nil(t, c.minibatcher.Batches[b.ID])
 
 	c.dispatcher.AssertNumberOfCalls(t, "SendBlobsToOperator", 6)
-	dispersalRequests, err := c.minibatchStore.GetMinibatchDispersalRequests(ctx, b.ID, 0)
+	dispersals, err := c.minibatchStore.GetDispersalsByMinibatch(ctx, b.ID, 0)
 	assert.NoError(t, err)
-	assert.Len(t, dispersalRequests, 2)
+	assert.Len(t, dispersals, 2)
 	opIDs := make([]core.OperatorID, 2)
-	for i, req := range dispersalRequests {
-		assert.Equal(t, req.BatchID, b.ID)
-		assert.Equal(t, req.MinibatchIndex, uint(0))
-		assert.Equal(t, req.NumBlobs, uint(2))
-		assert.NotNil(t, req.Socket)
-		assert.NotNil(t, req.RequestedAt)
-		opIDs[i] = req.OperatorID
+	for i, dispersal := range dispersals {
+		assert.Equal(t, dispersal.BatchID, b.ID)
+		assert.Equal(t, dispersal.MinibatchIndex, uint(0))
+		assert.Equal(t, dispersal.NumBlobs, uint(2))
+		assert.NotNil(t, dispersal.Socket)
+		assert.NotNil(t, dispersal.RequestedAt)
+		opIDs[i] = dispersal.OperatorID
+		assert.NotNil(t, dispersal.RespondedAt)
+		assert.NoError(t, dispersal.Error)
+		assert.Len(t, dispersal.Signatures, 1)
 	}
 	assert.ElementsMatch(t, opIDs, []core.OperatorID{opId0, opId1})
-
-	dispersalResponses, err := c.minibatchStore.GetMinibatchDispersalResponses(ctx, b.ID, 0)
-	assert.NoError(t, err)
-	assert.Len(t, dispersalResponses, 2)
-	for _, resp := range dispersalResponses {
-		assert.Equal(t, resp.BatchID, b.ID)
-		assert.Equal(t, resp.MinibatchIndex, uint(0))
-		assert.NotNil(t, resp.RespondedAt)
-		assert.NoError(t, resp.Error)
-		assert.Len(t, resp.Signatures, 1)
-	}
 }
 
 func TestDisperseMinibatchFailure(t *testing.T) {
@@ -411,44 +407,27 @@ func TestDisperseMinibatchFailure(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
 	assert.Equal(t, c.minibatcher.CurrentBatchID, b.ID)
-	assert.NotNil(t, b.HeaderHash)
 	assert.NotNil(t, b.CreatedAt)
 	assert.Equal(t, c.minibatcher.ReferenceBlockNumber, b.ReferenceBlockNumber)
-	mb, err := c.minibatchStore.GetMinibatch(ctx, c.minibatcher.CurrentBatchID, 0)
-	assert.NoError(t, err)
-	assert.NotNil(t, mb)
-	assert.Equal(t, c.minibatcher.CurrentBatchID, mb.BatchID)
-	assert.Equal(t, uint(0), mb.MinibatchIndex)
-	assert.Len(t, mb.BlobHeaderHashes, 2)
-	assert.Equal(t, uint64(12800), mb.BatchSize)
-	assert.Equal(t, c.minibatcher.ReferenceBlockNumber, mb.ReferenceBlockNumber)
 
 	c.pool.StopWait()
 	c.dispatcher.AssertNumberOfCalls(t, "SendBlobsToOperator", 2)
-	dispersalRequests, err := c.minibatchStore.GetMinibatchDispersalRequests(ctx, c.minibatcher.CurrentBatchID, 0)
+	dispersals, err := c.minibatchStore.GetDispersalsByMinibatch(ctx, c.minibatcher.CurrentBatchID, 0)
 	assert.NoError(t, err)
-	assert.Len(t, dispersalRequests, 2)
+	assert.Len(t, dispersals, 2)
 	opIDs := make([]core.OperatorID, 2)
-	for i, req := range dispersalRequests {
-		assert.Equal(t, req.BatchID, c.minibatcher.CurrentBatchID)
-		assert.Equal(t, req.MinibatchIndex, uint(0))
-		assert.Equal(t, req.NumBlobs, uint(2))
-		assert.NotNil(t, req.Socket)
-		assert.NotNil(t, req.RequestedAt)
-		opIDs[i] = req.OperatorID
+	for i, dispersal := range dispersals {
+		assert.Equal(t, dispersal.BatchID, c.minibatcher.CurrentBatchID)
+		assert.Equal(t, dispersal.MinibatchIndex, uint(0))
+		assert.Equal(t, dispersal.NumBlobs, uint(2))
+		assert.NotNil(t, dispersal.Socket)
+		assert.NotNil(t, dispersal.RequestedAt)
+		opIDs[i] = dispersal.OperatorID
+		assert.NotNil(t, dispersal.RespondedAt)
+		assert.NoError(t, dispersal.Error)
+		assert.Len(t, dispersal.Signatures, 1)
 	}
 	assert.ElementsMatch(t, opIDs, []core.OperatorID{opId0, opId1})
-
-	dispersalResponses, err := c.minibatchStore.GetMinibatchDispersalResponses(ctx, c.minibatcher.CurrentBatchID, 0)
-	assert.NoError(t, err)
-	assert.Len(t, dispersalResponses, 2)
-	for _, resp := range dispersalResponses {
-		assert.Equal(t, resp.BatchID, c.minibatcher.CurrentBatchID)
-		assert.Equal(t, resp.MinibatchIndex, uint(0))
-		assert.NotNil(t, resp.RespondedAt)
-		assert.NoError(t, resp.Error)
-		assert.Len(t, resp.Signatures, 1)
-	}
 }
 
 func TestSendBlobsToOperatorWithRetries(t *testing.T) {
@@ -529,22 +508,16 @@ func TestSendBlobsToOperatorWithRetriesCanceled(t *testing.T) {
 	c.dispatcher.On("SendBlobsToOperator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, context.Canceled)
 	c.minibatcher.DisperseBatch(ctx, batch.State, batch.EncodedBlobs, batch.BatchHeader, c.minibatcher.CurrentBatchID, minibatchIndex)
 	c.pool.StopWait()
-	requests, err := c.minibatchStore.GetMinibatchDispersalRequests(ctx, c.minibatcher.CurrentBatchID, minibatchIndex)
+	dispersals, err := c.minibatchStore.GetDispersalsByMinibatch(ctx, c.minibatcher.CurrentBatchID, minibatchIndex)
 	assert.NoError(t, err)
-	assert.Len(t, requests, 2)
+	assert.Len(t, dispersals, 2)
 
-	responses, err := c.minibatchStore.GetMinibatchDispersalResponses(ctx, c.minibatcher.CurrentBatchID, minibatchIndex)
-	assert.NoError(t, err)
 	indexedState, err := mockChainState.GetIndexedOperatorState(ctx, initialBlock, []core.QuorumID{0})
 	assert.NoError(t, err)
-	assert.Len(t, responses, len(indexedState.IndexedOperators))
-	for _, response := range responses {
-		assert.ErrorContains(t, response.Error, "context canceled")
-		for _, request := range requests {
-			if request.OperatorID == response.OperatorID {
-				assert.GreaterOrEqual(t, response.RespondedAt, request.RequestedAt)
-			}
-		}
+	assert.Len(t, dispersals, len(indexedState.IndexedOperators))
+	for _, dispersal := range dispersals {
+		assert.ErrorContains(t, dispersal.Error, "context canceled")
+		assert.GreaterOrEqual(t, dispersal.RespondedAt, dispersal.RequestedAt)
 	}
 }
 


### PR DESCRIPTION
## Why are these changes needed?
Two changes in minibatch data model:
- removed `Minibatch` record itself. This model was used for identifying all blobs when constructing a full batch. Instead of this model, we can use `BlobMinibatchMapping` for this purpose
- unified `DispersalRequest` and `DispersalResponse` into one model `Dispersal`. This ensures request and response are 1:1
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
