### PR TITLE
Validate protos workflow

### DIFF
--- a/.github/workflows/compile-protobufs.yaml
+++ b/.github/workflows/compile-protobufs.yaml
@@ -1,0 +1,22 @@
+name: compile-protobufs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  golangci:
+    name: Compile Protobufs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout EigenDA
+        uses: actions/checkout@v3
+      - name: Recompile Protobufs
+        run: |
+          make clean
+          make protoc
+      - name: Verify No Git Changes
+        run: ./api/builder/is-repo-clean.sh

--- a/api/builder/Dockerfile
+++ b/api/builder/Dockerfile
@@ -1,11 +1,17 @@
 FROM golang:1.21.12-bookworm
 
+# The URL where the protoc binary can be downloaded. Is different depending on architecture.
+ARG PROTOC_URL
+
+# The UID of the user to create
+ARG UID
+
 # Install core dependencies
 RUN apt update
 RUN apt install -y wget unzip bash
 
 # Set up user
-RUN useradd -m -s /bin/bash user
+RUN useradd -u $UID -m -s /bin/bash user
 USER user
 WORKDIR /home/user
 # Remove default crud
@@ -14,7 +20,7 @@ RUN rm .bash_logout
 RUN rm .profile
 
 # Install protoc
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-aarch_64.zip
+RUN wget $PROTOC_URL
 RUN mkdir protoc
 RUN cd protoc && unzip ../*.zip
 RUN rm ./*.zip

--- a/api/builder/build-docker.sh
+++ b/api/builder/build-docker.sh
@@ -3,10 +3,26 @@
 # The location where this script can be found.
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+ARCH=$(uname -m)
+if [ "${ARCH}" == "arm64" ]; then
+  PROTOC_URL='https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-aarch_64.zip'
+elif [ "${ARCH}" == "x86_64" ]; then
+  PROTOC_URL='https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip'
+else
+  echo "Unsupported architecture: ${ARCH}"
+  exit 1
+fi
+
 # Add the --no-cache flag to force a rebuild.
 # Add the --progress=plain flag to show verbose output during the build.
 
 docker build \
   -f "${SCRIPT_DIR}/Dockerfile" \
   --tag pbuf-compiler:latest \
+  --build-arg PROTOC_URL="${PROTOC_URL}" \
+  --build-arg UID=$(id -u) \
   .
+
+if [ $? -ne 0 ]; then
+  exit 1
+fi

--- a/api/builder/is-repo-clean.sh
+++ b/api/builder/is-repo-clean.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script exits with error code 0 if the git repository is clean, and error code 1 if it is not.
+# This is utilized by the github workflow that checks to see if the repo is clean after recompiling
+# protobufs.
+
+if output=$(git status --porcelain) && [ -z "$output" ]; then
+  echo "Repository is clean."
+  exit 0
+else
+  echo "Repository is dirty:"
+  git status
+  exit 1
+fi

--- a/api/builder/protoc-docker.sh
+++ b/api/builder/protoc-docker.sh
@@ -11,8 +11,15 @@ if [ -z "$(docker images -q pbuf-compiler:latest 2> /dev/null)" ]; then
   "${SCRIPT_DIR}"/build-docker.sh
 fi
 
+if [ $? -ne 0 ]; then
+  exit 1
+fi
 
 docker container run \
   --rm \
   --mount "type=bind,source=${ROOT},target=/home/user/eigenda" \
   pbuf-compiler bash -c "source ~/.bashrc && eigenda/api/builder/protoc.sh"
+
+if [ $? -ne 0 ]; then
+  exit 1
+fi

--- a/api/builder/protoc.sh
+++ b/api/builder/protoc.sh
@@ -12,6 +12,10 @@ PROTO_DIR="${API_DIR}/proto"
 GRPC_DIR="${API_DIR}/grpc"
 mkdir -p "${GRPC_DIR}"
 
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 PROTO_FILES=( $(find "${PROTO_DIR}" -name '*.proto') )
 
 protoc -I "${PROTO_DIR}" \
@@ -21,12 +25,20 @@ protoc -I "${PROTO_DIR}" \
 	--go-grpc_opt=paths=source_relative \
 	${PROTO_FILES[@]}
 
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
 # Build protobufs in the disperser/api/proto directory.
 
 DISPERSER_DIR="$SCRIPT_DIR/../../disperser"
 DISPERSER_PROTO_DIR="$DISPERSER_DIR/api/proto"
 DISPERSER_GRPC_DIR="$DISPERSER_DIR/api/grpc"
 mkdir -p "${DISPERSER_GRPC_DIR}"
+
+if [ $? -ne 0 ]; then
+  exit 1
+fi
 
 DISPERSER_PROTO_FILES=( $(find "${DISPERSER_PROTO_DIR}" -name '*.proto') )
 
@@ -36,3 +48,7 @@ protoc -I "${DISPERSER_PROTO_DIR}" -I "${PROTO_DIR}" \
 	--go-grpc_out="${DISPERSER_GRPC_DIR}" \
 	--go-grpc_opt=paths=source_relative \
 	${DISPERSER_PROTO_FILES[@]}
+
+if [ $? -ne 0 ]; then
+  exit 1
+fi

--- a/api/proto/retriever/retriever.proto
+++ b/api/proto/retriever/retriever.proto
@@ -41,7 +41,3 @@ message BlobReply {
 	// The blob retrieved and reconstructed from the EigenDA Nodes per BlobRequest.
 	bytes data = 1;
 }
-
-message TestMessageDoNotMerge {
-	string test_message = 1;
-}

--- a/api/proto/retriever/retriever.proto
+++ b/api/proto/retriever/retriever.proto
@@ -41,3 +41,7 @@ message BlobReply {
 	// The blob retrieved and reconstructed from the EigenDA Nodes per BlobRequest.
 	bytes data = 1;
 }
+
+message TestMessageDoNotMerge {
+	string test_message = 1;
+}


### PR DESCRIPTION
## Why are these changes needed?

Supersedes https://github.com/Layr-Labs/eigenda/pull/787 I still think it's ugly to commit compiled protobuf files, but I can understand the argument that removing them presents short term risks that could be disruptive.

This PR adds a new CI check that will fail if there are `.proto` changes without the compiled `.proto.go` files being properly checked in.

I have verified that this check passes when there are no spurious protobuf changes, and fails when I modify a protobuf file without committing the compiled files. This new job runs in parallel with the others and completes in less than a minute, so it shouldn't have any impact on the end-to-end time for checks to pass.

![Screenshot 2024-10-10 at 10 12 44 AM](https://github.com/user-attachments/assets/427ae214-a1e5-4b1e-b37c-15061dc32aeb)

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
