### PR TITLE
[v2] Update blob header hasher

### DIFF
--- a/core/chainio.go
+++ b/core/chainio.go
@@ -107,10 +107,10 @@ type Reader interface {
 	GetNumBlobVersions(ctx context.Context) (uint16, error)
 
 	// GetVersionedBlobParams returns the blob version parameters for the given block number and blob version.
-	GetVersionedBlobParams(ctx context.Context, blobVersion uint8) (*BlobVersionParameters, error)
+	GetVersionedBlobParams(ctx context.Context, blobVersion uint16) (*BlobVersionParameters, error)
 
 	// GetAllVersionedBlobParams returns the blob version parameters for all blob versions at the given block number.
-	GetAllVersionedBlobParams(ctx context.Context) (map[uint8]*BlobVersionParameters, error)
+	GetAllVersionedBlobParams(ctx context.Context) (map[uint16]*BlobVersionParameters, error)
 
 	// GetActiveReservations returns active reservations (end timestamp > current timestamp)
 	GetActiveReservations(ctx context.Context, accountIDs []gethcommon.Address) (map[gethcommon.Address]*ActiveReservation, error)

--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -647,7 +647,7 @@ func (t *Reader) GetNumBlobVersions(ctx context.Context) (uint16, error) {
 	})
 }
 
-func (t *Reader) GetVersionedBlobParams(ctx context.Context, blobVersion uint8) (*core.BlobVersionParameters, error) {
+func (t *Reader) GetVersionedBlobParams(ctx context.Context, blobVersion uint16) (*core.BlobVersionParameters, error) {
 	params, err := t.bindings.EigenDAServiceManager.GetBlobParams(&bind.CallOpts{
 		Context: ctx,
 	}, uint16(blobVersion))
@@ -661,7 +661,7 @@ func (t *Reader) GetVersionedBlobParams(ctx context.Context, blobVersion uint8) 
 	}, nil
 }
 
