### PR TITLE
Track bucket instead of sizes

### DIFF
--- a/disperser/encoder/metrics.go
+++ b/disperser/encoder/metrics.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Layr-Labs/eigenda/disperser/common"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -107,9 +106,9 @@ func (m *Metrics) ObserveLatency(stage string, duration time.Duration) {
 	m.Latency.WithLabelValues(stage).Observe(float64(duration.Milliseconds()))
 }
 
-func (m *Metrics) ObserveQueue(queueStats map[int]int) {
-	for blobSize, num := range queueStats {
-		m.BlobQueue.With(prometheus.Labels{"size_bucket": common.BlobSizeBucket(blobSize)}).Set(float64(num))
+func (m *Metrics) ObserveQueue(queueStats map[string]int) {
+	for bucket, num := range queueStats {
+		m.BlobQueue.With(prometheus.Labels{"size_bucket": bucket}).Set(float64(num))
 	}
 }
 


### PR DESCRIPTION
## Why are these changes needed?
Make the queue stats map track stats at bucket (not blob size) level.

Otherwise, if it tracks at blob size level, in worst case, there may be 32M entries, which will every inefficient to track (i.e. scan 32M entries each time it tries to update metric).


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
