### PR TITLE
Expose public ip service option on node plugin

### DIFF
--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -34,6 +34,7 @@ func main() {
 		plugin.EigenDAServiceManagerFlag,
 		plugin.ChurnerUrlFlag,
 		plugin.NumConfirmationsFlag,
+		plugin.PubIPProviderFlag,
 	}
 	app.Name = "eigenda-node-plugin"
 	app.Usage = "EigenDA Node Plugin"

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -24,7 +24,7 @@ var (
 	PubIPProviderFlag = cli.StringFlag{
 		Name:     "public-ip-provider",
 		Usage:    "The ip provider service used to obtain a operator's public IP [seeip (default), ipify)",
-		Required: true,
+		Required: false,
 		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "PUBLIC_IP_PROVIDER"),
 	}
 


### PR DESCRIPTION
## Why are these changes needed?
The default public ip lookup service is seeip (which is currently having an outage)
```
curl 'https://api.seeip.org/jsonip?'
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.18.0 (Ubuntu)</center>
</body>
</html>
```
If you change the ip lookup service in `.env`
```
# TODO: The ip provider service used to obtain a node's public IP [seeip (default), ipify)
NODE_PUBLIC_IP_PROVIDER=ipify
```
the node plugin continues to use seeip because the cmdline arg is not wired up. 

This change fixes that.


## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
