### PR TITLE
Add observability for operator stake distributions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # DataAPI build stage
 FROM common-builder AS dataapi-builder
+COPY operators ./operators
 WORKDIR /app/disperser
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -61,7 +62,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM common-builder AS retriever-builder
 COPY retriever /app/retriever
 COPY node /app/node
-COPY operators/churner /app/operators/churner
+COPY operators ./operators
 WORKDIR /app/retriever
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -70,7 +71,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Node build stage
 FROM common-builder AS node-builder
 COPY node /app/node
-COPY operators/churner /app/operators/churner
+COPY operators ./operators
 WORKDIR /app/node
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Nodeplugin build stage
 FROM common-builder AS node-plugin-builder
 COPY ./node /app/node
-COPY operators/churner /app/operators/churner
+COPY operators ./operators
 WORKDIR /app/node
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \

--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -528,6 +528,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/operators-info/operators-stake": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OperatorsStake"
+                ],
+                "summary": "Operator stake distribution query",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operator ID",
+                        "name": "operator_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.OperatorsStakeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/operators-info/port-check": {
             "get": {
                 "produces": [
@@ -829,6 +875,23 @@ const docTemplate = `{
                 }
             }
         },
+        "dataapi.OperatorStake": {
+            "type": "object",
+            "properties": {
+                "operator_id": {
+                    "type": "string"
+                },
+                "quorum_id": {
+                    "type": "string"
+                },
+                "rank": {
+                    "type": "integer"
+                },
+                "stake_percentage": {
+                    "type": "number"
+                }
+            }
+        },
         "dataapi.OperatorsNonsigningPercentage": {
             "type": "object",
             "properties": {
@@ -840,6 +903,20 @@ const docTemplate = `{
                 },
                 "meta": {
                     "$ref": "#/definitions/dataapi.Meta"
+                }
+            }
+        },
+        "dataapi.OperatorsStakeResponse": {
+            "type": "object",
+            "properties": {
+                "stake_ranked_operators": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataapi.OperatorStake"
+                        }
+                    }
                 }
             }
         },

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -524,6 +524,52 @@
                 }
             }
         },
+        "/operators-info/operators-stake": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OperatorsStake"
+                ],
+                "summary": "Operator stake distribution query",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operator ID",
+                        "name": "operator_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.OperatorsStakeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/operators-info/port-check": {
             "get": {
                 "produces": [
@@ -825,6 +871,23 @@
                 }
             }
         },
+        "dataapi.OperatorStake": {
+            "type": "object",
+            "properties": {
+                "operator_id": {
+                    "type": "string"
+                },
+                "quorum_id": {
+                    "type": "string"
+                },
+                "rank": {
+                    "type": "integer"
+                },
+                "stake_percentage": {
+                    "type": "number"
+                }
+            }
+        },
         "dataapi.OperatorsNonsigningPercentage": {
             "type": "object",
             "properties": {
@@ -836,6 +899,20 @@
                 },
                 "meta": {
                     "$ref": "#/definitions/dataapi.Meta"
+                }
+            }
+        },
+        "dataapi.OperatorsStakeResponse": {
+            "type": "object",
+            "properties": {
+                "stake_ranked_operators": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/dataapi.OperatorStake"
+                        }
+                    }
                 }
             }
         },

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -131,6 +131,17 @@ definitions:
       retrieval_socket:
         type: string
     type: object
+  dataapi.OperatorStake:
+    properties:
+      operator_id:
+        type: string
+      quorum_id:
+        type: string
+      rank:
+        type: integer
+      stake_percentage:
+        type: number
+    type: object
   dataapi.OperatorsNonsigningPercentage:
     properties:
       data:
@@ -139,6 +150,15 @@ definitions:
         type: array
       meta:
         $ref: '#/definitions/dataapi.Meta'
+    type: object
+  dataapi.OperatorsStakeResponse:
+    properties:
+      stake_ranked_operators:
+        additionalProperties:
+          items:
+            $ref: '#/definitions/dataapi.OperatorStake'
+          type: array
+        type: object
     type: object
   dataapi.QueriedStateOperatorMetadata:
     properties:
@@ -585,6 +605,36 @@ paths:
         is a query parameter with a default value of 14 and max value of 30.
       tags:
       - OperatorsInfo
