### PR TITLE
Perf observability: Add blob encoding latency at client side

### DIFF
--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -386,7 +386,7 @@ func (e *EncodingStreamer) RequestEncodingForBlob(ctx context.Context, metadata 
 					BlobMetadata:   metadata,
 					BlobQuorumInfo: res.BlobQuorumInfo,
 				}}
-				e.metrics.ObserveEncodingLatency("failed", res.BlobQuorumInfo.QuorumID, 0, float64(time.Since(start).Milliseconds()))
+				e.metrics.ObserveEncodingLatency("failed", res.BlobQuorumInfo.QuorumID, len(blob.Data), float64(time.Since(start).Milliseconds()))
 				return
 			}
 
@@ -401,7 +401,7 @@ func (e *EncodingStreamer) RequestEncodingForBlob(ctx context.Context, metadata 
 				},
 				Err: nil,
 			}
-			e.metrics.ObserveEncodingLatency("success", res.BlobQuorumInfo.QuorumID, 0, float64(time.Since(start).Milliseconds()))
+			e.metrics.ObserveEncodingLatency("success", res.BlobQuorumInfo.QuorumID, len(blob.Data), float64(time.Since(start).Milliseconds()))
 		})
 		e.EncodedBlobstore.PutEncodingRequest(blobKey, res.BlobQuorumInfo.QuorumID)
 	}

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -379,12 +379,14 @@ func (e *EncodingStreamer) RequestEncodingForBlob(ctx context.Context, metadata 
 		e.mu.Unlock()
 		e.Pool.Submit(func() {
 			defer cancel()
+			start := time.Now()
 			commits, chunks, err := e.encoderClient.EncodeBlob(encodingCtx, blob.Data, res.EncodingParams)
 			if err != nil {
 				encoderChan <- EncodingResultOrStatus{Err: err, EncodingResult: EncodingResult{
 					BlobMetadata:   metadata,
 					BlobQuorumInfo: res.BlobQuorumInfo,
 				}}
+				e.metrics.ObserveEncodingLatency("failed", res.BlobQuorumInfo.QuorumID, 0, float64(time.Since(start).Milliseconds()))
 				return
 			}
 
@@ -399,6 +401,7 @@ func (e *EncodingStreamer) RequestEncodingForBlob(ctx context.Context, metadata 
 				},
 				Err: nil,
 			}
+			e.metrics.ObserveEncodingLatency("success", res.BlobQuorumInfo.QuorumID, 0, float64(time.Since(start).Milliseconds()))
 		})
 		e.EncodedBlobstore.PutEncodingRequest(blobKey, res.BlobQuorumInfo.QuorumID)
 	}


### PR DESCRIPTION
## Why are these changes needed?
This adds blob encoding latency metric on the Batcher (i.e. client) side.

Currently we only have encoding latency on Encoder (i.e. server) side, which has the following problems:
- It doesn't track the TCP connection creation latency
- It doesn't track the request/response data transmission latency between Batcher and Encoder
- It doesn't track the queuing delay (in case of high traffic)

Having this Batcher-side latency metric addresses all of these problems, and provides a more accurate picture of encoding subsystem performance.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
