### PR TITLE
Use keys that do not collide when data is stored in a single bucket.

### DIFF
--- a/common/aws/cli.go
+++ b/common/aws/cli.go
@@ -28,9 +28,6 @@ type ClientConfig struct {
 	// EndpointURL of the S3 endpoint to use. If this is not set then the default AWS S3 endpoint will be used.
 	EndpointURL string
 
-	// FragmentPrefixChars is the number of characters of the key to use as the prefix for fragmented files.
-	// A value of "3" for the key "ABCDEFG" will result in the prefix "ABC". Default is 3.
-	FragmentPrefixChars int
 	// FragmentParallelismFactor helps determine the size of the pool of workers to help upload/download files.
 	// A non-zero value for this parameter adds a number of workers equal to the number of cores times this value.
 	// Default is 8. In general, the number of workers here can be a lot larger than the number of cores because the
@@ -120,7 +117,6 @@ func ReadClientConfig(ctx *cli.Context, flagPrefix string) ClientConfig {
 		AccessKey:                   ctx.GlobalString(common.PrefixFlag(flagPrefix, AccessKeyIdFlagName)),
 		SecretAccessKey:             ctx.GlobalString(common.PrefixFlag(flagPrefix, SecretAccessKeyFlagName)),
 		EndpointURL:                 ctx.GlobalString(common.PrefixFlag(flagPrefix, EndpointURLFlagName)),
-		FragmentPrefixChars:         ctx.GlobalInt(common.PrefixFlag(flagPrefix, FragmentPrefixCharsFlagName)),
 		FragmentParallelismFactor:   ctx.GlobalInt(common.PrefixFlag(flagPrefix, FragmentParallelismFactorFlagName)),
 		FragmentParallelismConstant: ctx.GlobalInt(common.PrefixFlag(flagPrefix, FragmentParallelismConstantFlagName)),
 		FragmentReadTimeout:         ctx.GlobalDuration(common.PrefixFlag(flagPrefix, FragmentReadTimeoutFlagName)),
@@ -132,7 +128,6 @@ func ReadClientConfig(ctx *cli.Context, flagPrefix string) ClientConfig {
 func DefaultClientConfig() *ClientConfig {
 	return &ClientConfig{
 		Region:                      "us-east-2",
-		FragmentPrefixChars:         3,
 		FragmentParallelismFactor:   8,
 		FragmentParallelismConstant: 0,
 		FragmentReadTimeout:         30 * time.Second,

--- a/common/aws/s3/client.go
+++ b/common/aws/s3/client.go
@@ -37,7 +37,7 @@ type client struct {
 
 var _ Client = (*client)(nil)
 
-func NewClient(ctx context.Context, cfg commonaws.ClientConfig, logger logging.Logger) (*client, error) {
+func NewClient(ctx context.Context, cfg commonaws.ClientConfig, logger logging.Logger) (Client, error) {
 	var err error
 	once.Do(func() {
 		customResolver := aws.EndpointResolverWithOptionsFunc(
@@ -196,7 +196,7 @@ func (s *client) FragmentedUploadObject(
 	data []byte,
 	fragmentSize int) error {
 
-	fragments, err := breakIntoFragments(key, data, s.cfg.FragmentPrefixChars, fragmentSize)
+	fragments, err := breakIntoFragments(key, data, fragmentSize)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func (s *client) FragmentedDownloadObject(
 		return nil, errors.New("fragmentSize must be greater than 0")
 	}
 
-	fragmentKeys, err := getFragmentKeys(key, s.cfg.FragmentPrefixChars, getFragmentCount(fileSize, fragmentSize))
+	fragmentKeys, err := getFragmentKeys(key, getFragmentCount(fileSize, fragmentSize))
 	if err != nil {
 		return nil, err
 	}

--- a/common/aws/s3/fragment.go
+++ b/common/aws/s3/fragment.go
@@ -19,19 +19,12 @@ func getFragmentCount(fileSize int, fragmentSize int) int {
 
 // getFragmentKey returns the key for the fragment at the given index.
 //
-// Fragment keys take the form of "prefix/body-index[f]". The prefix is the first prefixLength characters
-// of the file key. The body is the file key. The index is the index of the fragment. The character "f" is appended
-// to the key of the last fragment in the series.
+// Fragment keys take the form of "body-index[f]". The index is the index of the fragment. The character "f" is
+// appended to the key of the last fragment in the series.
 //
-// Example: fileKey="abc123", prefixLength=2, fragmentCount=3
-// The keys will be "ab/abc123-0", "ab/abc123-1", "ab/abc123-2f"
-func getFragmentKey(fileKey string, prefixLength int, fragmentCount int, index int) (string, error) {
-	var prefix string
-	if prefixLength > len(fileKey) {
-		prefix = fileKey
-	} else {
-		prefix = fileKey[:prefixLength]
-	}
+// Example: fileKey="abc123", fragmentCount=3
+// The keys will be "abc123-0", "abc123-1", "abc123-2f"
+func getFragmentKey(fileKey string, fragmentCount int, index int) (string, error) {
 
 	postfix := ""
 	if fragmentCount-1 == index {
@@ -42,7 +35,7 @@ func getFragmentKey(fileKey string, prefixLength int, fragmentCount int, index i
 		return "", fmt.Errorf("index %d is too high for fragment count %d", index, fragmentCount)
 	}
 
-	return fmt.Sprintf("%s/%s-%d%s", prefix, fileKey, index, postfix), nil
+	return fmt.Sprintf("%s-%d%s", fileKey, index, postfix), nil
 }
 
 // Fragment is a subset of a file.
@@ -53,7 +46,7 @@ type Fragment struct {
 }
 
 // breakIntoFragments breaks a file into fragments of the given size.
-func breakIntoFragments(fileKey string, data []byte, prefixLength int, fragmentSize int) ([]*Fragment, error) {
+func breakIntoFragments(fileKey string, data []byte, fragmentSize int) ([]*Fragment, error) {
 	fragmentCount := getFragmentCount(len(data), fragmentSize)
 	fragments := make([]*Fragment, fragmentCount)
 	for i := 0; i < fragmentCount; i++ {
@@ -63,7 +56,7 @@ func breakIntoFragments(fileKey string, data []byte, prefixLength int, fragmentS
 			end = len(data)
 		}
 
-		fragmentKey, err := getFragmentKey(fileKey, prefixLength, fragmentCount, i)
+		fragmentKey, err := getFragmentKey(fileKey, fragmentCount, i)
 		if err != nil {
 			return nil, err
 		}
@@ -77,10 +70,10 @@ func breakIntoFragments(fileKey string, data []byte, prefixLength int, fragmentS
 }
 
 // getFragmentKeys returns the keys for all fragments of a file.
-func getFragmentKeys(fileKey string, prefixLength int, fragmentCount int) ([]string, error) {
+func getFragmentKeys(fileKey string, fragmentCount int) ([]string, error) {
 	keys := make([]string, fragmentCount)
 	for i := 0; i < fragmentCount; i++ {
-		fragmentKey, err := getFragmentKey(fileKey, prefixLength, fragmentCount, i)
+		fragmentKey, err := getFragmentKey(fileKey, fragmentCount, i)
 		if err != nil {
 			return nil, err
 		}

--- a/common/aws/s3/scoped_keys.go
+++ b/common/aws/s3/scoped_keys.go
@@ -12,13 +12,13 @@ const (
 	// to change it that we have not yet implemented.
 	prefixLength = 3
 
-	// blobNamespace is the postfix for a blob key.
+	// blobNamespace is the namespace for a blob key.
 	blobNamespace = "blob"
 
-	// chunkNamespace is the postfix for a chunk key.
+	// chunkNamespace is the namespace for a chunk key.
 	chunkNamespace = "chunk"
 
-	// proofNamespace is the postfix for a proof key.
+	// proofNamespace is the namespace for a proof key.
 	proofNamespace = "proof"
 )
 

--- a/common/aws/s3/scoped_keys.go
+++ b/common/aws/s3/scoped_keys.go
@@ -1,0 +1,55 @@
+package s3
+
+import (
+	"fmt"
+	v2 "github.com/Layr-Labs/eigenda/core/v2"
+)
+
+const (
+	// prefixLength is the number of characters to use from the base key to form the prefix.
+	// Assuming keys take the form of a random hash in hex, 3 will yield 16^3 = 4096 possible prefixes.
+	// This is currently hard coded because it is not expected to change, and it would require migration
+	// to change it that we have not yet implemented.
+	prefixLength = 3
+
+	// blobNamespace is the postfix for a blob key.
+	blobNamespace = "blob"
+
+	// chunkNamespace is the postfix for a chunk key.
+	chunkNamespace = "chunk"
+
+	// proofNamespace is the postfix for a proof key.
+	proofNamespace = "proof"
+)
+
+// ScopedKey returns a key that is scoped to a "namespace". Keys take the form of "prefix/namespace/baseKey".
+// Although there is no runtime enforcement, neither the base key nor the namespace should contain any
+// non-alphanumeric characters.
+func ScopedKey(namespace string, baseKey string, prefixLength int) string {
+	var prefix string
+	if prefixLength > len(baseKey) {
+		prefix = baseKey
+	} else {
+		prefix = baseKey[:prefixLength]
+	}
+
+	return fmt.Sprintf("%s/%s/%s", prefix, namespace, baseKey)
+}
+
+// ScopedBlobKey returns a key scoped to the blob namespace. Used to name files containing blobs in S3.
+// A key scoped for blobs will never collide with a key scoped for chunks or proofs.
+func ScopedBlobKey(blobKey v2.BlobKey) string {
+	return ScopedKey(blobNamespace, blobKey.Hex(), prefixLength)
+}
+
+// ScopedChunkKey returns a key scoped to the chunk namespace. Used to name files containing chunks in S3.
+// A key scoped for chunks will never collide with a key scoped for blobs or proofs.
+func ScopedChunkKey(blobKey v2.BlobKey) string {
+	return ScopedKey(chunkNamespace, blobKey.Hex(), prefixLength)
+}
+
+// ScopedProofKey returns a key scoped to the proof namespace. Used to name files containing proofs in S3.
+// A key scoped for proofs will never collide with a key scoped for blobs or chunks.
+func ScopedProofKey(blobKey v2.BlobKey) string {
+	return ScopedKey(proofNamespace, blobKey.Hex(), prefixLength)
+}

--- a/disperser/apiserver/disperse_blob_v2.go
+++ b/disperser/apiserver/disperse_blob_v2.go
@@ -50,7 +50,7 @@ func (s *DispersalServerV2) StoreBlob(ctx context.Context, data []byte, blobHead
 		return v2.BlobKey{}, err
 	}
 
-	if err := s.blobStore.StoreBlob(ctx, blobKey.Hex(), data); err != nil {
+	if err := s.blobStore.StoreBlob(ctx, blobKey, data); err != nil {
 		return v2.BlobKey{}, err
 	}
 

--- a/disperser/apiserver/server_v2_test.go
+++ b/disperser/apiserver/server_v2_test.go
@@ -84,7 +84,7 @@ func TestV2DisperseBlob(t *testing.T) {
 	assert.Equal(t, blobKey[:], reply.BlobKey)
 
 	// Check if the blob is stored
-	storedData, err := c.BlobStore.GetBlob(ctx, blobKey.Hex())
+	storedData, err := c.BlobStore.GetBlob(ctx, blobKey)
 	assert.NoError(t, err)
 	assert.Equal(t, data, storedData)
 

--- a/disperser/common/v2/blobstore/s3_blob_store.go
+++ b/disperser/common/v2/blobstore/s3_blob_store.go
@@ -2,6 +2,7 @@ package blobstore
 
 import (
 	"context"
+	v2 "github.com/Layr-Labs/eigenda/core/v2"
 
 	"github.com/Layr-Labs/eigenda/common/aws/s3"
 	"github.com/Layr-Labs/eigenda/disperser/common"
@@ -24,8 +25,9 @@ func NewBlobStore(s3BucketName string, s3Client s3.Client, logger logging.Logger
 }
 
 // StoreBlob adds a blob to the blob store
-func (b *BlobStore) StoreBlob(ctx context.Context, blobKey string, data []byte) error {
-	err := b.s3Client.UploadObject(ctx, b.bucketName, blobKey, data)
+func (b *BlobStore) StoreBlob(ctx context.Context, key v2.BlobKey, data []byte) error {
+
+	err := b.s3Client.UploadObject(ctx, b.bucketName, s3.ScopedBlobKey(key), data)
 	if err != nil {
 		b.logger.Errorf("failed to upload blob in bucket %s: %v", b.bucketName, err)
 		return err
@@ -34,10 +36,10 @@ func (b *BlobStore) StoreBlob(ctx context.Context, blobKey string, data []byte) 
 }
 
 // GetBlob retrieves a blob from the blob store
-func (b *BlobStore) GetBlob(ctx context.Context, blobKey string) ([]byte, error) {
-	data, err := b.s3Client.DownloadObject(ctx, b.bucketName, blobKey)
+func (b *BlobStore) GetBlob(ctx context.Context, key v2.BlobKey) ([]byte, error) {
+	data, err := b.s3Client.DownloadObject(ctx, b.bucketName, s3.ScopedBlobKey(key))
 	if errors.Is(err, s3.ErrObjectNotFound) {
-		b.logger.Warnf("blob not found in bucket %s: %s", b.bucketName, blobKey)
+		b.logger.Warnf("blob not found in bucket %s: %s", b.bucketName, key)
 		return nil, common.ErrBlobNotFound
 	}
 

--- a/disperser/common/v2/blobstore/s3_blob_store_test.go
+++ b/disperser/common/v2/blobstore/s3_blob_store_test.go
@@ -2,21 +2,25 @@ package blobstore_test
 
 import (
 	"context"
+	tu "github.com/Layr-Labs/eigenda/common/testutils"
+	v2 "github.com/Layr-Labs/eigenda/core/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStoreGetBlob(t *testing.T) {
-	err := blobStore.StoreBlob(context.Background(), "testBlobKey", []byte("testBlobData"))
+	testBlobKey := v2.BlobKey(tu.RandomBytes(32))
+	err := blobStore.StoreBlob(context.Background(), testBlobKey, []byte("testBlobData"))
 	assert.NoError(t, err)
-	data, err := blobStore.GetBlob(context.Background(), "testBlobKey")
+	data, err := blobStore.GetBlob(context.Background(), testBlobKey)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("testBlobData"), data)
 }
 
 func TestGetBlobNotFound(t *testing.T) {
-	data, err := blobStore.GetBlob(context.Background(), "nonExistentBlobKey")
+	testBlobKey := v2.BlobKey(tu.RandomBytes(32))
+	data, err := blobStore.GetBlob(context.Background(), testBlobKey)
 	assert.Error(t, err)
 	assert.Nil(t, data)
 }

--- a/relay/chunkstore/chunk_reader.go
+++ b/relay/chunkstore/chunk_reader.go
@@ -58,9 +58,7 @@ func (r *chunkReader) GetChunkProofs(
 	ctx context.Context,
 	blobKey v2.BlobKey) ([]*encoding.Proof, error) {
 
-	s3Key := blobKey.Hex()
-
-	bytes, err := r.client.DownloadObject(ctx, r.bucket, s3Key)
+	bytes, err := r.client.DownloadObject(ctx, r.bucket, s3.ScopedProofKey(blobKey))
 	if err != nil {
 		r.logger.Error("Failed to download chunks from S3: %v", err)
 		return nil, fmt.Errorf("failed to download chunks from S3: %w", err)
@@ -92,12 +90,10 @@ func (r *chunkReader) GetChunkCoefficients(
 	blobKey v2.BlobKey,
 	fragmentInfo *encoding.FragmentInfo) ([]*rs.Frame, error) {
 
-	s3Key := blobKey.Hex()
-
 	bytes, err := r.client.FragmentedDownloadObject(
 		ctx,
 		r.bucket,
-		s3Key,
+		s3.ScopedChunkKey(blobKey),
 		int(fragmentInfo.TotalChunkSizeBytes),
 		int(fragmentInfo.FragmentSizeBytes))
 


### PR DESCRIPTION
## Why are these changes needed?

This PR makes it so that the data stored in S3 does not have name collisions between blobs, chunks, and proofs. Prior to this change, I had been thinking that we'd use different buckets. After this merges, all v2 data will be able to be stored in a single bucket.

## Checks

- [x] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
