### PR TITLE
Perf observability: Add attestation and encoding throughput

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -328,6 +328,9 @@ func (b *Batcher) updateConfirmationInfo(
 		requestTime := time.Unix(0, int64(metadata.RequestMetadata.RequestedAt))
 		b.Metrics.ObserveLatency("E2E", float64(time.Since(requestTime).Milliseconds()))
 		b.Metrics.ObserveBlobAge("confirmed", float64(time.Since(requestTime).Milliseconds()))
+		for _, quorumInfo := range batchData.blobHeaders[blobIndex].QuorumInfos {
+			b.Metrics.IncrementBlobSize("confirmed", quorumInfo.QuorumID, int(metadata.RequestMetadata.BlobSize))
+		}
 	}
 
 	return blobsToRetry, nil

--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -420,6 +420,7 @@ func (e *EncodingStreamer) ProcessEncodedBlobs(ctx context.Context, result Encod
 
 	requestTime := time.Unix(0, int64(result.BlobMetadata.RequestMetadata.RequestedAt))
 	e.batcherMetrics.ObserveBlobAge("encoded", float64(time.Since(requestTime).Milliseconds()))
+	e.batcherMetrics.IncrementBlobSize("encoded", result.BlobQuorumInfo.QuorumID, int(result.BlobMetadata.RequestMetadata.BlobSize))
 
 	count, encodedSize := e.EncodedBlobstore.GetEncodedResultSize()
 	e.metrics.UpdateEncodedBlobs(count, encodedSize)

--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -189,7 +189,7 @@ func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "blobs_total",
-				Help:      "the number and unencoded size of total dispersal blobs, if a blob is multiple quorums, it'll only be counted once",
+				Help:      "the number and unencoded size of total dispersal blobs, if a blob is in multiple quorums, it'll only be counted once",
 			},
 			[]string{"state", "data"}, // state is either success or failure
 		),
@@ -234,7 +234,7 @@ func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
 		BlobSizeTotal: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "blobs_size_total",
+				Name:      "blob_size_total",
 				Help:      "the size in bytes of unencoded blobs, if a blob is in multiple quorums, it'll be acounted multiple times",
 			},
 			[]string{"stage", "quorum"},


### PR DESCRIPTION
## Why are these changes needed?
This will enable us to have visibility into the throughput at 3 key stages: ingestion (at disperser API server, metrics already exist), encoding, and attestation. Such visibility will enable clear picture of system throughput and bottleneck.

This also adds the throughput breakdown by quorum to improve the multi-quorum understanding.

Tested:
On preprod, this is a healthy throughput where there is no bottleneck

![Screenshot 2024-08-26 at 5 21 43 PM](https://github.com/user-attachments/assets/96d0cf57-383d-430e-be33-d871c696be18)



<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
