### PR TITLE
[v2] metadata store dispersal operations

### DIFF
--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -301,6 +302,52 @@ type BatchHeader struct {
 	ReferenceBlockNumber uint64
 }
 
+// GetBatchHeaderHash returns the hash of the batch header
+func (h BatchHeader) Hash() ([32]byte, error) {
+	var headerHash [32]byte
+
+	// The order here has to match the field ordering of ReducedBatchHeader defined in IEigenDAServiceManager.sol
+	// ref: https://github.com/Layr-Labs/eigenda/blob/master/contracts/src/interfaces/IEigenDAServiceManager.sol#L43
+	batchHeaderType, err := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{
+			Name: "blobHeadersRoot",
+			Type: "bytes32",
+		},
+		{
+			Name: "referenceBlockNumber",
+			Type: "uint32",
+		},
+	})
+	if err != nil {
+		return headerHash, err
+	}
+
+	arguments := abi.Arguments{
+		{
+			Type: batchHeaderType,
+		},
+	}
+
+	s := struct {
+		BlobHeadersRoot      [32]byte
+		ReferenceBlockNumber uint32
+	}{
+		BlobHeadersRoot:      h.BatchRoot,
+		ReferenceBlockNumber: uint32(h.ReferenceBlockNumber),
+	}
+
+	bytes, err := arguments.Pack(s)
+	if err != nil {
+		return headerHash, err
+	}
+
+	hasher := sha3.NewLegacyKeccak256()
+	hasher.Write(bytes)
+	copy(headerHash[:], hasher.Sum(nil)[:32])
+
+	return headerHash, nil
+}
+
 type Batch struct {
 	BatchHeader      *BatchHeader
 	BlobCertificates []*BlobCertificate
@@ -320,6 +367,27 @@ type BlobVersionParameters struct {
 
 func (p BlobVersionParameters) MaxNumOperators() uint32 {
 	return uint32(math.Floor(float64(p.NumChunks) * (1 - 1/(p.ReconstructionThreshold*float64(p.CodingRate)))))
+}
+
+// DispersalRequest is a request to disperse a batch to a specific operator
+type DispersalRequest struct {
+	core.OperatorID `dynamodbav:"-"`
+	OperatorAddress gethcommon.Address
+	Socket          string
+	DispersedAt     uint64
+
+	BatchHeader
+}
+
+// DispersalResponse is a response to a dispersal request
+type DispersalResponse struct {
+	*DispersalRequest
+
+	RespondedAt uint64
+	// Signature is the signature of the response by the operator
+	Signature [32]byte
+	// Error is the error message if the dispersal failed
+	Error string
 }
 
 const (

--- a/core/v2/types_test.go
+++ b/core/v2/types_test.go
@@ -55,3 +55,17 @@ func TestBlobKeyFromHeader(t *testing.T) {
 	// 0xb19d368345990c79744fe571fe99f427f35787b9383c55089fb5bd6a5c171bbc verified in solidity
 	assert.Equal(t, "b19d368345990c79744fe571fe99f427f35787b9383c55089fb5bd6a5c171bbc", blobKey.Hex())
 }
+
+func TestBatchHeaderHAsh(t *testing.T) {
+	batchRoot := [32]byte{}
+	copy(batchRoot[:], []byte("1"))
+	batchHeader := &v2.BatchHeader{
+		ReferenceBlockNumber: 1,
+		BatchRoot:            batchRoot,
+	}
+
+	hash, err := batchHeader.Hash()
+	assert.NoError(t, err)
+	// 0x891d0936da4627f445ef193aad63afb173409af9e775e292e4e35aff790a45e2 verified in solidity
+	assert.Equal(t, "891d0936da4627f445ef193aad63afb173409af9e775e292e4e35aff790a45e2", hex.EncodeToString(hash[:]))
+}


### PR DESCRIPTION
## Why are these changes needed?
Adding blob metadata store operations to put/get dispersal requests and responses
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
