### PR TITLE
docs: update docs

### DIFF
--- a/encoding/kzg/prover/gnark/multiframe_proof.go
+++ b/encoding/kzg/prover/gnark/multiframe_proof.go
@@ -177,9 +177,7 @@ func (p *KzgMultiProofGnarkBackend) GetSlicesCoeff(polyFr []fr.Element, dimE, j,
 	return tm.GetFFTCoeff()
 }
 
-/*
-returns the power of 2 which is immediately bigger than the input
-*/
+// returns the power of 2 which is immediately bigger than the input
 func CeilIntPowerOf2Num(d uint64) uint64 {
 	nextPower := math.Ceil(math.Log2(float64(d)))
 	return uint64(math.Pow(2.0, nextPower))

--- a/encoding/test/main.go
+++ b/encoding/test/main.go
@@ -26,29 +26,27 @@ func main() {
 	//readpoints()
 }
 
-/*
-func readpoints() {
-	kzgConfig := &kzg.KzgConfig{
-		G1Path:          "../../inabox/resources/kzg/g1.point",
-		G2Path:          "../../inabox/resources/kzg/g2.point",
-		CacheDir:        "SRSTables",
-		SRSOrder:        3000,
-		SRSNumberToLoad: 3000,
-		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
-	}
-
-	// create encoding object
-	kzgGroup, _ := prover.NewProver(kzgConfig, true)
-	fmt.Println("there are ", len(kzgGroup.Srs.G1), "points")
-	for i := 0; i < len(kzgGroup.Srs.G1); i++ {
-
-		fmt.Printf("%v %v\n", i, string(kzgGroup.Srs.G1[i].String()))
-	}
-	if kzgGroup.Srs.G1[0].X == kzg.GenG1.X && kzgGroup.Srs.G1[0].Y == kzg.GenG1.Y {
-		fmt.Println("start with gen")
-	}
-}
-*/
+// func readpoints() {
+// 	kzgConfig := &kzg.KzgConfig{
+//		G1Path:          "../../inabox/resources/kzg/g1.point",
+//		G2Path:          "../../inabox/resources/kzg/g2.point",
+//		CacheDir:        "SRSTables",
+//		SRSOrder:        3000,
+//		SRSNumberToLoad: 3000,
+//		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
+//	}
+//
+//	// create encoding object
+//	kzgGroup, _ := prover.NewProver(kzgConfig, true)
+//	fmt.Println("there are ", len(kzgGroup.Srs.G1), "points")
+//	for i := 0; i < len(kzgGroup.Srs.G1); i++ {
+//
+//		fmt.Printf("%v %v\n", i, string(kzgGroup.Srs.G1[i].String()))
+//	}
+//	if kzgGroup.Srs.G1[0].X == kzg.GenG1.X && kzgGroup.Srs.G1[0].Y == kzg.GenG1.Y {
+//		fmt.Println("start with gen")
+//	}
+// }
 
 func TestKzgRs() {
 	numSymbols := 1024


### PR DESCRIPTION
when I was reading the code, I found that there are two styles of multi-line comments in file descriptions, namely '/**/' and '//'. I chose the ‘//’ comment when adjusting, because I found that most of the multi-line comments using file descriptions in the project were ‘//’