### PR TITLE
[disperser] Return non-internal error for context errors

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -55,7 +55,11 @@ func NewErrorUnimplemented() error {
 
 // HTTP Mapping: 504 Gateway Timeout
 func NewErrorDeadlineExceeded(msg string) error {
-	return newErrorGRPC(codes.DeadlineExceeded, "msg")
+	return newErrorGRPC(codes.DeadlineExceeded, msg)
+}
+
+func NewErrorCanceled(msg string) error {
+	return newErrorGRPC(codes.Canceled, msg)
 }
 
 // ErrorFailover is returned by the disperser-client and eigenda-client to signify


### PR DESCRIPTION
## Why are these changes needed?
In cases like context timeouts/cancellation, return non-500 error.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
