### PR TITLE
Make the latency accounting more accurate for encoder

### DIFF
--- a/disperser/encoder/metrics.go
+++ b/disperser/encoder/metrics.go
@@ -97,11 +97,6 @@ func (m *Metrics) ObserveLatency(stage string, duration time.Duration) {
 	m.Latency.WithLabelValues(stage).Observe(float64(duration.Milliseconds()))
 }
 
-func (m *Metrics) TakeLatency(encoding, total time.Duration) {
-	m.Latency.WithLabelValues("encoding").Observe(float64(encoding.Milliseconds()))
-	m.Latency.WithLabelValues("total").Observe(float64(total.Milliseconds()))
-}
-
 func (m *Metrics) Start(ctx context.Context) {
 	m.logger.Info("Starting metrics server at ", "port", m.httpPort)
 

--- a/disperser/encoder/metrics.go
+++ b/disperser/encoder/metrics.go
@@ -93,6 +93,10 @@ func (m *Metrics) IncrementCanceledBlobRequestNum(blobSize int) {
 	m.BlobSizeTotal.WithLabelValues("canceled").Add(float64(blobSize))
 }
 
+func (m *Metrics) ObserveLatency(stage string, duration time.Duration) {
+	m.Latency.WithLabelValues(stage).Observe(float64(duration.Milliseconds()))
+}
+
 func (m *Metrics) TakeLatency(encoding, total time.Duration) {
 	m.Latency.WithLabelValues("encoding").Observe(float64(encoding.Milliseconds()))
 	m.Latency.WithLabelValues("total").Observe(float64(total.Milliseconds()))


### PR DESCRIPTION
## Why are these changes needed?
Currently, it's not counting the queuing time.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
