### PR TITLE
Adds operator ejections dataapi endpoint

### DIFF
--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -549,6 +549,18 @@ const docTemplate = `{
                         "description": "Operator ID filter",
                         "name": "operator_id",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return first N ejections [default: 1000]",
+                        "name": "first",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Skip first N ejections [default: 0]",
+                        "name": "skip",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -546,7 +546,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID filter",
+                        "description": "Operator ID filter [default: all operators]",
                         "name": "operator_id",
                         "in": "query"
                     },

--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -528,6 +528,57 @@ const docTemplate = `{
                 }
             }
         },
+        "/operators-info/ejected-operators": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OperatorsInfo"
+                ],
+                "summary": "Fetch list of operators that have been ejected over lookback days interval.",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Lookback in days [default: 1]",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Operator ID",
+                        "name": "operator_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.QueriedOperatorEjectionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/operators-info/operators-stake": {
             "get": {
                 "produces": [
@@ -916,6 +967,37 @@ const docTemplate = `{
                         "items": {
                             "$ref": "#/definitions/dataapi.OperatorStake"
                         }
+                    }
+                }
+            }
+        },
+        "dataapi.QueriedOperatorEjections": {
+            "type": "object",
+            "properties": {
+                "block_number": {
+                    "type": "integer"
+                },
+                "block_timestamp": {
+                    "type": "string"
+                },
+                "operator_id": {
+                    "type": "string"
+                },
+                "quorum": {
+                    "type": "integer"
+                },
+                "transaction_hash": {
+                    "type": "string"
+                }
+            }
+        },
+        "dataapi.QueriedOperatorEjectionsResponse": {
+            "type": "object",
+            "properties": {
+                "ejections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dataapi.QueriedOperatorEjections"
                     }
                 }
             }

--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -528,7 +528,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/operators-info/ejected-operators": {
+        "/operators-info/operator-ejections": {
             "get": {
                 "produces": [
                     "application/json"
@@ -536,7 +536,7 @@ const docTemplate = `{
                 "tags": [
                     "OperatorsInfo"
                 ],
-                "summary": "Fetch list of operators that have been ejected over lookback days interval.",
+                "summary": "Fetch list of operator ejections over last N days.",
                 "parameters": [
                     {
                         "type": "integer",
@@ -546,7 +546,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID",
+                        "description": "Operator ID filter",
                         "name": "operator_id",
                         "in": "query"
                     }

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -524,7 +524,7 @@
                 }
             }
         },
-        "/operators-info/ejected-operators": {
+        "/operators-info/operator-ejections": {
             "get": {
                 "produces": [
                     "application/json"
@@ -532,7 +532,7 @@
                 "tags": [
                     "OperatorsInfo"
                 ],
-                "summary": "Fetch list of operators that have been ejected over lookback days interval.",
+                "summary": "Fetch list of operator ejections over last N days.",
                 "parameters": [
                     {
                         "type": "integer",
@@ -542,7 +542,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID",
+                        "description": "Operator ID filter",
                         "name": "operator_id",
                         "in": "query"
                     }

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -542,7 +542,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID filter",
+                        "description": "Operator ID filter [default: all operators]",
                         "name": "operator_id",
                         "in": "query"
                     },

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -545,6 +545,18 @@
                         "description": "Operator ID filter",
                         "name": "operator_id",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return first N ejections [default: 1000]",
+                        "name": "first",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Skip first N ejections [default: 0]",
+                        "name": "skip",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -524,6 +524,57 @@
                 }
             }
         },
+        "/operators-info/ejected-operators": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "OperatorsInfo"
+                ],
+                "summary": "Fetch list of operators that have been ejected over lookback days interval.",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Lookback in days [default: 1]",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Operator ID",
+                        "name": "operator_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.QueriedOperatorEjectionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/dataapi.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/operators-info/operators-stake": {
             "get": {
                 "produces": [
@@ -912,6 +963,37 @@
                         "items": {
                             "$ref": "#/definitions/dataapi.OperatorStake"
                         }
+                    }
+                }
+            }
+        },
+        "dataapi.QueriedOperatorEjections": {
+            "type": "object",
+            "properties": {
+                "block_number": {
+                    "type": "integer"
+                },
+                "block_timestamp": {
+                    "type": "string"
+                },
+                "operator_id": {
+                    "type": "string"
+                },
+                "quorum": {
+                    "type": "integer"
+                },
+                "transaction_hash": {
+                    "type": "string"
+                }
+            }
+        },
+        "dataapi.QueriedOperatorEjectionsResponse": {
+            "type": "object",
+            "properties": {
+                "ejections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dataapi.QueriedOperatorEjections"
                     }
                 }
             }

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -636,6 +636,14 @@ paths:
         in: query
         name: operator_id
         type: string
