### PR TITLE
Normalize allowlist lookups to use lowercase non-checksummed authenticated address

### DIFF
--- a/disperser/apiserver/config.go
+++ b/disperser/apiserver/config.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
@@ -164,9 +165,11 @@ func ReadAllowlistFromFile(f string) (Allowlist, error) {
 	}
 
 	for _, entry := range allowlistEntries {
-		rateInfoByQuorum, ok := allowlist[entry.Account]
+		// normalize to lowercase (non-checksummed) address
+		account := strings.ToLower(entry.Account)
+		rateInfoByQuorum, ok := allowlist[account]
 		if !ok {
-			allowlist[entry.Account] = map[core.QuorumID]PerUserRateInfo{
+			allowlist[account] = map[core.QuorumID]PerUserRateInfo{
 				core.QuorumID(entry.QuorumID): {
 					Name:       entry.Name,
 					Throughput: common.RateParam(entry.ByteRate),

--- a/disperser/apiserver/config.go
+++ b/disperser/apiserver/config.go
@@ -165,7 +165,7 @@ func ReadAllowlistFromFile(f string) (Allowlist, error) {
 	}
 
 	for _, entry := range allowlistEntries {
-		// normalize to lowercase (non-checksummed) address
+		// normalize to lowercase (non-checksummed) address or IP address
 		account := strings.ToLower(entry.Account)
 		rateInfoByQuorum, ok := allowlist[account]
 		if !ok {

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -325,16 +325,10 @@ func (s *DispersalServer) getAccountRate(origin, authenticatedAddress string, qu
 
 	// Check if the address is in the allowlist
 	if len(authenticatedAddress) > 0 {
+		// normalize to lowercase (non-checksummed) address
+		authenticatedAddress = strings.ToLower(authenticatedAddress)
+
 		quorumRates, ok := s.rateConfig.Allowlist[authenticatedAddress]
-		if !ok {
-			// check fallback address (non-checksummed)
-			fallbackAuthenticatedAddress := strings.ToLower(authenticatedAddress)
-			quorumRates, ok = s.rateConfig.Allowlist[fallbackAuthenticatedAddress]
-			if ok {
-				s.logger.Warn("authenticated address found via fallback lookup", "authenticatedAddress", authenticatedAddress, "fallback", fallbackAuthenticatedAddress)
-				authenticatedAddress = fallbackAuthenticatedAddress
-			}
-		}
 		if ok {
 			rateInfo, ok := quorumRates[quorumID]
 			if ok {
@@ -351,7 +345,6 @@ func (s *DispersalServer) getAccountRate(origin, authenticatedAddress string, qu
 		} else {
 			s.logger.Warn("authenticated address not found in allowlist", "authenticatedAddress", authenticatedAddress)
 		}
-
 	}
 
 	// Check if the origin is in the allowlist

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -325,7 +325,7 @@ func (s *DispersalServer) getAccountRate(origin, authenticatedAddress string, qu
 
 	// Check if the address is in the allowlist
 	if len(authenticatedAddress) > 0 {
-		// normalize to lowercase (non-checksummed) address
+		// normalize to lowercase (non-checksummed) address or IP address
 		authenticatedAddress = strings.ToLower(authenticatedAddress)
 
 		quorumRates, ok := s.rateConfig.Allowlist[authenticatedAddress]

--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -453,6 +453,13 @@ func TestParseAllowlist(t *testing.T) {
     "quorumID": 1,
     "blobRate": 0.1,
     "byteRate": 4092
+  },
+  {
+    "name": "bar",
+    "account": "0xcb14cFAaC122E52024232583e7354589AedE74Ff",
+    "quorumID": 1,
+    "blobRate": 0.1,
+    "byteRate": 4092
   }
 ]
 	`)
@@ -466,7 +473,6 @@ func TestParseAllowlist(t *testing.T) {
 	assert.Contains(t, rateConfig.Allowlist, "5.5.5.5")
 	assert.Contains(t, rateConfig.Allowlist["0.1.2.3"], uint8(0))
 	assert.Contains(t, rateConfig.Allowlist["0.1.2.3"], uint8(1))
-	assert.Contains(t, rateConfig.Allowlist["5.5.5.5"], uint8(1))
 	assert.NotContains(t, rateConfig.Allowlist["5.5.5.5"], uint8(0))
 	assert.Equal(t, rateConfig.Allowlist["0.1.2.3"][0].Name, "eigenlabs")
 	assert.Equal(t, rateConfig.Allowlist["0.1.2.3"][0].BlobRate, uint32(0.01*1e6))
@@ -477,6 +483,13 @@ func TestParseAllowlist(t *testing.T) {
 	assert.Equal(t, rateConfig.Allowlist["5.5.5.5"][1].Name, "foo")
 	assert.Equal(t, rateConfig.Allowlist["5.5.5.5"][1].BlobRate, uint32(0.1*1e6))
 	assert.Equal(t, rateConfig.Allowlist["5.5.5.5"][1].Throughput, uint32(4092))
+
+	// verify checksummed address is normalized to lowercase
+	assert.Contains(t, rateConfig.Allowlist, "0xcb14cfaac122e52024232583e7354589aede74ff")
+	assert.Contains(t, rateConfig.Allowlist["0xcb14cfaac122e52024232583e7354589aede74ff"], uint8(1))
+	assert.Equal(t, rateConfig.Allowlist["0xcb14cfaac122e52024232583e7354589aede74ff"][1].Name, "bar")
+	assert.Equal(t, rateConfig.Allowlist["0xcb14cfaac122e52024232583e7354589aede74ff"][1].BlobRate, uint32(0.1*1e6))
+	assert.Equal(t, rateConfig.Allowlist["0xcb14cfaac122e52024232583e7354589aede74ff"][1].Throughput, uint32(4092))
 }
 
 func TestLoadAllowlistFromFile(t *testing.T) {
@@ -513,6 +526,7 @@ func TestLoadAllowlistFromFile(t *testing.T) {
 	assert.Contains(t, al["0.1.2.3"], uint8(1))
 	assert.Contains(t, al["5.5.5.5"], uint8(1))
 	assert.NotContains(t, al["5.5.5.5"], uint8(0))
+	assert.NotContains(t, al, "0xcb14cfaac122e52024232583e7354589aede74ff")
 	assert.Equal(t, al["0.1.2.3"][0].Name, "eigenlabs")
 	assert.Equal(t, al["0.1.2.3"][0].BlobRate, uint32(0.01*1e6))
 	assert.Equal(t, al["0.1.2.3"][0].Throughput, uint32(1024))
@@ -538,6 +552,13 @@ func TestLoadAllowlistFromFile(t *testing.T) {
     "quorumID": 1,
     "blobRate": 1,
     "byteRate": 1234
+  },
+  {
+    "name": "bar",
+    "account": "0xcb14cFAaC122E52024232583e7354589AedE74Ff",
+    "quorumID": 1,
+    "blobRate": 0.1,
+    "byteRate": 4092
   }
 ]
 	`)
@@ -556,6 +577,13 @@ func TestLoadAllowlistFromFile(t *testing.T) {
 	assert.Equal(t, al["7.7.7.7"][1].Name, "world")
 	assert.Equal(t, al["7.7.7.7"][1].BlobRate, uint32(1*1e6))
 	assert.Equal(t, al["7.7.7.7"][1].Throughput, uint32(1234))
+
+	// verify checksummed address is normalized to lowercase
+	assert.Contains(t, al, "0xcb14cfaac122e52024232583e7354589aede74ff")
+	assert.Contains(t, al["0xcb14cfaac122e52024232583e7354589aede74ff"], uint8(1))
+	assert.Equal(t, al["0xcb14cfaac122e52024232583e7354589aede74ff"][1].Name, "bar")
+	assert.Equal(t, al["0xcb14cfaac122e52024232583e7354589aede74ff"][1].BlobRate, uint32(0.1*1e6))
+	assert.Equal(t, al["0xcb14cfaac122e52024232583e7354589aede74ff"][1].Throughput, uint32(4092))
 }
 
 func overwriteFile(t *testing.T, f *os.File, content string) {
@@ -677,7 +705,7 @@ func newTestServer(transactor core.Writer) *apiserver.DispersalServer {
 					BlobRate:   5 * 1e6,
 				},
 			},
-			"0x1aa8226f6d354380dDE75eE6B634875c4203e522": map[uint8]apiserver.PerUserRateInfo{
+			"0x1aa8226f6d354380dde75ee6b634875c4203e522": map[uint8]apiserver.PerUserRateInfo{
 				0: {
 					Name:       "eigenlabs",
 					Throughput: 100 * 1024,


### PR DESCRIPTION
## Why are these changes needed?

This mitigates a recent incident where the allowlist contained a non-checksummed address for LayerN, but LayerN requests contained a checksummed address resulting in failed rateConfig lookup.

This change normalizes the addresses to lowercase when loading the allowlist rateConfig, and always lowers the authenticatedAccount when doing rate bucket lookup.

This approach allows the allowList to be specified as checksummed or non-checksummed address, as well as the dispersalRequest account to be specified as checksummed or non-checksummed address.

## Checks

- [x] I've made sure the lint is passing in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
