### PR TITLE
Fix grpc size comments

### DIFF
--- a/node/grpc/server.go
+++ b/node/grpc/server.go
@@ -232,7 +232,6 @@ func (s *Server) StoreChunks(ctx context.Context, in *pb.StoreChunksRequest) (*p
 			bundleSize += proto.Size(bundle)
 		}
 	}
-	// Caveat: proto.Size() returns int, so this log will not work for larger protobuf message (over about 2GiB).
 	s.node.Logger.Info("StoreChunks RPC request received", "num of blobs", len(in.Blobs), "request message size", proto.Size(in), "total size of blob headers", blobHeadersSize, "total size of bundles", bundleSize)
 
 	// Validate the request.
@@ -307,7 +306,6 @@ func (s *Server) StoreBlobs(ctx context.Context, in *pb.StoreBlobsRequest) (*pb.
 			bundleSize += proto.Size(bundle)
 		}
 	}
-	// Caveat: proto.Size() returns int, so this log will not work for larger protobuf message (over about 2GiB).
 	s.node.Logger.Info("StoreBlobs RPC request received", "numBlobs", len(in.Blobs), "reqMsgSize", proto.Size(in), "blobHeadersSize", blobHeadersSize, "bundleSize", bundleSize, "referenceBlockNumber", in.GetReferenceBlockNumber())
 
 	// Process the request


### PR DESCRIPTION
## Why are these changes needed?
proto.Size() returns int, which is 64 bits on 64 bits machine.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
