### PR TITLE
refactor: make disperser client reuse same grpc connection

### DIFF
--- a/api/clients/disperser_client.go
+++ b/api/clients/disperser_client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	disperser_rpc "github.com/Layr-Labs/eigenda/api/grpc/disperser"
@@ -18,8 +19,8 @@ import (
 )
 
 type Config struct {
-	Hostname          string
-	Port              string
+	Hostname string
+	Port     string
 	// BlobDispersal Timeouts for both authenticated and unauthenticated dispersals
 	// GetBlobStatus and RetrieveBlob timeouts are hardcoded to 60seconds
 	// TODO: do we want to add config timeouts for those separate requests?
@@ -37,47 +38,73 @@ func NewConfig(hostname, port string, timeout time.Duration, useSecureGrpcFlag b
 }
 
 type DisperserClient interface {
+	Close() error
 	DisperseBlob(ctx context.Context, data []byte, customQuorums []uint8) (*disperser.BlobStatus, []byte, error)
 	DisperseBlobAuthenticated(ctx context.Context, data []byte, customQuorums []uint8) (*disperser.BlobStatus, []byte, error)
 	GetBlobStatus(ctx context.Context, key []byte) (*disperser_rpc.BlobStatusReply, error)
 	RetrieveBlob(ctx context.Context, batchHeaderHash []byte, blobIndex uint32) ([]byte, error)
 }
 
+// See the NewDisperserClient constructor's documentation for details and usage examples.
 type disperserClient struct {
 	config *Config
 	signer core.BlobRequestSigner
+	// conn and client are not initialized in the constructor, but are initialized lazily
+	// whenever a method is called, using initOnce to make sure initialization happens only once
+	// and is thread-safe
+	initOnce sync.Once
+	conn     *grpc.ClientConn
+	client   disperser_rpc.DisperserClient
 }
 
 var _ DisperserClient = &disperserClient{}
 
-func NewDisperserClient(config *Config, signer core.BlobRequestSigner) DisperserClient {
+// DisperserClient maintains a single underlying grpc connection to the disperser server,
+// through which it sends requests to disperse blobs, get blob status, and retrieve blobs.
+// The connection is established lazily on the first method call. Don't forget to call Close(),
+// which is safe to call even if the connection was never established.
+//
+// DisperserClient is safe to be used concurrently by multiple goroutines.
+//
+// Example usage:
+//
+//	client := NewDisperserClient(config, signer)
+//	defer client.Close()
+//
+//	// The connection will be established on the first call
+//	status, requestId, err := client.DisperseBlob(ctx, someData, someQuorums)
+//	if err != nil {
+//	    // Handle error
+//	}
+//
+//	// Subsequent calls will use the existing connection
+//	status2, requestId2, err := client.DisperseBlob(ctx, otherData, otherQuorums)
+func NewDisperserClient(config *Config, signer core.BlobRequestSigner) *disperserClient {
 	return &disperserClient{
 		config: config,
 		signer: signer,
+		// conn and client are initialized lazily
 	}
 }
 
-func (c *disperserClient) getDialOptions() []grpc.DialOption {
-	if c.config.UseSecureGrpcFlag {
-		config := &tls.Config{}
-		credential := credentials.NewTLS(config)
-		return []grpc.DialOption{grpc.WithTransportCredentials(credential)}
-	} else {
-		return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+// Close closes the grpc connection to the disperser server.
+// It is thread safe and can be called multiple times.
+func (c *disperserClient) Close() error {
+	if c.conn != nil {
+		err := c.conn.Close()
+		c.conn = nil
+		c.client = nil
+		return err
 	}
+	return nil
 }
 
 func (c *disperserClient) DisperseBlob(ctx context.Context, data []byte, quorums []uint8) (*disperser.BlobStatus, []byte, error) {
-	addr := fmt.Sprintf("%v:%v", c.config.Hostname, c.config.Port)
-
-	dialOptions := c.getDialOptions()
-	conn, err := grpc.Dial(addr, dialOptions...)
+	err := c.initOnceGrpcConnection()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("error initializing connection: %w", err)
 	}
-	defer func() { _ = conn.Close() }()
 
-	disperserClient := disperser_rpc.NewDisperserClient(conn)
 	ctxTimeout, cancel := context.WithTimeout(ctx, c.config.Timeout)
 	defer cancel()
 
@@ -96,7 +123,7 @@ func (c *disperserClient) DisperseBlob(ctx context.Context, data []byte, quorums
 		CustomQuorumNumbers: quorumNumbers,
 	}
 
-	reply, err := disperserClient.DisperseBlob(ctxTimeout, request)
+	reply, err := c.client.DisperseBlob(ctxTimeout, request)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,6 +137,11 @@ func (c *disperserClient) DisperseBlob(ctx context.Context, data []byte, quorums
 }
 
 func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []byte, quorums []uint8) (*disperser.BlobStatus, []byte, error) {
+	err := c.initOnceGrpcConnection()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error initializing connection: %w", err)
+	}
+
 	if c.signer == nil {
 		return nil, nil, fmt.Errorf("uninitialized signer for authenticated dispersal")
 	}
@@ -137,22 +169,11 @@ func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []
 		AccountId:           accountId,
 	}
 
-	addr := fmt.Sprintf("%v:%v", c.config.Hostname, c.config.Port)
-
-	dialOptions := c.getDialOptions()
-	conn, err := grpc.Dial(addr, dialOptions...)
-
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() { _ = conn.Close() }()
-
-	disperserClient := disperser_rpc.NewDisperserClient(conn)
 	ctxTimeout, cancel := context.WithTimeout(ctx, c.config.Timeout)
 
 	defer cancel()
 
-	stream, err := disperserClient.DisperseBlobAuthenticated(ctxTimeout)
+	stream, err := c.client.DisperseBlobAuthenticated(ctxTimeout)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error while calling DisperseBlobAuthenticated: %w", err)
 	}
@@ -215,14 +236,11 @@ func (c *disperserClient) DisperseBlobAuthenticated(ctx context.Context, data []
 }
 
 func (c *disperserClient) GetBlobStatus(ctx context.Context, requestID []byte) (*disperser_rpc.BlobStatusReply, error) {
-	addr := fmt.Sprintf("%v:%v", c.config.Hostname, c.config.Port)
-	dialOptions := c.getDialOptions()
-	conn, err := grpc.Dial(addr, dialOptions...)
+	err := c.initOnceGrpcConnection()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error initializing connection: %w", err)
 	}
 
-	disperserClient := disperser_rpc.NewDisperserClient(conn)
 	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*60)
 	defer cancel()
 
