### PR TITLE
Fix: Append metadata when constructing batch

### DIFF
--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -703,19 +703,17 @@ func (e *EncodingStreamer) CreateBatch(ctx context.Context) (*batch, error) {
 	}
 
 	// Transform maps to slices so orders in different slices match
-	encodedBlobs := make([]core.EncodedBlob, len(metadataByKey))
-	blobHeaders := make([]*core.BlobHeader, len(metadataByKey))
-	metadatas := make([]*disperser.BlobMetadata, len(metadataByKey))
-	i := 0
+	encodedBlobs := make([]core.EncodedBlob, 0, len(metadataByKey))
+	blobHeaders := make([]*core.BlobHeader, 0, len(metadataByKey))
+	metadatas := make([]*disperser.BlobMetadata, 0, len(metadataByKey))
 	for key := range metadataByKey {
 		err := e.transitionBlobToDispersing(ctx, metadataByKey[key])
 		if err != nil {
 			continue
 		}
-		encodedBlobs[i] = encodedBlobByKey[key]
-		blobHeaders[i] = blobHeaderByKey[key]
-		metadatas[i] = metadataByKey[key]
-		i++
+		encodedBlobs = append(encodedBlobs, encodedBlobByKey[key])
+		blobHeaders = append(blobHeaders, blobHeaderByKey[key])
+		metadatas = append(metadatas, metadataByKey[key])
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), e.ChainStateTimeout)


### PR DESCRIPTION
## Why are these changes needed?
Instead of allocating metadata into specific indices, append to allocated slice so no nil values are in the slice
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
