### PR TITLE
Update docker-publish-release to not trigger on pull requests

### DIFF
--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -4,7 +4,8 @@ on:
   push:
     tags:
       - v*
-  pull_request:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
Also triggers, but does not publish, on merge to master

## Why are these changes needed?

Should not run on pull request

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
