### PR TITLE
[ci] Generate unit test coverage on PR

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -37,7 +37,7 @@ runs:
         go-version: ${{inputs.go-version}}
 
     - name: Download coverage artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: coverage
         path: .

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 
 - [ ] I've made sure the lint is passing in this PR.
 - [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
+- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
 - Testing Strategy
    - [ ] Unit tests
    - [ ] Integration tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,6 +46,13 @@ jobs:
           name: coverage
           path: coverage.out
 
+      - name: Extract coverage
+        shell: bash
+        run: |
+          COVERAGE=$(go tool cover -func="coverage.out" | tail -1 | grep -Eo '[0-9]+\.[0-9]')
+          echo "coverage: $COVERAGE% of statements"
+
+
   coverage-report:
     name: Coverage Report
     needs: unit-tests


### PR DESCRIPTION
## Why are these changes needed?
- bumps `actions/download-artifact` version
- prints new test coverage in `unit-tests` action
- adds a check in PR template to confirm the PR doesn't impair coverage
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
