### PR TITLE
rm sig check

### DIFF
--- a/api/clients/config.go
+++ b/api/clients/config.go
@@ -52,6 +52,10 @@ func (c *EigenDAClientConfig) CheckAndSetDefaults() error {
 	if c.ResponseTimeout == 0 {
 		c.ResponseTimeout = 30 * time.Second
 	}
+	if len(c.SignerPrivateKeyHex) > 0 && len(c.SignerPrivateKeyHex) != 64 {
+		return fmt.Errorf("a valid length SignerPrivateKeyHex needs to have 64 bytes")
+	}
+
 	if len(c.RPC) == 0 {
 		return fmt.Errorf("EigenDAClientConfig.RPC not set")
 	}

--- a/api/clients/config.go
+++ b/api/clients/config.go
@@ -52,9 +52,6 @@ func (c *EigenDAClientConfig) CheckAndSetDefaults() error {
 	if c.ResponseTimeout == 0 {
 		c.ResponseTimeout = 30 * time.Second
 	}
-	if len(c.SignerPrivateKeyHex) != 64 {
-		return fmt.Errorf("EigenDAClientConfig.SignerPrivateKeyHex should be 64 hex characters long, should not have 0x prefix")
-	}
 	if len(c.RPC) == 0 {
 		return fmt.Errorf("EigenDAClientConfig.RPC not set")
 	}

--- a/api/clients/disperser_client.go
+++ b/api/clients/disperser_client.go
@@ -107,10 +107,14 @@ func (c *disperserClient) DisperseBlob(ctx context.Context, data []byte, quorums
 }
 
 func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []byte, quorums []uint8) (*disperser.BlobStatus, []byte, error) {
+	if c.signer == nil {
+		return nil, nil, fmt.Errorf("uninitialized signer for authenticated dispersal")
+	}
+
 	// first check if signer is valid
 	accountId, err := c.signer.GetAccountID()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("please configure signer key if you want to use authenticated endpoint %w", err)
 	}
 
 	quorumNumbers := make([]uint32, len(quorums))

--- a/api/clients/disperser_client.go
+++ b/api/clients/disperser_client.go
@@ -138,10 +138,16 @@ func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []
 	if err != nil {
 		return nil, nil, fmt.Errorf("encountered an error to convert a 32-bytes into a valid field element, please use the correct format where every 32bytes(big-endian) is less than 21888242871839275222246405745257275088548364400416034343698204186575808495617, %w", err)
 	}
+
+	accountId, err := c.signer.GetAccountID()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	request := &disperser_rpc.DisperseBlobRequest{
 		Data:                data,
 		CustomQuorumNumbers: quorumNumbers,
-		AccountId:           c.signer.GetAccountID(),
+		AccountId:           accountId,
 	}
 
 	// Send the initial request

--- a/api/clients/disperser_client.go
+++ b/api/clients/disperser_client.go
@@ -107,6 +107,28 @@ func (c *disperserClient) DisperseBlob(ctx context.Context, data []byte, quorums
 }
 
 func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []byte, quorums []uint8) (*disperser.BlobStatus, []byte, error) {
+	// first check if signer is valid
+	accountId, err := c.signer.GetAccountID()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	quorumNumbers := make([]uint32, len(quorums))
+	for i, q := range quorums {
+		quorumNumbers[i] = uint32(q)
+	}
+
+	// check every 32 bytes of data are within the valid range for a bn254 field element
+	_, err = rs.ToFrArray(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encountered an error to convert a 32-bytes into a valid field element, please use the correct format where every 32bytes(big-endian) is less than 21888242871839275222246405745257275088548364400416034343698204186575808495617, %w", err)
+	}
+
+	request := &disperser_rpc.DisperseBlobRequest{
+		Data:                data,
+		CustomQuorumNumbers: quorumNumbers,
+		AccountId:           accountId,
+	}
 
 	addr := fmt.Sprintf("%v:%v", c.config.Hostname, c.config.Port)
 
@@ -126,28 +148,6 @@ func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []
 	stream, err := disperserClient.DisperseBlobAuthenticated(ctxTimeout)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error while calling DisperseBlobAuthenticated: %w", err)
-	}
-
-	quorumNumbers := make([]uint32, len(quorums))
-	for i, q := range quorums {
-		quorumNumbers[i] = uint32(q)
-	}
-
-	// check every 32 bytes of data are within the valid range for a bn254 field element
-	_, err = rs.ToFrArray(data)
-	if err != nil {
-		return nil, nil, fmt.Errorf("encountered an error to convert a 32-bytes into a valid field element, please use the correct format where every 32bytes(big-endian) is less than 21888242871839275222246405745257275088548364400416034343698204186575808495617, %w", err)
-	}
-
-	accountId, err := c.signer.GetAccountID()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	request := &disperser_rpc.DisperseBlobRequest{
-		Data:                data,
-		CustomQuorumNumbers: quorumNumbers,
-		AccountId:           accountId,
 	}
 
 	// Send the initial request

