### PR TITLE
Perf: cache the operator state

### DIFF
--- a/disperser/batcher/encoding_streamer.go
+++ b/disperser/batcher/encoding_streamer.go
@@ -2,9 +2,9 @@ package batcher
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -720,11 +720,9 @@ func (e *EncodingStreamer) validateMetadataQuorums(metadatas []*disperser.BlobMe
 	return validMetadata
 }
 
-func computeCacheKey(id uint, slice []uint8) string {
-	parts := make([]string, len(slice)+1)
-	parts[0] = strconv.FormatUint(uint64(id), 10)
-	for i, v := range slice {
-		parts[i+1] = strconv.FormatUint(uint64(v), 10)
-	}
-	return strings.Join(parts, "_")
+func computeCacheKey(blockNumber uint, quorumIDs []uint8) string {
+	bytes := make([]byte, 8+len(quorumIDs))
+	binary.LittleEndian.PutUint64(bytes, uint64(blockNumber))
+	copy(bytes[8:], quorumIDs)
+	return string(bytes)
 }


### PR DESCRIPTION
## Why are these changes needed?
The Batcher is making unnecessary RPC calls, hurting performance and adding cost.

It can spend 722ms on getting operator state:
![blobage-batcher-getoperatorstate](https://github.com/user-attachments/assets/225f2e0e-ac49-4ef7-8832-08249c2105ab)


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
