### PR TITLE
Update `RelayKey` type to `uint32`

### DIFF
--- a/core/chainio.go
+++ b/core/chainio.go
@@ -122,10 +122,10 @@ type Reader interface {
 	GetOnDemandPaymentByAccount(ctx context.Context, blockNumber uint32, accountID string) (OnDemandPayment, error)
 
 	// GetRelayURL returns the relay URL address for the given key.
-	GetRelayURL(ctx context.Context, key uint16) (string, error)
+	GetRelayURL(ctx context.Context, key uint32) (string, error)
 
 	// GetRelayURLs returns the relay URL addresses for all relays.
-	GetRelayURLs(ctx context.Context) (map[uint16]string, error)
+	GetRelayURLs(ctx context.Context) (map[uint32]string, error)
 }
 
 type Writer interface {

--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -712,7 +712,7 @@ func (t *Reader) GetOperatorSocket(ctx context.Context, operatorId core.Operator
 	return socket, nil
 }
 
-func (t *Reader) GetRelayURL(ctx context.Context, key uint16) (string, error) {
+func (t *Reader) GetRelayURL(ctx context.Context, key uint32) (string, error) {
 	if t.bindings.RelayRegistry == nil {
 		return "", errors.New("relay registry not deployed")
 	}
@@ -722,13 +722,13 @@ func (t *Reader) GetRelayURL(ctx context.Context, key uint16) (string, error) {
 	}, uint32(key))
 }
 
-func (t *Reader) GetRelayURLs(ctx context.Context) (map[uint16]string, error) {
+func (t *Reader) GetRelayURLs(ctx context.Context) (map[uint32]string, error) {
 	if t.bindings.RelayRegistry == nil {
 		return nil, errors.New("relay registry not deployed")
 	}
 
-	res := make(map[uint16]string)
-	relayKey := uint16(0)
+	res := make(map[uint32]string)
+	relayKey := uint32(0)
 	for {
 		url, err := t.bindings.RelayRegistry.GetRelayURL(&bind.CallOpts{
 			Context: ctx,

--- a/core/mock/writer.go
+++ b/core/mock/writer.go
@@ -251,18 +251,18 @@ func (t *MockWriter) GetOperatorSocket(ctx context.Context, operatorID core.Oper
 	return result.(string), args.Error(1)
 }
 
-func (t *MockWriter) GetRelayURL(ctx context.Context, key uint16) (string, error) {
+func (t *MockWriter) GetRelayURL(ctx context.Context, key uint32) (string, error) {
 	args := t.Called()
 	result := args.Get(0)
 	return result.(string), args.Error(1)
 }
 
-func (t *MockWriter) GetRelayURLs(ctx context.Context) (map[uint16]string, error) {
+func (t *MockWriter) GetRelayURLs(ctx context.Context) (map[uint32]string, error) {
 	args := t.Called()
 	result := args.Get(0)
 	if result == nil {
 		return nil, args.Error(1)
 	}
 
-	return result.(map[uint16]string), args.Error(1)
+	return result.(map[uint32]string), args.Error(1)
 }

--- a/core/v2/serialization.go
+++ b/core/v2/serialization.go
@@ -184,7 +184,7 @@ func (c *BlobCertificate) Hash() ([32]byte, error) {
 		},
 		{
 			Name: "relayKeys",
-			Type: "uint16[]",
+			Type: "uint32[]",
 		},
 	})
 	if err != nil {

--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -161,7 +161,7 @@ func (b *BlobHeader) GetEncodingParams(blobParams *core.BlobVersionParameters) (
 	}, nil
 }
 
-type RelayKey = uint16
+type RelayKey = uint32
 
 type BlobCertificate struct {
 	BlobHeader *BlobHeader


### PR DESCRIPTION
## Why are these changes needed?
Updating from uint16 to uint32 to match what's [onchain](https://github.com/Layr-Labs/eigenda/pull/781/files#diff-cdec0952c8ced0c189294d47b7ed4e379fd7d9a1f870f3cbf2500278ac2f1a5eR10)
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
