### PR TITLE
Recover failed blobs in encoding streamer

### DIFF
--- a/core/thegraph/state.go
+++ b/core/thegraph/state.go
@@ -133,7 +133,7 @@ func (ics *indexedChainState) GetIndexedOperatorState(ctx context.Context, block
 	aggKeys := make(map[uint8]*core.G1Point)
 	for _, apk := range aggregatePublicKeys {
 		if apk.Err != nil {
-			ics.logger.Warn("Error getting aggregate public key", "err", apk.Err)
+			ics.logger.Error("Error getting aggregate public key", "err", apk.Err)
 			continue
 		}
 		if apk.Err == nil && apk.AggregatePubk != nil {


### PR DESCRIPTION
## Why are these changes needed?
After marking blobs as `DISPERSING` state, it can still fail to construct a batch downstream. In that case, we should recover the blob status back to `PROCESSING`. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