+      - description: 'Return first N ejections [default: 1000]'
+        in: query
+        name: first
+        type: integer
+      - description: 'Skip first N ejections [default: 0]'
+        in: query
+        name: skip
+        type: integer
       produces:
       - application/json
       responses:

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -625,14 +625,14 @@ paths:
         is a query parameter with a default value of 14 and max value of 30.
       tags:
       - OperatorsInfo
-  /operators-info/ejected-operators:
+  /operators-info/operator-ejections:
     get:
       parameters:
       - description: 'Lookback in days [default: 1]'
         in: query
         name: days
         type: integer
-      - description: Operator ID
+      - description: Operator ID filter
         in: query
         name: operator_id
         type: string
@@ -655,7 +655,7 @@ paths:
           description: 'error: Server error'
           schema:
             $ref: '#/definitions/dataapi.ErrorResponse'
-      summary: Fetch list of operators that have been ejected over lookback days interval.
+      summary: Fetch list of operator ejections over last N days.
       tags:
       - OperatorsInfo
   /operators-info/operators-stake:

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -632,7 +632,7 @@ paths:
         in: query
         name: days
         type: integer
-      - description: Operator ID filter
+      - description: 'Operator ID filter [default: all operators]'
         in: query
         name: operator_id
         type: string

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -160,6 +160,26 @@ definitions:
           type: array
         type: object
     type: object
+  dataapi.QueriedOperatorEjections:
+    properties:
+      block_number:
+        type: integer
+      block_timestamp:
+        type: string
+      operator_id:
+        type: string
+      quorum:
+        type: integer
+      transaction_hash:
+        type: string
+    type: object
+  dataapi.QueriedOperatorEjectionsResponse:
+    properties:
+      ejections:
+        items:
+          $ref: '#/definitions/dataapi.QueriedOperatorEjections'
+        type: array
+    type: object
   dataapi.QueriedStateOperatorMetadata:
     properties:
       block_number:
@@ -603,6 +623,39 @@ paths:
             $ref: '#/definitions/dataapi.ErrorResponse'
       summary: Fetch list of operators that have been deregistered for days. Days
         is a query parameter with a default value of 14 and max value of 30.
+      tags:
+      - OperatorsInfo
+  /operators-info/ejected-operators:
+    get:
+      parameters:
+      - description: 'Lookback in days [default: 1]'
+        in: query
+        name: days
+        type: integer
+      - description: Operator ID
+        in: query
+        name: operator_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dataapi.QueriedOperatorEjectionsResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/dataapi.ErrorResponse'
+      summary: Fetch list of operators that have been ejected over lookback days interval.
       tags:
       - OperatorsInfo
   /operators-info/operators-stake:

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -96,6 +96,21 @@ func (s *server) getRegisteredOperatorForDays(ctx context.Context, days int32) (
 	return RegisteredOperatorMetadata, nil
 }
 
