### PR TITLE
Adds grpcurl/reflection support for v1 apis via disperser-v2 reflection service

### DIFF
--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/api"
 	pbcommon "github.com/Layr-Labs/eigenda/api/grpc/common"
+	pbv1 "github.com/Layr-Labs/eigenda/api/grpc/disperser"
 	pb "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	"github.com/Layr-Labs/eigenda/common"
 	healthcheck "github.com/Layr-Labs/eigenda/common/healthcheck"
@@ -30,6 +31,11 @@ type OnchainState struct {
 	RequiredQuorums       []core.QuorumID
 	BlobVersionParameters *corev2.BlobVersionParameterMap
 	TTL                   time.Duration
+}
+
+// Include disperser v1 protos to support grpcurl/reflection of v1 APIs
+type DispersalServerV1 struct {
+	pbv1.UnimplementedDisperserServer
 }
 
 type DispersalServerV2 struct {
@@ -97,6 +103,9 @@ func (s *DispersalServerV2) Start(ctx context.Context) error {
 	gs := grpc.NewServer(opt)
 	reflection.Register(gs)
 	pb.RegisterDisperserServer(gs, s)
+
+	// Unimplemented v1 server for grpcurl/reflection support
+	pbv1.RegisterDisperserServer(gs, &DispersalServerV1{})
 
 	// Register Server for Health Checks
 	name := pb.Disperser_ServiceDesc.ServiceName


### PR DESCRIPTION
## Why are these changes needed?

Adds grpcurl/reflection support for both v1 + v2 apis inside disperser-v2 to serve reflection requests from a single DNS
<img width="860" alt="image" src="https://github.com/user-attachments/assets/88e12abe-667a-4b8f-979e-ad1a757b5112">

To continue using `disperser*.eigenda.xzy` as the primary dispersal endpoint, we need to route reflection requests to a consolidated service that include both v1 + v2 proto service definitions
    
If v1 method is called on v2 server, it will return `NOT_IMPLEMENTED`. Note that v1 methods will never route to a v2 server because of the ALB routing rules.

```
> grpcurl disperser-preprod-holesky.eigenda.xyz:443 list
disperser.Disperser
disperser.v2.Disperser
grpc.health.v1.Health
grpc.reflection.v1.ServerReflection
grpc.reflection.v1alpha.ServerReflection
```

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(
