### PR TITLE
Fix docker-publish-release docker bake

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,10 @@
 # VARIABLES
 variable "REGISTRY" {
-  default = "ghcr.io/layr-labs/eigenda"
+  default = "ghcr.io"
+}
+
+variable "REPO" {
+  default = "layr-labs/eigenda"
 }
 
 variable "BUILD_TAG" {
@@ -126,11 +130,11 @@ target "_release" {
 
 target "node-release" {
   inherits = ["node", "_release"]
-  tags     = ["${REGISTRY}/opr-node:${BUILD_TAG}"]
+  tags     = ["${REGISTRY}/${REPO}/opr-node:${BUILD_TAG}"]
 }
 
 target "nodeplugin-release" {
   inherits = ["nodeplugin", "_release"]
-  tags     = ["${REGISTRY}/opr-nodeplugin:${BUILD_TAG}"]
+  tags     = ["${REGISTRY}/${REPO}/opr-nodeplugin:${BUILD_TAG}"]
 }
 


### PR DESCRIPTION
## Why are these changes needed?

When we fixed the devops docker builds, we added REGISTRY variable in docker-bake, but we did not separate the registry URL from the repo path which broke our push config.


## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
