### PR TITLE
Rewards mainnet demo

### DIFF
--- a/contracts/script/deploy/holesky/EigenDASM_RewardsUpgrade.s.sol
+++ b/contracts/script/deploy/holesky/EigenDASM_RewardsUpgrade.s.sol
@@ -18,7 +18,7 @@ import {IStakeRegistry} from "eigenlayer-middleware/interfaces/IStakeRegistry.so
 import {EigenDAServiceManager} from "../../../src/core/EigenDAServiceManager.sol";
 
 /**
- * @title ServiceManagerBaseUpgrade for Preprod contracts.
+ * @title ServiceManagerBaseUpgrade for Testnet Holesky contracts.
  * Assumes EOA deploying has permissions to call the proxyAdmin to upgrade.
  *
  *
@@ -73,7 +73,7 @@ contract ServiceManagerBaseUpgrade is ExistingDeploymentParser {
         // Verify Eigenlayer contracts parsed from config
         _verifyContractPointers();
         _verifyImplementations();
-        _verifyContractsInitialized({isInitialDeployment: false});
+        _verifyContractsInitialized();
         _verifyInitializationParams();
     }
 

--- a/contracts/script/deploy/holesky/EigenDASM_RewardsUpgrade_preprod.s.sol
+++ b/contracts/script/deploy/holesky/EigenDASM_RewardsUpgrade_preprod.s.sol
@@ -73,7 +73,7 @@ contract ServiceManagerBaseUpgrade is ExistingDeploymentParser {
         // Verify Eigenlayer contracts parsed from config
         _verifyContractPointers();
         _verifyImplementations();
-        _verifyContractsInitialized({isInitialDeployment: false});
+        _verifyContractsInitialized();
         _verifyInitializationParams();
     }
 

--- a/contracts/script/deploy/mainnet/EigenDASM_RewardsUpgrade_example.s.sol
+++ b/contracts/script/deploy/mainnet/EigenDASM_RewardsUpgrade_example.s.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ERC20PresetFixedSupply} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {
+    ExistingDeploymentParser,
+    RewardsCoordinator,
+    IRewardsCoordinator,
+    IPauserRegistry,
+    IStrategy,
+    IERC20
+} from "eigenlayer-scripts/utils/ExistingDeploymentParser.sol";
+import {IRegistryCoordinator} from "eigenlayer-middleware/interfaces/IRegistryCoordinator.sol";
+import {IStakeRegistry} from "eigenlayer-middleware/interfaces/IStakeRegistry.sol";
+    
+import {EigenDAServiceManager} from "../../../src/core/EigenDAServiceManager.sol";
+
+/**
+ * @title ServiceManagerBaseUpgrade for Mainnet contracts addresses
+ * NOTE: This script will not actually run on mainnet for EigenDA as it assumes the EOA deploying
+ * has permissions to call the proxyAdmin to upgrade. This is not the case as contract upgrades are behind a
+ * 10-day timelock deploy with a multisig. This is meant to provide a template for upgrading the ServiceManagerBase for AVSs
+ * and to create a valid AVS rewards submission.
+ *
+ *
+ * Local Fork: Deploy/Upgrade RewardsCoordinator
+ * anvil --fork-url $RPC_MAINNET
+ * forge script script/deploy/mainnet/EigenDASM_RewardsUpgrade_example.s.sol:ServiceManagerBaseUpgrade --rpc-url http://127.0.0.1:8545 -vvvv
+ */
+contract ServiceManagerBaseUpgrade is ExistingDeploymentParser {
+    // Hardcode these values to your needs
+    address public serviceManager = 0x870679E138bCdf293b7Ff14dD44b70FC97e12fc0;
+    address public serviceManagerImplementation = 0xCDFFF07d5b8AcdAd13607615118a2e65030f5be1;
+
+    ProxyAdmin public avsProxyAdmin = ProxyAdmin(0x8247EF5705d3345516286B72bFE6D690197C2E99);
+    address registryCoordinator = 0x0BAAc79acD45A023E19345c352d8a7a83C4e5656;
+    address stakeRegistry = 0x006124Ae7976137266feeBFb3F4D2BE4C073139D;
+
+    // owner address to prank who has permissions to upgrade. Actual mainnet upgrades go through a 10-day timelock
+    // but for purposes of a example script of upgrading and creating a AVS rewards submission with mainnet addresses,
+    // we will prank this prank address in our script tests
+    address deployerAddress = 0x369e6F597e22EaB55fFb173C6d9cD234BD699111;
+
+    function run() external {
+        // 1. Setup and parse existing EigenLayer Mainnet contracts
+        _parseInitialDeploymentParams(
+            "script/deploy/mainnet/config/mainnet.config.json"
+        );
+        _parseDeployedContracts(
+            "script/deploy/mainnet/config/mainnet_addresses.json"
+        );
+
+        // 2. prank to set rewardsInitiator
+        // Set rewardsInitiator
+        vm.prank(EigenDAServiceManager(serviceManager).owner());
+        EigenDAServiceManager(serviceManager).setRewardsInitiator(deployerAddress);
+
+        // 3. test deployment upgrade and createAVSRewardsSubmission
+        vm.startPrank(deployerAddress);
+
+        emit log_named_address("Deployer Address", msg.sender);
+        _upgradeServiceManager();
+        _createAVSRewardsSubmission();
+
+        vm.stopPrank(); 
+
+        // 4. Sanity Checks
+        _verifyUpgrade();
+
+        // Verify Eigenlayer contracts parsed from config
+        _verifyContractPointers();
+        _verifyImplementations();
+        // comment out initalize checks because mainnet initialize interfaces are different from current implementation
+        // ex. EigenPodManager from pending PEPE upgrade
+        // _verifyContractsInitialized();
+        _verifyInitializationParams();
+    }
+
+    /// @dev Should override this to change to your specific upgrade needs
+    function _upgradeServiceManager() internal virtual {
+        // 1. Deploy new ServiceManager implementation contract
+        serviceManagerImplementation = address(
+            new EigenDAServiceManager(
+                avsDirectory,
+                rewardsCoordinator,
+                IRegistryCoordinator(registryCoordinator),
+                IStakeRegistry(stakeRegistry)
+            )
+        );
+
+        // 2. Upgrade the ServiceManager proxy to the new implementation
+        avsProxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(serviceManager))),
+            address(serviceManagerImplementation)
+        );
+    }
+
+    /// @notice Example createAVSRewardsSubmission call with the ServiceManager
+    function _createAVSRewardsSubmission() internal {
+        
+        uint256 mockTokenInitialSupply = 1e30;
+        // actual strategy addresses
+        address stETHStrategy = 0x93c4b944D05dfe6df7645A86cd2206016c51564D;
+        address rETHStrategy = 0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2;
+
+        IRewardsCoordinator.StrategyAndMultiplier[] memory strategyAndMultipliers = new IRewardsCoordinator.StrategyAndMultiplier[](2);
+        // Strategy addresses must be in ascending order
+        strategyAndMultipliers[0] = IRewardsCoordinator.StrategyAndMultiplier({
+            strategy: IStrategy(rETHStrategy),
+            multiplier: 1e18
+        });
+        strategyAndMultipliers[1] = IRewardsCoordinator.StrategyAndMultiplier({
+            strategy: IStrategy(stETHStrategy),
+            multiplier: 1e18
+        });
+
+        IERC20 token = new ERC20PresetFixedSupply(
+            "HARRYPOTTEROBAMASONIC10INU",
+            "BITCOIN",
+            mockTokenInitialSupply,
+            deployerAddress
+        );
+
+        // must be in multiples of weeks i.e startTimestamp % 604800 == 0
+        uint32 startTimestamp = 1710979200 + 2 weeks;
+        // must be in multiples of weeks i.e duration % 604800 == 0
+        uint32 duration = 10 weeks;
+        // amount <= 1e38 - 1
+        uint256 amount = 5000000e18;
+
+        // Create RewardsSubmission input param
+        IRewardsCoordinator.RewardsSubmission[]
+            memory rewardsSubmissions = new IRewardsCoordinator.RewardsSubmission[](1);
+        rewardsSubmissions[0] = IRewardsCoordinator.RewardsSubmission({
+            strategiesAndMultipliers: strategyAndMultipliers,
+            token: token,
+            amount: amount,
+            startTimestamp: startTimestamp,
+            duration: duration
+        });
+
+
+        token.approve(serviceManager, amount);
+        EigenDAServiceManager(serviceManager).createAVSRewardsSubmission(rewardsSubmissions);
+    }
+
+    /// @dev check implementation address set properly
+    function _verifyUpgrade() internal virtual {
+        // Preprod RewardsCoordinator
+        require(
+            address(rewardsCoordinator) == 0x7750d328b314EfFa365A0402CcfD489B80B0adda,
+            "ServiceManagerBaseUpgrade: RewardsCoordinator address is incorrect"
+        );
+        require(
+            avsProxyAdmin.getProxyImplementation(
+                TransparentUpgradeableProxy(payable(serviceManager))
+            ) == serviceManagerImplementation,
+            "ServiceManagerBaseUpgrade: ServiceMananger implementation initially set incorrectly"
+        );
+    }
+}

