### PR TITLE
Add encoder queueing stats for autoscaling

### DIFF
--- a/disperser/batcher/metrics.go
+++ b/disperser/batcher/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/disperser"
+	"github.com/Layr-Labs/eigenda/disperser/common"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -370,7 +371,7 @@ func (e *EncodingStreamerMetrics) UpdateEncodedBlobs(count int, size uint64) {
 }
 
 func (e *EncodingStreamerMetrics) ObserveEncodingLatency(state string, quorumId core.QuorumID, blobSize int, latencyMs float64) {
-	e.BlobEncodingLatency.WithLabelValues(state, fmt.Sprintf("%d", quorumId), blobSizeBucket(blobSize)).Observe(latencyMs)
+	e.BlobEncodingLatency.WithLabelValues(state, fmt.Sprintf("%d", quorumId), common.BlobSizeBucket(blobSize)).Observe(latencyMs)
 }
 
 func (t *TxnManagerMetrics) ObserveLatency(stage string, latencyMs float64) {
@@ -407,35 +408,4 @@ func (f *FinalizerMetrics) UpdateLastSeenFinalizedBlock(blockNumber uint64) {
 
 func (f *FinalizerMetrics) ObserveLatency(stage string, latencyMs float64) {
 	f.Latency.WithLabelValues(stage).Observe(latencyMs)
-}
-
-// blobSizeBucket maps the blob size into a bucket that's defined according to
-// the power of 2.
-func blobSizeBucket(blobSize int) string {
-	switch {
-	case blobSize <= 32*1024:
-		return "32KiB"
-	case blobSize <= 64*1024:
-		return "64KiB"
-	case blobSize <= 128*1024:
-		return "128KiB"
-	case blobSize <= 256*1024:
-		return "256KiB"
-	case blobSize <= 512*1024:
-		return "512KiB"
-	case blobSize <= 1024*1024:
-		return "1MiB"
-	case blobSize <= 2*1024*1024:
-		return "2MiB"
-	case blobSize <= 4*1024*1024:
-		return "4MiB"
-	case blobSize <= 8*1024*1024:
-		return "8MiB"
-	case blobSize <= 16*1024*1024:
-		return "16MiB"
-	case blobSize <= 32*1024*1024:
-		return "32MiB"
-	default:
-		return "invalid"
-	}
 }

--- a/disperser/common/utils.go
+++ b/disperser/common/utils.go
@@ -1,0 +1,42 @@
+package common
+
+// BlobSizeBucket maps the blob size into a bucket that's defined according to
+// the power of 2.
+func BlobSizeBucket(blobSize int) string {
+	switch {
+	case blobSize <= 1*1024:
+		return "1KiB"
+	case blobSize <= 2*1024:
+		return "2KiB"
+	case blobSize <= 4*1024:
+		return "4KiB"
+	case blobSize <= 8*1024:
+		return "8KiB"
+	case blobSize <= 16*1024:
+		return "16KiB"
+	case blobSize <= 32*1024:
+		return "32KiB"
+	case blobSize <= 64*1024:
+		return "64KiB"
+	case blobSize <= 128*1024:
+		return "128KiB"
+	case blobSize <= 256*1024:
+		return "256KiB"
+	case blobSize <= 512*1024:
+		return "512KiB"
+	case blobSize <= 1024*1024:
+		return "1MiB"
+	case blobSize <= 2*1024*1024:
+		return "2MiB"
+	case blobSize <= 4*1024*1024:
+		return "4MiB"
+	case blobSize <= 8*1024*1024:
+		return "8MiB"
+	case blobSize <= 16*1024*1024:
+		return "16MiB"
+	case blobSize <= 32*1024*1024:
+		return "32MiB"
+	default:
+		return "invalid"
+	}
+}

--- a/disperser/encoder/server.go
+++ b/disperser/encoder/server.go
@@ -47,6 +47,7 @@ func NewEncoderServer(config ServerConfig, logger logging.Logger, prover encodin
 
 		runningRequests: make(chan struct{}, config.MaxConcurrentRequests),
 		requestPool:     make(chan blobRequest, config.RequestPoolSize),
+		queueStats:      make(map[int]int),
 	}
 }
 


### PR DESCRIPTION
## Why are these changes needed?
The encoding queue is the indication to apply back pressure for autoscaling/ratelimiting of the encoding subsystem.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
