### PR TITLE
chore(inabox): multiplex inabox logs to stdout to help debug easier

### DIFF
--- a/inabox/deploy/deploy.go
+++ b/inabox/deploy/deploy.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"math/big"
 	"os"
@@ -126,7 +127,7 @@ func (env *Config) DeployExperiment() {
 		log.Panicf("error opening file: %v", err)
 	}
 	defer f.Close()
-	log.SetOutput(f)
+	log.SetOutput(io.MultiWriter(os.Stdout, f))
 
 	// Create a new experiment and deploy the contracts
 

--- a/inabox/deploy/utils.go
+++ b/inabox/deploy/utils.go
@@ -160,6 +160,7 @@ func execForgeScript(script, privateKey string, deployer *ContractDeployer, extr
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 
+	log.Println("Executing forge script with command: ", cmd.String())
 	err := cmd.Run()
 	if err != nil {
 		log.Print(fmt.Sprint(err) + ": " + stderr.String())


### PR DESCRIPTION
## Why are these changes needed?

Debugging why inabox was failing on my machine took me longer than it should have. Couldn't figure out why the log statements were not logging to stdout. Added a multiplexer to send logs both to the output file, but also to stdout. If a deploy command fails, I should be able to see the logs directly without needing to figure out which file the logs are piped too.

Also added a print statement to print the forge command being executed to help with debugging.
