### PR TITLE
Fix Subgraph README.md typo

### DIFF
--- a/subgraphs/README.md
+++ b/subgraphs/README.md
@@ -18,7 +18,7 @@ yarn global add @graphprotocol/graph-cli # install if u haven't
 # or install on MacOS
 npm install -g @graphprotocol/graph-cli
 
-graph init ----from-contract <contract_addr> --network {goerli,mainnet} --abi abis/Contract.json 
+graph init --from-contract <contract_addr> --network {goerli,mainnet} --abi abis/Contract.json 
 ```
 
 And go through the dialog.


### PR DESCRIPTION


## Why are these changes needed?

There is a typo int a shell example were there are 4 hyphens instead of 2 on the graph init parameters.
This commit is fixing this typo

## Checks
This is a Readme typo. 
The command has been tested locally.
