### PR TITLE
fix(api): failover error bugs

### DIFF
--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -9,10 +9,6 @@ import (
 func TestErrorFailoverErrorsIs(t *testing.T) {
 	baseErr := fmt.Errorf("some error")
 	failoverErr := NewErrorFailover(baseErr)
-	wrappedFailoverErr := fmt.Errorf("some extra context: %w", failoverErr)
-	if !errors.Is(wrappedFailoverErr, &ErrorFailover{}) {
-		// do something...
-	}
 
 	// error comparison only checks the type of the error
 	if !errors.Is(failoverErr, &ErrorFailover{}) {

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -7,17 +7,32 @@ import (
 )
 
 func TestErrorFailoverErrorsIs(t *testing.T) {
-	baseErr := fmt.Errorf("some error")
+	baseErr := fmt.Errorf("base error")
 	failoverErr := NewErrorFailover(baseErr)
+	otherFailoverErr := NewErrorFailover(fmt.Errorf("some other error"))
+	wrappedFailoverErr := fmt.Errorf("wrapped: %w", failoverErr)
 
-	// error comparison only checks the type of the error
+	if !errors.Is(failoverErr, failoverErr) {
+		t.Error("should match itself")
+	}
+
+	if !errors.Is(failoverErr, baseErr) {
+		t.Error("should match base error")
+	}
+
+	if errors.Is(failoverErr, fmt.Errorf("some other error")) {
+		t.Error("should not match other errors")
+	}
+
+	if !errors.Is(failoverErr, otherFailoverErr) {
+		t.Error("should match other failover error")
+	}
+
 	if !errors.Is(failoverErr, &ErrorFailover{}) {
 		t.Error("should match ErrorFailover type")
 	}
 
-	// can also compare if failover error is wrapped
-	wrapped := fmt.Errorf("wrapped: %w", failoverErr)
-	if !errors.Is(wrapped, &ErrorFailover{}) {
+	if !errors.Is(wrappedFailoverErr, &ErrorFailover{}) {
 		t.Error("should match ErrorFailover type even when wrapped")
 	}
 

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrorFailoverErrorsIs(t *testing.T) {
+	baseErr := fmt.Errorf("some error")
+	failoverErr := NewErrorFailover(baseErr)
+	wrappedFailoverErr := fmt.Errorf("some extra context: %w", failoverErr)
+	if !errors.Is(wrappedFailoverErr, &ErrorFailover{}) {
+		// do something...
+	}
+
+	// error comparison only checks the type of the error
+	if !errors.Is(failoverErr, &ErrorFailover{}) {
+		t.Error("should match ErrorFailover type")
+	}
+
+	// can also compare if failover error is wrapped
+	wrapped := fmt.Errorf("wrapped: %w", failoverErr)
+	if !errors.Is(wrapped, &ErrorFailover{}) {
+		t.Error("should match ErrorFailover type even when wrapped")
+	}
+
+}
+
+func TestErrorFailoverZeroValue(t *testing.T) {
+	var failoverErr ErrorFailover
+	if failoverErr.Error() != "Failover" {
+		t.Error("should return 'Failover' for zero value")
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?

2 big bugs in my ErrorFailover implementation:
1. I misunderstood how errors.Is works, so could only compare if the underlying wrapped error was exactly equal, which is not useful (and made the logic in disperser/eigenda-clients incorrect)
2. err.Error() would panic when ErrorFailover{} was created with a nil wrapped error

Added tests to make sure the above are fixed, forever.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
