### PR TITLE
Fix race condition when rebuilding proto files.

### DIFF
--- a/api/builder/clean.sh
+++ b/api/builder/clean.sh
@@ -7,8 +7,22 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 API_DIR="${SCRIPT_DIR}/.."
 GRPC_DIR="${API_DIR}/grpc"
-find "${GRPC_DIR}" -name '*.pb.go' -type f | xargs rm -rf
+# Delete all compiled protobufs
+files=$(find "${GRPC_DIR}" -name '*.pb.go' -type f)
+for file in $files; do
+    rm -rf $file
+done
+# Delete all empty directories
+find "${GRPC_DIR}" -type d -empty -delete
+
 
 DISPERSER_DIR="$SCRIPT_DIR/../../disperser"
 DISPERSER_GRPC_DIR="$DISPERSER_DIR/api/grpc"
+# Delete all compiled protobufs
 find "${DISPERSER_GRPC_DIR}" -name '*.pb.go' -type f | xargs rm -rf
+files=$(find "${DISPERSER_GRPC_DIR}" -name '*.pb.go' -type f)
+for file in $files; do
+    rm -rf $file
+done
+# Delete all empty directories
+find "${DISPERSER_GRPC_DIR}" -type d -empty -delete

--- a/api/builder/clean.sh
+++ b/api/builder/clean.sh
@@ -7,15 +7,19 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 API_DIR="${SCRIPT_DIR}/.."
 GRPC_DIR="${API_DIR}/grpc"
-# Delete all compiled protobufs
-find "${GRPC_DIR}" -name '*.pb.go' -type f | xargs rm -rf
-# Delete all empty directories
-find "${GRPC_DIR}" -type d -empty -delete
 
+if [ -d "${GRPC_DIR}" ]; then
+  # Delete all compiled protobufs
+  find "${GRPC_DIR}" -name '*.pb.go' -type f | xargs rm -rf
+  # Delete all empty directories
+  find "${GRPC_DIR}" -type d -empty -delete
+fi
 
 DISPERSER_DIR="$SCRIPT_DIR/../../disperser"
 DISPERSER_GRPC_DIR="$DISPERSER_DIR/api/grpc"
-# Delete all compiled protobufs
-find "${DISPERSER_GRPC_DIR}" -name '*.pb.go' -type f | xargs rm -rf
-# Delete all empty directories
-find "${DISPERSER_GRPC_DIR}" -type d -empty -delete
+if [ -d "${DISPERSER_GRPC_DIR}" ]; then
+  # Delete all compiled protobufs
+  find "${DISPERSER_GRPC_DIR}" -name '*.pb.go' -type f | xargs rm -rf
+  # Delete all empty directories
+  find "${DISPERSER_GRPC_DIR}" -type d -empty -delete
+fi

--- a/api/builder/clean.sh
+++ b/api/builder/clean.sh
@@ -8,10 +8,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 API_DIR="${SCRIPT_DIR}/.."
 GRPC_DIR="${API_DIR}/grpc"
 # Delete all compiled protobufs
-files=$(find "${GRPC_DIR}" -name '*.pb.go' -type f)
-for file in $files; do
-    rm -rf $file
-done
+find "${GRPC_DIR}" -name '*.pb.go' -type f | xargs rm -rf
 # Delete all empty directories
 find "${GRPC_DIR}" -type d -empty -delete
 
@@ -20,9 +17,5 @@ DISPERSER_DIR="$SCRIPT_DIR/../../disperser"
 DISPERSER_GRPC_DIR="$DISPERSER_DIR/api/grpc"
 # Delete all compiled protobufs
 find "${DISPERSER_GRPC_DIR}" -name '*.pb.go' -type f | xargs rm -rf
-files=$(find "${DISPERSER_GRPC_DIR}" -name '*.pb.go' -type f)
-for file in $files; do
-    rm -rf $file
-done
 # Delete all empty directories
 find "${DISPERSER_GRPC_DIR}" -type d -empty -delete


### PR DESCRIPTION
## Why are these changes needed?

There was an odd race condition that would cause `make protoc` to fail if run multiple times in a row. I think it had something to do with asynchronous file system operations. I didn't totally understand the problem, but deleting the protobuf directories when cleaning make the issue go away.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] hand tests 
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
