### PR TITLE
[v2] Node v2 gRPC Entrypoint

### DIFF
--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/node"
 	"github.com/Layr-Labs/eigenda/node/flags"
-	"github.com/Layr-Labs/eigenda/node/grpc"
+	nodegrpc "github.com/Layr-Labs/eigenda/node/grpc"
 )
 
 var (
@@ -85,8 +85,9 @@ func NodeMain(ctx *cli.Context) error {
 	}
 
 	// Creates the GRPC server.
-	server := grpc.NewServer(config, node, logger, ratelimiter)
-	server.Start()
+	server := nodegrpc.NewServer(config, node, logger, ratelimiter)
+	serverV2 := nodegrpc.NewServerV2(config, node, logger, ratelimiter)
+	err = nodegrpc.RunServers(server, serverV2, config, logger)
 
-	return nil
+	return err
 }

--- a/node/grpc/run.go
+++ b/node/grpc/run.go
@@ -1,0 +1,81 @@
+package grpc
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	pb "github.com/Layr-Labs/eigenda/api/grpc/node"
+	pbv2 "github.com/Layr-Labs/eigenda/api/grpc/node/v2"
+	"github.com/Layr-Labs/eigenda/common/healthcheck"
+	"github.com/Layr-Labs/eigenda/node"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+const localhost = "0.0.0.0"
+
+func RunServers(serverV1 *Server, serverV2 *ServerV2, config *node.Config, logger logging.Logger) error {
+	if serverV1 == nil {
+		return errors.New("node V1 server is not configured")
+	}
+	if serverV2 == nil {
+		return errors.New("node V2 server is not configured")
+	}
+
+	go func() {
+		for {
+			addr := fmt.Sprintf("%s:%s", localhost, config.InternalDispersalPort)
+			listener, err := net.Listen("tcp", addr)
+			if err != nil {
+				logger.Fatalf("Could not start tcp listener: %v", err)
+			}
+
+			opt := grpc.MaxRecvMsgSize(60 * 1024 * 1024 * 1024) // 60 GiB
+			gs := grpc.NewServer(opt)
+
+			// Register reflection service on gRPC server
+			// This makes "grpcurl -plaintext localhost:9000 list" command work
+			reflection.Register(gs)
+
+			pb.RegisterDispersalServer(gs, serverV1)
+			pbv2.RegisterDispersalServer(gs, serverV2)
+
+			healthcheck.RegisterHealthServer("node.Dispersal", gs)
+
+			logger.Info("port", config.InternalDispersalPort, "address", listener.Addr().String(), "GRPC Listening")
+			if err := gs.Serve(listener); err != nil {
+				logger.Error("dispersal server failed; restarting.", "err", err)
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			addr := fmt.Sprintf("%s:%s", localhost, config.InternalRetrievalPort)
+			listener, err := net.Listen("tcp", addr)
+			if err != nil {
+				logger.Fatalf("Could not start tcp listener: %v", err)
+			}
+
+			opt := grpc.MaxRecvMsgSize(1024 * 1024 * 300) // 300 MiB
+			gs := grpc.NewServer(opt)
+
+			// Register reflection service on gRPC server
+			// This makes "grpcurl -plaintext localhost:9000 list" command work
+			reflection.Register(gs)
+
+			pb.RegisterRetrievalServer(gs, serverV1)
+			pbv2.RegisterRetrievalServer(gs, serverV2)
+			healthcheck.RegisterHealthServer("node.Retrieval", gs)
+
+			logger.Info("port", config.InternalRetrievalPort, "address", listener.Addr().String(), "GRPC Listening")
+			if err := gs.Serve(listener); err != nil {
+				logger.Error("retrieval server failed; restarting.", "err", err)
+			}
+		}
+	}()
+
+	return nil
+}

--- a/node/grpc/server_v2.go
+++ b/node/grpc/server_v2.go
@@ -1,0 +1,62 @@
+package grpc
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	"github.com/Layr-Labs/eigenda/api"
+	pb "github.com/Layr-Labs/eigenda/api/grpc/node/v2"
+	"github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/node"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/shirou/gopsutil/mem"
+	"google.golang.org/grpc/codes"
+)
+
+// ServerV2 implements the Node v2 proto APIs.
+type ServerV2 struct {
+	pb.UnimplementedDispersalServer
+	pb.UnimplementedRetrievalServer
+
+	node   *node.Node
+	config *node.Config
+	logger logging.Logger
+
+	ratelimiter common.RateLimiter
+
+	mu *sync.Mutex
+}
+
+// NewServerV2 creates a new Server instance with the provided parameters.
+func NewServerV2(config *node.Config, node *node.Node, logger logging.Logger, ratelimiter common.RateLimiter) *ServerV2 {
+	return &ServerV2{
+		config:      config,
+		logger:      logger,
+		node:        node,
+		ratelimiter: ratelimiter,
+		mu:          &sync.Mutex{},
+	}
+}
+
+func (s *ServerV2) NodeInfo(ctx context.Context, in *pb.NodeInfoRequest) (*pb.NodeInfoReply, error) {
+	if s.config.DisableNodeInfoResources {
+		return &pb.NodeInfoReply{Semver: node.SemVer}, nil
+	}
+
+	memBytes := uint64(0)
+	v, err := mem.VirtualMemory()
+	if err == nil {
+		memBytes = v.Total
+	}
+
+	return &pb.NodeInfoReply{Semver: node.SemVer, Os: runtime.GOOS, Arch: runtime.GOARCH, NumCpu: uint32(runtime.GOMAXPROCS(0)), MemBytes: memBytes}, nil
+}
+
+func (s *ServerV2) StoreChunks(ctx context.Context, in *pb.StoreChunksRequest) (*pb.StoreChunksReply, error) {
+	return &pb.StoreChunksReply{}, api.NewGRPCError(codes.Unimplemented, "not implemented")
+}
+
+func (s *ServerV2) GetChunks(context.Context, *pb.GetChunksRequest) (*pb.GetChunksReply, error) {
+	return &pb.GetChunksReply{}, api.NewGRPCError(codes.Unimplemented, "not implemented")
+}