@@ -230,7 +248,7 @@ func (c *disperserClient) GetBlobStatus(ctx context.Context, requestID []byte) (
 		RequestId: requestID,
 	}
 
-	reply, err := disperserClient.GetBlobStatus(ctxTimeout, request)
+	reply, err := c.client.GetBlobStatus(ctxTimeout, request)
 	if err != nil {
 		return nil, err
 	}
@@ -239,19 +257,14 @@ func (c *disperserClient) GetBlobStatus(ctx context.Context, requestID []byte) (
 }
 
 func (c *disperserClient) RetrieveBlob(ctx context.Context, batchHeaderHash []byte, blobIndex uint32) ([]byte, error) {
-	addr := fmt.Sprintf("%v:%v", c.config.Hostname, c.config.Port)
-
-	options := c.getDialOptions()
-	options = append(options, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(100*1024*1024))) // 100MiB receive buffer
-
-	conn, err := grpc.Dial(addr, options...)
+	err := c.initOnceGrpcConnection()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error initializing connection: %w", err)
 	}
-	disperserClient := disperser_rpc.NewDisperserClient(conn)
+
 	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*60)
 	defer cancel()
-	reply, err := disperserClient.RetrieveBlob(ctxTimeout, &disperser_rpc.RetrieveBlobRequest{
+	reply, err := c.client.RetrieveBlob(ctxTimeout, &disperser_rpc.RetrieveBlobRequest{
 		BatchHeaderHash: batchHeaderHash,
 		BlobIndex:       blobIndex,
 	})
@@ -260,3 +273,30 @@ func (c *disperserClient) RetrieveBlob(ctx context.Context, batchHeaderHash []by
 	}
 	return reply.Data, nil
 }
+
+func (c *disperserClient) initOnceGrpcConnection() error {
+	var initErr error
+	c.initOnce.Do(func() {
+		addr := fmt.Sprintf("%v:%v", c.config.Hostname, c.config.Port)
+		dialOptions := getGrpcDialOptions(c.config.UseSecureGrpcFlag)
+		conn, err := grpc.Dial(addr, dialOptions...)
+		if err != nil {
+			initErr = err
+			return
+		}
+		c.conn = conn
+		c.client = disperser_rpc.NewDisperserClient(conn)
+	})
+	return initErr
+}
+
+func getGrpcDialOptions(useSecureGrpcFlag bool) []grpc.DialOption {
+	options := []grpc.DialOption{}
+	if useSecureGrpcFlag {
+		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+	} else {
+		options = append(options, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	return options
+}
+

--- a/api/clients/mock/disperser_client.go
+++ b/api/clients/mock/disperser_client.go
@@ -116,3 +116,8 @@ func (c *MockDisperserClient) RetrieveBlob(ctx context.Context, batchHeaderHash 
 	}
 	return blob, err
 }
+
+func (c *MockDisperserClient) Close() error {
+	args := c.Called()
+	return args.Error(0)
+}

--- a/tools/traffic/config.go
+++ b/tools/traffic/config.go
@@ -38,12 +38,12 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		customQuorumsUint8[i] = uint8(q)
 	}
 	return &Config{
-		Config: *clients.NewConfig(
-			ctx.GlobalString(flags.HostnameFlag.Name),
-			ctx.GlobalString(flags.GrpcPortFlag.Name),
-			ctx.Duration(flags.TimeoutFlag.Name),
-			ctx.GlobalBool(flags.UseSecureGrpcFlag.Name),
-		),
+		Config: clients.Config{
+			Hostname:          ctx.GlobalString(flags.HostnameFlag.Name),
+			Port:              ctx.GlobalString(flags.GrpcPortFlag.Name),
+			Timeout:           ctx.Duration(flags.TimeoutFlag.Name),
+			UseSecureGrpcFlag: ctx.GlobalBool(flags.UseSecureGrpcFlag.Name),
+		},
 		NumInstances:           ctx.GlobalUint(flags.NumInstancesFlag.Name),
 		RequestInterval:        ctx.Duration(flags.RequestIntervalFlag.Name),
 		DataSize:               ctx.GlobalUint64(flags.DataSizeFlag.Name),

--- a/tools/traffic/workers/mock_disperser.go
+++ b/tools/traffic/workers/mock_disperser.go
@@ -42,3 +42,8 @@ func (m *MockDisperserClient) RetrieveBlob(ctx context.Context, batchHeaderHash 
 	args := m.mock.Called(batchHeaderHash, blobIndex)
 	return args.Get(0).([]byte), args.Error(1)
 }
+
+func (m *MockDisperserClient) Close() error {
+	args := m.mock.Called()
+	return args.Error(0)
+}


### PR DESCRIPTION
## Why are these changes needed?

grpc "connections" are actually virtual connections: the docs/specs calls them channels.
They are not a physical underlying tcp/http connection but actually manage underlying connections. Hence, they are not meant to be redialed on every request. They should be created once, and reused for multiple requests, which is what this PR does.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
