### PR TITLE
Add latency metric for dispersal/retrieval with blob size breakdown

### DIFF
--- a/disperser/metrics.go
+++ b/disperser/metrics.go
@@ -24,6 +24,7 @@ type Metrics struct {
 	NumBlobRequests *prometheus.CounterVec
 	NumRpcRequests  *prometheus.CounterVec
 	BlobSize        *prometheus.GaugeVec
+	BlobLatency     *prometheus.GaugeVec
 	Latency         *prometheus.SummaryVec
 
 	httpPort string
@@ -78,6 +79,15 @@ func NewMetrics(reg *prometheus.Registry, httpPort string, logger logging.Logger
 			},
 			[]string{"method"},
 		),
+		BlobLatency: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "blob_latency_ms",
+				Help:      "blob dispersal or retrieval latency by size",
+			},
+			[]string{"method", "size_bucket"},
+		),
+
 		registry: reg,
 		httpPort: httpPort,
 		logger:   logger.With("component", "DisperserMetrics"),


### PR DESCRIPTION
## Why are these changes needed?
To enable the understanding of dispersal/retrieval latency v.s. blob sizes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
