### PR TITLE
Reduce the operator latency metric cardinality

### DIFF
--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -182,8 +182,8 @@ func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
 		OperatorLatency: promauto.With(reg).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
-				Name:      "operator_latency",
-				Help:      "the attestation latency observed for operators",
+				Name:      "operator_attestation_latency_ms",
+				Help:      "attestation latency in ms observed for operators",
 			},
 			[]string{"operator_id"},
 		),


### PR DESCRIPTION
## Why are these changes needed?
Currently `attestation_latency_ms` metric has a high cardinality, because each operator will have 12 time series (and there are many hundreds of operators), due to:
- breakdown by failure/success
- breakdown by percentiles, due to the use of latency summary
- extra stream sum/count due to the use of latency summary

This PR changes to:
- use gauge, not latency/distribution: this avoids the percentiles, as well as sum/count
- ignore failed requests: just success requests latency should give us enough understanding

As a result, there is 1 time series per operator.

**12 time series per operator:**
```
eigenda_batcher_attestation_latency_ms{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="failure",quantile="0.5"} NaN
eigenda_batcher_attestation_latency_ms{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="failure",quantile="0.9"} NaN
eigenda_batcher_attestation_latency_ms{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="failure",quantile="0.95"} NaN
eigenda_batcher_attestation_latency_ms{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="failure",quantile="0.99"} NaN
eigenda_batcher_attestation_latency_ms_sum{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="failure"} 30669
eigenda_batcher_attestation_latency_ms_count{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="failure"} 1
eigenda_batcher_attestation_latency_ms{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="success",quantile="0.5"} 832
eigenda_batcher_attestation_latency_ms{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="success",quantile="0.9"} 857
eigenda_batcher_attestation_latency_ms{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="success",quantile="0.95"} 857
eigenda_batcher_attestation_latency_ms{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="success",quantile="0.99"} 857
eigenda_batcher_attestation_latency_ms_sum{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="success"} 3.465767e+06
eigenda_batcher_attestation_latency_ms_count{operator_id="ff7ca6eb4373179d6d3fb35a62911d7dda217b44d3e2db42dc6b912c393d0663",status="success"} 3288
```

**Before:**
![Screenshot 2024-09-19 at 6 26 00 PM](https://github.com/user-attachments/assets/c3483263-0f92-44cf-be49-8c0d44e362e4)


**After:**
![Screenshot 2024-09-19 at 6 26 10 PM](https://github.com/user-attachments/assets/cea2670d-bbcd-419e-a977-1a553ddc0fdf)






<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
