### PR TITLE
Cache operator state

### DIFF
--- a/api/clients/retrieval_client_test.go
+++ b/api/clients/retrieval_client_test.go
@@ -99,7 +99,7 @@ func setup(t *testing.T) {
 	indexer = &indexermock.MockIndexer{}
 	indexer.On("Index").Return(nil).Once()
 
-	ics, err := coreindexer.NewIndexedChainState(chainState, indexer)
+	ics, err := coreindexer.NewIndexedChainState(chainState, indexer, 0)
 	if err != nil {
 		panic("failed to create a new indexed chain state")
 	}

--- a/core/indexer/state_mock_test.go
+++ b/core/indexer/state_mock_test.go
@@ -1,0 +1,82 @@
+package indexer_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/core/indexer"
+	coremock "github.com/Layr-Labs/eigenda/core/mock"
+	indexermock "github.com/Layr-Labs/eigenda/indexer/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type testComponents struct {
+	ChainState        *coremock.ChainDataMock
+	Indexer           *indexermock.MockIndexer
+	IndexedChainState *indexer.IndexedChainState
+}
+
+func TestIndexedOperatorStateCache(t *testing.T) {
+	c := createTestComponents(t)
+	pubKeys := &indexer.OperatorPubKeys{}
+	c.Indexer.On("GetObject", mock.Anything, 0).Return(pubKeys, nil)
+	sockets := indexer.OperatorSockets{
+		core.OperatorID{0, 1}: "socket1",
+	}
+	c.Indexer.On("GetObject", mock.Anything, 1).Return(sockets, nil)
+
+	operatorState := &core.OperatorState{
+		Operators: map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo{
+			0: {
+				core.OperatorID{0}: {
+					Stake: big.NewInt(100),
+					Index: 0,
+				},
+			},
+		},
+	}
+	c.ChainState.On("GetOperatorState", mock.Anything, uint(100), []core.QuorumID{0}).Return(operatorState, nil)
+	c.ChainState.On("GetOperatorState", mock.Anything, uint(100), []core.QuorumID{1}).Return(operatorState, nil)
+	c.ChainState.On("GetOperatorState", mock.Anything, uint(101), []core.QuorumID{0, 1}).Return(operatorState, nil)
+
+	ctx := context.Background()
+	// Get the operator state for block 100 and quorum 0
+	_, err := c.IndexedChainState.GetIndexedOperatorState(ctx, uint(100), []core.QuorumID{0})
+	assert.NoError(t, err)
+	c.ChainState.AssertNumberOfCalls(t, "GetOperatorState", 1)
+
+	// Get the operator state for block 100 and quorum 0 again
+	_, err = c.IndexedChainState.GetIndexedOperatorState(ctx, uint(100), []core.QuorumID{0})
+	assert.NoError(t, err)
+	c.ChainState.AssertNumberOfCalls(t, "GetOperatorState", 1)
+
+	// Get the operator state for block 100 and quorum 1
+	_, err = c.IndexedChainState.GetIndexedOperatorState(ctx, uint(100), []core.QuorumID{1})
+	assert.NoError(t, err)
+	c.ChainState.AssertNumberOfCalls(t, "GetOperatorState", 2)
+
+	// Get the operator state for block 101 and quorum 0 & 1
+	_, err = c.IndexedChainState.GetIndexedOperatorState(ctx, uint(101), []core.QuorumID{0, 1})
+	assert.NoError(t, err)
+	c.ChainState.AssertNumberOfCalls(t, "GetOperatorState", 3)
+
+	// Get the operator state for block 101 and quorum 0 & 1 again
+	_, err = c.IndexedChainState.GetIndexedOperatorState(ctx, uint(101), []core.QuorumID{0, 1})
+	assert.NoError(t, err)
+	c.ChainState.AssertNumberOfCalls(t, "GetOperatorState", 3)
+}
+
+func createTestComponents(t *testing.T) *testComponents {
+	chainState := &coremock.ChainDataMock{}
+	idx := &indexermock.MockIndexer{}
+	ics, err := indexer.NewIndexedChainState(chainState, idx, 1)
+	assert.NoError(t, err)
+	return &testComponents{
+		ChainState:        chainState,
+		Indexer:           idx,
+		IndexedChainState: ics,
+	}
+}

--- a/core/indexer/state_test.go
+++ b/core/indexer/state_test.go
@@ -137,7 +137,7 @@ func mustMakeChainState(env *deploy.Config, store indexer.HeaderStore, logger lo
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	chainState, err := indexedstate.NewIndexedChainState(cs, indexer)
+	chainState, err := indexedstate.NewIndexedChainState(cs, indexer, 0)
 	if err != nil {
 		panic(err)
 	}

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -225,6 +225,7 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 }
 
 func (d *ChainDataMock) GetOperatorState(ctx context.Context, blockNumber uint, quorums []core.QuorumID) (*core.OperatorState, error) {
+	_ = d.Called(ctx, blockNumber, quorums)
 	state := d.GetTotalOperatorStateWithQuorums(ctx, blockNumber, quorums)
 
 	return state.OperatorState, nil

--- a/core/v2/validator.go
+++ b/core/v2/validator.go
@@ -83,6 +83,7 @@ func (v *ShardValidator) ValidateBlobs(ctx context.Context, blobs []*BlobShard, 
 			return fmt.Errorf("number of bundles (%d) does not match number of quorums (%d)", len(blob.Chunks), len(blob.BlobHeader.QuorumNumbers))
 		}
 
+		// TODO(ian-shim): cache the operator state
 		state, err := v.chainState.GetOperatorState(ctx, uint(blob.ReferenceBlockNumber), blob.BlobHeader.QuorumNumbers)
 		if err != nil {
 			return err

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -216,7 +216,7 @@ func RunBatcher(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		ics, err = coreindexer.NewIndexedChainState(cs, indexer)
+		ics, err = coreindexer.NewIndexedChainState(cs, indexer, 0)
 		if err != nil {
 			return err
 		}

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -189,7 +189,7 @@ func setupRetrievalClient(testConfig *deploy.Config) error {
 		return err
 	}
 
-	ics, err := coreindexer.NewIndexedChainState(cs, indexer)
+	ics, err := coreindexer.NewIndexedChainState(cs, indexer, 0)
 	if err != nil {
 		return err
 	}

--- a/retriever/cmd/main.go
+++ b/retriever/cmd/main.go
@@ -122,7 +122,7 @@ func RetrieverMain(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		ics, err = coreindexer.NewIndexedChainState(cs, indexer)
+		ics, err = coreindexer.NewIndexedChainState(cs, indexer, 0)
 		if err != nil {
 			return err
 		}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -590,6 +590,7 @@ func TestDispersalAndRetrieval(t *testing.T) {
 		},
 	}, nil)
 
+	cst.On("GetOperatorState", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	operatorState, err := cst.GetOperatorState(ctx, 0, []core.QuorumID{0})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
## Why are these changes needed?
Integrating operator state cache directly into `ChainState`
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
