### PR TITLE
feat!: eigenda client confirmation depth

### DIFF
--- a/api/clients/config.go
+++ b/api/clients/config.go
@@ -26,19 +26,15 @@ type EigenDAClientConfig struct {
 
 	// The Ethereum RPC URL to use for querying the Ethereum blockchain.
 	// This is used to make sure that the blob has been confirmed on-chain.
-	// Only needed when WaitForConfirmationDepth > 0.
 	EthRpcUrl string
 
 	// The address of the EigenDAServiceManager contract, used to make sure that the blob has been confirmed on-chain.
-	// Only needed when WaitForConfirmationDepth > 0.
 	SvcManagerAddr string
 
 	// The number of Ethereum blocks to wait after the blob's batch has been included onchain, before returning from PutBlob calls.
 	// Only makes sense to wait for < 24 blocks (2 epochs). Otherwise, use WaitForFinalization instead.
 	//
 	// When WaitForFinalization is true, this field is ignored.
-	// 
-	// If WaitForConfirmationDepth > 0, then EthRpcUrl and SvcManagerAddr must be set.
 	WaitForConfirmationDepth uint64
 
 	// If true, will wait for the blob to finalize, if false, will wait only for the blob to confirm.
@@ -78,17 +74,13 @@ func (c *EigenDAClientConfig) CheckAndSetDefaults() error {
 			log.Printf("Warning: WaitForConfirmationDepth is set to %v > 24 (2 epochs == finality). Consider setting WaitForFinalization to true instead.\n", c.WaitForConfirmationDepth)
 		}
 	}
