### PR TITLE
[v2] Disperser `GetBlobStatus` endpoint

### DIFF
--- a/disperser/apiserver/get_blob_status_v2.go
+++ b/disperser/apiserver/get_blob_status_v2.go
@@ -1,0 +1,94 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Layr-Labs/eigenda/api"
+	pb "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
+	dispcommon "github.com/Layr-Labs/eigenda/disperser/common"
+	dispv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
+)
+
+func (s *DispersalServerV2) GetBlobStatus(ctx context.Context, req *pb.BlobStatusRequest) (*pb.BlobStatusReply, error) {
+	if req.GetBlobKey() == nil || len(req.GetBlobKey()) != 32 {
+		return nil, api.NewErrorInvalidArg("invalid blob key")
+	}
+
+	blobKey, err := corev2.BytesToBlobKey(req.GetBlobKey())
+	if err != nil {
+		return nil, api.NewErrorInvalidArg("invalid blob key")
+	}
+
+	metadata, err := s.blobMetadataStore.GetBlobMetadata(ctx, blobKey)
+	if err != nil {
+		s.logger.Error("failed to get blob metadata", "err", err, "blobKey", blobKey.Hex())
+		return nil, api.NewErrorInternal(fmt.Sprintf("failed to get blob metadata: %s", err.Error()))
+	}
+
+	if metadata.BlobStatus != dispv2.Certified {
+		return &pb.BlobStatusReply{
+			Status: metadata.BlobStatus.ToProfobuf(),
+		}, nil
+	}
+
+	cert, _, err := s.blobMetadataStore.GetBlobCertificate(ctx, blobKey)
+	if err != nil {
+		s.logger.Error("failed to get blob certificate", "err", err, "blobKey", blobKey.Hex())
+		if errors.Is(err, dispcommon.ErrMetadataNotFound) {
+			return nil, api.NewErrorNotFound("no such blob certificate found")
+		}
+		return nil, api.NewErrorInternal(fmt.Sprintf("failed to get blob certificate: %s", err.Error()))
+	}
+
+	// For certified blobs, include signed batch and blob verification info
+	blobVerificationInfos, err := s.blobMetadataStore.GetBlobVerificationInfos(ctx, blobKey)
+	if err != nil {
+		s.logger.Error("failed to get blob verification info", "err", err, "blobKey", blobKey.Hex())
+		return nil, api.NewErrorInternal(fmt.Sprintf("failed to get blob verification info: %s", err.Error()))
+	}
+
+	if len(blobVerificationInfos) == 0 {
+		s.logger.Error("no verification info found for certified blob", "blobKey", blobKey.Hex())
+		return nil, api.NewErrorInternal("no verification info found")
+	}
+
+	if len(blobVerificationInfos) > 1 {
+		s.logger.Warn("multiple verification info found for certified blob", "blobKey", blobKey.Hex())
+	}
+
+	for _, verificationInfo := range blobVerificationInfos {
+		// get the signed batch from this verification info
+		batchHeaderHash, err := verificationInfo.BatchHeader.Hash()
+		if err != nil {
+			s.logger.Error("failed to get batch header hash", "err", err, "blobKey", blobKey.Hex())
+			continue
+		}
+		batchHeader, attestation, err := s.blobMetadataStore.GetSignedBatch(ctx, batchHeaderHash)
+		if err != nil {
+			s.logger.Error("failed to get signed batch", "err", err, "blobKey", blobKey.Hex())
+			continue
+		}
+
+		blobVerificationInfoProto, err := verificationInfo.ToProtobuf(cert)
+		if err != nil {
+			s.logger.Error("failed to convert blob verification info to protobuf", "err", err, "blobKey", blobKey.Hex())
+			continue
+		}
+
+		// return the first signed batch found
+		return &pb.BlobStatusReply{
+			Status: metadata.BlobStatus.ToProfobuf(),
+			SignedBatch: &pb.SignedBatch{
+				Header:      batchHeader.ToProtobuf(),
+				Attestation: attestation.ToProtobuf(),
+			},
+			BlobVerificationInfo: blobVerificationInfoProto,
+		}, nil
+	}
+
+	s.logger.Error("no signed batch found for certified blob", "blobKey", blobKey.Hex())
+	return nil, api.NewErrorInternal("no signed batch found")
+}

