### PR TITLE
[v2] disperser client payments api

### DIFF
--- a/api/clients/accountant.go
+++ b/api/clients/accountant.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	commonpb "github.com/Layr-Labs/eigenda/api/grpc/common"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/meterer"
 )
@@ -16,7 +15,7 @@ import (
 var requiredQuorums = []uint8{0, 1}
 
 type Accountant interface {
-	AccountBlob(ctx context.Context, numSymbols uint64, quorums []uint8) (*commonpb.PaymentHeader, error)
+	AccountBlob(ctx context.Context, numSymbols uint64, quorums []uint8) (*core.PaymentMetadata, error)
 }
 
 var _ Accountant = &accountant{}
@@ -116,7 +115,7 @@ func (a *accountant) BlobPaymentInfo(ctx context.Context, numSymbols uint64, quo
 }
 
 // AccountBlob accountant provides and records payment information
-func (a *accountant) AccountBlob(ctx context.Context, numSymbols uint64, quorums []uint8) (*commonpb.PaymentHeader, error) {
+func (a *accountant) AccountBlob(ctx context.Context, numSymbols uint64, quorums []uint8) (*core.PaymentMetadata, error) {
 	binIndex, cumulativePayment, err := a.BlobPaymentInfo(ctx, numSymbols, quorums)
 	if err != nil {
 		return nil, err
@@ -127,9 +126,8 @@ func (a *accountant) AccountBlob(ctx context.Context, numSymbols uint64, quorums
 		BinIndex:          binIndex,
 		CumulativePayment: cumulativePayment,
 	}
-	protoPaymentHeader := pm.ConvertToProtoPaymentHeader()
 
-	return protoPaymentHeader, nil
+	return pm, nil
 }
 
 // TODO: PaymentCharged and SymbolsCharged copied from meterer, should be refactored

--- a/api/clients/accountant.go
+++ b/api/clients/accountant.go
@@ -162,33 +162,19 @@ func (a *accountant) GetRelativeBinRecord(index uint32) *BinRecord {
 func (a *accountant) SetPaymentState(paymentState *disperser_rpc.GetPaymentStateReply) error {
 	if paymentState == nil {
 		return fmt.Errorf("payment state cannot be nil")
-	}
-
-	if paymentState.PaymentGlobalParams == nil {
+	} else if paymentState.GetPaymentGlobalParams() == nil {
 		return fmt.Errorf("payment global params cannot be nil")
-	}
-
-	if paymentState.OnchainCumulativePayment == nil {
+	} else if paymentState.GetOnchainCumulativePayment() == nil {
 		return fmt.Errorf("onchain cumulative payment cannot be nil")
-	}
-
-	if paymentState.CumulativePayment == nil {
+	} else if paymentState.GetCumulativePayment() == nil {
 		return fmt.Errorf("cumulative payment cannot be nil")
-	}
-
-	if paymentState.Reservation == nil {
+	} else if paymentState.GetReservation() == nil {
 		return fmt.Errorf("reservation cannot be nil")
-	}
-
-	if paymentState.Reservation.QuorumNumbers == nil {
+	} else if paymentState.GetReservation().GetQuorumNumbers() == nil {
 		return fmt.Errorf("reservation quorum numbers cannot be nil")
-	}
-
-	if paymentState.Reservation.QuorumSplit == nil {
+	} else if paymentState.GetReservation().GetQuorumSplit() == nil {
 		return fmt.Errorf("reservation quorum split cannot be nil")
-	}
-
-	if paymentState.BinRecords == nil {
+	} else if paymentState.GetBinRecords() == nil {
 		return fmt.Errorf("bin records cannot be nil")
 	}
 

--- a/api/clients/disperser_client_v2.go
+++ b/api/clients/disperser_client_v2.go
@@ -89,7 +89,11 @@ func (c *disperserClientV2) PopulateAccountant(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error getting payment state for initializing accountant: %w", err)
 	}
-	c.accountant.SetPaymentState(paymentState)
+
+	err = c.accountant.SetPaymentState(paymentState)
+	if err != nil {
+		return fmt.Errorf("error setting payment state for accountant: %w", err)
+	}
 	return nil
 }
 

--- a/api/clients/disperser_client_v2.go
+++ b/api/clients/disperser_client_v2.go
@@ -84,7 +84,6 @@ func NewDisperserClientV2(config *DisperserClientV2Config, signer corev2.BlobReq
 }
 
 // PopulateAccountant populates the accountant with the payment state from the disperser.
-// This function is required to be called before using the accountant. Perhaps rename to Start()?
 func (c *disperserClientV2) PopulateAccountant(ctx context.Context) error {
 	paymentState, err := c.GetPaymentState(ctx)
 	if err != nil {
@@ -119,6 +118,9 @@ func (c *disperserClientV2) DisperseBlob(
 
 	if c.signer == nil {
 		return nil, [32]byte{}, api.NewErrorInternal("uninitialized signer for authenticated dispersal")
+	}
+	if c.accountant == nil {
+		return nil, [32]byte{}, api.NewErrorInternal("uninitialized accountant for paid dispersal; make sure to call PopulateAccountant after creating the client")
 	}
 
 	symbolLength := encoding.GetBlobLengthPowerOf2(uint(len(data)))

--- a/api/clients/disperser_client_v2.go
+++ b/api/clients/disperser_client_v2.go
@@ -35,7 +35,7 @@ type disperserClientV2 struct {
 	conn       *grpc.ClientConn
 	client     disperser_rpc.DisperserClient
 	prover     encoding.Prover
-	accountant *accountant
+	accountant *Accountant
 }
 
 var _ DisperserClientV2 = &disperserClientV2{}
@@ -60,7 +60,7 @@ var _ DisperserClientV2 = &disperserClientV2{}
 //
 //	// Subsequent calls will use the existing connection
 //	status2, blobKey2, err := client.DisperseBlob(ctx, data, blobHeader)
-func NewDisperserClientV2(config *DisperserClientV2Config, signer corev2.BlobRequestSigner, prover encoding.Prover, accountant *accountant) (*disperserClientV2, error) {
+func NewDisperserClientV2(config *DisperserClientV2Config, signer corev2.BlobRequestSigner, prover encoding.Prover, accountant *Accountant) (*disperserClientV2, error) {
 	if config == nil {
 		return nil, api.NewErrorInvalidArg("config must be provided")
 	}

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -255,6 +255,10 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 	for i, v := range reservation.QuorumNumbers {
 		quorumNumbers[i] = uint32(v)
 	}
+	quorumSplit := make([]uint32, len(reservation.QuorumSplit))
+	for i, v := range reservation.QuorumSplit {
+		quorumSplit[i] = uint32(v)
+	}
 	// build reply
 	reply := &pb.GetPaymentStateReply{
 		PaymentGlobalParams: &paymentGlobalParams,
@@ -264,6 +268,7 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 			StartTimestamp:   uint32(reservation.StartTimestamp),
 			EndTimestamp:     uint32(reservation.EndTimestamp),
 			QuorumNumbers:    quorumNumbers,
+			QuorumSplit:      quorumSplit,
 		},
 		CumulativePayment:        largestCumulativePayment.Bytes(),
 		OnchainCumulativePayment: onDemandPayment.CumulativePayment.Bytes(),


### PR DESCRIPTION
## Why are these changes needed?

properly construct payment header in the dispersal request

For easy initialization of DisperserClient, pass in an empty accountant `&accountant{}` and then call `client.PopulateAccountant(ctx)` to populate the accountant by getting payment information both on-chain and off-chain for the local signer.

For more customized initialization, the user can explicitly construct their accountant and pass in as the argument



## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
