### PR TITLE
[node] Make `GetChunks` compatible with minibatches

### DIFF
--- a/node/store_test.go
+++ b/node/store_test.go
@@ -327,6 +327,16 @@ func TestStoreBatchSuccess(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, s.HasKey(ctx, blobKey2))
 
+	// Check the chunks.
+	chunks, format, err := s.GetChunks(ctx, batchHeaderHash, 0, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, pb.ChunkEncodingFormat_GOB, format)
+	assert.Equal(t, chunks, blobsProto[0].Bundles[0].Chunks)
+	chunks, format, err = s.GetChunks(ctx, batchHeaderHash, 1, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, pb.ChunkEncodingFormat_GOB, format)
+	assert.Equal(t, chunks, blobsProto[1].Bundles[0].Chunks)
+
 	// Store the batch again it should be no-op.
 	_, err = s.StoreBatch(ctx, batchHeader, blobs, blobsProto)
 	assert.NotNil(t, err)
@@ -452,15 +462,12 @@ func TestStoreBatchBlobMapping(t *testing.T) {
 	assert.True(t, s.HasKey(ctx, blobIndexKey0))
 	assert.True(t, s.HasKey(ctx, blobIndexKey1))
 
-	var h [32]byte
 	bhh0, err := s.GetBlobHeaderHashAtIndex(ctx, batchHeaderHash, 0)
 	assert.Nil(t, err)
-	copy(h[:], bhh0)
-	assert.Equal(t, blobHeaderHash0, h)
+	assert.Equal(t, blobHeaderHash0, bhh0)
 	bhh1, err := s.GetBlobHeaderHashAtIndex(ctx, batchHeaderHash, 1)
 	assert.Nil(t, err)
-	copy(h[:], bhh1)
-	assert.Equal(t, blobHeaderHash1, h)
+	assert.Equal(t, blobHeaderHash1, bhh1)
 
 	// Check blob headers by GetBlobHeader method
 	var protoBlobHeader pb.BlobHeader

--- a/node/store_utils.go
+++ b/node/store_utils.go
@@ -21,7 +21,6 @@ const (
 	// batchMappingExpirationPrefix is the prefix of the batch mapping expiration key.
 	// This key is used to expire the batch to blob index mapping used to identify blob index in a full batch.
 	batchMappingExpirationPrefix = "_BATCHEXPIRATION_"
-	blobPrefix                   = "_BLOB_"      // The prefix of the blob key.
 	blobIndexPrefix              = "_BLOB_INDEX" // The prefix of the blob index key.
 )
 
@@ -40,8 +39,7 @@ func EncodeBlobKey(batchHeaderHash [32]byte, blobIndex int, quorumID core.Quorum
 }
 
 func EncodeBlobKeyByHash(blobHeaderHash [32]byte, quorumID core.QuorumID) ([]byte, error) {
-	prefix := []byte(blobHeaderPrefix)
-	buf := bytes.NewBuffer(append(prefix, blobHeaderHash[:]...))
+	buf := bytes.NewBuffer(blobHeaderHash[:])
 	err := binary.Write(buf, binary.LittleEndian, quorumID)
 	if err != nil {
 		return nil, err
@@ -50,8 +48,7 @@ func EncodeBlobKeyByHash(blobHeaderHash [32]byte, quorumID core.QuorumID) ([]byt
 }
 
 func EncodeBlobKeyByHashPrefix(blobHeaderHash [32]byte) []byte {
-	prefix := []byte(blobHeaderPrefix)
-	buf := bytes.NewBuffer(append(prefix, blobHeaderHash[:]...))
+	buf := bytes.NewBuffer(blobHeaderHash[:])
 	return buf.Bytes()
 }
 


### PR DESCRIPTION
## Why are these changes needed?
Make chunk retrieval compatible with minibatches. If the retrieval with previous schema fails, it tries with the new schema. 

To be merged on top of https://github.com/Layr-Labs/eigenda/pull/698
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
