### PR TITLE
Remove deprecated linter golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ protoc: clean
 	$(PROTOS_DISPERSER)/**/*.proto
 
 lint:
-	golint -set_exit_status ./...
 	go tool fix ./..
 	golangci-lint run
 


### PR DESCRIPTION
## Why are these changes needed?

> NOTE: Golint is https://github.com/golang/go/issues/38968. There's no drop-in replacement for it, but tools such as [Staticcheck](https://staticcheck.io/) and go vet should be used instead.
https://github.com/golang/lint?tab=readme-ov-file

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
