### PR TITLE
Add per quorum semever stake percentage metrics

### DIFF
--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -26,8 +26,12 @@ type Metrics struct {
 
 	NumRequests    *prometheus.CounterVec
 	Latency        *prometheus.SummaryVec
-	Semvers        *prometheus.GaugeVec
 	OperatorsStake *prometheus.GaugeVec
+
+	Semvers                *prometheus.GaugeVec
+	SemversStakePctQuorum0 *prometheus.GaugeVec
+	SemversStakePctQuorum1 *prometheus.GaugeVec
+	SemversStakePctQuorum2 *prometheus.GaugeVec
 
 	httpPort string
 	logger   logging.Logger
@@ -114,6 +118,18 @@ func (g *Metrics) IncrementNotFoundRequestNum(method string) {
 func (g *Metrics) UpdateSemverCounts(semverData map[string]*semver.SemverMetrics) {
 	for semver, metrics := range semverData {
 		g.Semvers.WithLabelValues(semver).Set(float64(metrics.Operators))
+		for quorum, stakePct := range metrics.QuorumStakePercentage {
+			switch quorum {
+			case 0:
+				g.SemversStakePctQuorum0.WithLabelValues(semver).Set(stakePct)
+			case 1:
+				g.SemversStakePctQuorum1.WithLabelValues(semver).Set(stakePct)
+			case 2:
+				g.SemversStakePctQuorum2.WithLabelValues(semver).Set(stakePct)
+			default:
+				g.logger.Error("Unable to log semver quorum stake percentage for quorum", "semver", semver, "quorum", quorum, "stake", stakePct)
+			}
+		}
 	}
 }
 

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -119,6 +119,7 @@ func (g *Metrics) UpdateSemverCounts(semverData map[string]*semver.SemverMetrics
 	for semver, metrics := range semverData {
 		g.Semvers.WithLabelValues(semver).Set(float64(metrics.Operators))
 		for quorum, stakePct := range metrics.QuorumStakePercentage {
+			g.logger.Debug("Logging semver quorum stake percentage", "semver", semver, "quorum", quorum, "stake", stakePct)
 			switch quorum {
 			case 0:
 				g.SemversStakePctQuorum0.WithLabelValues(semver).Set(stakePct)

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -68,6 +68,27 @@ func NewMetrics(blobMetadataStore *blobstore.BlobMetadataStore, httpPort string,
 			},
 			[]string{"semver"},
 		),
+		SemversStakePctQuorum0: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "node_semvers_stake_pct_quorum_0",
+				Help: "Node semver stake percentage in quorum 0",
+			},
+			[]string{"semver_stake_pct_quorum_0"},
+		),
+		SemversStakePctQuorum1: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "node_semvers_stake_pct_quorum_1",
+				Help: "Node semver stake percentage in quorum 1",
+			},
+			[]string{"semver_stake_pct_quorum_1"},
+		),
+		SemversStakePctQuorum2: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "node_semvers_stake_pct_quorum_2",
+				Help: "Node semver stake percentage in quorum 2",
+			},
+			[]string{"semver_stake_pct_quorum_2"},
+		),
 		OperatorsStake: promauto.With(reg).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
@@ -119,7 +140,6 @@ func (g *Metrics) UpdateSemverCounts(semverData map[string]*semver.SemverMetrics
 	for semver, metrics := range semverData {
 		g.Semvers.WithLabelValues(semver).Set(float64(metrics.Operators))
 		for quorum, stakePct := range metrics.QuorumStakePercentage {
-			g.logger.Debug("Logging semver quorum stake percentage", "semver", semver, "quorum", quorum, "stake", stakePct)
 			switch quorum {
 			case 0:
 				g.SemversStakePctQuorum0.WithLabelValues(semver).Set(stakePct)


### PR DESCRIPTION
## Why are these changes needed?
Allows us to chart semver stake percentage per quorum

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