--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -45,8 +45,10 @@ func NewEigenDAClient(log log.Logger, config EigenDAClientConfig) (*EigenDAClien
 	var signer core.BlobRequestSigner
 	if len(config.SignerPrivateKeyHex) == 64 {
 		signer = auth.NewLocalBlobRequestSigner(config.SignerPrivateKeyHex)
-	} else {
+	} else if len(config.SignerPrivateKeyHex) == 0 {
 		signer = auth.NewLocalNoopSigner()
+	} else {
+		return nil, fmt.Errorf("invalid length for signer private key")
 	}
 
 	llConfig := NewConfig(host, port, config.ResponseTimeout, !config.DisableTLS)

--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
 	grpcdisperser "github.com/Layr-Labs/eigenda/api/grpc/disperser"
+	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/auth"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/ethereum/go-ethereum/log"
@@ -41,7 +42,13 @@ func NewEigenDAClient(log log.Logger, config EigenDAClientConfig) (*EigenDAClien
 		return nil, fmt.Errorf("failed to parse EigenDA RPC: %w", err)
 	}
 
-	signer := auth.NewLocalBlobRequestSigner(config.SignerPrivateKeyHex)
+	var signer core.BlobRequestSigner
+	if len(config.SignerPrivateKeyHex) == 64 {
+		signer = auth.NewLocalBlobRequestSigner(config.SignerPrivateKeyHex)
+	} else {
+		signer = auth.NewLocalNoopSigner()
+	}
+
 	llConfig := NewConfig(host, port, config.ResponseTimeout, !config.DisableTLS)
 	llClient := NewDisperserClient(llConfig, signer)
 

--- a/api/clients/eigenda_client_test.go
+++ b/api/clients/eigenda_client_test.go
@@ -515,5 +515,5 @@ func TestPutBlobNoopSigner(t *testing.T) {
 	test[0] = 0x00 // make sure the first byte of the requst is always 0
 	quorums := []uint8{0}
 	_, _, err := disperserClient.DisperseBlobAuthenticated(context.Background(), test, quorums)
-	assert.EqualError(t, err, "noop signer cannot get accountID")
+	assert.EqualError(t, err, "please configure signer key if you want to use authenticated endpoint noop signer cannot get accountID")
 }

--- a/api/clients/eigenda_client_test.go
+++ b/api/clients/eigenda_client_test.go
@@ -11,6 +11,7 @@ import (
 	clientsmock "github.com/Layr-Labs/eigenda/api/clients/mock"
 	"github.com/Layr-Labs/eigenda/api/grpc/common"
 	grpcdisperser "github.com/Layr-Labs/eigenda/api/grpc/disperser"
+	"github.com/Layr-Labs/eigenda/core/auth"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/assert"
@@ -504,4 +505,15 @@ func TestPutBlobTotalTimeout(t *testing.T) {
 	// should timeout even though it would have finalized eventually
 	require.Error(t, err)
 	require.Nil(t, blobInfo)
+}
+
+func TestPutBlobNoopSigner(t *testing.T) {
+	config := clients.NewConfig("nohost", "noport", time.Second, false)
+	disperserClient := clients.NewDisperserClient(config, auth.NewLocalNoopSigner())
+
+	test := []byte("test")
+	test[0] = 0x00 // make sure the first byte of the requst is always 0
+	quorums := []uint8{0}
+	_, _, err := disperserClient.DisperseBlobAuthenticated(context.Background(), test, quorums)
+	assert.EqualError(t, err, "noop signer cannot get accountID")
 }

--- a/core/auth.go
+++ b/core/auth.go
@@ -6,5 +6,5 @@ type BlobRequestAuthenticator interface {
 
 type BlobRequestSigner interface {
 	SignBlobRequest(header BlobAuthHeader) ([]byte, error)
-	GetAccountID() string
+	GetAccountID() (string, error)
 }

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -19,9 +19,12 @@ func TestAuthentication(t *testing.T) {
 	privateKeyHex := "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	signer := auth.NewLocalBlobRequestSigner(privateKeyHex)
 
+	accountId, err := signer.GetAccountID()
+	assert.NoError(t, err)
+
 	testHeader := core.BlobAuthHeader{
 		BlobCommitments:    encoding.BlobCommitments{},
-		AccountID:          signer.GetAccountID(),
+		AccountID:          accountId,
 		Nonce:              rand.Uint32(),
 		AuthenticationData: []byte{},
 	}
@@ -46,9 +49,12 @@ func TestAuthenticationFail(t *testing.T) {
 	privateKeyHex := "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	signer := auth.NewLocalBlobRequestSigner(privateKeyHex)
 
+	accountId, err := signer.GetAccountID()
+	assert.NoError(t, err)
+
 	testHeader := core.BlobAuthHeader{
 		BlobCommitments:    encoding.BlobCommitments{},
-		AccountID:          signer.GetAccountID(),
+		AccountID:          accountId,
 		Nonce:              rand.Uint32(),
 		AuthenticationData: []byte{},
 	}
@@ -65,4 +71,19 @@ func TestAuthenticationFail(t *testing.T) {
 	err = authenticator.AuthenticateBlobRequest(testHeader)
 	assert.Error(t, err)
 
+}
+
+func TestNoopSignerFail(t *testing.T) {
+	signer := auth.NewLocalNoopSigner()
+	accountId, err := signer.GetAccountID()
+	assert.EqualError(t, err, "noop signer cannot get accountID")
+
+	testHeader := core.BlobAuthHeader{
+		BlobCommitments:    encoding.BlobCommitments{},
+		AccountID:          accountId,
+		Nonce:              rand.Uint32(),
+		AuthenticationData: []byte{},
+	}
+	_, err = signer.SignBlobRequest(testHeader)
+	assert.EqualError(t, err, "noop signer cannot sign blob request")
 }

--- a/core/auth/signer.go
+++ b/core/auth/signer.go
@@ -47,9 +47,23 @@ func (s *LocalBlobRequestSigner) SignBlobRequest(header core.BlobAuthHeader) ([]
 	return sig, nil
 }
 
-func (s *LocalBlobRequestSigner) GetAccountID() string {
+func (s *LocalBlobRequestSigner) GetAccountID() (string, error) {
 
 	publicKeyBytes := crypto.FromECDSAPub(&s.PrivateKey.PublicKey)
-	return hexutil.Encode(publicKeyBytes)
+	return hexutil.Encode(publicKeyBytes), nil
 
+}
+
+type LocalNoopSigner struct{}
+
+func NewLocalNoopSigner() *LocalNoopSigner {
+	return &LocalNoopSigner{}
+}
+
+func (s *LocalNoopSigner) SignBlobRequest(header core.BlobAuthHeader) ([]byte, error) {
+	return nil, fmt.Errorf("noop signer cannot sign blob request")
+}
+
+func (s *LocalNoopSigner) GetAccountID() (string, error) {
+	return "", fmt.Errorf("noop signer cannot get accountID")
 }

--- a/disperser/apiserver/ratelimit_test.go
+++ b/disperser/apiserver/ratelimit_test.go
@@ -225,12 +225,15 @@ func simulateClient(t *testing.T, signer core.BlobRequestSigner, origin string, 
 		stream.Close()
 	}()
 
-	err := stream.SendFromClient(&pb.AuthenticatedRequest{
+	accountId, err := signer.GetAccountID()
+	assert.NoError(t, err)
+
+	err = stream.SendFromClient(&pb.AuthenticatedRequest{
 		Payload: &pb.AuthenticatedRequest_DisperseRequest{
 			DisperseRequest: &pb.DisperseBlobRequest{
 				Data:                data,
 				CustomQuorumNumbers: quorums,
-				AccountId:           signer.GetAccountID(),
+				AccountId:           accountId,
 			},
 		},
 	})


### PR DESCRIPTION
## Feature addition
 - allowing users without disperser to use EigenDAClient. For rollup, rollup nodes that do not assume the batcher role do not need the ability to disperse blobs. But the current EigenDAClient necessitate a hex private keys. This PR serves to remove such restrictions. Such that anyone can read from EigenDA without a privateKey

## Method
 - this PR adds a new struct that implement the interface [BlobRequestSigner](https://github.com/Layr-Labs/eigenda/blob/master/core/auth.go#L7C6-L7C23) called LocalNoopSigner, it returns error for all methods. For a user without setting the private key, but uses the signer to send the blob. It will encounter a problem. 

## Test with proxy
### Send without privateKey
<img width="1518" alt="Screenshot 2024-09-20 at 12 37 39 PM" src="https://github.com/user-attachments/assets/2745d3e0-5bb7-4809-b9d0-1ee557dda27a">

### Send with privateKey (i.e it is working)
<img width="1723" alt="Screenshot 2024-09-20 at 1 36 23 PM" src="https://github.com/user-attachments/assets/671402a0-c2bc-4316-8433-012c5b2bb30d">

### retrieve without privatekey (working)
<img width="1714" alt="Screenshot 2024-09-20 at 2 43 32 PM" src="https://github.com/user-attachments/assets/3ba1cd4b-5b00-4aee-8be6-7f5c34f014d2">



## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
