### PR TITLE
[v2] Disperser server `GetBlobCommitment` endpoint

### DIFF
--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api"
+	pbcommon "github.com/Layr-Labs/eigenda/api/grpc/common"
 	pb "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	"github.com/Layr-Labs/eigenda/common"
 	healthcheck "github.com/Layr-Labs/eigenda/common/healthcheck"
@@ -15,6 +16,7 @@ import (
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/disperser"
 	"github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
+	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -38,6 +40,7 @@ type DispersalServerV2 struct {
 	chainReader   core.Reader
 	ratelimiter   common.RateLimiter
 	authenticator corev2.BlobRequestAuthenticator
+	prover        encoding.Prover
 	logger        logging.Logger
 
 	// state
@@ -55,6 +58,7 @@ func NewDispersalServerV2(
 	chainReader core.Reader,
 	ratelimiter common.RateLimiter,
 	authenticator corev2.BlobRequestAuthenticator,
+	prover encoding.Prover,
 	maxNumSymbolsPerBlob uint64,
 	onchainStateRefreshInterval time.Duration,
 	_logger logging.Logger,
@@ -70,6 +74,7 @@ func NewDispersalServerV2(
 		chainReader:   chainReader,
 		ratelimiter:   ratelimiter,
 		authenticator: authenticator,
+		prover:        prover,
 		logger:        logger,
 
 		onchainState:                OnchainState{},
@@ -149,7 +154,40 @@ func (s *DispersalServerV2) GetBlobStatus(ctx context.Context, req *pb.BlobStatu
 }
 
 func (s *DispersalServerV2) GetBlobCommitment(ctx context.Context, req *pb.BlobCommitmentRequest) (*pb.BlobCommitmentReply, error) {
-	return &pb.BlobCommitmentReply{}, api.NewErrorUnimplemented()
+	if s.prover == nil {
+		return nil, api.NewErrorUnimplemented()
+	}
+	blobSize := len(req.GetData())
+	if blobSize == 0 {
+		return nil, api.NewErrorInvalidArg("data is empty")
+	}
+	if uint64(blobSize) > s.maxNumSymbolsPerBlob*encoding.BYTES_PER_SYMBOL {
+		return nil, api.NewErrorInvalidArg(fmt.Sprintf("blob size cannot exceed %v bytes", s.maxNumSymbolsPerBlob*encoding.BYTES_PER_SYMBOL))
+	}
+	c, err := s.prover.GetCommitments(req.GetData())
+	if err != nil {
+		return nil, api.NewErrorInternal("failed to get commitments")
+	}
+	commitment, err := c.Commitment.Serialize()
+	if err != nil {
+		return nil, api.NewErrorInternal("failed to serialize commitment")
+	}
+	lengthCommitment, err := c.LengthCommitment.Serialize()
+	if err != nil {
+		return nil, api.NewErrorInternal("failed to serialize length commitment")
+	}
+	lengthProof, err := c.LengthProof.Serialize()
+	if err != nil {
+		return nil, api.NewErrorInternal("failed to serialize length proof")
+	}
+
+	return &pb.BlobCommitmentReply{
+		BlobCommitment: &pbcommon.BlobCommitment{
+			Commitment:       commitment,
+			LengthCommitment: lengthCommitment,
+			LengthProof:      lengthProof,
+			Length:           uint32(c.Length),
+		}}, nil
 }
 
 func (s *DispersalServerV2) RefreshAllowlist() error {

--- a/disperser/cmd/apiserver/config.go
+++ b/disperser/cmd/apiserver/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/disperser/apiserver"
 	"github.com/Layr-Labs/eigenda/disperser/cmd/apiserver/flags"
 	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
+	"github.com/Layr-Labs/eigenda/encoding/kzg"
 	"github.com/urfave/cli"
 )
 
@@ -31,6 +32,7 @@ type Config struct {
 	MetricsConfig               disperser.MetricsConfig
 	RatelimiterConfig           ratelimit.Config
 	RateConfig                  apiserver.RateConfig
+	EncodingConfig              kzg.KzgConfig
 	EnableRatelimiter           bool
 	EnablePaymentMeterer        bool
 	UpdateInterval              int
@@ -88,6 +90,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		},
 		RatelimiterConfig:           ratelimiterConfig,
 		RateConfig:                  rateConfig,
+		EncodingConfig:              kzg.ReadCLIConfig(ctx),
 		EnableRatelimiter:           ctx.GlobalBool(flags.EnableRatelimiter.Name),
 		EnablePaymentMeterer:        ctx.GlobalBool(flags.EnablePaymentMeterer.Name),
 		ReservationsTableName:       ctx.GlobalString(flags.ReservationsTableName.Name),

--- a/disperser/cmd/apiserver/flags/flags.go
+++ b/disperser/cmd/apiserver/flags/flags.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
@@ -8,6 +9,7 @@ import (
 	"github.com/Layr-Labs/eigenda/common/geth"
 	"github.com/Layr-Labs/eigenda/common/ratelimit"
 	"github.com/Layr-Labs/eigenda/disperser/apiserver"
+	"github.com/Layr-Labs/eigenda/encoding/kzg"
 	"github.com/urfave/cli"
 )
 
@@ -154,6 +156,73 @@ var (
 	}
 )
 
+var kzgFlags = []cli.Flag{
+	// KZG flags for encoding
+	// These are copied from encoding/kzg/cli.go as optional flags for compatibility between v1 and v2 dispersers
+	// These flags are only used in v2 disperser
+	cli.StringFlag{
+		Name:     kzg.G1PathFlagName,
+		Usage:    "Path to G1 SRS",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "G1_PATH"),
+	},
+	cli.StringFlag{
+		Name:     kzg.G2PathFlagName,
+		Usage:    "Path to G2 SRS. Either this flag or G2_POWER_OF_2_PATH needs to be specified. For operator node, if both are specified, the node uses G2_POWER_OF_2_PATH first, if failed then tries to G2_PATH",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "G2_PATH"),
+	},
+	cli.StringFlag{
+		Name:     kzg.CachePathFlagName,
+		Usage:    "Path to SRS Table directory",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "CACHE_PATH"),
+	},
+	cli.Uint64Flag{
+		Name:     kzg.SRSOrderFlagName,
+		Usage:    "Order of the SRS",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "SRS_ORDER"),
+	},
+	cli.Uint64Flag{
+		Name:     kzg.SRSLoadingNumberFlagName,
+		Usage:    "Number of SRS points to load into memory",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "SRS_LOAD"),
+	},
+	cli.Uint64Flag{
+		Name:     kzg.NumWorkerFlagName,
+		Usage:    "Number of workers for multithreading",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "NUM_WORKERS"),
+		Value:    uint64(runtime.GOMAXPROCS(0)),
+	},
+	cli.BoolFlag{
+		Name:     kzg.VerboseFlagName,
+		Usage:    "Enable to see verbose output for encoding/decoding",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "VERBOSE"),
+	},
+	cli.BoolFlag{
+		Name:     kzg.CacheEncodedBlobsFlagName,
+		Usage:    "Enable to cache encoded results",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "CACHE_ENCODED_BLOBS"),
+	},
+	cli.BoolFlag{
+		Name:     kzg.PreloadEncoderFlagName,
+		Usage:    "Set to enable Encoder PreLoading",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "PRELOAD_ENCODER"),
+	},
+	cli.StringFlag{
+		Name:     kzg.G2PowerOf2PathFlagName,
+		Usage:    "Path to G2 SRS points that are on power of 2. Either this flag or G2_PATH needs to be specified. For operator node, if both are specified, the node uses G2_POWER_OF_2_PATH first, if failed then tries to G2_PATH",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "G2_POWER_OF_2_PATH"),
+	},
+}
+
 var requiredFlags = []cli.Flag{
 	S3BucketNameFlag,
 	DynamoDBTableNameFlag,
@@ -189,4 +258,5 @@ func init() {
 	Flags = append(Flags, ratelimit.RatelimiterCLIFlags(envVarPrefix, FlagPrefix)...)
 	Flags = append(Flags, aws.ClientFlags(envVarPrefix, FlagPrefix)...)
 	Flags = append(Flags, apiserver.CLIFlags(envVarPrefix)...)
+	Flags = append(Flags, kzgFlags...)
 }


### PR DESCRIPTION
## Why are these changes needed?
Loads a prover with G2 points and computes commitment on `GetBlobCommitment` request
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