--- a/node/grpc/server_v2_test.go
+++ b/node/grpc/server_v2_test.go
@@ -1,0 +1,128 @@
+package grpc_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	commonpb "github.com/Layr-Labs/eigenda/api/grpc/common"
+	pbv2 "github.com/Layr-Labs/eigenda/api/grpc/node/v2"
+	"github.com/Layr-Labs/eigenda/common"
+	commonmock "github.com/Layr-Labs/eigenda/common/mock"
+	"github.com/Layr-Labs/eigenda/core"
+	coremock "github.com/Layr-Labs/eigenda/core/mock"
+	"github.com/Layr-Labs/eigenda/node"
+	"github.com/Layr-Labs/eigenda/node/grpc"
+	"github.com/Layr-Labs/eigensdk-go/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newTestServerV2(t *testing.T, mockValidator bool) *grpc.ServerV2 {
+	return newTestServerV2WithConfig(t, mockValidator, makeConfig(t))
+}
+
+func newTestServerV2WithConfig(t *testing.T, mockValidator bool, config *node.Config) *grpc.ServerV2 {
+	var err error
+	keyPair, err = core.GenRandomBlsKeys()
+	if err != nil {
+		panic("failed to create a BLS Key")
+	}
+	opID = [32]byte{}
+	copy(opID[:], []byte(fmt.Sprintf("%d", 3)))
+	loggerConfig := common.DefaultLoggerConfig()
+	logger, err := common.NewLogger(loggerConfig)
+	if err != nil {
+		panic("failed to create a logger")
+	}
+
+	err = os.MkdirAll(config.DbPath, os.ModePerm)
+	if err != nil {
+		panic("failed to create a directory for db")
+	}
+	noopMetrics := metrics.NewNoopMetrics()
+	reg := prometheus.NewRegistry()
+	tx := &coremock.MockTransactor{}
+
+	ratelimiter := &commonmock.NoopRatelimiter{}
+
+	var val core.ShardValidator
+
+	if mockValidator {
+		mockVal := coremock.NewMockShardValidator()
+		mockVal.On("ValidateBlobs", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockVal.On("ValidateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		val = mockVal
+	} else {
+
+		_, v, err := makeTestComponents()
+		if err != nil {
+			panic("failed to create test encoder")
+		}
+
+		asn := &core.StdAssignmentCoordinator{}
+
+		cst, err := coremock.MakeChainDataMock(map[uint8]int{
+			0: 10,
+			1: 10,
+			2: 10,
+		})
+		if err != nil {
+			panic("failed to create test encoder")
+		}
+
+		val = core.NewShardValidator(v, asn, cst, opID)
+	}
+
+	metrics := node.NewMetrics(noopMetrics, reg, logger, ":9090", opID, -1, tx, chainState)
+	store, err := node.NewLevelDBStore(config.DbPath, logger, metrics, 1e9, 1e9)
+	if err != nil {
+		panic("failed to create a new levelDB store")
+	}
+
+	node := &node.Node{
+		Config:     config,
+		Logger:     logger,
+		KeyPair:    keyPair,
+		Metrics:    metrics,
+		Store:      store,
+		ChainState: chainState,
+		Validator:  val,
+	}
+	return grpc.NewServerV2(config, node, logger, ratelimiter)
+}
+
+func TestV2NodeInfoRequest(t *testing.T) {
+	server := newTestServerV2(t, true)
+	resp, err := server.NodeInfo(context.Background(), &pbv2.NodeInfoRequest{})
+	assert.True(t, resp.Semver == "0.0.0")
+	assert.True(t, err == nil)
+}
+
+func TestV2StoreChunks(t *testing.T) {
+	server := newTestServerV2(t, true)
+	_, err := server.StoreChunks(context.Background(), &pbv2.StoreChunksRequest{
+		BlobCertificates: []*commonpb.BlobCertificate{},
+	})
+	assert.ErrorContains(t, err, "not implemented")
+}
+
+func TestV2GetChunks(t *testing.T) {
+	server := newTestServerV2(t, true)
+
+	_, err := server.GetChunks(context.Background(), &pbv2.GetChunksRequest{
+		BlobKey: []byte{0},
+	})
+	assert.ErrorContains(t, err, "not implemented")
+}
+
+func GetV2BlobCertificate(t *testing.T) {
+	server := newTestServerV2(t, true)
+
+	_, err := server.GetBlobCertificate(context.Background(), &pbv2.GetBlobCertificateRequest{
+		BlobKey: []byte{0},
+	})
+	assert.ErrorContains(t, err, "not implemented")
+}


### PR DESCRIPTION
## Why are these changes needed?
Adding entrypoint for node v2 grpc server. Both v1 and v2 endpoints are configured to the same ports. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
