### PR TITLE
Do not fail the object fetch when object size is unknown

### DIFF
--- a/common/aws/s3/client.go
+++ b/common/aws/s3/client.go
@@ -18,6 +18,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	defaultBlobBufferSizeByte = 128 * 1024
+)
+
 var (
 	once              sync.Once
 	ref               *client
@@ -106,7 +110,7 @@ func NewClient(ctx context.Context, cfg commonaws.ClientConfig, logger logging.L
 }
 
 func (s *client) DownloadObject(ctx context.Context, bucket string, key string) ([]byte, error) {
-	objectSize := 128 * 1024
+	objectSize := defaultBlobBufferSizeByte
 	size, err := s.HeadObject(ctx, bucket, key)
 	if err == nil {
 		objectSize = int(*size)

--- a/common/aws/s3/client.go
+++ b/common/aws/s3/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"runtime"
 	"sync"
 
@@ -106,24 +105,13 @@ func NewClient(ctx context.Context, cfg commonaws.ClientConfig, logger logging.L
 	return ref, err
 }
 
-func PeekObjectSize(ctx context.Context, s3Client *s3.Client, bucket, key string) (int64, error) {
-	input := &s3.HeadObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	}
-	result, err := s3Client.HeadObject(ctx, input)
-	if err != nil {
-		return 0, fmt.Errorf("failed to head object: %w", err)
-	}
-	return *result.ContentLength, nil
-}
-
 func (s *client) DownloadObject(ctx context.Context, bucket string, key string) ([]byte, error) {
-	size, err := PeekObjectSize(ctx, s.s3Client, bucket, key)
-	if err != nil {
-		return nil, err
+	objectSize := 128 * 1024
+	size, err := s.HeadObject(ctx, bucket, key)
+	if err == nil {
+		objectSize = int(*size)
 	}
-	buffer := manager.NewWriteAtBuffer(make([]byte, 0, size))
+	buffer := manager.NewWriteAtBuffer(make([]byte, 0, objectSize))
 
 	var partMiBs int64 = 10
 	downloader := manager.NewDownloader(s.s3Client, func(d *manager.Downloader) {


### PR DESCRIPTION
## Why are these changes needed?
If it fails to peek the object size, we just use a default size and continue to download the blob (instead of failing it).

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