--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,7 @@ var (
 	localStackPort   = "4569"
 	allowlistFile    *os.File
 	testMaxBlobSize  = 2 * 1024 * 1024
+	mockCommitment   = encoding.BlobCommitments{}
 )
 
 func TestMain(m *testing.M) {
@@ -658,6 +660,50 @@ func setup() {
 	}
 
 	dispersalServer = newTestServer(transactor, "setup")
+
+	var X1, Y1 fp.Element
+	X1 = *X1.SetBigInt(big.NewInt(1))
+	Y1 = *Y1.SetBigInt(big.NewInt(2))
+
+	var lengthXA0, lengthXA1, lengthYA0, lengthYA1 fp.Element
+	_, err = lengthXA0.SetString("10857046999023057135944570762232829481370756359578518086990519993285655852781")
+	if err != nil {
+		teardown()
+		panic("failed to create mock commitment: " + err.Error())
+	}
+	_, err = lengthXA1.SetString("11559732032986387107991004021392285783925812861821192530917403151452391805634")
+	if err != nil {
+		teardown()
+		panic("failed to create mock commitment: " + err.Error())
+	}
+	_, err = lengthYA0.SetString("8495653923123431417604973247489272438418190587263600148770280649306958101930")
+	if err != nil {
+		teardown()
+		panic("failed to create mock commitment: " + err.Error())
+	}
+	_, err = lengthYA1.SetString("4082367875863433681332203403145435568316851327593401208105741076214120093531")
+	if err != nil {
+		teardown()
+		panic("failed to create mock commitment: " + err.Error())
+	}
+
+	var lengthProof, lengthCommitment bn254.G2Affine
+	lengthProof.X.A0 = lengthXA0
+	lengthProof.X.A1 = lengthXA1
+	lengthProof.Y.A0 = lengthYA0
+	lengthProof.Y.A1 = lengthYA1
+
+	lengthCommitment = lengthProof
+
+	mockCommitment = encoding.BlobCommitments{
+		Commitment: &encoding.G1Commitment{
+			X: X1,
+			Y: Y1,
+		},
+		LengthCommitment: (*encoding.G2Commitment)(&lengthCommitment),
+		LengthProof:      (*encoding.G2Commitment)(&lengthProof),
+		Length:           16,
+	}
 }
 
 func teardown() {

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -144,10 +144,6 @@ func (s *DispersalServerV2) Start(ctx context.Context) error {
 	return nil
 }
 
-func (s *DispersalServerV2) GetBlobStatus(ctx context.Context, req *pb.BlobStatusRequest) (*pb.BlobStatusReply, error) {
-	return &pb.BlobStatusReply{}, api.NewErrorUnimplemented()
-}
-
 func (s *DispersalServerV2) GetBlobCommitment(ctx context.Context, req *pb.BlobCommitmentRequest) (*pb.BlobCommitmentReply, error) {
 	return &pb.BlobCommitmentReply{}, api.NewErrorUnimplemented()
 }

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -448,6 +448,12 @@ func TestBlobMetadataStoreBatchAttestation(t *testing.T) {
 	err = blobMetadataStore.PutAttestation(ctx, attestation)
 	assert.ErrorIs(t, err, common.ErrAlreadyExists)
 
+	// attempt to retrieve batch header and attestation at the same time
+	fetchedHeader, fetchedAttestation, err = blobMetadataStore.GetSignedBatch(ctx, bhh)
+	assert.NoError(t, err)
+	assert.Equal(t, h, fetchedHeader)
+	assert.Equal(t, attestation, fetchedAttestation)
+
 	deleteItems(t, []commondynamodb.Key{
 		{
 			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},


### PR DESCRIPTION
## Why are these changes needed?
Implementation of `GetBlobStatus` endpoint on v2 dispersal server
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
