### PR TITLE
Fix docker build args and restore semver info on operator node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 # syntax=docker/dockerfile:1
+
+# Declare build arguments
+# NOTE: to use these args, they must be *consumed* in the child scope (see node-builder)
+# https://docs.docker.com/build/building/variables/#scoping
+ARG SEMVER=""
+ARG GITCOMMIT=""
+ARG GITDATE=""
+
 FROM golang:1.21.1-alpine3.18 AS base-builder
 RUN apk add --no-cache make musl-dev linux-headers gcc git jq bash
 
@@ -63,9 +71,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Node build stage
 FROM common-builder AS node-builder
-ARG SEMVER=""
-ARG GITCOMMIT=""
-ARG GITDATE=""
+ARG SEMVER
+ARG GITCOMMIT
+ARG GITDATE
 COPY node /app/node
 COPY operators ./operators
 WORKDIR /app/node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
 # syntax=docker/dockerfile:1
-
-# Declare build arguments
-# TODO: this is only used for node image right now, should we also use it for nodeplugin?
-ARG SEMVER=""
-ARG GITCOMMIT=""
-ARG GITDATE=""
-
 FROM golang:1.21.1-alpine3.18 AS base-builder
 RUN apk add --no-cache make musl-dev linux-headers gcc git jq bash
 
@@ -70,6 +63,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Node build stage
 FROM common-builder AS node-builder
+ARG SEMVER=""
+ARG GITCOMMIT=""
+ARG GITDATE=""
 COPY node /app/node
 COPY operators ./operators
 WORKDIR /app/node


### PR DESCRIPTION
The build args need to be defined in the builder context

```
> BUILD_TAG=0.8.5 SEMVER=0.8.5 GITDATE=1730418012 GIT_SHA=f3cec0c9fed730c1d852420bbf57a3852ff583ef GIT_SHORT_SHA=f3cec0c docker buildx bake node

> docker run ghcr.io/layr-labs/eigenda/node:0.8.5 --version
2024/11/01 01:32:10 maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined
da-node version 0.8.5-f3cec0c-1730418012
```
- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
