### PR TITLE
Use v4 upload artifact for unit test github workflow.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./test.sh -coverprofile=coverage.out
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage.out


### PR DESCRIPTION
## Why are these changes needed?

Fixes [a failure](https://github.com/Layr-Labs/eigenda/actions/runs/10812206983) caused by the deprecation of the old upload artifact workflow.

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