-	if c.WaitForConfirmationDepth > 0 {
-		if c.SvcManagerAddr == "" {
-			return fmt.Errorf("EigenDAClientConfig.SvcManagerAddr not set. Needed because WaitForConfirmationDepth > 0")
-		}
-		if c.EthRpcUrl == "" {
-			return fmt.Errorf("EigenDAClientConfig.EthRpcUrl not set. Needed because WaitForConfirmationDepth > 0")
-		}
+	if c.SvcManagerAddr == "" {
+		return fmt.Errorf("EigenDAClientConfig.SvcManagerAddr not set. Needed to verify blob confirmed on-chain.")
 	}
-	if c.SvcManagerAddr == "" && c.WaitForConfirmationDepth > 0 {
-		return fmt.Errorf("EigenDAClientConfig.SvcManagerAddr not set. Needed because WaitForConfirmationDepth > 0")
+	if c.EthRpcUrl == "" {
+		return fmt.Errorf("EigenDAClientConfig.EthRpcUrl not set. Needed to verify blob confirmed on-chain.")
 	}
+
 	if c.StatusQueryRetryInterval == 0 {
 		c.StatusQueryRetryInterval = 5 * time.Second
 	}

--- a/api/clients/config.go
+++ b/api/clients/config.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
@@ -22,6 +23,23 @@ type EigenDAClientConfig struct {
 
 	// The amount of time to wait between status queries of a newly dispersed blob
 	StatusQueryRetryInterval time.Duration
+
+	// The Ethereum RPC URL to use for querying the Ethereum blockchain.
+	// This is used to make sure that the blob has been confirmed on-chain.
+	// Only needed when WaitForConfirmationDepth > 0.
+	EthRpcUrl string
+
+	// The address of the EigenDAServiceManager contract, used to make sure that the blob has been confirmed on-chain.
+	// Only needed when WaitForConfirmationDepth > 0.
+	SvcManagerAddr string
+
+	// The number of Ethereum blocks to wait after the blob's batch has been included onchain, before returning from PutBlob calls.
+	// Only makes sense to wait for < 24 blocks (2 epochs). Otherwise, use WaitForFinalization instead.
+	//
+	// When WaitForFinalization is true, this field is ignored.
+	// 
+	// If WaitForConfirmationDepth > 0, then EthRpcUrl and SvcManagerAddr must be set.
+	WaitForConfirmationDepth uint64
 
 	// If true, will wait for the blob to finalize, if false, will wait only for the blob to confirm.
 	WaitForFinalization bool
@@ -51,6 +69,26 @@ type EigenDAClientConfig struct {
 }
 
 func (c *EigenDAClientConfig) CheckAndSetDefaults() error {
+	if c.WaitForFinalization {
+		if c.WaitForConfirmationDepth != 0 {
+			log.Println("Warning: WaitForFinalization is set to true, WaitForConfirmationDepth will be ignored")
+		}
+	} else {
+		if c.WaitForConfirmationDepth > 24 {
+			log.Printf("Warning: WaitForConfirmationDepth is set to %v > 24 (2 epochs == finality). Consider setting WaitForFinalization to true instead.\n", c.WaitForConfirmationDepth)
+		}
+	}
+	if c.WaitForConfirmationDepth > 0 {
+		if c.SvcManagerAddr == "" {
+			return fmt.Errorf("EigenDAClientConfig.SvcManagerAddr not set. Needed because WaitForConfirmationDepth > 0")
+		}
+		if c.EthRpcUrl == "" {
+			return fmt.Errorf("EigenDAClientConfig.EthRpcUrl not set. Needed because WaitForConfirmationDepth > 0")
+		}
+	}
+	if c.SvcManagerAddr == "" && c.WaitForConfirmationDepth > 0 {
+		return fmt.Errorf("EigenDAClientConfig.SvcManagerAddr not set. Needed because WaitForConfirmationDepth > 0")
+	}
 	if c.StatusQueryRetryInterval == 0 {
 		c.StatusQueryRetryInterval = 5 * time.Second
 	}

--- a/api/clients/config.go
+++ b/api/clients/config.go
@@ -32,7 +32,7 @@ type EigenDAClientConfig struct {
 	SvcManagerAddr string
 
 	// The number of Ethereum blocks to wait after the blob's batch has been included onchain, before returning from PutBlob calls.
-	// Only makes sense to wait for < 24 blocks (2 epochs). Otherwise, use WaitForFinalization instead.
+	// In most cases only makes sense if < 64 blocks (2 epochs). Otherwise, consider using WaitForFinalization instead.
 	//
 	// When WaitForFinalization is true, this field is ignored.
 	WaitForConfirmationDepth uint64
@@ -70,8 +70,8 @@ func (c *EigenDAClientConfig) CheckAndSetDefaults() error {
 			log.Println("Warning: WaitForFinalization is set to true, WaitForConfirmationDepth will be ignored")
 		}
 	} else {
-		if c.WaitForConfirmationDepth > 24 {
-			log.Printf("Warning: WaitForConfirmationDepth is set to %v > 24 (2 epochs == finality). Consider setting WaitForFinalization to true instead.\n", c.WaitForConfirmationDepth)
+		if c.WaitForConfirmationDepth > 64 {
+			log.Printf("Warning: WaitForConfirmationDepth is set to %v > 64 (2 epochs == finality). Consider setting WaitForFinalization to true instead.\n", c.WaitForConfirmationDepth)
 		}
 	}
 	if c.SvcManagerAddr == "" {

--- a/api/clients/config_test.go
+++ b/api/clients/config_test.go
@@ -106,52 +106,6 @@ func TestEigenDAClientConfig_CheckAndSetDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("WaitForFinalization and WaitForConfirmationDepth interaction", func(t *testing.T) {
-		testCases := []struct {
-			name                   string
-			waitForFinalization    bool
-			confirmationDepth      uint64
-			shouldWarnFinalization bool
-			shouldWarnDepthTooHigh bool
-		}{
-			{
-				name:                   "WaitForFinalization true ignores depth",
-				waitForFinalization:    true,
-				confirmationDepth:      10,
-				shouldWarnFinalization: true,
-				shouldWarnDepthTooHigh: false,
-			},
-			{
-				name:                   "High confirmation depth without finalization",
-				waitForFinalization:    false,
-				confirmationDepth:      25,
-				shouldWarnFinalization: false,
-				shouldWarnDepthTooHigh: true,
-			},
-			{
-				name:                   "Normal confirmation depth",
-				waitForFinalization:    false,
-				confirmationDepth:      12,
-				shouldWarnFinalization: false,
-				shouldWarnDepthTooHigh: false,
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				config := newValidConfig()
-				config.WaitForFinalization = tc.waitForFinalization
-				config.WaitForConfirmationDepth = tc.confirmationDepth
-				err := config.CheckAndSetDefaults()
-				require.NoError(t, err)
-
-				// Note: In a real implementation, you might want to use a custom logger
-				// to capture and verify the warning messages. This test structure
-				// demonstrates what we would verify if we had that capability.
-			})
-		}
-	})
-
 	t.Run("Custom timeouts", func(t *testing.T) {
 		config := newValidConfig()
 		customRetryInterval := 10 * time.Second

--- a/api/clients/config_test.go
+++ b/api/clients/config_test.go
@@ -1,0 +1,186 @@
+package clients
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+// Claude generated tests... don't blame the copy paster.
+func TestEigenDAClientConfig_CheckAndSetDefaults(t *testing.T) {
+	// Helper function to create a valid base config
+	newValidConfig := func() *EigenDAClientConfig {
+		return &EigenDAClientConfig{
+			RPC:            "http://localhost:8080",
+			EthRpcUrl:      "http://localhost:8545",
+			SvcManagerAddr: "0x1234567890123456789012345678901234567890",
+		}
+	}
+
+	t.Run("Valid minimal configuration", func(t *testing.T) {
+		config := newValidConfig()
+		err := config.CheckAndSetDefaults()
+		require.NoError(t, err)
+
+		// Check default values are set
+		assert.Equal(t, 5*time.Second, config.StatusQueryRetryInterval)
+		assert.Equal(t, 25*time.Minute, config.StatusQueryTimeout)
+		assert.Equal(t, 30*time.Second, config.ResponseTimeout)
+	})
+
+	t.Run("Missing required fields", func(t *testing.T) {
+		testCases := []struct {
+			name        string
+			modifyConf  func(*EigenDAClientConfig)
+			expectedErr string
+		}{
+			{
+				name: "Missing RPC",
+				modifyConf: func(c *EigenDAClientConfig) {
+					c.RPC = ""
+				},
+				expectedErr: "EigenDAClientConfig.RPC not set",
+			},
+			{
+				name: "Missing EthRpcUrl",
+				modifyConf: func(c *EigenDAClientConfig) {
+					c.EthRpcUrl = ""
+				},
+				expectedErr: "EigenDAClientConfig.EthRpcUrl not set. Needed to verify blob confirmed on-chain.",
+			},
+			{
+				name: "Missing SvcManagerAddr",
+				modifyConf: func(c *EigenDAClientConfig) {
+					c.SvcManagerAddr = ""
+				},
+				expectedErr: "EigenDAClientConfig.SvcManagerAddr not set. Needed to verify blob confirmed on-chain.",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				config := newValidConfig()
+				tc.modifyConf(config)
+				err := config.CheckAndSetDefaults()
+				assert.EqualError(t, err, tc.expectedErr)
+			})
+		}
+	})
+
+	t.Run("SignerPrivateKeyHex validation", func(t *testing.T) {
+		testCases := []struct {
+			name        string
+			keyHex      string
+			shouldError bool
+		}{
+			{
+				name:        "Empty key (valid for read-only)",
+				keyHex:      "",
+				shouldError: false,
+			},
+			{
+				name:        "Valid length key (64 bytes)",
+				keyHex:      "1234567890123456789012345678901234567890123456789012345678901234",
+				shouldError: false,
+			},
+			{
+				name:        "Invalid length key",
+				keyHex:      "123456",
+				shouldError: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				config := newValidConfig()
+				config.SignerPrivateKeyHex = tc.keyHex
+				err := config.CheckAndSetDefaults()
+				if tc.shouldError {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), "SignerPrivateKeyHex")
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("WaitForFinalization and WaitForConfirmationDepth interaction", func(t *testing.T) {
+		testCases := []struct {
+			name                   string
+			waitForFinalization    bool
+			confirmationDepth      uint64
+			shouldWarnFinalization bool
+			shouldWarnDepthTooHigh bool
+		}{
+			{
+				name:                   "WaitForFinalization true ignores depth",
+				waitForFinalization:    true,
+				confirmationDepth:      10,
+				shouldWarnFinalization: true,
+				shouldWarnDepthTooHigh: false,
+			},
+			{
+				name:                   "High confirmation depth without finalization",
+				waitForFinalization:    false,
+				confirmationDepth:      25,
+				shouldWarnFinalization: false,
+				shouldWarnDepthTooHigh: true,
+			},
+			{
+				name:                   "Normal confirmation depth",
+				waitForFinalization:    false,
+				confirmationDepth:      12,
+				shouldWarnFinalization: false,
+				shouldWarnDepthTooHigh: false,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				config := newValidConfig()
+				config.WaitForFinalization = tc.waitForFinalization
+				config.WaitForConfirmationDepth = tc.confirmationDepth
+				err := config.CheckAndSetDefaults()
+				require.NoError(t, err)
+
+				// Note: In a real implementation, you might want to use a custom logger
+				// to capture and verify the warning messages. This test structure
+				// demonstrates what we would verify if we had that capability.
+			})
+		}
+	})
+
+	t.Run("Custom timeouts", func(t *testing.T) {
+		config := newValidConfig()
+		customRetryInterval := 10 * time.Second
+		customQueryTimeout := 30 * time.Minute
+		customResponseTimeout := 45 * time.Second
+
+		config.StatusQueryRetryInterval = customRetryInterval
+		config.StatusQueryTimeout = customQueryTimeout
+		config.ResponseTimeout = customResponseTimeout
+
+		err := config.CheckAndSetDefaults()
+		require.NoError(t, err)
+
+		assert.Equal(t, customRetryInterval, config.StatusQueryRetryInterval)
+		assert.Equal(t, customQueryTimeout, config.StatusQueryTimeout)
+		assert.Equal(t, customResponseTimeout, config.ResponseTimeout)
+	})
+
+	t.Run("Optional fields", func(t *testing.T) {
+		config := newValidConfig()
+		config.CustomQuorumIDs = []uint{2, 3, 4}
+		config.DisableTLS = true
+		config.DisablePointVerificationMode = true
+
+		err := config.CheckAndSetDefaults()
+		require.NoError(t, err)
+
+		assert.Equal(t, []uint{2, 3, 4}, config.CustomQuorumIDs)
+		assert.True(t, config.DisableTLS)
+		assert.True(t, config.DisablePointVerificationMode)
+	})
+}

--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -130,8 +130,6 @@ func NewEigenDAClient(log log.Logger, config EigenDAClientConfig) (*EigenDAClien
 	}, nil
 }
 
-// Deprecated: do not rely on this function. Do not use m.Codec directly either.
-// These will eventually be removed and not exposed.
 func (m *EigenDAClient) GetCodec() codecs.BlobCodec {
 	return m.Codec
 }

--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -164,9 +164,9 @@ func (m *EigenDAClient) GetBlob(ctx context.Context, batchHeaderHash []byte, blo
 // to be reached (guarded by WaitForFinalization config param) before returning.
 // This function is resilient to transient failures and timeouts.
 //
-// Upon return the blob is guaranteed to be: 
-//  - finalized onchain (if Config.WaitForFinalization is true), or
-//  - confirmed at a certain depth (if Config.WaitForFinalization is false, in which case Config.WaitForConfirmationDepth specifies the depth).
+// Upon return the blob is guaranteed to be:
+//   - finalized onchain (if Config.WaitForFinalization is true), or
+//   - confirmed at a certain depth (if Config.WaitForFinalization is false, in which case Config.WaitForConfirmationDepth specifies the depth).
 func (m *EigenDAClient) PutBlob(ctx context.Context, data []byte) (*grpcdisperser.BlobInfo, error) {
 	resultChan, errorChan := m.PutBlobAsync(ctx, data)
 	select { // no timeout here because we depend on the configured timeout in PutBlobAsync
@@ -313,7 +313,10 @@ func (m EigenDAClient) getConfDeepBlockNumber(ctx context.Context, depth uint64)
 	// If curBlock < depth, this will return the genesis block number (0),
 	// which would cause to accept as confirmed a block that isn't depth deep.
 	// TODO: there's prob a better way to deal with this, like returning a special error
-	return new(big.Int).SetUint64(max(curBlockNumber-depth, 0)), nil
+	if curBlockNumber < depth {
+		return big.NewInt(0), nil
+	}
+	return new(big.Int).SetUint64(curBlockNumber - depth), nil
 }
 
 // batchIdConfirmedAtDepth checks if a batch ID has been confirmed at a certain depth.

--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -165,6 +165,10 @@ func (m *EigenDAClient) GetBlob(ctx context.Context, batchHeaderHash []byte, blo
 // PutBlob encodes and writes a blob to EigenDA, waiting for a desired blob status
 // to be reached (guarded by WaitForFinalization config param) before returning.
 // This function is resilient to transient failures and timeouts.
+//
+// Upon return the blob is guaranteed to be: 
+//  - finalized onchain (if Config.WaitForFinalization is true), or
+//  - confirmed at a certain depth (if Config.WaitForFinalization is false, in which case Config.WaitForConfirmationDepth specifies the depth).
 func (m *EigenDAClient) PutBlob(ctx context.Context, data []byte) (*grpcdisperser.BlobInfo, error) {
 	resultChan, errorChan := m.PutBlobAsync(ctx, data)
 	select { // no timeout here because we depend on the configured timeout in PutBlobAsync

--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -81,16 +81,13 @@ func NewEigenDAClient(log log.Logger, config EigenDAClientConfig) (*EigenDAClien
 
 	var ethClient *ethclient.Client
 	var edasmCaller *edasm.ContractEigenDAServiceManagerCaller
-	if config.WaitForConfirmationDepth > 0 {
-		ethClient, err = ethclient.Dial(config.EthRpcUrl)
-		if err != nil {
-			return nil, fmt.Errorf("failed to dial ETH RPC node: %w", err)
-		}
-		edasmCaller, err = edasm.NewContractEigenDAServiceManagerCaller(common.HexToAddress(config.SvcManagerAddr), ethClient)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create EigenDAServiceManagerCaller: %w", err)
-		}
-
+	ethClient, err = ethclient.Dial(config.EthRpcUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial ETH RPC node: %w", err)
+	}
+	edasmCaller, err = edasm.NewContractEigenDAServiceManagerCaller(common.HexToAddress(config.SvcManagerAddr), ethClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create EigenDAServiceManagerCaller: %w", err)
 	}
 
 	host, port, err := net.SplitHostPort(config.RPC)
@@ -321,7 +318,7 @@ func (m EigenDAClient) getConfDeepBlockNumber(ctx context.Context, depth uint64)
 // It returns true if the batch ID has been confirmed at the given depth, and false otherwise,
 // or returns an error if any of the network calls fail.
 func (m EigenDAClient) batchIdConfirmedAtDepth(ctx context.Context, batchId uint32, depth uint64) (bool, error) {
-	confDeepBlockNumber, err := m.getConfDeepBlockNumber(ctx, m.Config.WaitForConfirmationDepth)
+	confDeepBlockNumber, err := m.getConfDeepBlockNumber(ctx, depth)
 	if err != nil {
 		return false, fmt.Errorf("failed to get confirmation deep block number: %w", err)
 	}

--- a/api/clients/eigenda_client_e2e_test.go
+++ b/api/clients/eigenda_client_e2e_test.go
@@ -77,7 +77,8 @@ func TestClientUsingTestnet(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, data, string(blob))
 
-		// assert confirmation depth
+		// assert confirmation depth by making sure the batch metadata hash was registered onchain
+		// at least confDepth blocks ago
 		blockNumCur, err := client.ethClient.BlockNumber(context.Background())
 		assert.NoError(t, err)
 		blockNumAtDepth := new(big.Int).SetUint64(blockNumCur - confDepth)

--- a/api/clients/eigenda_client_e2e_test.go
+++ b/api/clients/eigenda_client_e2e_test.go
@@ -19,6 +19,9 @@ func init() {
 	flag.BoolVar(&runTestnetIntegrationTests, "testnet-integration", false, "Run testnet-based integration tests")
 }
 
+// TestClientUsingTestnet tests the eigenda client against holesky testnet disperser.
+// We don't test waiting for finality because that adds 12 minutes to the test, and is not necessary
+// because we already test for this in the unit tests using a mock disperser which is much faster.
 func TestClientUsingTestnet(t *testing.T) {
 	if !runTestnetIntegrationTests {
 		t.Skip("Skipping testnet integration test")
@@ -33,10 +36,7 @@ func TestClientUsingTestnet(t *testing.T) {
 			StatusQueryRetryInterval: 5 * time.Second,
 			CustomQuorumIDs:          []uint{},
 			SignerPrivateKeyHex:      "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1",
-			// Waiting for finality adds 12 minutes to the test, and is not necessary
-			// because we already test for this correct behavior in the unit tests using a mock disperser
-			// which is much faster.
-			WaitForFinalization: false,
+			WaitForFinalization:      false,
 		})
 		data := "hello world!"
 		assert.NoError(t, err)

--- a/api/clients/eigenda_client_e2e_test.go
+++ b/api/clients/eigenda_client_e2e_test.go
@@ -31,8 +31,11 @@ func TestClientUsingTestnet(t *testing.T) {
 		t.Parallel()
 		logger := log.NewLogger(log.NewTerminalHandler(os.Stdout, true))
 		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
-			RPC:                      "disperser-holesky.eigenda.xyz:443",
-			StatusQueryTimeout:       25 * time.Minute,
+			RPC: "disperser-holesky.eigenda.xyz:443",
+			// Should need way less than 20 minutes, but we set it to 20 minutes to be safe
+			// In worst case we had 10 min batching interval + some time for the tx to land onchain,
+			// plus wait for 3 blocks of confirmation.
+			StatusQueryTimeout:       20 * time.Minute,
 			StatusQueryRetryInterval: 5 * time.Second,
 			CustomQuorumIDs:          []uint{},
 			SignerPrivateKeyHex:      "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1",
@@ -57,8 +60,11 @@ func TestClientUsingTestnet(t *testing.T) {
 		confDepth := uint64(3)
 		logger := log.NewLogger(log.NewTerminalHandler(os.Stdout, true))
 		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
-			RPC:                      "disperser-holesky.eigenda.xyz:443",
-			StatusQueryTimeout:       25 * time.Minute,
+			RPC: "disperser-holesky.eigenda.xyz:443",
+			// Should need way less than 20 minutes, but we set it to 20 minutes to be safe
+			// In worst case we had 10 min batching interval + some time for the tx to land onchain,
+			// plus wait for 3 blocks of confirmation.
+			StatusQueryTimeout:       20 * time.Minute,
 			StatusQueryRetryInterval: 5 * time.Second,
 			CustomQuorumIDs:          []uint{},
 			SignerPrivateKeyHex:      "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1",

--- a/api/clients/eigenda_client_e2e_test.go
+++ b/api/clients/eigenda_client_e2e_test.go
@@ -1,13 +1,14 @@
-package clients_test
+package clients
 
 import (
 	"context"
 	"flag"
+	"math/big"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/Layr-Labs/eigenda/api/clients"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,25 +23,64 @@ func TestClientUsingTestnet(t *testing.T) {
 	if !runTestnetIntegrationTests {
 		t.Skip("Skipping testnet integration test")
 	}
-	logger := log.NewLogger(log.NewTerminalHandler(os.Stderr, true))
-	client, err := clients.NewEigenDAClient(logger, clients.EigenDAClientConfig{
-		RPC:                      "disperser-holesky.eigenda.xyz:443",
-		StatusQueryTimeout:       25 * time.Minute,
-		StatusQueryRetryInterval: 5 * time.Second,
-		CustomQuorumIDs:          []uint{},
-		SignerPrivateKeyHex:      "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1",
-		// Waiting for finality adds 12 minutes to the test, and is not necessary
-		// because we already test for this correct behavior in the unit tests using a mock disperser
-		// which is much faster.
-		WaitForFinalization: false,
+
+	t.Run("PutBlobWaitForConfirmationAndGetBlob", func(t *testing.T) {
+		t.Parallel()
+		logger := log.NewLogger(log.NewTerminalHandler(os.Stdout, true))
+		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
+			RPC:                      "disperser-holesky.eigenda.xyz:443",
+			StatusQueryTimeout:       25 * time.Minute,
+			StatusQueryRetryInterval: 5 * time.Second,
+			CustomQuorumIDs:          []uint{},
+			SignerPrivateKeyHex:      "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1",
+			// Waiting for finality adds 12 minutes to the test, and is not necessary
+			// because we already test for this correct behavior in the unit tests using a mock disperser
+			// which is much faster.
+			WaitForFinalization: false,
+		})
+		data := "hello world!"
+		assert.NoError(t, err)
+		blobInfo, err := client.PutBlob(context.Background(), []byte(data))
+		assert.NoError(t, err)
+		batchHeaderHash := blobInfo.BlobVerificationProof.BatchMetadata.BatchHeaderHash
+		blobIndex := blobInfo.BlobVerificationProof.BlobIndex
+		blob, err := client.GetBlob(context.Background(), batchHeaderHash, blobIndex)
+		assert.NoError(t, err)
+		assert.Equal(t, data, string(blob))
 	})
-	data := "hello world!"
-	assert.NoError(t, err)
-	blobInfo, err := client.PutBlob(context.Background(), []byte(data))
-	assert.NoError(t, err)
-	batchHeaderHash := blobInfo.BlobVerificationProof.BatchMetadata.BatchHeaderHash
-	blobIndex := blobInfo.BlobVerificationProof.BlobIndex
-	blob, err := client.GetBlob(context.Background(), batchHeaderHash, blobIndex)
-	assert.NoError(t, err)
-	assert.Equal(t, data, string(blob))
+
+	t.Run("PutBlobWaitForConfirmationDepthAndGetBlob", func(t *testing.T) {
+		t.Parallel()
+		confDepth := uint64(3)
+		logger := log.NewLogger(log.NewTerminalHandler(os.Stdout, true))
+		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
+			RPC:                      "disperser-holesky.eigenda.xyz:443",
+			StatusQueryTimeout:       25 * time.Minute,
+			StatusQueryRetryInterval: 5 * time.Second,
+			CustomQuorumIDs:          []uint{},
+			SignerPrivateKeyHex:      "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1",
+			WaitForFinalization:      false,
+			WaitForConfirmationDepth: confDepth,
+			SvcManagerAddr:           "0xD4A7E1Bd8015057293f0D0A557088c286942e84b",
+			EthRpcUrl:                "https://1rpc.io/holesky",
+		})
+		data := "hello world!"
+		assert.NoError(t, err)
+		blobInfo, err := client.PutBlob(context.Background(), []byte(data))
+		assert.NoError(t, err)
+		batchHeaderHash := blobInfo.BlobVerificationProof.BatchMetadata.BatchHeaderHash
+		blobIndex := blobInfo.BlobVerificationProof.BlobIndex
+		blob, err := client.GetBlob(context.Background(), batchHeaderHash, blobIndex)
+		assert.NoError(t, err)
+		assert.Equal(t, data, string(blob))
+
+		// assert confirmation depth
+		blockNumCur, err := client.ethClient.BlockNumber(context.Background())
+		assert.NoError(t, err)
+		blockNumAtDepth := new(big.Int).SetUint64(blockNumCur - confDepth)
+		batchId := blobInfo.BlobVerificationProof.GetBatchId()
+		onchainBatchMetadataHash, err := client.edasmCaller.BatchIdToBatchMetadataHash(&bind.CallOpts{BlockNumber: blockNumAtDepth}, batchId)
+		assert.NoError(t, err)
+		assert.NotEqual(t, onchainBatchMetadataHash, make([]byte, 32))
+	})
 }

--- a/api/clients/eigenda_client_e2e_test.go
+++ b/api/clients/eigenda_client_e2e_test.go
@@ -27,7 +27,7 @@ func TestClientUsingTestnet(t *testing.T) {
 		t.Skip("Skipping testnet integration test")
 	}
 
-	t.Run("PutBlobWaitForConfirmationAndGetBlob", func(t *testing.T) {
+	t.Run("PutBlobWaitForConfirmationDepth0AndGetBlob", func(t *testing.T) {
 		t.Parallel()
 		logger := log.NewLogger(log.NewTerminalHandler(os.Stdout, true))
 		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
@@ -37,6 +37,9 @@ func TestClientUsingTestnet(t *testing.T) {
 			CustomQuorumIDs:          []uint{},
 			SignerPrivateKeyHex:      "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1",
 			WaitForFinalization:      false,
+			WaitForConfirmationDepth: 0,
+			SvcManagerAddr:           "0xD4A7E1Bd8015057293f0D0A557088c286942e84b",
+			EthRpcUrl:                "https://1rpc.io/holesky",
 		})
 		data := "hello world!"
 		assert.NoError(t, err)
@@ -49,7 +52,7 @@ func TestClientUsingTestnet(t *testing.T) {
 		assert.Equal(t, data, string(blob))
 	})
 
-	t.Run("PutBlobWaitForConfirmationDepthAndGetBlob", func(t *testing.T) {
+	t.Run("PutBlobWaitForConfirmationDepth3AndGetBlob", func(t *testing.T) {
 		t.Parallel()
 		confDepth := uint64(3)
 		logger := log.NewLogger(log.NewTerminalHandler(os.Stdout, true))


### PR DESCRIPTION
Closes EBE-107.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Starting to upstream some of the eigenda-proxy features to eigenda-client.
This PR is needed for https://github.com/Layr-Labs/eigenda-proxy/issues/187

Did not add a unit test, as I'm not a big fan of mock-based tests, which is the only pattern we have currently to test the eigenda-client. Added an e2e test on holesky instead, but this does not seem to be checked by any of our ci workflows... PR incoming (https://github.com/Layr-Labs/eigenda/pull/820 ).

BREAKING CHANGES:
- eth-rpc-url and eigenda-service-manager address are now mandatory configs to instantiate the eigenda-client

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