+  /operators-info/operators-stake:
+    get:
+      parameters:
+      - description: Operator ID
+        in: query
+        name: operator_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dataapi.OperatorsStakeResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+      summary: Operator stake distribution query
+      tags:
+      - OperatorsStake
   /operators-info/port-check:
     get:
       parameters:

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
+	"github.com/Layr-Labs/eigenda/operators"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -22,9 +23,10 @@ type MetricsConfig struct {
 type Metrics struct {
 	registry *prometheus.Registry
 
-	NumRequests *prometheus.CounterVec
-	Latency     *prometheus.SummaryVec
-	Semvers     *prometheus.GaugeVec
+	NumRequests    *prometheus.CounterVec
+	Latency        *prometheus.SummaryVec
+	Semvers        *prometheus.GaugeVec
+	OperatorsStake *prometheus.GaugeVec
 
 	httpPort string
 	logger   logging.Logger
@@ -60,6 +62,16 @@ func NewMetrics(blobMetadataStore *blobstore.BlobMetadataStore, httpPort string,
 				Help: "Node semver install base",
 			},
 			[]string{"semver"},
+		),
+		OperatorsStake: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "operators_stake",
+				Help:      "the sum of stake percentages of top N operators",
+			},
+			// The "quorum" can be: total, 0, 1, ...
+			// The "topn" can be: 1, 2, 3, 5, 8, 10
+			[]string{"quorum", "topn"},
 		),
 		registry: reg,
 		httpPort: httpPort,
