### PR TITLE
Downgrade disperser error logs

### DIFF
--- a/disperser/common/blobstore/shared_storage.go
+++ b/disperser/common/blobstore/shared_storage.go
@@ -114,7 +114,13 @@ func (s *SharedBlobStore) StoreBlob(ctx context.Context, blob *core.Blob, reques
 	}
 	err = s.blobMetadataStore.QueueNewBlobMetadata(ctx, &metadata)
 	if err != nil {
-		s.logger.Error("error uploading blob metadata", "err", err)
+		if errors.Is(err, context.Canceled) {
+			s.logger.Warn("context canceled while queuing new blob metadata", "err", err)
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			s.logger.Warn("context deadline exceeded while queuing new blob metadata", "err", err)
+		} else {
+			s.logger.Error("error uploading blob metadata", "err", err)
+		}
 		return metadataKey, err
 	}
 


### PR DESCRIPTION
## Why are these changes needed?
Lowering some logs to `Warn` level to reduce noise as they're not unexpected
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
