### PR TITLE
Fix printf lint warning

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.60
           args: --timeout 3m --verbose

--- a/api/errors.go
+++ b/api/errors.go
@@ -15,7 +15,7 @@ import (
 //   before return to users from APIs.
 
 func NewGRPCError(code codes.Code, msg string) error {
-	return status.Errorf(code, msg)
+	return status.Error(code, msg)
 }
 
 // HTTP Mapping: 400 Bad Request


### PR DESCRIPTION
## Why are these changes needed?

Running linter locally with a newer version than CI fails

```
❯ golangci-lint version
golangci-lint has version 1.60.3 built with go1.23.0 from c2e095c on 2024-08-22T21:45:24Z
❯ golangci-lint run ./...
api/errors.go:18:29: printf: non-constant format string in call to google.golang.org/grpc/status.Errorf (govet)
	return status.Errorf(code, msg)
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
