### PR TITLE
[v2] Make `ChunkWriter` requests idempotent

### DIFF
--- a/common/aws/mock/s3_client.go
+++ b/common/aws/mock/s3_client.go
@@ -25,6 +25,15 @@ func (s *S3Client) DownloadObject(ctx context.Context, bucket string, key string
 	return data, nil
 }
 
+func (s *S3Client) HeadObject(ctx context.Context, bucket string, key string) (*int64, error) {
+	data, ok := s.bucket[key]
+	if !ok {
+		return nil, s3.ErrObjectNotFound
+	}
+	size := int64(len(data))
+	return &size, nil
+}
+
 func (s *S3Client) UploadObject(ctx context.Context, bucket string, key string, data []byte) error {
 	s.bucket[key] = data
 	return nil

--- a/common/aws/mock/s3_client.go
+++ b/common/aws/mock/s3_client.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/Layr-Labs/eigenda/common/aws/s3"
@@ -9,15 +10,29 @@ import (
 
 type S3Client struct {
 	bucket map[string][]byte
+	Called map[string]int
 }
 
 var _ s3.Client = (*S3Client)(nil)
 
 func NewS3Client() *S3Client {
-	return &S3Client{bucket: make(map[string][]byte)}
+	return &S3Client{
+		bucket: make(map[string][]byte),
+		Called: map[string]int{
+			"DownloadObject":           0,
+			"HeadObject":               0,
+			"UploadObject":             0,
+			"DeleteObject":             0,
+			"ListObjects":              0,
+			"CreateBucket":             0,
+			"FragmentedUploadObject":   0,
+			"FragmentedDownloadObject": 0,
+		},
+	}
 }
 
 func (s *S3Client) DownloadObject(ctx context.Context, bucket string, key string) ([]byte, error) {
+	s.Called["DownloadObject"]++
 	data, ok := s.bucket[key]
 	if !ok {
 		return []byte{}, s3.ErrObjectNotFound
@@ -26,6 +41,7 @@ func (s *S3Client) DownloadObject(ctx context.Context, bucket string, key string
 }
 
 func (s *S3Client) HeadObject(ctx context.Context, bucket string, key string) (*int64, error) {
+	s.Called["HeadObject"]++
 	data, ok := s.bucket[key]
 	if !ok {
 		return nil, s3.ErrObjectNotFound
@@ -35,17 +51,20 @@ func (s *S3Client) HeadObject(ctx context.Context, bucket string, key string) (*
 }
 
 func (s *S3Client) UploadObject(ctx context.Context, bucket string, key string, data []byte) error {
+	s.Called["UploadObject"]++
 	s.bucket[key] = data
 	return nil
 }
 
 func (s *S3Client) DeleteObject(ctx context.Context, bucket string, key string) error {
+	s.Called["DeleteObject"]++
 	delete(s.bucket, key)
 	return nil
 }
 
 func (s *S3Client) ListObjects(ctx context.Context, bucket string, prefix string) ([]s3.Object, error) {
-	objects := make([]s3.Object, 0, 5)
+	s.Called["ListObjects"]++
+	objects := make([]s3.Object, 0, 1000)
 	for k, v := range s.bucket {
 		if strings.HasPrefix(k, prefix) {
 			objects = append(objects, s3.Object{Key: k, Size: int64(len(v))})
@@ -55,6 +74,7 @@ func (s *S3Client) ListObjects(ctx context.Context, bucket string, prefix string
 }
 
 func (s *S3Client) CreateBucket(ctx context.Context, bucket string) error {
+	s.Called["CreateBucket"]++
 	return nil
 }
 
@@ -64,7 +84,14 @@ func (s *S3Client) FragmentedUploadObject(
 	key string,
 	data []byte,
 	fragmentSize int) error {
-	s.bucket[key] = data
+	s.Called["FragmentedUploadObject"]++
+	fragments, err := s3.BreakIntoFragments(key, data, fragmentSize)
+	if err != nil {
+		return err
+	}
+	for _, fragment := range fragments {
+		s.bucket[fragment.FragmentKey] = fragment.Data
+	}
 	return nil
 }
 
@@ -74,9 +101,34 @@ func (s *S3Client) FragmentedDownloadObject(
 	key string,
 	fileSize int,
 	fragmentSize int) ([]byte, error) {
-	data, ok := s.bucket[key]
-	if !ok {
-		return []byte{}, s3.ErrObjectNotFound
+	s.Called["FragmentedDownloadObject"]++
+	if fileSize <= 0 {
+		return nil, errors.New("fileSize must be greater than 0")
+	}
+	if fragmentSize <= 0 {
+		return nil, errors.New("fragmentSize must be greater than 0")
+	}
+
+	count := 0
+	if fileSize < fragmentSize {
+		count = 1
+	} else if fileSize%fragmentSize == 0 {
+		count = fileSize / fragmentSize
+	} else {
+		count = fileSize/fragmentSize + 1
+	}
+	fragmentKeys, err := s3.GetFragmentKeys(key, count)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, 0, fileSize)
+	for _, fragmentKey := range fragmentKeys {
+		fragmentData, ok := s.bucket[fragmentKey]
+		if !ok {
+			return nil, s3.ErrObjectNotFound
+		}
+		data = append(data, fragmentData...)
 	}
 	return data, nil
 }

--- a/common/aws/s3/client.go
+++ b/common/aws/s3/client.go
@@ -124,6 +124,18 @@ func (s *client) DownloadObject(ctx context.Context, bucket string, key string) 
 	return buffer.Bytes(), nil
 }
 
+func (s *client) HeadObject(ctx context.Context, bucket string, key string) (*int64, error) {
+	output, err := s.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return output.ContentLength, nil
+}
+
 func (s *client) UploadObject(ctx context.Context, bucket string, key string, data []byte) error {
 	var partMiBs int64 = 10
 	uploader := manager.NewUploader(s.s3Client, func(u *manager.Uploader) {
@@ -155,6 +167,7 @@ func (s *client) DeleteObject(ctx context.Context, bucket string, key string) er
 	return err
 }
 
+// ListObjects lists all items metadata in a bucket with the given prefix up to 1000 items.
 func (s *client) ListObjects(ctx context.Context, bucket string, prefix string) ([]Object, error) {
 	output, err := s.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),

--- a/common/aws/s3/fragment.go
+++ b/common/aws/s3/fragment.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -80,6 +81,23 @@ func GetFragmentKeys(fileKey string, fragmentCount int) ([]string, error) {
 		keys[i] = fragmentKey
 	}
 	return keys, nil
+}
+
+// AllFragmentsExist returns true if all keys are fragment keys.
+// It checks if all fragment keys starting with 0th fragment and ending with nth fragment (marked by "f" postfix) exist.
+// Warning: this function sorts the input slice in place and therefore mutates the ordering of the input slice.
+func SortAndCheckAllFragmentsExist(keys []string) bool {
+	sort.Strings(keys)
+	for i, key := range keys {
+		if !strings.HasSuffix(key, "-"+strconv.Itoa(i)) {
+			if strings.HasSuffix(key, "-"+strconv.Itoa(i)+"f") {
+				return i == len(keys)-1
+			}
+			return false
+		}
+	}
+
+	return false
 }
 
 // recombineFragments recombines fragments into a single file.

--- a/common/aws/s3/fragment.go
+++ b/common/aws/s3/fragment.go
@@ -45,8 +45,8 @@ type Fragment struct {
 	Index       int
 }
 
-// breakIntoFragments breaks a file into fragments of the given size.
-func breakIntoFragments(fileKey string, data []byte, fragmentSize int) ([]*Fragment, error) {
+// BreakIntoFragments breaks a file into fragments of the given size.
+func BreakIntoFragments(fileKey string, data []byte, fragmentSize int) ([]*Fragment, error) {
 	fragmentCount := getFragmentCount(len(data), fragmentSize)
 	fragments := make([]*Fragment, fragmentCount)
 	for i := 0; i < fragmentCount; i++ {
@@ -69,8 +69,8 @@ func breakIntoFragments(fileKey string, data []byte, fragmentSize int) ([]*Fragm
 	return fragments, nil
 }
 
-// getFragmentKeys returns the keys for all fragments of a file.
-func getFragmentKeys(fileKey string, fragmentCount int) ([]string, error) {
+// GetFragmentKeys returns the keys for all fragments of a file.
+func GetFragmentKeys(fileKey string, fragmentCount int) ([]string, error) {
 	keys := make([]string, fragmentCount)
 	for i := 0; i < fragmentCount; i++ {
 		fragmentKey, err := getFragmentKey(fileKey, fragmentCount, i)

--- a/common/aws/s3/fragment_test.go
+++ b/common/aws/s3/fragment_test.go
@@ -2,11 +2,12 @@ package s3
 
 import (
 	"fmt"
-	tu "github.com/Layr-Labs/eigenda/common/testutils"
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"strings"
 	"testing"
+
+	tu "github.com/Layr-Labs/eigenda/common/testutils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetFragmentCount(t *testing.T) {
@@ -115,7 +116,7 @@ func TestKeyPostfix(t *testing.T) {
 func TestExampleInGodoc(t *testing.T) {
 	fileKey := "abc123"
 	fragmentCount := 3
-	fragmentKeys, err := getFragmentKeys(fileKey, fragmentCount)
+	fragmentKeys, err := GetFragmentKeys(fileKey, fragmentCount)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(fragmentKeys))
 	assert.Equal(t, "abc123-0", fragmentKeys[0])
@@ -129,7 +130,7 @@ func TestGetFragmentKeys(t *testing.T) {
 	fileKey := tu.RandomString(10)
 	fragmentCount := rand.Intn(10) + 10
 
-	fragmentKeys, err := getFragmentKeys(fileKey, fragmentCount)
+	fragmentKeys, err := GetFragmentKeys(fileKey, fragmentCount)
 	assert.NoError(t, err)
 	assert.Equal(t, fragmentCount, len(fragmentKeys))
 
@@ -159,7 +160,7 @@ func TestGetFragments(t *testing.T) {
 	data := tu.RandomBytes(1000)
 	fragmentSize := rand.Intn(100) + 100
 
-	fragments, err := breakIntoFragments(fileKey, data, fragmentSize)
+	fragments, err := BreakIntoFragments(fileKey, data, fragmentSize)
 	assert.NoError(t, err)
 	assert.Equal(t, getFragmentCount(len(data), fragmentSize), len(fragments))
 
@@ -190,7 +191,7 @@ func TestGetFragmentsSmallFile(t *testing.T) {
 	data := tu.RandomBytes(10)
 	fragmentSize := rand.Intn(100) + 100
 
-	fragments, err := breakIntoFragments(fileKey, data, fragmentSize)
+	fragments, err := BreakIntoFragments(fileKey, data, fragmentSize)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(fragments))
 
@@ -208,7 +209,7 @@ func TestGetFragmentsExactlyOnePerfectlySizedFile(t *testing.T) {
 	fragmentSize := rand.Intn(100) + 100
 	data := tu.RandomBytes(fragmentSize)
 
-	fragments, err := breakIntoFragments(fileKey, data, fragmentSize)
+	fragments, err := BreakIntoFragments(fileKey, data, fragmentSize)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(fragments))
 
@@ -226,7 +227,7 @@ func TestRecombineFragments(t *testing.T) {
 	data := tu.RandomBytes(1000)
 	fragmentSize := rand.Intn(100) + 100
 
-	fragments, err := breakIntoFragments(fileKey, data, fragmentSize)
+	fragments, err := BreakIntoFragments(fileKey, data, fragmentSize)
 	assert.NoError(t, err)
 	recombinedData, err := recombineFragments(fragments)
 	assert.NoError(t, err)
@@ -250,7 +251,7 @@ func TestRecombineFragmentsSmallFile(t *testing.T) {
 	data := tu.RandomBytes(10)
 	fragmentSize := rand.Intn(100) + 100
 
-	fragments, err := breakIntoFragments(fileKey, data, fragmentSize)
+	fragments, err := BreakIntoFragments(fileKey, data, fragmentSize)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(fragments))
 	recombinedData, err := recombineFragments(fragments)
@@ -265,7 +266,7 @@ func TestMissingFragment(t *testing.T) {
 	data := tu.RandomBytes(1000)
 	fragmentSize := rand.Intn(100) + 100
 
-	fragments, err := breakIntoFragments(fileKey, data, fragmentSize)
+	fragments, err := BreakIntoFragments(fileKey, data, fragmentSize)
 	assert.NoError(t, err)
 
 	fragmentIndexToSkip := rand.Intn(len(fragments))
@@ -282,7 +283,7 @@ func TestMissingFinalFragment(t *testing.T) {
 	data := tu.RandomBytes(1000)
 	fragmentSize := rand.Intn(100) + 100
 
-	fragments, err := breakIntoFragments(fileKey, data, fragmentSize)
+	fragments, err := BreakIntoFragments(fileKey, data, fragmentSize)
 	assert.NoError(t, err)
 	fragments = fragments[:len(fragments)-1]
 

--- a/common/aws/s3/fragment_test.go
+++ b/common/aws/s3/fragment_test.go
@@ -8,6 +8,7 @@ import (
 
 	tu "github.com/Layr-Labs/eigenda/common/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetFragmentCount(t *testing.T) {
@@ -289,4 +290,44 @@ func TestMissingFinalFragment(t *testing.T) {
 
 	_, err = recombineFragments(fragments)
 	assert.Error(t, err)
+}
+
+func TestSortAndCheckAllFragmentsExist(t *testing.T) {
+	keys := []string{ // valid keys
+		"abc-2",
+		"abc-3f",
+		"abc-1",
+		"abc-0",
+	}
+	require.True(t, SortAndCheckAllFragmentsExist(keys))
+
+	keys = []string{ // no final fragment
+		"abc-2",
+		"abc-3",
+		"abc-1",
+		"abc-0",
+	}
+	require.False(t, SortAndCheckAllFragmentsExist(keys))
+
+	keys = []string{ // extra fragment after final fragment
+		"abc-2f",
+		"abc-3",
+		"abc-1",
+		"abc-0",
+	}
+	require.False(t, SortAndCheckAllFragmentsExist(keys))
+
+	keys = []string{ // missing fragment
+		"abc-2",
+		"abc-3f",
+		"abc-1",
+	}
+	require.False(t, SortAndCheckAllFragmentsExist(keys))
+
+	keys = []string{ // missing fragment
+		"abc-2",
+		"abc-3f",
+		"abc-0",
+	}
+	require.False(t, SortAndCheckAllFragmentsExist(keys))
 }

--- a/common/aws/s3/s3.go
+++ b/common/aws/s3/s3.go
@@ -8,6 +8,9 @@ type Client interface {
 	// DownloadObject downloads an object from S3.
 	DownloadObject(ctx context.Context, bucket string, key string) ([]byte, error)
 
+	// HeadObject retrieves the size of an object in S3. Returns error if the object does not exist.
+	HeadObject(ctx context.Context, bucket string, key string) (*int64, error)
+
 	// UploadObject uploads an object to S3.
 	UploadObject(ctx context.Context, bucket string, key string, data []byte) error
 

--- a/disperser/cmd/encoder/config.go
+++ b/disperser/cmd/encoder/config.go
@@ -57,6 +57,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			MaxConcurrentRequests:    ctx.GlobalInt(flags.MaxConcurrentRequestsFlag.Name),
 			RequestPoolSize:          ctx.GlobalInt(flags.RequestPoolSizeFlag.Name),
 			EnableGnarkChunkEncoding: ctx.Bool(flags.EnableGnarkChunkEncodingFlag.Name),
+			PreventReencoding:        ctx.Bool(flags.PreventReencodingFlag.Name),
 		},
 		MetricsConfig: encoder.MetrisConfig{
 			HTTPPort:      ctx.GlobalString(flags.MetricsHTTPPort.Name),

--- a/disperser/cmd/encoder/flags/flags.go
+++ b/disperser/cmd/encoder/flags/flags.go
@@ -67,6 +67,12 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "ENABLE_GNARK_CHUNK_ENCODING"),
 	}
+	PreventReencodingFlag = cli.BoolTFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "prevent-reencoding"),
+		Usage:    "if true, will prevent reencoding of chunks by checking if the chunk already exists in the chunk store",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "PREVENT_REENCODING"),
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -81,6 +87,7 @@ var optionalFlags = []cli.Flag{
 	EnableGnarkChunkEncodingFlag,
 	EncoderVersionFlag,
 	S3BucketNameFlag,
+	PreventReencodingFlag,
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/disperser/encoder/config.go
+++ b/disperser/encoder/config.go
@@ -9,4 +9,5 @@ type ServerConfig struct {
 	MaxConcurrentRequests    int
 	RequestPoolSize          int
 	EnableGnarkChunkEncoding bool
+	PreventReencoding        bool
 }

--- a/disperser/encoder/server_v2_test.go
+++ b/disperser/encoder/server_v2_test.go
@@ -7,17 +7,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Layr-Labs/eigenda/common/aws/mock"
 	"github.com/Layr-Labs/eigenda/core"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	pb "github.com/Layr-Labs/eigenda/disperser/api/grpc/encoder/v2"
+	"github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
 	"github.com/Layr-Labs/eigenda/disperser/encoder"
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/encoding/kzg"
 	"github.com/Layr-Labs/eigenda/encoding/kzg/prover"
 	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
+	"github.com/Layr-Labs/eigenda/relay/chunkstore"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
+
+type testComponents struct {
+	encoderServer    *encoder.EncoderServerV2
+	blobStore        *blobstore.BlobStore
+	chunkStoreWriter chunkstore.ChunkWriter
+	chunkStoreReader chunkstore.ChunkReader
+	s3Client         *mock.S3Client
+	dynamoDBClient   *mock.MockDynamoDBClient
+}
 
 func makeTestProver(numPoint uint64) (encoding.Prover, error) {
 	// We need the larger SRS for testing the encoder with 8192 chunks
@@ -62,6 +75,9 @@ func TestEncodeBlob(t *testing.T) {
 		return codec.ConvertByPaddingEmptyByte(data)
 	}
 
+	c := createTestComponents(t)
+	server := c.encoderServer
+
 	// Setup test data
 	data := createTestData(t, testDataSize)
 	blobSize := uint(len(data))
@@ -84,19 +100,16 @@ func TestEncodeBlob(t *testing.T) {
 	}
 
 	// Store test data
-	if err := blobStore.StoreBlob(ctx, blobKey, data); !assert.NoError(t, err, "Failed to store blob") {
+	if err := c.blobStore.StoreBlob(ctx, blobKey, data); !assert.NoError(t, err, "Failed to store blob") {
 		t.FailNow()
 	}
 
 	// Verify storage succeded
 	t.Run("Verify Blob Storage", func(t *testing.T) {
-		storedData, err := blobStore.GetBlob(ctx, blobKey)
+		storedData, err := c.blobStore.GetBlob(ctx, blobKey)
 		assert.NoError(t, err, "Failed to get stored blob")
 		assert.Equal(t, data, storedData, "Stored data doesn't match original")
 	})
-
-	// Initialize encoder server
-	server := initializeEncoder(t)
 
 	// Create and execute encoding request
 	req := &pb.EncodeBlobRequest{
@@ -107,10 +120,18 @@ func TestEncodeBlob(t *testing.T) {
 		},
 	}
 
+	expectedUploadCalls := 1
+	expectedFragmentedUploadObjectCalls := 0
+	assert.Equal(t, c.s3Client.Called["UploadObject"], expectedUploadCalls)
+	assert.Equal(t, c.s3Client.Called["FragmentedUploadObject"], expectedFragmentedUploadObjectCalls)
 	resp, err := server.EncodeBlob(ctx, req)
 	if !assert.NoError(t, err, "EncodeBlob failed") {
 		t.FailNow()
 	}
+	expectedUploadCalls++
+	expectedFragmentedUploadObjectCalls++
+	assert.Equal(t, c.s3Client.Called["UploadObject"], expectedUploadCalls)
+	assert.Equal(t, c.s3Client.Called["FragmentedUploadObject"], expectedFragmentedUploadObjectCalls)
 
 	// Verify encoding results
 	t.Run("Verify Encoding Results", func(t *testing.T) {
@@ -119,21 +140,39 @@ func TestEncodeBlob(t *testing.T) {
 		assert.Equal(t, uint32(512*1024), resp.FragmentInfo.FragmentSizeBytes, "Unexpected fragment size")
 	})
 
+	expectedFragmentInfo := &encoding.FragmentInfo{
+		TotalChunkSizeBytes: resp.FragmentInfo.TotalChunkSizeBytes,
+		FragmentSizeBytes:   resp.FragmentInfo.FragmentSizeBytes,
+	}
+
 	// Verify chunk store data
 	t.Run("Verify Chunk Store Data", func(t *testing.T) {
 		// Check proofs
-		proofs, err := chunkStoreReader.GetChunkProofs(ctx, blobKey)
+		assert.True(t, c.chunkStoreWriter.ProofExists(ctx, blobKey))
+		proofs, err := c.chunkStoreReader.GetChunkProofs(ctx, blobKey)
 		assert.NoError(t, err, "Failed to get chunk proofs")
 		assert.Len(t, proofs, int(numChunks), "Unexpected number of proofs")
 
 		// Check coefficients
-		fragmentInfo := &encoding.FragmentInfo{
-			TotalChunkSizeBytes: resp.FragmentInfo.TotalChunkSizeBytes,
-			FragmentSizeBytes:   resp.FragmentInfo.FragmentSizeBytes,
-		}
-		coefficients, err := chunkStoreReader.GetChunkCoefficients(ctx, blobKey, fragmentInfo)
+		coefExist, fetchedFragmentInfo := c.chunkStoreWriter.CoefficientsExists(ctx, blobKey)
+		assert.True(t, coefExist, "Coefficients should exist")
+		assert.Equal(t, expectedFragmentInfo, fetchedFragmentInfo, "Unexpected fragment info")
+
+		coefficients, err := c.chunkStoreReader.GetChunkCoefficients(ctx, blobKey, expectedFragmentInfo)
 		assert.NoError(t, err, "Failed to get chunk coefficients")
 		assert.Len(t, coefficients, int(numChunks), "Unexpected number of coefficients")
+	})
+
+	t.Run("Verify Re-encoding is prevented", func(t *testing.T) {
+		assert.Equal(t, c.s3Client.Called["UploadObject"], expectedUploadCalls)
+		assert.Equal(t, c.s3Client.Called["FragmentedUploadObject"], expectedFragmentedUploadObjectCalls)
+		// Create and execute encoding request again
+		resp, err := server.EncodeBlob(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, uint32(294916), resp.FragmentInfo.TotalChunkSizeBytes, "Unexpected total chunk size")
+		assert.Equal(t, uint32(512*1024), resp.FragmentInfo.FragmentSizeBytes, "Unexpected fragment size")
+		assert.Equal(t, c.s3Client.Called["UploadObject"], expectedUploadCalls)
+		assert.Equal(t, c.s3Client.Called["FragmentedUploadObject"], expectedFragmentedUploadObjectCalls)
 	})
 }
 
@@ -153,17 +192,29 @@ func createTestBlobHeader(t *testing.T) *corev2.BlobHeader {
 }
 
 // Helper function to initialize encoder
-func initializeEncoder(t *testing.T) *encoder.EncoderServerV2 {
+func createTestComponents(t *testing.T) *testComponents {
 	t.Helper()
 	prover, err := makeTestProver(300000)
-	if !assert.NoError(t, err, "Failed to create prover") {
-		t.FailNow()
-	}
-
+	require.NoError(t, err, "Failed to create prover")
 	metrics := encoder.NewMetrics("9000", logger)
-	return encoder.NewEncoderServerV2(encoder.ServerConfig{
+	s3Client := mock.NewS3Client()
+	dynamoDBClient := &mock.MockDynamoDBClient{}
+	blobStore := blobstore.NewBlobStore(s3BucketName, s3Client, logger)
+	chunkStoreWriter := chunkstore.NewChunkWriter(logger, s3Client, s3BucketName, 512*1024)
+	chunkStoreReader := chunkstore.NewChunkReader(logger, s3Client, s3BucketName, []uint32{})
+	encoderServer := encoder.NewEncoderServerV2(encoder.ServerConfig{
 		GrpcPort:              "8080",
 		MaxConcurrentRequests: 10,
 		RequestPoolSize:       5,
+		PreventReencoding:     true,
 	}, blobStore, chunkStoreWriter, logger, prover, metrics)
+
+	return &testComponents{
+		encoderServer:    encoderServer,
+		blobStore:        blobStore,
+		chunkStoreWriter: chunkStoreWriter,
+		chunkStoreReader: chunkStoreReader,
+		s3Client:         s3Client,
+		dynamoDBClient:   dynamoDBClient,
+	}
 }

--- a/disperser/encoder/setup_test.go
+++ b/disperser/encoder/setup_test.go
@@ -81,7 +81,7 @@ func setup() {
 	chunkStoreWriter = chunkstore.NewChunkWriter(logger, s3Client, s3BucketName, 512*1024)
 
 	// Initialize chunk store reader
-	chunkStoreReader = chunkstore.NewChunkReader(logger, nil, s3Client, s3BucketName, []uint32{})
+	chunkStoreReader = chunkstore.NewChunkReader(logger, s3Client, s3BucketName, []uint32{})
 
 	var X1, Y1 fp.Element
 	X1 = *X1.SetBigInt(big.NewInt(1))

--- a/disperser/encoder/setup_test.go
+++ b/disperser/encoder/setup_test.go
@@ -1,37 +1,22 @@
 package encoder_test
 
 import (
-	"context"
-	"fmt"
 	"math/big"
 	"os"
 	"testing"
 
-	"github.com/Layr-Labs/eigenda/common/aws"
-	"github.com/Layr-Labs/eigenda/common/aws/s3"
-	"github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
 	"github.com/Layr-Labs/eigenda/encoding"
-	"github.com/Layr-Labs/eigenda/inabox/deploy"
-	"github.com/Layr-Labs/eigenda/relay/chunkstore"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	"github.com/google/uuid"
-	"github.com/ory/dockertest/v3"
 )
 
 var (
-	logger             = logging.NewNoopLogger()
-	dockertestPool     *dockertest.Pool
-	dockertestResource *dockertest.Resource
-	deployLocalStack   bool
-	localStackPort     = "4571"
-	blobStore          *blobstore.BlobStore
-	chunkStoreWriter   chunkstore.ChunkWriter
-	chunkStoreReader   chunkstore.ChunkReader
-	UUID               = uuid.New()
-	s3BucketName       = "test-eigenda"
-	mockCommitment     = encoding.BlobCommitments{}
+	logger         = logging.NewNoopLogger()
+	UUID           = uuid.New()
+	s3BucketName   = "test-eigenda"
+	mockCommitment = encoding.BlobCommitments{}
 )
 
 func TestMain(m *testing.M) {
@@ -42,52 +27,11 @@ func TestMain(m *testing.M) {
 }
 
 func setup() {
-	deployLocalStack = !(os.Getenv("DEPLOY_LOCALSTACK") == "false")
-	if !deployLocalStack {
-		localStackPort = os.Getenv("LOCALSTACK_PORT")
-	}
-	if deployLocalStack {
-		var err error
-		dockertestPool, dockertestResource, err = deploy.StartDockertestWithLocalstackContainer(localStackPort)
-		if err != nil {
-			teardown()
-			panic("failed to start localstack container")
-		}
-	}
-	cfg := aws.DefaultClientConfig()
-	cfg.AccessKey = "localstack"
-	cfg.SecretAccessKey = "localstack"
-	cfg.EndpointURL = fmt.Sprintf("http://0.0.0.0:%s", localStackPort)
-	cfg.Region = "us-east-1"
-
-	// Initialize S3 client
-	s3Client, err := s3.NewClient(context.Background(), *cfg, logger)
-	if err != nil {
-		teardown()
-		panic("failed to create s3 client: " + err.Error())
-	}
-
-	// Create S3 buckets
-	err = s3Client.CreateBucket(context.Background(), s3BucketName)
-	if err != nil {
-		teardown()
-		panic("failed to create s3 bucket: " + err.Error())
-	}
-
-	// Initialize blob store
-	blobStore = blobstore.NewBlobStore(s3BucketName, s3Client, logger)
-
-	// Initialize chunk store writer
-	chunkStoreWriter = chunkstore.NewChunkWriter(logger, s3Client, s3BucketName, 512*1024)
-
-	// Initialize chunk store reader
-	chunkStoreReader = chunkstore.NewChunkReader(logger, s3Client, s3BucketName, []uint32{})
-
 	var X1, Y1 fp.Element
 	X1 = *X1.SetBigInt(big.NewInt(1))
 	Y1 = *Y1.SetBigInt(big.NewInt(2))
 	var lengthXA0, lengthXA1, lengthYA0, lengthYA1 fp.Element
-	_, err = lengthXA0.SetString("10857046999023057135944570762232829481370756359578518086990519993285655852781")
+	_, err := lengthXA0.SetString("10857046999023057135944570762232829481370756359578518086990519993285655852781")
 	if err != nil {
 		teardown()
 		panic("failed to create mock commitment: " + err.Error())
@@ -124,8 +68,4 @@ func setup() {
 	}
 }
 
-func teardown() {
-	if deployLocalStack {
-		deploy.PurgeDockertestResources(dockertestPool, dockertestResource)
-	}
-}
+func teardown() {}

--- a/relay/chunkstore/chunk_reader.go
+++ b/relay/chunkstore/chunk_reader.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Layr-Labs/eigenda/common/aws/s3"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
-	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/encoding/rs"
 	"github.com/Layr-Labs/eigensdk-go/logging"
@@ -28,11 +27,10 @@ type ChunkReader interface {
 var _ ChunkReader = (*chunkReader)(nil)
 
 type chunkReader struct {
-	logger        logging.Logger
-	metadataStore *blobstore.BlobMetadataStore
-	client        s3.Client
-	bucket        string
-	shards        []uint32
+	logger logging.Logger
+	client s3.Client
+	bucket string
+	shards []uint32
 }
 
 // NewChunkReader creates a new ChunkReader.
@@ -41,17 +39,15 @@ type chunkReader struct {
 // If empty, it will return data for all shards. (Note: shard feature is not yet implemented.)
 func NewChunkReader(
 	logger logging.Logger,
-	metadataStore *blobstore.BlobMetadataStore,
 	s3Client s3.Client,
 	bucketName string,
 	shards []uint32) ChunkReader {
 
 	return &chunkReader{
-		logger:        logger,
-		metadataStore: metadataStore,
-		client:        s3Client,
-		bucket:        bucketName,
-		shards:        shards,
+		logger: logger,
+		client: s3Client,
+		bucket: bucketName,
+		shards: shards,
 	}
 }
 

--- a/relay/chunkstore/chunk_store_test.go
+++ b/relay/chunkstore/chunk_store_test.go
@@ -19,6 +19,7 @@ import (
 	rs_cpu "github.com/Layr-Labs/eigenda/encoding/rs/cpu"
 	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
+	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
@@ -151,7 +152,7 @@ func RandomProofsTest(t *testing.T, client s3.Client) {
 	fragmentSize := rand.Intn(1024) + 100 // ignored since we aren't writing coefficients
 
 	writer := NewChunkWriter(logger, client, bucket, fragmentSize)
-	reader := NewChunkReader(logger, nil, client, bucket, make([]uint32, 0))
+	reader := NewChunkReader(logger, client, bucket, make([]uint32, 0))
 
 	expectedValues := make(map[corev2.BlobKey][]*encoding.Proof)
 
@@ -226,7 +227,7 @@ func RandomCoefficientsTest(t *testing.T, client s3.Client) {
 	require.NotNil(t, encoder)
 
 	writer := NewChunkWriter(logger, client, bucket, fragmentSize)
-	reader := NewChunkReader(logger, nil, client, bucket, make([]uint32, 0))
+	reader := NewChunkReader(logger, client, bucket, make([]uint32, 0))
 
 	expectedValues := make(map[corev2.BlobKey][]*rs.Frame)
 	metadataMap := make(map[corev2.BlobKey]*encoding.FragmentInfo)
@@ -266,5 +267,66 @@ func TestRandomCoefficients(t *testing.T) {
 
 		err = builder.finish()
 		require.NoError(t, err)
+	}
+}
+
+func TestIdempotency(t *testing.T) {
+	tu.InitializeRandom()
+	client := mock.NewS3Client()
+
+	// logger, err := common.NewLogger(common.DefaultLoggerConfig())
+	// require.NoError(t, err)
+	logger := logging.NewNoopLogger()
+
+	chunkSize := uint64(rand.Intn(1024) + 100)
+	fragmentSize := int(chunkSize / 2)
+
+	params := encoding.ParamsFromSysPar(3, 1, chunkSize)
+	encoder, _ := rs.NewEncoder(params, true)
+
+	n := uint8(math.Log2(float64(encoder.NumEvaluations())))
+	if encoder.ChunkLength == 1 {
+		n = uint8(math.Log2(float64(2 * encoder.NumChunks)))
+	}
+	fs := fft.NewFFTSettings(n)
+
+	RsComputeDevice := &rs_cpu.RsCpuComputeDevice{
+		Fs:             fs,
+		EncodingParams: params,
+	}
+
+	encoder.Computer = RsComputeDevice
+	require.NotNil(t, encoder)
+
+	writer := NewChunkWriter(logger, client, bucket, fragmentSize)
+	expectedUploadCalls := 0
+	expectedFragmentedUploadObjectCalls := 0
+	ctx := context.Background()
+	for i := 0; i < 100; i++ {
+		key := corev2.BlobKey(tu.RandomBytes(32))
+
+		proofs := getProofs(t, rand.Intn(100)+100)
+		err := writer.PutChunkProofs(ctx, key, proofs)
+		require.NoError(t, err)
+		expectedUploadCalls++
+		require.Equal(t, expectedUploadCalls, client.Called["UploadObject"])
+
+		// Attempt to upload the same proofs again
+		require.True(t, writer.ProofExists(ctx, key))
+		err = writer.PutChunkProofs(ctx, key, proofs)
+		require.NoError(t, err)
+		require.Equal(t, expectedUploadCalls, client.Called["UploadObject"])
+
+		coefficients := generateRandomFrames(t, encoder, int(chunkSize))
+		metadata, err := writer.PutChunkCoefficients(ctx, key, coefficients)
+		require.NoError(t, err)
+		expectedFragmentedUploadObjectCalls++
+		require.Equal(t, expectedFragmentedUploadObjectCalls, client.Called["FragmentedUploadObject"])
+
+		// Attempt to upload the same coefficients again
+		newMetadata, err := writer.PutChunkCoefficients(ctx, key, coefficients)
+		require.NoError(t, err)
+		require.Equal(t, metadata, newMetadata)
+		require.Equal(t, expectedFragmentedUploadObjectCalls, client.Called["UploadObject"])
 	}
 }

--- a/relay/chunkstore/chunk_writer.go
+++ b/relay/chunkstore/chunk_writer.go
@@ -85,3 +85,7 @@ func (c *chunkWriter) PutChunkCoefficients(
 		FragmentSizeBytes:   uint32(c.fragmentSize),
 	}, nil
 }
+
+// func (c *chunkWriter) headObject(ctx context.Context, blobKey corev2.BlobKey) (int, error) {
+// 	return c.s3Client.HeadObject(ctx, c.bucketName, s3.ScopedChunkKey(blobKey))
+// }

--- a/relay/chunkstore/chunk_writer.go
+++ b/relay/chunkstore/chunk_writer.go
@@ -21,6 +21,10 @@ type ChunkWriter interface {
 		ctx context.Context,
 		blobKey corev2.BlobKey,
 		frames []*rs.Frame) (*encoding.FragmentInfo, error)
+	// ProofExists checks if the proofs for the blob key exist in the chunk store.
+	ProofExists(ctx context.Context, blobKey corev2.BlobKey) bool
+	// CoefficientsExists checks if the coefficients for the blob key exist in the chunk store.
+	CoefficientsExists(ctx context.Context, blobKey corev2.BlobKey, dataSize int64) bool
 }
 
 var _ ChunkWriter = (*chunkWriter)(nil)
@@ -48,6 +52,15 @@ func NewChunkWriter(
 }
 
 func (c *chunkWriter) PutChunkProofs(ctx context.Context, blobKey corev2.BlobKey, proofs []*encoding.Proof) error {
+	if len(proofs) == 0 {
+		return fmt.Errorf("no proofs to upload")
+	}
+
+	if c.ProofExists(ctx, blobKey) {
+		c.logger.Infof("Proofs already exist for blob key %s", blobKey)
+		return nil
+	}
+
 	bytes := make([]byte, 0, bn254.SizeOfG1AffineCompressed*len(proofs))
 	for _, proof := range proofs {
 		proofBytes := proof.Bytes()
@@ -67,11 +80,21 @@ func (c *chunkWriter) PutChunkCoefficients(
 	ctx context.Context,
 	blobKey corev2.BlobKey,
 	frames []*rs.Frame) (*encoding.FragmentInfo, error) {
-
+	if len(frames) == 0 {
+		return nil, fmt.Errorf("no frames to upload")
+	}
 	bytes, err := rs.GnarkEncodeFrames(frames)
 	if err != nil {
-		c.logger.Errorf("Failed to encode frames: %v", err)
+		c.logger.Error("Failed to encode frames", "err", err)
 		return nil, fmt.Errorf("failed to encode frames: %v", err)
+	}
+
+	if c.CoefficientsExists(ctx, blobKey, int64(len(bytes))) {
+		c.logger.Infof("Coefficients already exist for blob key %s", blobKey)
+		return &encoding.FragmentInfo{
+			TotalChunkSizeBytes: uint32(len(bytes)),
+			FragmentSizeBytes:   uint32(c.fragmentSize),
+		}, nil
 	}
 
 	err = c.s3Client.FragmentedUploadObject(ctx, c.bucketName, s3.ScopedChunkKey(blobKey), bytes, c.fragmentSize)
@@ -86,6 +109,26 @@ func (c *chunkWriter) PutChunkCoefficients(
 	}, nil
 }
 
-// func (c *chunkWriter) headObject(ctx context.Context, blobKey corev2.BlobKey) (int, error) {
-// 	return c.s3Client.HeadObject(ctx, c.bucketName, s3.ScopedChunkKey(blobKey))
-// }
+func (c *chunkWriter) ProofExists(ctx context.Context, blobKey corev2.BlobKey) bool {
+	size, err := c.s3Client.HeadObject(ctx, c.bucketName, s3.ScopedProofKey(blobKey))
+	if err == nil && size != nil && *size > 0 {
+		return true
+	}
+
+	return false
+}
+
+func (c *chunkWriter) CoefficientsExists(ctx context.Context, blobKey corev2.BlobKey, dataSize int64) bool {
+	// TODO(ian-shim): check latency
+	objs, err := c.s3Client.ListObjects(ctx, c.bucketName, s3.ScopedChunkKey(blobKey))
+	if err != nil {
+		return false
+	}
+
+	totalSize := int64(0)
+	for _, obj := range objs {
+		totalSize += obj.Size
+	}
+
+	return totalSize == dataSize
+}


### PR DESCRIPTION
## Why are these changes needed?
Makes `ChunkWriter` operations idempotent by querying (without downloading) the existing items. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the lint is passing in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