+// Function to get ejected operators for given number of days
+// Queries subgraph for ejected operators
+// Returns list of Operators with their quorum, block number, txn and timestemp they were ejected
+func (s *server) getEjectedOperatorForDays(ctx context.Context, days int32) ([]*QueriedOperatorEjections, error) {
+	startTime := time.Now()
+
+	operatorEjections, err := s.subgraphClient.QueryIndexedOperatorEjectionsForTimeWindow(ctx, days)
+	if err != nil {
+		return nil, err
+	}
+
+	s.logger.Info("Time taken to get ejected operators for days", "days", days, "duration", time.Since(startTime))
+	return operatorEjections, nil
+}
+
 func processOperatorOnlineCheck(queriedOperatorsInfo *IndexedQueriedOperatorInfo, operatorOnlineStatusresultsChan chan<- *QueriedStateOperatorMetadata, logger logging.Logger) {
 	operators := queriedOperatorsInfo.Operators
 	wp := workerpool.New(poolSize)

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -98,11 +98,11 @@ func (s *server) getRegisteredOperatorForDays(ctx context.Context, days int32) (
 
 // Function to get ejected operators for given number of days
 // Queries subgraph for ejected operators
-// Returns list of Operators with their quorum, block number, txn and timestemp they were ejected
-func (s *server) getEjectedOperatorForDays(ctx context.Context, days int32) ([]*QueriedOperatorEjections, error) {
+// Returns list of Ejections with operatorId, quorum, block number, txn and timestemp if ejection
+func (s *server) getOperatorEjectionsForDays(ctx context.Context, days int32, operatorId string) ([]*QueriedOperatorEjections, error) {
 	startTime := time.Now()
 
-	operatorEjections, err := s.subgraphClient.QueryIndexedOperatorEjectionsForTimeWindow(ctx, days)
+	operatorEjections, err := s.subgraphClient.QueryOperatorEjectionsForTimeWindow(ctx, days, operatorId)
 	if err != nil {
 		return nil, err
 	}

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -96,10 +96,9 @@ func (s *server) getRegisteredOperatorForDays(ctx context.Context, days int32) (
 	return RegisteredOperatorMetadata, nil
 }
 
-// Function to get ejected operators for given number of days
-// Queries subgraph for ejected operators
+// Function to get operator ejection over last N days
 // Returns list of Ejections with operatorId, quorum, block number, txn and timestemp if ejection
-func (s *server) getOperatorEjectionsForDays(ctx context.Context, days int32, operatorId string) ([]*QueriedOperatorEjections, error) {
+func (s *server) getOperatorEjections(ctx context.Context, days int32, operatorId string) ([]*QueriedOperatorEjections, error) {
 	startTime := time.Now()
 
 	operatorEjections, err := s.subgraphClient.QueryOperatorEjectionsForTimeWindow(ctx, days, operatorId)
@@ -107,7 +106,7 @@ func (s *server) getOperatorEjectionsForDays(ctx context.Context, days int32, op
 		return nil, err
 	}
 
-	s.logger.Info("Time taken to get ejected operators for days", "days", days, "duration", time.Since(startTime))
+	s.logger.Info("Get operator ejections", "days", days, "operatorId", operatorId, "duration", time.Since(startTime))
 	return operatorEjections, nil
 }
 

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -98,10 +98,10 @@ func (s *server) getRegisteredOperatorForDays(ctx context.Context, days int32) (
 
 // Function to get operator ejection over last N days
 // Returns list of Ejections with operatorId, quorum, block number, txn and timestemp if ejection
-func (s *server) getOperatorEjections(ctx context.Context, days int32, operatorId string) ([]*QueriedOperatorEjections, error) {
+func (s *server) getOperatorEjections(ctx context.Context, days int32, operatorId string, first uint, skip uint) ([]*QueriedOperatorEjections, error) {
 	startTime := time.Now()
 
-	operatorEjections, err := s.subgraphClient.QueryOperatorEjectionsForTimeWindow(ctx, days, operatorId)
+	operatorEjections, err := s.subgraphClient.QueryOperatorEjectionsForTimeWindow(ctx, days, operatorId, first, skip)
 	if err != nil {
 		return nil, err
 	}

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -106,7 +106,7 @@ func (s *server) getOperatorEjections(ctx context.Context, days int32, operatorI
 		return nil, err
 	}
 
-	s.logger.Info("Get operator ejections", "days", days, "operatorId", operatorId, "duration", time.Since(startTime))
+	s.logger.Info("Get operator ejections", "days", days, "operatorId", operatorId, "len", len(operatorEjections), "duration", time.Since(startTime))
 	return operatorEjections, nil
 }
 

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -900,8 +900,8 @@ func (s *server) FetchOperatorEjections(c *gin.Context) {
 		return
 	}
 
-	if daysInt > 30 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid 'days' parameter. Max value is 30"})
+	if daysInt > 90 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid 'days' parameter. Max value is 90"})
 		return
 	}
 

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -901,11 +901,6 @@ func (s *server) FetchOperatorEjections(c *gin.Context) {
 		return
 	}
 
-	if daysInt > 90 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid 'days' parameter. Max value is 90"})
-		return
-	}
-
 	first := c.DefaultQuery("first", "1000") // If not specified, defaults to 1000
 	firstInt, err := strconv.Atoi(first)
 	if err != nil {

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -149,7 +149,7 @@ type (
 	QueriedOperatorEjections struct {
 		OperatorId      string `json:"operator_id"`
 		Quorum          uint8  `json:"quorum"`
-		BlockNumber     uint   `json:"block_number"`
+		BlockNumber     uint64 `json:"block_number"`
 		BlockTimestamp  string `json:"block_timestamp"`
 		TransactionHash string `json:"transaction_hash"`
 	}

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -878,7 +878,7 @@ func (s *server) FetchRegisteredOperators(c *gin.Context) {
 //	@Tags		OperatorsInfo
 //	@Produce	json
 //	@Param		days		query		int		false	"Lookback in days [default: 1]"
-//	@Param		operator_id	query		string	false	"Operator ID filter"
+//	@Param		operator_id	query		string	false	"Operator ID filter [default: all operators]"
 //	@Success	200			{object}	QueriedOperatorEjectionsResponse
 //	@Failure	400			{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404			{object}	ErrorResponse	"error: Not found"

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -878,7 +878,7 @@ func (s *server) FetchRegisteredOperators(c *gin.Context) {
 //	@Tags		OperatorsInfo
 //	@Produce	json
 //	@Param		days		query		int		false	"Lookback in days [default: 1]"
-//	@Param		operator_id	query		string	false	"Operator ID filter"
+//	@Param		operator_id	query		string	false	"Operator ID filter [default: all operators]"
 //	@Param		first		query		int		false	"Return first N ejections [default: 1000]"
 //	@Param		skip		query		int		false	"Skip first N ejections [default: 0]"
 //	@Success	200			{object}	QueriedOperatorEjectionsResponse

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -883,7 +883,7 @@ func (s *server) FetchRegisteredOperators(c *gin.Context) {
 //	@Failure	400			{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404			{object}	ErrorResponse	"error: Not found"
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"
-//	@Router		/operators-info/ejected-operators [get]
+//	@Router		/operators-info/operator-ejections [get]
 func (s *server) FetchOperatorEjections(c *gin.Context) {
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
 		s.metrics.ObserveLatency("FetchOperatorEjections", f*1000) // make milliseconds

--- a/disperser/dataapi/subgraph/api.go
+++ b/disperser/dataapi/subgraph/api.go
@@ -27,8 +27,8 @@ type (
 		QueryOperatorInfoByOperatorIdAtBlockNumber(ctx context.Context, operatorId string, blockNumber uint32) (*IndexedOperatorInfo, error)
 		QueryOperatorAddedToQuorum(ctx context.Context, startBlock, endBlock uint32) ([]*OperatorQuorum, error)
 		QueryOperatorRemovedFromQuorum(ctx context.Context, startBlock, endBlock uint32) ([]*OperatorQuorum, error)
-		QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string) ([]*OperatorEjection, error)
-		QueryOperatorEjectionsGteBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*OperatorEjection, error)
+		QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string, first uint, skip uint) ([]*OperatorEjection, error)
+		QueryOperatorEjectionsGteBlockTimestamp(ctx context.Context, blockTimestamp uint64, first uint, skip uint) ([]*OperatorEjection, error)
 	}
 
 	api struct {
@@ -211,12 +211,14 @@ func (a *api) QueryOperatorInfoByOperatorIdAtBlockNumber(ctx context.Context, op
 	return &query.Operator, nil
 }
 
-func (a *api) QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string) ([]*OperatorEjection, error) {
+func (a *api) QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string, first uint, skip uint) ([]*OperatorEjection, error) {
 	var (
 		query     queryOperatorEjectedsByOperatorID
 		variables = map[string]any{
 			"blockTimestamp_gte": graphql.Int(blockTimestamp),
 			"operatorId":         graphql.String(operatorId),
+			"first":              graphql.Int(first),
+			"skip":               graphql.Int(skip),
 		}
 	)
 	err := a.operatorStateGql.Query(context.Background(), &query, variables)
@@ -227,11 +229,13 @@ func (a *api) QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Co
 	return query.OperatorEjections, nil
 }
 
-func (a *api) QueryOperatorEjectionsGteBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*OperatorEjection, error) {
+func (a *api) QueryOperatorEjectionsGteBlockTimestamp(ctx context.Context, blockTimestamp uint64, first uint, skip uint) ([]*OperatorEjection, error) {
 	var (
 		query     queryOperatorEjectedsGteBlockTimestamp
 		variables = map[string]any{
 			"blockTimestamp_gte": graphql.Int(blockTimestamp),
+			"first":              graphql.Int(first),
+			"skip":               graphql.Int(skip),
 		}
 	)
 	err := a.operatorStateGql.Query(context.Background(), &query, variables)

--- a/disperser/dataapi/subgraph/api.go
+++ b/disperser/dataapi/subgraph/api.go
@@ -27,7 +27,7 @@ type (
 		QueryOperatorInfoByOperatorIdAtBlockNumber(ctx context.Context, operatorId string, blockNumber uint32) (*IndexedOperatorInfo, error)
 		QueryOperatorAddedToQuorum(ctx context.Context, startBlock, endBlock uint32) ([]*OperatorQuorum, error)
 		QueryOperatorRemovedFromQuorum(ctx context.Context, startBlock, endBlock uint32) ([]*OperatorQuorum, error)
-		QueryOperatorEjectionsByOperatorId(ctx context.Context, operatorId string, blockTimestamp uint64) ([]*OperatorEjection, error)
+		QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string) ([]*OperatorEjection, error)
 		QueryOperatorEjectionsGteBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*OperatorEjection, error)
 	}
 
@@ -211,12 +211,12 @@ func (a *api) QueryOperatorInfoByOperatorIdAtBlockNumber(ctx context.Context, op
 	return &query.Operator, nil
 }
 
-func (a *api) QueryOperatorEjectionsByOperatorId(ctx context.Context, operatorId string, blockTimestamp uint64) ([]*OperatorEjection, error) {
+func (a *api) QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string) ([]*OperatorEjection, error) {
 	var (
 		query     queryOperatorEjectedsByOperatorID
 		variables = map[string]any{
 			"blockTimestamp_gte": graphql.Int(blockTimestamp),
-			"operatorId":         graphql.String(fmt.Sprintf("0x%s", operatorId)),
+			"operatorId":         graphql.String(operatorId),
 		}
 	)
 	err := a.operatorStateGql.Query(context.Background(), &query, variables)

--- a/disperser/dataapi/subgraph/mock/api.go
+++ b/disperser/dataapi/subgraph/mock/api.go
@@ -161,3 +161,25 @@ func (m *MockSubgraphApi) QueryOperatorRemovedFromQuorum(ctx context.Context, st
 
 	return value, args.Error(1)
 }
+
+func (m *MockSubgraphApi) QueryOperatorEjectionsGteBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*subgraph.OperatorEjection, error) {
+	args := m.Called()
+
+	var value []*subgraph.OperatorEjection
+	if args.Get(0) != nil {
+		value = args.Get(0).([]*subgraph.OperatorEjection)
+	}
+
+	return value, args.Error(1)
+}
+
+func (m *MockSubgraphApi) QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string) ([]*subgraph.OperatorEjection, error) {
+	args := m.Called()
+
+	var value []*subgraph.OperatorEjection
+	if args.Get(0) != nil {
+		value = args.Get(0).([]*subgraph.OperatorEjection)
+	}
+
+	return value, args.Error(1)
+}

--- a/disperser/dataapi/subgraph/mock/api.go
+++ b/disperser/dataapi/subgraph/mock/api.go
@@ -162,7 +162,7 @@ func (m *MockSubgraphApi) QueryOperatorRemovedFromQuorum(ctx context.Context, st
 	return value, args.Error(1)
 }
 
-func (m *MockSubgraphApi) QueryOperatorEjectionsGteBlockTimestamp(ctx context.Context, blockTimestamp uint64) ([]*subgraph.OperatorEjection, error) {
+func (m *MockSubgraphApi) QueryOperatorEjectionsGteBlockTimestamp(ctx context.Context, blockTimestamp uint64, first uint, skip uint) ([]*subgraph.OperatorEjection, error) {
 	args := m.Called()
 
 	var value []*subgraph.OperatorEjection
@@ -173,7 +173,7 @@ func (m *MockSubgraphApi) QueryOperatorEjectionsGteBlockTimestamp(ctx context.Co
 	return value, args.Error(1)
 }
 
-func (m *MockSubgraphApi) QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string) ([]*subgraph.OperatorEjection, error) {
+func (m *MockSubgraphApi) QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx context.Context, blockTimestamp uint64, operatorId string, first uint, skip uint) ([]*subgraph.OperatorEjection, error) {
 	args := m.Called()
 
 	var value []*subgraph.OperatorEjection

--- a/disperser/dataapi/subgraph/queries.go
+++ b/disperser/dataapi/subgraph/queries.go
@@ -36,11 +36,11 @@ type (
 		BlockTimestamp graphql.String
 	}
 	OperatorEjection struct {
-		OperatorId      graphql.String `graphql:"operatorId"`
-		QuorumNumber    graphql.String `graphql:"quorumNumber"`
-		BlockNumber     graphql.String `graphql:"blockNumber"`
-		BlockTimestamp  graphql.String `graphql:"blockTimestamp"`
-		TransactionHash graphql.String `graphql:"transactionHash"`
+		OperatorId      graphql.String
+		QuorumNumber    graphql.Int
+		BlockNumber     graphql.String
+		BlockTimestamp  graphql.String
+		TransactionHash graphql.String
 	}
 	BatchNonSigningOperatorIds struct {
 		NonSigning struct {

--- a/disperser/dataapi/subgraph/queries.go
+++ b/disperser/dataapi/subgraph/queries.go
@@ -35,6 +35,13 @@ type (
 		BlockNumber    graphql.String
 		BlockTimestamp graphql.String
 	}
+	OperatorEjection struct {
+		OperatorId      graphql.String `graphql:"operatorId"`
+		QuorumNumber    graphql.String `graphql:"quorumNumber"`
+		BlockNumber     graphql.String `graphql:"blockNumber"`
+		BlockTimestamp  graphql.String `graphql:"blockTimestamp"`
+		TransactionHash graphql.String `graphql:"transactionHash"`
+	}
 	BatchNonSigningOperatorIds struct {
 		NonSigning struct {
 			NonSigners []struct {
@@ -104,5 +111,11 @@ type (
 	}
 	queryOperatorRemovedFromQuorum struct {
 		OperatorRemovedFromQuorum []*OperatorQuorum `graphql:"operatorRemovedFromQuorums(first: $first, skip: $skip, orderBy: blockTimestamp, where: {and: [{blockNumber_gt: $blockNumber_gt}, {blockNumber_lt: $blockNumber_lt}]})"`
+	}
+	queryOperatorEjectedsGteBlockTimestamp struct {
+		OperatorEjections []*OperatorEjection `graphql:"operatorEjecteds(orderBy: blockTimestamp, where: {blockTimestamp_gte: $blockTimestamp_gte})"`
+	}
+	queryOperatorEjectedsByOperatorID struct {
+		OperatorEjections []*OperatorEjection `graphql:"operatorEjecteds(orderBy: blockTimestamp, where: {and: [{blockTimestamp_gte: $blockTimestamp_gte}, {operatorId: $operatorId}]})"`
 	}
 )

--- a/disperser/dataapi/subgraph/queries.go
+++ b/disperser/dataapi/subgraph/queries.go
@@ -113,9 +113,9 @@ type (
 		OperatorRemovedFromQuorum []*OperatorQuorum `graphql:"operatorRemovedFromQuorums(first: $first, skip: $skip, orderBy: blockTimestamp, where: {and: [{blockNumber_gt: $blockNumber_gt}, {blockNumber_lt: $blockNumber_lt}]})"`
 	}
 	queryOperatorEjectedsGteBlockTimestamp struct {
-		OperatorEjections []*OperatorEjection `graphql:"operatorEjecteds(orderBy: blockTimestamp, where: {blockTimestamp_gte: $blockTimestamp_gte})"`
+		OperatorEjections []*OperatorEjection `graphql:"operatorEjecteds(orderBy: blockTimestamp, where: {blockTimestamp_gte: $blockTimestamp_gte}, first: $first)"`
 	}
 	queryOperatorEjectedsByOperatorID struct {
-		OperatorEjections []*OperatorEjection `graphql:"operatorEjecteds(orderBy: blockTimestamp, where: {and: [{blockTimestamp_gte: $blockTimestamp_gte}, {operatorId: $operatorId}]})"`
+		OperatorEjections []*OperatorEjection `graphql:"operatorEjecteds(orderBy: blockTimestamp, where: {and: [{blockTimestamp_gte: $blockTimestamp_gte}, {operatorId: $operatorId}]}, first: $first, skip: $skip)"`
 	}
 )

--- a/disperser/dataapi/subgraph_client.go
+++ b/disperser/dataapi/subgraph_client.go
@@ -304,20 +304,13 @@ func (sc *subgraphClient) QueryOperatorEjectionsForTimeWindow(ctx context.Contex
 
 	queriedEjections := make([]*QueriedOperatorEjections, len(ejections))
 	for i, ejection := range ejections {
-		quorumNumber, err := strconv.ParseUint(string(ejection.QuorumNumber), 10, 8)
+		blockNumber, err := strconv.ParseUint(string(ejection.BlockNumber), 10, 64)
 		if err != nil {
-			fmt.Println("Error parsing quorumNumber:", err)
-			return nil, err
-		}
-		blockNumber, err := strconv.ParseUint(string(ejection.BlockNumber), 10, 32)
-		if err != nil {
-			fmt.Println("Error parsing blockNumber:", err)
 			return nil, err
 		}
 
 		timestamp, err := strconv.ParseInt(string(ejection.BlockTimestamp), 10, 64)
 		if err != nil {
-			fmt.Println("Error parsing timestamp:", err)
 			return nil, err
 		}
 
@@ -325,8 +318,8 @@ func (sc *subgraphClient) QueryOperatorEjectionsForTimeWindow(ctx context.Contex
 		blockTimestamp := t.Format(time.RFC3339)
 		queriedEjections[i] = &QueriedOperatorEjections{
 			OperatorId:      string(ejection.OperatorId),
-			Quorum:          uint8(quorumNumber),
-			BlockNumber:     uint(blockNumber),
+			Quorum:          uint8(ejection.QuorumNumber),
+			BlockNumber:     blockNumber,
 			BlockTimestamp:  blockTimestamp,
 			TransactionHash: string(ejection.TransactionHash),
 		}

--- a/disperser/dataapi/subgraph_client.go
+++ b/disperser/dataapi/subgraph_client.go
@@ -288,7 +288,7 @@ func (sc *subgraphClient) QueryOperatorEjectionsForTimeWindow(ctx context.Contex
 	lastNDayInSeconds := uint64(time.Now().Add(-time.Duration(days) * 24 * time.Hour).Unix())
 
 	var err error
-	var ejections = make([]*subgraph.OperatorEjection, 0)
+	var ejections []*subgraph.OperatorEjection
 
 	if operatorId == "" {
 		ejections, err = sc.api.QueryOperatorEjectionsGteBlockTimestamp(ctx, lastNDayInSeconds)

--- a/disperser/dataapi/subgraph_client.go
+++ b/disperser/dataapi/subgraph_client.go
@@ -36,7 +36,7 @@ type (
 		QueryOperatorQuorumEvent(ctx context.Context, startBlock, endBlock uint32) (*OperatorQuorumEvents, error)
 		QueryIndexedOperatorsWithStateForTimeWindow(ctx context.Context, days int32, state OperatorState) (*IndexedQueriedOperatorInfo, error)
 		QueryOperatorInfoByOperatorId(ctx context.Context, operatorId string) (*core.IndexedOperatorInfo, error)
-		QueryOperatorEjectionsForTimeWindow(ctx context.Context, days int32, operatorId string) ([]*QueriedOperatorEjections, error)
+		QueryOperatorEjectionsForTimeWindow(ctx context.Context, days int32, operatorId string, first uint, skip uint) ([]*QueriedOperatorEjections, error)
 	}
 	Batch struct {
 		Id              []byte
@@ -86,13 +86,6 @@ type (
 		Operators map[core.OperatorID]*QueriedOperatorInfo
 	}
 
-	//IndexedQueriedOperatorEjections struct {
-	//	OperatorId      string
-	//	QuorumNumber    uint8
-	//	BlockNumber     uint
-	//	BlockTimestamp  string
-	//	TransactionHash string
-	//}
 	NonSigner struct {
 		OperatorId string
 		Count      int
@@ -283,7 +276,7 @@ func (sc *subgraphClient) QueryIndexedOperatorsWithStateForTimeWindow(ctx contex
 	}, nil
 }
 
-func (sc *subgraphClient) QueryOperatorEjectionsForTimeWindow(ctx context.Context, days int32, operatorId string) ([]*QueriedOperatorEjections, error) {
+func (sc *subgraphClient) QueryOperatorEjectionsForTimeWindow(ctx context.Context, days int32, operatorId string, first uint, skip uint) ([]*QueriedOperatorEjections, error) {
 	// Query all operators in the last N days.
 	lastNDayInSeconds := uint64(time.Now().Add(-time.Duration(days) * 24 * time.Hour).Unix())
 
@@ -291,12 +284,12 @@ func (sc *subgraphClient) QueryOperatorEjectionsForTimeWindow(ctx context.Contex
 	var ejections []*subgraph.OperatorEjection
 
 	if operatorId == "" {
-		ejections, err = sc.api.QueryOperatorEjectionsGteBlockTimestamp(ctx, lastNDayInSeconds)
+		ejections, err = sc.api.QueryOperatorEjectionsGteBlockTimestamp(ctx, lastNDayInSeconds, first, skip)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		ejections, err = sc.api.QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx, lastNDayInSeconds, operatorId)
+		ejections, err = sc.api.QueryOperatorEjectionsGteBlockTimestampByOperatorId(ctx, lastNDayInSeconds, operatorId, first, skip)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Default look back is 1 day.
- Max lookback is 90 days
- Optional `operator_id` can be specified to limit ejection query to specific operator.

```
curl -X 'GET' \
  'https://dataapi-preprod-holesky.eigenda.xyz/api/v1/operators-info/operator-ejections?days=90' \
  -H 'accept: application/json'
{
  "ejections": [
    {
      "operator_id": "0x45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
      "quorum": 1,
      "block_number": 1956080,
      "block_timestamp": "2024-07-19T01:48:48Z",
      "transaction_hash": "0x3d0e493e09e960a8d373fdb904ab7cc6ece5d7f7385602a791e14aa44b2fed2e"
    },
    {
      "operator_id": "0x45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
      "quorum": 2,
      "block_number": 1956080,
      "block_timestamp": "2024-07-19T01:48:48Z",
      "transaction_hash": "0x3d0e493e09e960a8d373fdb904ab7cc6ece5d7f7385602a791e14aa44b2fed2e"
    },
    {
      "operator_id": "0xf512db9a07eefc22336c0de9f0dd8cb71400d0718e9ed00cb4af2643dc64325e",
      "quorum": 1,
      "block_number": 2126464,
      "block_timestamp": "2024-08-13T18:47:12Z",
      "transaction_hash": "0x23ba5240a21cb7e56a8deb971833d188ff5e30562bed5fb70e44b2a624809367"
    },
    {
      "operator_id": "0x45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
      "quorum": 1,
      "block_number": 2290044,
      "block_timestamp": "2024-09-07T18:47:12Z",
      "transaction_hash": "0x72044cb9bd5a05c5de466d698ffeff475d2e2e2df104e73b67bfac72bcc7814a"
    },
    {
      "operator_id": "0x45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
      "quorum": 2,
      "block_number": 2290044,
      "block_timestamp": "2024-09-07T18:47:12Z",
      "transaction_hash": "0x72044cb9bd5a05c5de466d698ffeff475d2e2e2df104e73b67bfac72bcc7814a"
    },
    {
      "operator_id": "0x45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
      "quorum": 1,
      "block_number": 2329091,
      "block_timestamp": "2024-09-13T18:47:24Z",
      "transaction_hash": "0x987fcdd225d72f2f22f9ae4eb32eaeb2f52dc301e585e7c1c503382c8c0e07cd"
    },
    {
      "operator_id": "0x45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
      "quorum": 2,
      "block_number": 2329091,
      "block_timestamp": "2024-09-13T18:47:24Z",
      "transaction_hash": "0x987fcdd225d72f2f22f9ae4eb32eaeb2f52dc301e585e7c1c503382c8c0e07cd"
    }
  ]
}
```

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
