### PR TITLE
Fix pointer issue

### DIFF
--- a/common/ratelimit/limiter.go
+++ b/common/ratelimit/limiter.go
@@ -129,7 +129,7 @@ func (d *rateLimiter) checkAllowed(ctx context.Context, params common.RequestPar
 				"requester_id":   params.RequesterID,
 				"requester_name": params.RequesterName,
 				"bucket_index":   strconv.Itoa(i),
-			}).Set(float64(bucketParams.BucketLevels[i]))
+			}).Set(float64(bucketLevels[i]))
 		}
 	}
 

--- a/common/ratelimit/limiter.go
+++ b/common/ratelimit/limiter.go
@@ -100,11 +100,13 @@ func (d *rateLimiter) checkAllowed(ctx context.Context, params common.RequestPar
 		}
 	}
 
+	bucketLevels := make([]time.Duration, len(d.globalRateParams.BucketSizes))
+
 	// Check whether the request is allowed based on the rate
 
 	// Get interval since last request
 	interval := time.Since(bucketParams.LastRequestTime)
-	bucketParams.LastRequestTime = time.Now().UTC()
+	lastRequestTime := time.Now().UTC()
 
 	// Calculate updated bucket levels
 	allowed := true
@@ -113,13 +115,11 @@ func (d *rateLimiter) checkAllowed(ctx context.Context, params common.RequestPar
 		// Determine bucket deduction
 		deduction := time.Microsecond * time.Duration(1e6*float32(params.BlobSize)/float32(params.Rate)/d.globalRateParams.Multipliers[i])
 
-		prevLevel := bucketParams.BucketLevels[i]
-
 		// Update the bucket level
-		bucketParams.BucketLevels[i] = getBucketLevel(bucketParams.BucketLevels[i], size, interval, deduction)
-		allowed = allowed && bucketParams.BucketLevels[i] > 0
+		bucketLevels[i] = getBucketLevel(bucketParams.BucketLevels[i], size, interval, deduction)
+		allowed = allowed && bucketLevels[i] > 0
 
-		d.logger.Debug("Bucket level updated", "key", params.RequesterID, "name", params.RequesterName, "prevLevel", prevLevel, "level", bucketParams.BucketLevels[i], "size", size, "interval", interval, "deduction", deduction, "allowed", allowed)
+		d.logger.Debug("Bucket level updated", "key", params.RequesterID, "name", params.RequesterName, "prevLevel", bucketParams.BucketLevels[i], "level", bucketLevels[i], "size", size, "interval", interval, "deduction", deduction, "allowed", allowed)
 
 		// Update metrics only if the requester name is provided. We're making
 		// an assumption that the requester name is only provided for authenticated
@@ -131,6 +131,11 @@ func (d *rateLimiter) checkAllowed(ctx context.Context, params common.RequestPar
 				"bucket_index":   strconv.Itoa(i),
 			}).Set(float64(bucketParams.BucketLevels[i]))
 		}
+	}
+
+	bucketParams = &common.RateBucketParams{
+		LastRequestTime: lastRequestTime,
+		BucketLevels:    bucketLevels,
 	}
 
 	return allowed, bucketParams


### PR DESCRIPTION
## Why are these changes needed?

Addresses a pointer issue in the below portion of the rate limiter implementation:

```
// Calculate updated bucket levels
	allowed := true
	for i, size := range d.globalRateParams.BucketSizes {

		// Determine bucket deduction
		deduction := time.Microsecond * time.Duration(1e6*float32(params.BlobSize)/float32(params.Rate)/d.globalRateParams.Multipliers[i])

		prevLevel := bucketParams.BucketLevels[i]

		// Update the bucket level
		bucketParams.BucketLevels[i] = getBucketLevel(bucketParams.BucketLevels[i], size, interval, deduction)
		allowed = allowed && bucketParams.BucketLevels[i] > 0

	}
```

This code returns the `bucketParams` struct, which is then push back to the rate limiter's KV store when the call is allowed. 

The problem here is that `bucketParams.BucketLevels` is an array slice and the KV store is an in-memory LRU cache. Even though `bucketParams` is a copy of the object stored in the KV store, both objects reference the same slice. The code here will directly update the slice, so that when `allowed` is false, the bucket level is inadvertently updated. 

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
