### PR TITLE
fix: make integration test use two quorums

### DIFF
--- a/inabox/tests/integration_test.go
+++ b/inabox/tests/integration_test.go
@@ -141,6 +141,15 @@ var _ = Describe("Inabox Integration", func() {
 			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
 			1, // retrieve blob 1 from quorum 1
 		)
+		Expect(err).To(BeNil())
+
+		_, err = retrievalClient.RetrieveBlob(ctx,
+			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
+			reply1.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
+			uint(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
+			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
+			2, // retrieve blob 1 from quorum 2
+		)
 		Expect(err).NotTo(BeNil())
 
 		retrieved, err = retrievalClient.RetrieveBlob(ctx,
@@ -159,6 +168,14 @@ var _ = Describe("Inabox Integration", func() {
 			uint(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
 			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
 			1, // retrieve from quorum 1
+		)
+		Expect(err).To(BeNil())
+		_, err = retrievalClient.RetrieveBlob(ctx,
+			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
+			reply2.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
+			uint(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
+			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
+			2, // retrieve from quorum 2
 		)
 		Expect(err).NotTo(BeNil())
 	})


### PR DESCRIPTION
## Why are these changes needed?
https://github.com/Layr-Labs/eigenda/pull/729 made quorum 0 & 1 required, so retrieval from quorum 1 should succeed, but retrieval from quorum 2 should fail. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
