### PR TITLE
[node] Don't store certs in store v2

### DIFF
--- a/node/store_v2.go
+++ b/node/store_v2.go
@@ -78,22 +78,10 @@ func (s *storeV2) StoreBatch(batch *corev2.Batch, rawBundles []*RawBundles) ([]k
 
 	// Store blob shards
 	for _, bundles := range rawBundles {
-		// Store blob certificate
-		blobCertificateKeyBuilder, err := s.db.GetKeyBuilder(BlobCertificateTableName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get key builder for blob certificate: %v", err)
-		}
 		blobKey, err := bundles.BlobCertificate.BlobHeader.BlobKey()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get blob key: %v", err)
 		}
-		blobCertificateKey := blobCertificateKeyBuilder.Key(blobKey[:])
-		blobCertificateBytes, err := bundles.BlobCertificate.Serialize()
-		if err != nil {
-			return nil, fmt.Errorf("failed to serialize blob certificate: %v", err)
-		}
-		keys = append(keys, blobCertificateKey)
-		dbBatch.PutWithTTL(blobCertificateKey, blobCertificateBytes, s.ttl)
 
 		// Store bundles
 		for quorum, bundle := range bundles.Bundles {


### PR DESCRIPTION
## Why are these changes needed?
Node doesn't need to store blob certs 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
