### PR TITLE
feat: dockerfile for deploying contracts

### DIFF
--- a/contracts/.dockerignore
+++ b/contracts/.dockerignore
@@ -1,0 +1,4 @@
+cache/
+out/
+broadcast/
+bindings/

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -17,4 +17,4 @@ docs/
 data/
 
 script/output/*
-script/eigenda_deploy_config.json
+script/input/eigenda_deploy_config.json

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -10,4 +10,4 @@ RUN forge build
 RUN forge test
 
 # Set the entrypoint to the forge command
-ENTRYPOINT ["forge"]
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,0 +1,13 @@
+# Use the latest foundry image
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:latest
+
+# Copy our source code into the container
+WORKDIR /app
+
+# Build and test the source code
+COPY . .
+RUN forge build
+RUN forge test
+
+# Set the entrypoint to the forge command
+ENTRYPOINT ["forge"]

--- a/contracts/script/GenerateUnitTestHashes.s.sol
+++ b/contracts/script/GenerateUnitTestHashes.s.sol
@@ -12,7 +12,7 @@ import "forge-std/console.sol";
 
 contract GenerateHashes is Script {
 
-    string deployConfigPath = "script/eigenda_deploy_config.json";
+    string deployConfigPath = "script/input/eigenda_deploy_config.json";
 
     // deploy all the EigenDA contracts. Relies on many EL contracts having already been deployed.
     function run() external {

--- a/contracts/script/SetUpEigenDA.s.sol
+++ b/contracts/script/SetUpEigenDA.s.sol
@@ -25,7 +25,7 @@ import "forge-std/StdJson.sol";
 // forge script script/Deployer.s.sol:SetupEigenDA --rpc-url $RPC_URL  --private-key $PRIVATE_KEY --broadcast -vvvv
 contract SetupEigenDA is EigenDADeployer, EigenLayerUtils {
 
-    string deployConfigPath = "script/eigenda_deploy_config.json";
+    string deployConfigPath = "script/input/eigenda_deploy_config.json";
 
     // deploy all the EigenDA contracts. Relies on many EL contracts having already been deployed.
     function run() external {

--- a/inabox/deploy/deploy.go
+++ b/inabox/deploy/deploy.go
@@ -91,7 +91,7 @@ func (env *Config) deployEigenDAContracts() {
 	if err != nil {
 		log.Panicf("Error: %s", err.Error())
 	}
-	writeFile("script/eigenda_deploy_config.json", data)
+	writeFile("script/input/eigenda_deploy_config.json", data)
 
 	execForgeScript("script/SetUpEigenDA.s.sol:SetupEigenDA", env.Pks.EcdsaMap[deployer.Name].PrivateKey, deployer, nil)
 


### PR DESCRIPTION
## Why are these changes needed?

Need an image for deploying contracts as part of my [kurtosis inabox](https://github.com/Layr-Labs/eigenda-package) project. Generally think this is something we should have as well. Every time we deploy, we should create an image tagged with the release name/version number that contains the exact contracts that were deployed. This way anyone that wants to work locally can use that image to deploy to anvil or some local devnet and reproduce the contracts at that point.

Not set on the exact dockerfile; open to improvements. Also think we should have all of our ad-hoc docker images in the bake file in #754.

Published this image at https://github.com/orgs/Layr-Labs/packages/container/package/eigenda%2Fcontract-deployer. Would a kind admin soul please link that image with the eigenda repo for easier discovery. cc @anupsv 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
