### PR TITLE
Pull out the pprof server

### DIFF
--- a/common/pprof/server.go
+++ b/common/pprof/server.go
@@ -1,4 +1,4 @@
-package apiserver
+package pprof
 
 import (
 	"fmt"

--- a/disperser/apiserver/server.go
+++ b/disperser/apiserver/server.go
@@ -17,6 +17,7 @@ import (
 	pb "github.com/Layr-Labs/eigenda/api/grpc/disperser"
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/healthcheck"
+	"github.com/Layr-Labs/eigenda/common/pprof"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/auth"
 	"github.com/Layr-Labs/eigenda/core/meterer"
@@ -819,7 +820,7 @@ func (s *DispersalServer) GetRateConfig() *RateConfig {
 }
 
 func (s *DispersalServer) Start(ctx context.Context) error {
-	pprofProfiler := NewPprofProfiler(s.serverConfig.PprofHttpPort, s.logger)
+	pprofProfiler := pprof.NewPprofProfiler(s.serverConfig.PprofHttpPort, s.logger)
 	if s.serverConfig.EnablePprof {
 		go pprofProfiler.Start()
 		s.logger.Info("Enabled pprof for disperser apiserver", "port", s.serverConfig.PprofHttpPort)


### PR DESCRIPTION
## Why are these changes needed?
To make it shareable for services beyond Disperser

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
