### PR TITLE
Unexport payment signer

### DIFF
--- a/core/auth/payment_signer_test.go
+++ b/core/auth/payment_signer_test.go
@@ -16,7 +16,8 @@ func TestPaymentSigner(t *testing.T) {
 	require.NoError(t, err)
 
 	privateKeyHex := hex.EncodeToString(crypto.FromECDSA(privateKey))
-	signer := auth.NewPaymentSigner(privateKeyHex)
+	signer, err := auth.NewPaymentSigner(privateKeyHex)
+	require.NoError(t, err)
 
 	t.Run("SignBlobPayment", func(t *testing.T) {
 		header := &commonpb.PaymentHeader{
@@ -30,8 +31,8 @@ func TestPaymentSigner(t *testing.T) {
 		assert.NotEmpty(t, signature)
 
 		// Verify the signature
-		isValid := auth.VerifyPaymentSignature(header, signature)
-		assert.True(t, isValid)
+		err = auth.VerifyPaymentSignature(header, signature)
+		assert.NoError(t, err)
 	})
 
 	t.Run("VerifyPaymentSignature_InvalidSignature", func(t *testing.T) {
@@ -43,8 +44,8 @@ func TestPaymentSigner(t *testing.T) {
 
 		// Create an invalid signature
 		invalidSignature := make([]byte, 65)
-		isValid := auth.VerifyPaymentSignature(header, invalidSignature)
-		assert.False(t, isValid)
+		err = auth.VerifyPaymentSignature(header, invalidSignature)
+		assert.Error(t, err)
 	})
 
 	t.Run("VerifyPaymentSignature_ModifiedHeader", func(t *testing.T) {
@@ -60,8 +61,8 @@ func TestPaymentSigner(t *testing.T) {
 		// Modify the header after signing
 		header.BinIndex = 2
 
-		isValid := auth.VerifyPaymentSignature(header, signature)
-		assert.False(t, isValid)
+		err = auth.VerifyPaymentSignature(header, signature)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
## Why are these changes needed?
Directly instantiating `PaymentSigner` without `PrivateKey` will panic when methods are called. 
This PR unexports `auth.PaymentSigner` so that it has to be instantiated with the constructor. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
