### PR TITLE
Optimize the Disperser perf

### DIFF
--- a/common/aws/s3/client.go
+++ b/common/aws/s3/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 
@@ -105,15 +106,32 @@ func NewClient(ctx context.Context, cfg commonaws.ClientConfig, logger logging.L
 	return ref, err
 }
 
+func PeekObjectSize(ctx context.Context, s3Client *s3.Client, bucket, key string) (int64, error) {
+	input := &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+	result, err := s3Client.HeadObject(ctx, input)
+	if err != nil {
+		return 0, fmt.Errorf("failed to head object: %w", err)
+	}
+	return *result.ContentLength, nil
+}
+
 func (s *client) DownloadObject(ctx context.Context, bucket string, key string) ([]byte, error) {
+	size, err := PeekObjectSize(ctx, s.s3Client, bucket, key)
+	if err != nil {
+		return nil, err
+	}
+	buffer := manager.NewWriteAtBuffer(make([]byte, 0, size))
+
 	var partMiBs int64 = 10
 	downloader := manager.NewDownloader(s.s3Client, func(d *manager.Downloader) {
 		d.PartSize = partMiBs * 1024 * 1024 // 10MB per part
 		d.Concurrency = 3                   //The number of goroutines to spin up in parallel per call to Upload when sending parts
 	})
 
-	buffer := manager.NewWriteAtBuffer([]byte{})
-	_, err := downloader.Download(ctx, buffer, &s3.GetObjectInput{
+	_, err = downloader.Download(ctx, buffer, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})


### PR DESCRIPTION
## Why are these changes needed?
The Disperser in particular the retrieval latency was 60+ seconds, when there was high traffic and/or large blobs.

There was due to inefficient memory management when dealing with blob buffer from S3, making it spend a lot of CPU/time on memory allocation and GC.

**Tested:**
From local retrieval query for a large blob,

Before:
```
time grpcurl -max-msg-sz 15000000 -proto ./api/proto/disperser/disperser.proto -import-path ./api/proto -d '{"batch_header_hash": "G9ntJR15dlOlljWQnx2avoT39XqLD5STAo91B8OMBqw=", "blob_index": 613 }' disperser-holesky.eigenda.xyz:443 disperser.Disperser/RetrieveBlob > /dev/null 2>&1
real	0m7.335s
user	0m0.357s
sys	0m0.157s
```

After:
```
time grpcurl -max-msg-sz 15000000 -proto ./api/proto/disperser/disperser.proto -import-path ./api/proto -d '{"batch_header_hash": "G9ntJR15dlOlljWQnx2avoT39XqLD5STAo91B8OMBqw=", "blob_index": 613 }' disperser-holesky.eigenda.xyz:443 disperser.Disperser/RetrieveBlob > /dev/null 2>&1

real	0m0.847s
user	0m0.382s
sys	0m0.152s
```

From pprof:

Before:
![mem](https://github.com/user-attachments/assets/550bdc70-875a-40d9-9afa-1c71b5570bc8)



After:

![Screenshot 2024-11-22 at 2 45 13 PM](https://github.com/user-attachments/assets/4195475e-f6ec-4d8b-912a-fd65b153e3c8)


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