-func (t *Reader) GetAllVersionedBlobParams(ctx context.Context) (map[uint8]*core.BlobVersionParameters, error) {
+func (t *Reader) GetAllVersionedBlobParams(ctx context.Context) (map[uint16]*core.BlobVersionParameters, error) {
 	if t.bindings.ThresholdRegistry == nil {
 		return nil, errors.New("threshold registry not deployed")
 	}
@@ -671,8 +671,8 @@ func (t *Reader) GetAllVersionedBlobParams(ctx context.Context) (map[uint8]*core
 		return nil, err
 	}
 
-	res := make(map[uint8]*core.BlobVersionParameters)
-	for version := uint8(0); version < uint8(numBlobVersions); version++ {
+	res := make(map[uint16]*core.BlobVersionParameters)
+	for version := uint16(0); version < uint16(numBlobVersions); version++ {
 		params, err := t.GetVersionedBlobParams(ctx, version)
 		if err != nil && strings.Contains(err.Error(), "execution reverted") {
 			break

--- a/core/mock/writer.go
+++ b/core/mock/writer.go
@@ -203,7 +203,7 @@ func (t *MockWriter) GetNumBlobVersions(ctx context.Context) (uint16, error) {
 	return result.(uint16), args.Error(1)
 }
 
-func (t *MockWriter) GetVersionedBlobParams(ctx context.Context, blobVersion uint8) (*core.BlobVersionParameters, error) {
+func (t *MockWriter) GetVersionedBlobParams(ctx context.Context, blobVersion uint16) (*core.BlobVersionParameters, error) {
 	args := t.Called()
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -212,13 +212,13 @@ func (t *MockWriter) GetVersionedBlobParams(ctx context.Context, blobVersion uin
 	return result.(*core.BlobVersionParameters), args.Error(1)
 }
 
-func (t *MockWriter) GetAllVersionedBlobParams(ctx context.Context) (map[uint8]*core.BlobVersionParameters, error) {
+func (t *MockWriter) GetAllVersionedBlobParams(ctx context.Context) (map[uint16]*core.BlobVersionParameters, error) {
 	args := t.Called()
 	result := args.Get(0)
 	if result == nil {
 		return nil, args.Error(1)
 	}
-	return result.(map[uint8]*core.BlobVersionParameters), args.Error(1)
+	return result.(map[uint16]*core.BlobVersionParameters), args.Error(1)
 }
 
 func (t *MockWriter) PubkeyHashToOperator(ctx context.Context, operatorId core.OperatorID) (gethcommon.Address, error) {

--- a/core/v2/serialization_test.go
+++ b/core/v2/serialization_test.go
@@ -48,13 +48,14 @@ func TestBlobKeyFromHeader(t *testing.T) {
 			AccountID:         "0x123",
 			ReservationPeriod: 5,
 			CumulativePayment: big.NewInt(100),
+			Salt:              42,
 		},
 		Signature: []byte{1, 2, 3},
 	}
 	blobKey, err := bh.BlobKey()
 	assert.NoError(t, err)
-	// 0x1354b29d9dd9a332959795d17f456c219566417fdbf1a7b4f5d118f5c2a36bbd verified in solidity
-	assert.Equal(t, "1354b29d9dd9a332959795d17f456c219566417fdbf1a7b4f5d118f5c2a36bbd", blobKey.Hex())
+	// 0x22c9e31c3d79c7c4085b564113f488019cbae18198c9a4fc4ecd70a5742e8638 verified in solidity
+	assert.Equal(t, "22c9e31c3d79c7c4085b564113f488019cbae18198c9a4fc4ecd70a5742e8638", blobKey.Hex())
 }
 
 func TestBatchHeaderHash(t *testing.T) {
@@ -102,6 +103,7 @@ func TestBlobCertHash(t *testing.T) {
 				AccountID:         "0x123",
 				ReservationPeriod: 5,
 				CumulativePayment: big.NewInt(100),
+				Salt:              42,
 			},
 			Signature: []byte{1, 2, 3},
 		},
@@ -110,8 +112,8 @@ func TestBlobCertHash(t *testing.T) {
 
 	hash, err := blobCert.Hash()
 	assert.NoError(t, err)
-	// 0xad938e477d0bc1f9f4e8de7c5cd837560bdbb2dc7094207a7ad53e7442611a43 verified in solidity
-	assert.Equal(t, "ad938e477d0bc1f9f4e8de7c5cd837560bdbb2dc7094207a7ad53e7442611a43", hex.EncodeToString(hash[:]))
+	// 0x182087a394c8aab23e8da107c820679333c1efee66fd4380ba283c0e4c09efd6 verified in solidity
+	assert.Equal(t, "182087a394c8aab23e8da107c820679333c1efee66fd4380ba283c0e4c09efd6", hex.EncodeToString(hash[:]))
 }
 
 func TestBlobCertSerialization(t *testing.T) {
@@ -130,6 +132,7 @@ func TestBlobCertSerialization(t *testing.T) {
 				AccountID:         "0x123",
 				ReservationPeriod: 5,
 				CumulativePayment: big.NewInt(100),
+				Salt:              42,
 			},
 			Signature: []byte{1, 2, 3},
 		},

--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -14,7 +14,7 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
-type BlobVersion = uint8
+type BlobVersion = uint16
 
 // Assignment contains information about the set of chunks that a specific node will receive
 type Assignment struct {

--- a/disperser/dataapi/server_v2_test.go
+++ b/disperser/dataapi/server_v2_test.go
@@ -190,7 +190,7 @@ func TestFetchBlobHandlerV2(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, "Queued", response.Status)
-	assert.Equal(t, uint8(0), response.BlobHeader.BlobVersion)
+	assert.Equal(t, uint16(0), response.BlobHeader.BlobVersion)
 	assert.Equal(t, blobHeader.Signature, response.BlobHeader.Signature)
 	assert.Equal(t, blobHeader.PaymentMetadata.AccountID, response.BlobHeader.PaymentMetadata.AccountID)
 	assert.Equal(t, blobHeader.PaymentMetadata.ReservationPeriod, response.BlobHeader.PaymentMetadata.ReservationPeriod)

--- a/relay/relay_test_utils.go
+++ b/relay/relay_test_utils.go
@@ -183,7 +183,7 @@ func newMockChainReader() *coremock.MockWriter {
 	return w
 }
 
-func mockBlobParamsMap() map[uint8]*core.BlobVersionParameters {
+func mockBlobParamsMap() map[v2.BlobVersion]*core.BlobVersionParameters {
 	blobParams := &core.BlobVersionParameters{
 		NumChunks:       8192,
 		CodingRate:      8,


### PR DESCRIPTION
## Why are these changes needed?
- uses `uint16` for blob versions instead of `uint8`
- updates blob header hasher based on https://github.com/Layr-Labs/eigenda/pull/781/commits/76b43959db9a908e4d46d2eec5b92c12b4c4c303
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
