### PR TITLE
Add additional queue metrics

### DIFF
--- a/disperser/encoder/metrics.go
+++ b/disperser/encoder/metrics.go
@@ -27,6 +27,8 @@ type Metrics struct {
 	BlobSizeTotal         *prometheus.CounterVec
 	Latency               *prometheus.SummaryVec
 	BlobQueue             *prometheus.GaugeVec
+	QueueCapacity         prometheus.Gauge
+	QueueUtilization      prometheus.Gauge
 }
 
 func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
@@ -71,6 +73,20 @@ func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
 			},
 			[]string{"size_bucket"},
 		),
+		QueueCapacity: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "eigenda_encoder",
+				Name:      "request_pool_capacity",
+				Help:      "The maximum capacity of the request pool",
+			},
+		),
+		QueueUtilization: promauto.With(reg).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "eigenda_encoder",
+				Name:      "request_pool_utilization",
+				Help:      "Current utilization of request pool (total across all buckets)",
+			},
+		),
 	}
 }
 
@@ -107,9 +123,16 @@ func (m *Metrics) ObserveLatency(stage string, duration time.Duration) {
 }
 
 func (m *Metrics) ObserveQueue(queueStats map[string]int) {
+	total := 0
 	for bucket, num := range queueStats {
 		m.BlobQueue.With(prometheus.Labels{"size_bucket": bucket}).Set(float64(num))
+		total += num
 	}
+	m.QueueUtilization.Set(float64(total))
+}
+
+func (m *Metrics) SetQueueCapacity(capacity int) {
+	m.QueueCapacity.Set(float64(capacity))
 }
 
 func (m *Metrics) Start(ctx context.Context) {

--- a/disperser/encoder/metrics.go
+++ b/disperser/encoder/metrics.go
@@ -29,7 +29,6 @@ type Metrics struct {
 	BlobQueue             *prometheus.GaugeVec
 	QueueCapacity         prometheus.Gauge
 	QueueUtilization      prometheus.Gauge
-	IncomingRequestRate *prometheus.GaugeVec
 }
 
 func NewMetrics(reg *prometheus.Registry, httpPort string, logger logging.Logger) *Metrics {
@@ -86,14 +85,6 @@ func NewMetrics(reg *prometheus.Registry, httpPort string, logger logging.Logger
 				Name:      "request_pool_utilization",
 				Help:      "Current utilization of request pool (total across all buckets)",
 			},
-		),
-		IncomingRequestRate: promauto.With(reg).NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "eigenda_encoder",
-				Name:      "incoming_request_rate",
-				Help:      "The rate of incoming requests per second, categorized by size bucket",
-			},
-			[]string{"size_bucket"},
 		),
 	}
 }

--- a/disperser/encoder/metrics.go
+++ b/disperser/encoder/metrics.go
@@ -29,10 +29,10 @@ type Metrics struct {
 	BlobQueue             *prometheus.GaugeVec
 	QueueCapacity         prometheus.Gauge
 	QueueUtilization      prometheus.Gauge
+	IncomingRequestRate *prometheus.GaugeVec
 }
 
-func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
-	reg := prometheus.NewRegistry()
+func NewMetrics(reg *prometheus.Registry, httpPort string, logger logging.Logger) *Metrics {
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(collectors.NewGoCollector())
 
@@ -86,6 +86,14 @@ func NewMetrics(httpPort string, logger logging.Logger) *Metrics {
 				Name:      "request_pool_utilization",
 				Help:      "Current utilization of request pool (total across all buckets)",
 			},
+		),
+		IncomingRequestRate: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "eigenda_encoder",
+				Name:      "incoming_request_rate",
+				Help:      "The rate of incoming requests per second, categorized by size bucket",
+			},
+			[]string{"size_bucket"},
 		),
 	}
 }

--- a/disperser/encoder/server_v2_test.go
+++ b/disperser/encoder/server_v2_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Layr-Labs/eigenda/encoding/kzg/prover"
 	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
 	"github.com/Layr-Labs/eigenda/relay/chunkstore"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
@@ -196,7 +197,7 @@ func createTestComponents(t *testing.T) *testComponents {
 	t.Helper()
 	prover, err := makeTestProver(300000)
 	require.NoError(t, err, "Failed to create prover")
-	metrics := encoder.NewMetrics("9000", logger)
+	metrics := encoder.NewMetrics(prometheus.NewRegistry(), "9000", logger)
 	s3Client := mock.NewS3Client()
 	dynamoDBClient := &mock.MockDynamoDBClient{}
 	blobStore := blobstore.NewBlobStore(s3BucketName, s3Client, logger)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -173,12 +173,12 @@ func mustMakeDisperser(t *testing.T, cst core.IndexedChainState, store disperser
 	}
 
 	p0, _ := mustMakeTestComponents()
-	metrics := encoder.NewMetrics("9000", logger)
+	metrics := encoder.NewMetrics(prometheus.NewRegistry(), "9000", logger)
 	grpcEncoder := encoder.NewEncoderServer(encoder.ServerConfig{
 		GrpcPort:              encoderPort,
 		MaxConcurrentRequests: 16,
 		RequestPoolSize:       32,
-	}, logger, p0, metrics)
+	}, logger, p0, metrics, nil)
 
 	encoderClient, err := encoder.NewEncoderClient(batcherConfig.EncoderSocket, 10*time.Second)
 	if err != nil {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -178,7 +178,7 @@ func mustMakeDisperser(t *testing.T, cst core.IndexedChainState, store disperser
 		GrpcPort:              encoderPort,
 		MaxConcurrentRequests: 16,
 		RequestPoolSize:       32,
-	}, logger, p0, metrics, nil)
+	}, logger, p0, metrics, grpcprom.NewServerMetrics())
 
 	encoderClient, err := encoder.NewEncoderClient(batcherConfig.EncoderSocket, 10*time.Second)
 	if err != nil {


### PR DESCRIPTION
## Why are these changes needed?

![image](https://github.com/user-attachments/assets/ce11c84c-0fdc-432f-b508-3a32d234a614)

Added max queue capacity so we can do computations to get utilization (useful if we want to scale using percentage of the request pool). Also adds overall request pool utilization for convenience.


This PR also adds GRPC metrics similar to https://github.com/Layr-Labs/eigenda/pull/891

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
