### PR TITLE
Remove PadToPowerOf2 function

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -23,25 +23,3 @@ func NextPowerOf2[T constraints.Integer](d T) T {
 	nextPower := math.Ceil(math.Log2(float64(d)))
 	return T(math.Pow(2.0, nextPower))
 }
-
-// PadToPowerOf2 pads a byte slice to the nearest power of 2 length by appending zeros
-func PadToPowerOf2(data []byte) []byte {
-	length := len(data)
-	if length == 0 {
-		return []byte{0}
-	}
-
-	// If length is already a power of 2, return original
-	if length&(length-1) == 0 {
-		return data
-	}
-
-	// Create a new slice with the power-of-2 length
-	paddedData := make([]byte, NextPowerOf2(uint64(len(data))))
-
-	// Copy original data
-	copy(paddedData, data)
-
-	// The remaining bytes will be zero by default
-	return paddedData
-}

--- a/disperser/encoder/server_v2_test.go
+++ b/disperser/encoder/server_v2_test.go
@@ -59,7 +59,7 @@ func TestEncodeBlob(t *testing.T) {
 			t.FailNow()
 		}
 
-		return core.PadToPowerOf2(codec.ConvertByPaddingEmptyByte(data))
+		return codec.ConvertByPaddingEmptyByte(data)
 	}
 
 	// Setup test data
@@ -68,7 +68,7 @@ func TestEncodeBlob(t *testing.T) {
 	blobLength := encoding.GetBlobLength(blobSize)
 
 	// Get chunk length for blob version 0
-	chunkLength, err := corev2.GetChunkLength(0, uint32(blobLength))
+	chunkLength, err := corev2.GetChunkLength(0, core.NextPowerOf2(uint32(blobLength)))
 	if !assert.NoError(t, err, "Failed to get chunk length") {
 		t.FailNow()
 	}


### PR DESCRIPTION
## Why are these changes needed?

Blob does not need to be padded to a power of 2, just need to ensure the chunk length is a power of 2.

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