--- a/contracts/script/deploy/mainnet/config/mainnet.config.json
+++ b/contracts/script/deploy/mainnet/config/mainnet.config.json
@@ -2,7 +2,58 @@
     "chainInfo": {
       "chainId": 1
     },
-  
+    "multisig_addresses": {
+      "communityMultisig": "0xFEA47018D632A77bA579846c840d5706705Dc598",
+      "executorMultisig": "0x369e6F597e22EaB55fFb173C6d9cD234BD699111",
+      "operationsMultisig": "0xBE1685C81aA44FF9FB319dD389addd9374383e90",
+      "pauserMultisig": "0x5050389572f2d220ad927CcbeA0D406831012390",
+      "timelock": "0xA6Db1A8C5a981d1536266D2a393c5F8dDb210EAF"
+    },
+    "strategies": {
+      "numStrategies": 0,
+      "MAX_PER_DEPOSIT": 115792089237316195423570985008687907853269984665640564039457584007913129639935,
+      "MAX_TOTAL_DEPOSITS": 115792089237316195423570985008687907853269984665640564039457584007913129639935,
+      "strategiesToDeploy": []
+    },
+    "strategyManager": {
+      "init_strategy_whitelister": "0x28Ade60640fdBDb2609D8d8734D1b5cBeFc0C348",
+      "init_paused_status": 0
+    },
+    "delegationManager": {
+      "init_paused_status": 0,
+      "init_minWithdrawalDelayBlocks": 50400
+    },
+    "rewardsCoordinator": {
+      "init_paused_status": 2,
+      "CALCULATION_INTERVAL_SECONDS": 604800,
+      "MAX_REWARDS_DURATION": 6048000,
+      "MAX_RETROACTIVE_LENGTH": 14515200,
+      "MAX_FUTURE_LENGTH": 2592000,
+      "GENESIS_REWARDS_TIMESTAMP": 1710979200,
+      "rewards_updater_address": "0x8f94F55fD8c9E090296283137C303fE97d32A9e2",
+      "activation_delay": 604800,
+      "calculation_interval_seconds": 604800,
+      "global_operator_commission_bips": 1000
+    },
+    "avsDirectory": {
+      "init_paused_status": 0
+    },
+    "slasher": {
+      "init_paused_status": 0
+    },
+    "eigenPod": {
+      "MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR": 32000000000,
+      "GENESIS_TIME": 1606824023
+    },
+    "eigenPodManager": {
+      "init_paused_status": 0,
+      "deneb_fork_timestamp": "1707305664"
+    },
+    "delayedWithdrawalRouter": {
+      "init_paused_status": 0,
+      "init_withdrawalDelayBlocks": 50400
+    },
+    "ethPOSDepositAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
     "permissions" : {
       "owner": "0xBE1685C81aA44FF9FB319dD389addd9374383e90",
       "upgrader": "0x369e6F597e22EaB55fFb173C6d9cD234BD699111",

--- a/contracts/script/deploy/mainnet/config/mainnet_addresses.json
+++ b/contracts/script/deploy/mainnet/config/mainnet_addresses.json
@@ -6,15 +6,17 @@
       "beaconOracleAddress": "0x343907185b71aDF0eBa9567538314396aa985442",
       "delayedWithdrawalRouter": "0x7Fe7E9CC0F274d2435AD5d56D5fa73E47F6A23D8",
       "delayedWithdrawalRouterImplementation": "0x4bb6731b02314d40abbffbc4540f508874014226",
-      "delegation": "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",
-      "delegationImplementation": "0x1784be6401339fc0fedf7e9379409f5c1bfe9dda",
+      "delegationManager": "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",
+      "delegationManagerImplementation": "0x1784be6401339fc0fedf7e9379409f5c1bfe9dda",
       "eigenLayerPauserReg": "0x0c431C66F4dE941d089625E5B423D00707977060",
       "eigenLayerProxyAdmin": "0x8b9566AdA63B64d1E1dcF1418b43fd1433b72444",
       "eigenPodBeacon": "0x5a2a4F2F3C18f09179B6703e63D9eDD165909073",
-      "eigenPodImplementation": "0x8ba40da60f0827d027f029acee62609f0527a255",
+      "eigenPodImplementation": "0x28144C53bA98B4e909Df5bC7cA33eAf0404cFfcc",
       "eigenPodManager": "0x91E677b07F7AF907ec9a428aafA9fc14a0d3A338",
       "eigenPodManagerImplementation": "0xe4297e3dadbc7d99e26a2954820f514cb50c5762",
       "emptyContract": "0x1f96861fEFa1065a5A96F20Deb6D8DC3ff48F7f9",
+      "rewardsCoordinator": "0x7750d328b314EfFa365A0402CcfD489B80B0adda",
+      "rewardsCoordinatorImplementation": "0x5bf7c13D5FAdba224ECB3D5C0a67A231D1628785",
       "slasher": "0xD92145c07f8Ed1D392c1B88017934E301CC1c3Cd",
       "slasherImplementation": "0xf3234220163a757edf1e11a8a085638d9b236614",
       "strategies": {
@@ -31,8 +33,19 @@
         "lsETH": "0xAe60d8180437b5C34bB956822ac2710972584473",
         "mETH": "0x298aFB19A105D59E74658C4C334Ff360BadE6dd2"
       },
+      "numStrategiesDeployed": 0,
+      "strategyAddresses": [],
       "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-      "strategyManagerImplementation": "0x70f44c13944d49a236e3cd7a94f48f5dab6c619b"
+      "strategyManagerImplementation": "0x70f44c13944d49a236e3cd7a94f48f5dab6c619b",
+      "token": {
+      "tokenProxyAdmin": "0x3f5Ab2D4418d38568705bFd6672630fCC3435CC9",
+      "EIGEN": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
+      "bEIGEN": "0x83E9115d334D248Ce39a6f36144aEaB5b3456e75",
+      "EIGENImpl": "0x7ec354c84680112d3cff1544ec1eb19ca583700b",
+      "bEIGENImpl": "0xB91c69Af3eE022bd0a59Da082945914BFDcEFFE3",
+      "eigenStrategy": "0xaCB55C530Acdb2849e6d4f36992Cd8c9D50ED8F7",
+      "eigenStrategyImpl": "0x27e7a3a81741b9fcc5ad7edcbf9f8a72a5c00428"
+    }
     },
     "chainInfo": {
       "chainId": 1


### PR DESCRIPTION
## Why are these changes needed?
Example upgrade script for mainnet EigenLayer contracts for the Rewards Release.
The EigenLayer RewardsCoordinator is deployed at `0x7750d328b314EfFa365A0402CcfD489B80B0adda`

## Checks

- [X] I've made sure contracts build and tested scripts on local Anvil
- [X] I've made sure that eigenlayer-middleware points to release tag `v0.2.1-mainnet-rewards`
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