@@ -101,6 +113,26 @@ func (g *Metrics) IncrementNotFoundRequestNum(method string) {
 func (g *Metrics) UpdateSemverCounts(semverData map[string]int) {
 	for semver, count := range semverData {
 		g.Semvers.WithLabelValues(semver).Set(float64(count))
+	}
+}
+
+func (g *Metrics) updateStakeMetrics(rankedOperators []*operators.OperatorStakeShare, label string) {
+	indices := []int{0, 1, 2, 4, 7, 9}
+	accuStake := float64(0)
+	idx := 0
+	for i, op := range rankedOperators {
+		accuStake += op.StakeShare
+		if idx < len(indices) && i == indices[idx] {
+			g.OperatorsStake.WithLabelValues(label, fmt.Sprintf("%d", i+1)).Set(accuStake / 100)
+			idx++
+		}
+	}
+}
+
+func (g *Metrics) UpdateOperatorsStake(totalRanked []*operators.OperatorStakeShare, quorumRanked map[uint8][]*operators.OperatorStakeShare) {
+	g.updateStakeMetrics(totalRanked, "total")
+	for q, operators := range quorumRanked {
+		g.updateStakeMetrics(operators, fmt.Sprintf("%d", q))
 	}
 }
 

--- a/node/metrics.go
+++ b/node/metrics.go
@@ -3,13 +3,12 @@ package node
 import (
 	"context"
 	"fmt"
-	"math/big"
-	"sort"
 	"strconv"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/eth"
+	"github.com/Layr-Labs/eigenda/operators"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	eigenmetrics "github.com/Layr-Labs/eigensdk-go/metrics"
 
@@ -252,33 +251,14 @@ func (g *Metrics) collectOnchainMetrics() {
 			g.logger.Error("Failed to query chain RPC for operator state", "blockNumber", blockNum, "quorumIds", quorumIds, "err", err)
 			continue
 		}
-		type OperatorStakeShare struct {
-			operatorId core.OperatorID
-			stakeShare float64
-		}
-		for q, operators := range state.Operators {
-			operatorStakeShares := make([]*OperatorStakeShare, 0)
-			totalStake := new(big.Float).SetInt(state.Totals[q].Stake)
-			for opId, opInfo := range operators {
-				opStake := new(big.Float).SetInt(opInfo.Stake)
-				share, _ := new(big.Float).Quo(
-					new(big.Float).Mul(opStake, big.NewFloat(10000)),
-					totalStake).Float64()
-				operatorStakeShares = append(operatorStakeShares, &OperatorStakeShare{operatorId: opId, stakeShare: share})
-			}
-			// Descending order by stake share in the quorum.
-			sort.Slice(operatorStakeShares, func(i, j int) bool {
-				if operatorStakeShares[i].stakeShare == operatorStakeShares[j].stakeShare {
-					return operatorStakeShares[i].operatorId.Hex() < operatorStakeShares[j].operatorId.Hex()
-				}
-				return operatorStakeShares[i].stakeShare > operatorStakeShares[j].stakeShare
-			})
-			for i, op := range operatorStakeShares {
-				if op.operatorId == g.operatorId {
+		_, quorumRankedOperators := operators.GetRankedOperators(state)
+		for q, _ := range state.Operators {
+			for i, op := range quorumRankedOperators[q] {
+				if op.OperatorId == g.operatorId {
 					g.allQuorumCache[q] = true
-					g.RegisteredQuorumsStakeShare.WithLabelValues(fmt.Sprintf("%d", q)).Set(op.stakeShare)
+					g.RegisteredQuorumsStakeShare.WithLabelValues(fmt.Sprintf("%d", q)).Set(op.StakeShare)
 					g.RegisteredQuorumsRank.WithLabelValues(fmt.Sprintf("%d", q)).Set(float64(i + 1))
-					g.logger.Info("Current operator registration onchain", "operatorId", g.operatorId.Hex(), "blockNumber", blockNum, "quorumId", q, "stakeShare (basis point)", op.stakeShare, "rank", i+1)
+					g.logger.Info("Current operator registration onchain", "operatorId", g.operatorId.Hex(), "blockNumber", blockNum, "quorumId", q, "stakeShare (basis point)", op.StakeShare, "rank", i+1)
 					break
 				}
 			}

--- a/operators/utils.go
+++ b/operators/utils.go
@@ -1,0 +1,59 @@
+package operators
+
+import (
+	"math/big"
+	"sort"
+
+	"github.com/Layr-Labs/eigenda/core"
+)
+
+type OperatorStakeShare struct {
+	OperatorId core.OperatorID
+	StakeShare float64
+}
+
+// The GetRankedOperators returns ranked operators list, by total-quorum-stake and by individual
+// quorums.
+func GetRankedOperators(state *core.OperatorState) ([]*OperatorStakeShare, map[uint8][]*OperatorStakeShare) {
+	tqsRankedOperators := make([]*OperatorStakeShare, 0)
+	quorumRankedOperators := make(map[uint8][]*OperatorStakeShare)
+	tqs := make(map[core.OperatorID]*OperatorStakeShare)
+	for q, operators := range state.Operators {
+		operatorStakeShares := make([]*OperatorStakeShare, 0)
+		totalStake := new(big.Float).SetInt(state.Totals[q].Stake)
+		for opId, opInfo := range operators {
+			opStake := new(big.Float).SetInt(opInfo.Stake)
+			share, _ := new(big.Float).Quo(
+				new(big.Float).Mul(opStake, big.NewFloat(10000)),
+				totalStake).Float64()
+			operatorStakeShares = append(operatorStakeShares, &OperatorStakeShare{OperatorId: opId, StakeShare: share})
+		}
+		// Descending order by stake share in the quorum.
+		sort.Slice(operatorStakeShares, func(i, j int) bool {
+			if operatorStakeShares[i].StakeShare == operatorStakeShares[j].StakeShare {
+				return operatorStakeShares[i].OperatorId.Hex() < operatorStakeShares[j].OperatorId.Hex()
+			}
+			return operatorStakeShares[i].StakeShare > operatorStakeShares[j].StakeShare
+		})
+
+		for _, op := range operatorStakeShares {
+			quorumRankedOperators[q] = append(quorumRankedOperators[q], op)
+			if _, ok := tqs[op.OperatorId]; !ok {
+				tqs[op.OperatorId] = &OperatorStakeShare{OperatorId: op.OperatorId, StakeShare: op.StakeShare}
+			} else {
+				tqs[op.OperatorId].StakeShare += op.StakeShare
+			}
+		}
+	}
+	for _, op := range tqs {
+		tqsRankedOperators = append(tqsRankedOperators, op)
+	}
+	// Descending order by total stake share across the quorums.
+	sort.Slice(tqsRankedOperators, func(i, j int) bool {
+		if tqsRankedOperators[i].StakeShare == tqsRankedOperators[j].StakeShare {
+			return tqsRankedOperators[i].OperatorId.Hex() < tqsRankedOperators[j].OperatorId.Hex()
+		}
+		return tqsRankedOperators[i].StakeShare > tqsRankedOperators[j].StakeShare
+	})
+	return tqsRankedOperators, quorumRankedOperators
+}


### PR DESCRIPTION
## Why are these changes needed?
Operator stake distributions is a fundamental issue. This PR adds:
- API
- Metrics

Tested:
![topn concentration](https://github.com/user-attachments/assets/af006b5f-8660-40b5-9302-2f13781abf09)


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
