### PR TITLE
[ci] Disable graph indexer integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,9 +82,6 @@ jobs:
       - name: eigenda-client
         run: go test -v ./api/clients --testnet-integration
 
-      - name: Graph Indexer
-        run: make build && go test -v ./core/thegraph
-
       - name: Inabox E2E
         run: make build && cd inabox && make run-e2e
 


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
