### PR TITLE
[v2] Node v2 storage implementation

### DIFF
--- a/core/v2/core_test.go
+++ b/core/v2/core_test.go
@@ -205,14 +205,12 @@ func checkBatchByUniversalVerifier(
 	cst core.IndexedChainState,
 	packagedBlobs map[core.OperatorID][]*corev2.BlobShard,
 	pool common.WorkerPool,
-	referenceBlockNumber uint64,
 ) error {
 
 	ctx := context.Background()
 
 	quorums := []core.QuorumID{0, 1}
 	state, _ := cst.GetIndexedOperatorState(context.Background(), 0, quorums)
-	// numBlob := len(encodedBlobs)
 
 	var errList *multierror.Error
 
@@ -222,7 +220,7 @@ func checkBatchByUniversalVerifier(
 
 		blobs := packagedBlobs[id]
 
-		err := val.ValidateBlobs(ctx, blobs, pool, referenceBlockNumber)
+		err := val.ValidateBlobs(ctx, blobs, pool, state.OperatorState)
 		if err != nil {
 			errList = multierror.Append(errList, err)
 		}
@@ -268,7 +266,7 @@ func TestValidationSucceeds(t *testing.T) {
 		packagedBlobs, cst := prepareBlobs(t, operatorCount, headers, blobs, bn)
 
 		t.Run(fmt.Sprintf("universal verifier operatorCount=%v over %v blobs", operatorCount, len(blobs)), func(t *testing.T) {
-			err := checkBatchByUniversalVerifier(cst, packagedBlobs, pool, bn)
+			err := checkBatchByUniversalVerifier(cst, packagedBlobs, pool)
 			assert.NoError(t, err)
 		})
 

--- a/core/v2/serialization.go
+++ b/core/v2/serialization.go
@@ -1,6 +1,8 @@
 package v2
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
 	"math/big"
 
@@ -218,6 +220,19 @@ func (c *BlobCertificate) Hash() ([32]byte, error) {
 	return blobCertHash, nil
 }
 
+func (c *BlobCertificate) Serialize() ([]byte, error) {
+	return encode(c)
+}
+
+func DeserializeBlobCertificate(data []byte) (*BlobCertificate, error) {
+	var c BlobCertificate
+	err := decode(data, &c)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
 // GetBatchHeaderHash returns the hash of the batch header
 func (h BatchHeader) Hash() ([32]byte, error) {
 	var headerHash [32]byte
@@ -262,4 +277,37 @@ func (h BatchHeader) Hash() ([32]byte, error) {
 	copy(headerHash[:], hasher.Sum(nil)[:32])
 
 	return headerHash, nil
+}
+
+func (h BatchHeader) Serialize() ([]byte, error) {
+	return encode(h)
+}
+
+func DeserializeBatchHeader(data []byte) (*BatchHeader, error) {
+	var h BatchHeader
+	err := decode(data, &h)
+	if err != nil {
+		return nil, err
+	}
+	return &h, nil
+}
+
+func encode(obj any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(obj)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func decode(data []byte, obj any) error {
+	buf := bytes.NewBuffer(data)
+	dec := gob.NewDecoder(buf)
+	err := dec.Decode(obj)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -202,7 +202,9 @@ func (c *BlobCertificate) ToProtobuf() (*commonpb.BlobCertificate, error) {
 }
 
 type BatchHeader struct {
-	BatchRoot            [32]byte
+	// BatchRoot is the root of a Merkle tree whose leaves are the keys of the blobs in the batch
+	BatchRoot [32]byte
+	// ReferenceBlockNumber is the block number at which all operator information (stakes, indexes, etc.) is taken from
 	ReferenceBlockNumber uint64
 }
 

--- a/core/v2/validator.go
+++ b/core/v2/validator.go
@@ -72,7 +72,7 @@ func (v *ShardValidator) validateBlobQuorum(quorum core.QuorumID, blob *BlobShar
 	return chunks, &assignment, nil
 }
 
-func (v *ShardValidator) ValidateBlobs(ctx context.Context, blobs []*BlobShard, pool common.WorkerPool, referenceBlockNumber uint64) error {
+func (v *ShardValidator) ValidateBlobs(ctx context.Context, blobs []*BlobShard, pool common.WorkerPool, state *core.OperatorState) error {
 	var err error
 	subBatchMap := make(map[encoding.EncodingParams]*encoding.SubBatch)
 	blobCommitmentList := make([]encoding.BlobCommitments, len(blobs))
@@ -80,11 +80,6 @@ func (v *ShardValidator) ValidateBlobs(ctx context.Context, blobs []*BlobShard, 
 	for k, blob := range blobs {
 		if len(blob.Bundles) != len(blob.BlobHeader.QuorumNumbers) {
 			return fmt.Errorf("number of bundles (%d) does not match number of quorums (%d)", len(blob.Bundles), len(blob.BlobHeader.QuorumNumbers))
-		}
-
-		state, err := v.chainState.GetOperatorState(ctx, uint(referenceBlockNumber), blob.BlobHeader.QuorumNumbers)
-		if err != nil {
-			return err
 		}
 
 		// Saved for the blob length validation

--- a/node/grpc/server_v2.go
+++ b/node/grpc/server_v2.go
@@ -55,7 +55,3 @@ func (s *ServerV2) NodeInfo(ctx context.Context, in *pb.NodeInfoRequest) (*pb.No
 func (s *ServerV2) StoreChunks(ctx context.Context, in *pb.StoreChunksRequest) (*pb.StoreChunksReply, error) {
 	return &pb.StoreChunksReply{}, api.NewErrorUnimplemented()
 }
-
-func (s *ServerV2) GetChunks(context.Context, *pb.GetChunksRequest) (*pb.GetChunksReply, error) {
-	return &pb.GetChunksReply{}, api.NewErrorUnimplemented()
-}

--- a/node/store_v2.go
+++ b/node/store_v2.go
@@ -1,0 +1,102 @@
+package node
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/Layr-Labs/eigenda/common/kvstore"
+	"github.com/Layr-Labs/eigenda/core"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+)
+
+const (
+	BatchHeaderTableName     = "batch_headers"
+	BlobCertificateTableName = "blob_certificates"
+	BundleTableName          = "bundles"
+)
+
+type StoreV2 struct {
+	db     kvstore.TableStore
+	logger logging.Logger
+
+	ttl time.Duration
+}
+
+func NewLevelDBStoreV2(db kvstore.TableStore, logger logging.Logger) *StoreV2 {
+	return &StoreV2{
+		db:     db,
+		logger: logger,
+	}
+}
+
+func (s *StoreV2) StoreBatch(ctx context.Context, batch *corev2.Batch, rawBundles []*RawBundles) error {
+	dbBatch := s.db.NewTTLBatch()
+
+	batchHeaderKeyBuilder, err := s.db.GetKeyBuilder(BatchHeaderTableName)
+	if err != nil {
+		return fmt.Errorf("failed to get key builder for batch header: %v", err)
+	}
+
+	batchHeaderHash, err := batch.BatchHeader.Hash()
+	if err != nil {
+		return fmt.Errorf("failed to hash batch header: %v", err)
+	}
+
+	// Store batch header
+	batchHeaderBytes, err := batch.BatchHeader.Serialize()
+	if err != nil {
+		return fmt.Errorf("failed to serialize batch header: %v", err)
+	}
+
+	batchHeaderKey := batchHeaderKeyBuilder.Key(batchHeaderHash[:])
+	dbBatch.PutWithTTL(batchHeaderKey, batchHeaderBytes, s.ttl)
+
+	// Store blob shards
+	for _, bundles := range rawBundles {
+		// Store blob certificate
+		blobCertificateKeyBuilder, err := s.db.GetKeyBuilder(BlobCertificateTableName)
+		if err != nil {
+			return fmt.Errorf("failed to get key builder for blob certificate: %v", err)
+		}
+		blobKey, err := bundles.BlobCertificate.BlobHeader.BlobKey()
+		if err != nil {
+			return fmt.Errorf("failed to get blob key: %v", err)
+		}
+		blobCertificateKey := blobCertificateKeyBuilder.Key(blobKey[:])
+		blobCertificateBytes, err := bundles.BlobCertificate.Serialize()
+		if err != nil {
+			return fmt.Errorf("failed to serialize blob certificate: %v", err)
+		}
+		dbBatch.PutWithTTL(blobCertificateKey, blobCertificateBytes, s.ttl)
+
+		// Store bundles
+		for quorum, bundle := range bundles.Bundles {
+			bundlesKeyBuilder, err := s.db.GetKeyBuilder(BundleTableName)
+			if err != nil {
+				return fmt.Errorf("failed to get key builder for bundles: %v", err)
+			}
+
+			k, err := BundleKey(blobKey, quorum)
+			if err != nil {
+				return fmt.Errorf("failed to get key for bundles: %v", err)
+			}
+
+			dbBatch.PutWithTTL(bundlesKeyBuilder.Key(k), bundle, s.ttl)
+		}
+	}
+
+	return dbBatch.Apply()
+}
+
+func BundleKey(blobKey corev2.BlobKey, quorumID core.QuorumID) ([]byte, error) {
+	buf := bytes.NewBuffer(blobKey[:])
+	err := binary.Write(buf, binary.LittleEndian, quorumID)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/node/store_v2_test.go
+++ b/node/store_v2_test.go
@@ -1,0 +1,103 @@
+package node_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/common/kvstore"
+	"github.com/Layr-Labs/eigenda/common/kvstore/tablestore"
+	"github.com/Layr-Labs/eigenda/core"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/Layr-Labs/eigenda/node"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreBatchV2(t *testing.T) {
+	ctx := context.Background()
+	_, batch, bundles := mockBatch(t)
+
+	blobShards := make([]*corev2.BlobShard, len(batch.BlobCertificates))
+	rawBundles := make([]*node.RawBundles, len(batch.BlobCertificates))
+	for i, cert := range batch.BlobCertificates {
+		blobShards[i] = &corev2.BlobShard{
+			BlobCertificate: cert,
+			Bundles:         make(map[core.QuorumID]core.Bundle),
+		}
+		rawBundles[i] = &node.RawBundles{
+			BlobCertificate: cert,
+			Bundles:         make(map[core.QuorumID][]byte),
+		}
+
+		for quorum, bundle := range bundles[i] {
+			blobShards[i].Bundles[quorum] = bundle
+			bundleBytes, err := bundle.Serialize()
+			assert.NoError(t, err)
+			rawBundles[i].Bundles[quorum] = bundleBytes
+		}
+	}
+
+	s, db := createStoreV2(t)
+	defer func() {
+		_ = db.Shutdown()
+	}()
+	err := s.StoreBatch(ctx, batch, rawBundles)
+	require.NoError(t, err)
+
+	tables := db.GetTables()
+	require.ElementsMatch(t, []string{node.BatchHeaderTableName, node.BlobCertificateTableName, node.BundleTableName}, tables)
+
+	// Check batch header
+	bhh, err := batch.BatchHeader.Hash()
+	require.NoError(t, err)
+	batchHeaderKeyBuilder, err := db.GetKeyBuilder(node.BatchHeaderTableName)
+	require.NoError(t, err)
+	bhhBytes, err := db.Get(batchHeaderKeyBuilder.Key(bhh[:]))
+	require.NoError(t, err)
+	assert.NotNil(t, bhhBytes)
+	deserializedBatchHeader, err := corev2.DeserializeBatchHeader(bhhBytes)
+	require.NoError(t, err)
+	assert.Equal(t, batch.BatchHeader, deserializedBatchHeader)
+
+	// Check blob certificates
+	blobCertKeyBuilder, err := db.GetKeyBuilder(node.BlobCertificateTableName)
+	require.NoError(t, err)
+	for _, cert := range batch.BlobCertificates {
+		blobKey, err := cert.BlobHeader.BlobKey()
+		require.NoError(t, err)
+		blobCertKey := blobCertKeyBuilder.Key(blobKey[:])
+		blobCertBytes, err := db.Get(blobCertKey)
+		require.NoError(t, err)
+		assert.NotNil(t, blobCertBytes)
+		deserializedBlobCert, err := corev2.DeserializeBlobCertificate(blobCertBytes)
+		require.NoError(t, err)
+		assert.Equal(t, cert, deserializedBlobCert)
+	}
+
+	// Check bundles
+	bundleKeyBuilder, err := db.GetKeyBuilder(node.BundleTableName)
+	require.NoError(t, err)
+	for _, bundles := range rawBundles {
+		blobKey, err := bundles.BlobCertificate.BlobHeader.BlobKey()
+		require.NoError(t, err)
+		for quorum, bundle := range bundles.Bundles {
+			k, err := node.BundleKey(blobKey, quorum)
+			require.NoError(t, err)
+			bundleBytes, err := db.Get(bundleKeyBuilder.Key(k))
+			require.NoError(t, err)
+			assert.NotNil(t, bundleBytes)
+			require.Equal(t, bundle, bundleBytes)
+		}
+	}
+}
+
+func createStoreV2(t *testing.T) (*node.StoreV2, kvstore.TableStore) {
+	logger := logging.NewNoopLogger()
+	config := tablestore.DefaultLevelDBConfig(t.TempDir())
+	config.Schema = []string{node.BatchHeaderTableName, node.BlobCertificateTableName, node.BundleTableName}
+	tStore, err := tablestore.Start(logger, config)
+	require.NoError(t, err)
+	s := node.NewLevelDBStoreV2(tStore, logger)
+	return s, tStore
+}


### PR DESCRIPTION
## Why are these changes needed?
`node.StoreV2` implements `StoreBatch` method compatible with v2 dispersal requests. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
