### PR TITLE
chore: update eigenda_client.go to print waiting loop as debug logs instead of info logs

### DIFF
--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -170,7 +170,7 @@ func (m EigenDAClient) putBlob(ctx context.Context, rawData []byte, resultChan c
 
 			switch statusRes.Status {
 			case grpcdisperser.BlobStatus_PROCESSING, grpcdisperser.BlobStatus_DISPERSING:
-				m.Log.Info("Blob submitted, waiting for dispersal from EigenDA", "requestID", base64RequestID)
+				m.Log.Debug("Blob submitted, waiting for dispersal from EigenDA", "requestID", base64RequestID)
 			case grpcdisperser.BlobStatus_FAILED:
 				m.Log.Error("EigenDA blob dispersal failed in processing", "requestID", base64RequestID, "err", err)
 				errChan <- fmt.Errorf("EigenDA blob dispersal failed in processing, requestID=%s: %w", base64RequestID, err)


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We use this in the eigenda-proxy. Seeing a lot of repeating logs which just clutter the output:
![image](https://github.com/user-attachments/assets/f2066f4a-dbaa-48dd-a1cc-b711e7882ffa)


## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
