### PR TITLE
style: remove unneeded lint checkbox in pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,6 @@
 
 ## Checks
 
-- [ ] I've made sure the lint is passing in this PR.
 - [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
 - [ ] I've checked the new test coverage and the coverage percentage didn't drop.
 - Testing Strategy


### PR DESCRIPTION
## Why are these changes needed?

Not sure why we have this checkbox since we have a CI action that lints. We should instead just make it impossible to merge a PR where the lint workflow is failing (I can't change these settings because not admin on this repo).

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
