### PR TITLE
Set up v2 `EncodingClient` in `EncodingManager`

### DIFF
--- a/disperser/cmd/controller/config.go
+++ b/disperser/cmd/controller/config.go
@@ -42,7 +42,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	ethClientConfig := geth.ReadEthClientConfig(ctx)
+	ethClientConfig := geth.ReadEthClientConfigRPCOnly(ctx)
 	numRelayAssignments := ctx.GlobalInt(flags.NumRelayAssignmentFlag.Name)
 	if numRelayAssignments < 1 || numRelayAssignments > int(MaxUint16) {
 		return Config{}, fmt.Errorf("invalid number of relay assignments: %d", numRelayAssignments)
@@ -53,7 +53,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 	}
 	relays := make([]corev2.RelayKey, len(availableRelays))
 	for i, relay := range availableRelays {
-		if relay < 1 || relay > 65_535 {
+		if relay < 0 || relay > 65_535 {
 			return Config{}, fmt.Errorf("invalid relay: %d", relay)
 		}
 		relays[i] = corev2.RelayKey(relay)
@@ -70,6 +70,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			NumEncodingRetries:     ctx.GlobalInt(flags.NumEncodingRetriesFlag.Name),
 			NumRelayAssignment:     uint16(numRelayAssignments),
 			AvailableRelays:        relays,
+			EncoderAddress:         ctx.GlobalString(flags.EncoderAddressFlag.Name),
 		},
 		DispatcherConfig: controller.DispatcherConfig{
 			PullInterval:           ctx.GlobalDuration(flags.DispatcherPullIntervalFlag.Name),

--- a/disperser/cmd/controller/flags/flags.go
+++ b/disperser/cmd/controller/flags/flags.go
@@ -61,6 +61,12 @@ var (
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "AVAILABLE_RELAYS"),
 	}
+	EncoderAddressFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "encoder-address"),
+		Usage:    "the http ip:port which the distributed encoder server is listening",
+		Required: true,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "ENCODER_ADDRESS"),
+	}
 	EncodingRequestTimeoutFlag = cli.DurationFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "encoding-request-timeout"),
 		Usage:    "Timeout for encoding requests",
@@ -153,6 +159,7 @@ var requiredFlags = []cli.Flag{
 	UseGraphFlag,
 	EncodingPullIntervalFlag,
 	AvailableRelaysFlag,
+	EncoderAddressFlag,
 	DispatcherPullIntervalFlag,
 	NodeRequestTimeoutFlag,
 	NumConnectionsToNodesFlag,

--- a/disperser/cmd/controller/main.go
+++ b/disperser/cmd/controller/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Layr-Labs/eigenda/disperser/cmd/controller/flags"
 	"github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
 	"github.com/Layr-Labs/eigenda/disperser/controller"
+	"github.com/Layr-Labs/eigenda/disperser/encoder"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/gammazero/workerpool"
@@ -75,12 +76,16 @@ func RunController(ctx *cli.Context) error {
 		config.DynamoDBTableName,
 	)
 
+	encoderClient, err := encoder.NewEncoderClientV2(config.EncodingManagerConfig.EncoderAddress)
+	if err != nil {
+		return fmt.Errorf("failed to create encoder client: %v", err)
+	}
 	encodingPool := workerpool.New(config.NumConcurrentEncodingRequests)
 	encodingManager, err := controller.NewEncodingManager(
 		config.EncodingManagerConfig,
 		blobMetadataStore,
 		encodingPool,
-		nil, // TODO(ian-shim): configure encodingClient
+		encoderClient,
 		chainReader,
 		logger,
 	)

--- a/disperser/controller/encoding_manager.go
+++ b/disperser/controller/encoding_manager.go
@@ -22,7 +22,7 @@ import (
 var errNoBlobsToEncode = errors.New("no blobs to encode")
 
 type EncodingManagerConfig struct {
-	PullInterval           time.Duration
+	PullInterval time.Duration
 
 	EncodingRequestTimeout time.Duration
 	StoreTimeout           time.Duration
@@ -32,6 +32,8 @@ type EncodingManagerConfig struct {
 	NumRelayAssignment uint16
 	// AvailableRelays is a list of available relays
 	AvailableRelays []corev2.RelayKey
+	// EncoderAddress is the address of the encoder
+	EncoderAddress string
 }
 
 // EncodingManager is responsible for pulling queued blobs from the blob

--- a/disperser/encoder/client_v2.go
+++ b/disperser/encoder/client_v2.go
@@ -3,7 +3,6 @@ package encoder
 import (
 	"context"
 	"fmt"
-	"time"
 
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/disperser"
@@ -14,14 +13,12 @@ import (
 )
 
 type clientV2 struct {
-	addr    string
-	timeout time.Duration
+	addr string
 }
 
-func NewEncoderClientV2(addr string, timeout time.Duration) (disperser.EncoderClientV2, error) {
+func NewEncoderClientV2(addr string) (disperser.EncoderClientV2, error) {
 	return &clientV2{
-		addr:    addr,
-		timeout: timeout,
+		addr: addr,
 	}, nil
 }
 
@@ -46,13 +43,6 @@ func (c *clientV2) EncodeBlob(ctx context.Context, blobKey corev2.BlobKey, encod
 			ChunkLength: encodingParams.ChunkLength,
 			NumChunks:   encodingParams.NumChunks,
 		},
-	}
-
-	// Add timeout if specified
-	if c.timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, c.timeout)
-		defer cancel()
 	}
 
 	// Make the RPC call


### PR DESCRIPTION
## Why are these changes needed?
- sets up encoding client in encoding manager
- removes `timeout` from the client and uses context in the parameter
- make controller use EthClient in RPC only mode
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
