### PR TITLE
payments  - global reservation uses interval config

### DIFF
--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -786,7 +786,7 @@ func (t *Reader) GetGlobalSymbolsPerSecond(ctx context.Context) (uint64, error) 
 	return globalSymbolsPerSecond.Uint64(), nil
 }
 
-func (t *Reader) GetGlobalRateBinInterval(ctx context.Context) (uint64, error) {
+func (t *Reader) GetGlobalRateBinInterval(ctx context.Context) (uint32, error) {
 	if t.bindings.PaymentVault == nil {
 		return 0, errors.New("payment vault not deployed")
 	}
@@ -796,7 +796,7 @@ func (t *Reader) GetGlobalRateBinInterval(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return globalRateBinInterval.Uint64(), nil
+	return uint32(globalRateBinInterval.Uint64()), nil
 }
 
 func (t *Reader) GetMinNumSymbols(ctx context.Context) (uint32, error) {

--- a/core/meterer/meterer_test.go
+++ b/core/meterer/meterer_test.go
@@ -171,7 +171,7 @@ func TestMetererReservations(t *testing.T) {
 	ctx := context.Background()
 	paymentChainState.On("GetReservationWindow", testifymock.Anything).Return(uint32(1), nil)
 	paymentChainState.On("GetGlobalSymbolsPerSecond", testifymock.Anything).Return(uint64(1009), nil)
-	paymentChainState.On("GetGlobalRateBinInterval", testifymock.Anything).Return(uint64(1), nil)
+	paymentChainState.On("GetGlobalRateBinInterval", testifymock.Anything).Return(uint32(1), nil)
 	paymentChainState.On("GetMinNumSymbols", testifymock.Anything).Return(uint32(3), nil)
 
 	reservationPeriod := meterer.GetReservationPeriod(uint64(time.Now().Unix()), mt.ChainPaymentState.GetReservationWindow())

--- a/core/meterer/offchain_store.go
+++ b/core/meterer/offchain_store.go
@@ -93,9 +93,9 @@ func (s *OffchainStore) UpdateReservationBin(ctx context.Context, accountID stri
 	return binUsageValue, nil
 }
 
-func (s *OffchainStore) UpdateGlobalBin(ctx context.Context, reservationPeriod uint64, size uint64) (uint64, error) {
+func (s *OffchainStore) UpdateGlobalBin(ctx context.Context, reservationPeriod uint32, size uint64) (uint64, error) {
 	key := map[string]types.AttributeValue{
-		"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriod, 10)},
+		"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.FormatUint(uint64(reservationPeriod), 10)},
 	}
 
 	res, err := s.dynamoClient.IncrementBy(ctx, s.globalBinTableName, key, "BinUsage", size)

--- a/core/meterer/onchain_state.go
+++ b/core/meterer/onchain_state.go
@@ -20,7 +20,7 @@ type OnchainPayment interface {
 	GetOnDemandPaymentByAccount(ctx context.Context, accountID gethcommon.Address) (*core.OnDemandPayment, error)
 	GetOnDemandQuorumNumbers(ctx context.Context) ([]uint8, error)
 	GetGlobalSymbolsPerSecond() uint64
-	GetGlobalRateBinInterval() uint64
+	GetGlobalRateBinInterval() uint32
 	GetMinNumSymbols() uint32
 	GetPricePerSymbol() uint32
 	GetReservationWindow() uint32
@@ -42,7 +42,7 @@ type OnchainPaymentState struct {
 
 type PaymentVaultParams struct {
 	GlobalSymbolsPerSecond uint64
-	GlobalRateBinInterval  uint64
+	GlobalRateBinInterval  uint32
 	MinNumSymbols          uint32
 	PricePerSymbol         uint32
 	ReservationWindow      uint32
@@ -211,7 +211,7 @@ func (pcs *OnchainPaymentState) GetGlobalSymbolsPerSecond() uint64 {
 	return pcs.PaymentVaultParams.Load().GlobalSymbolsPerSecond
 }
 
-func (pcs *OnchainPaymentState) GetGlobalRateBinInterval() uint64 {
+func (pcs *OnchainPaymentState) GetGlobalRateBinInterval() uint32 {
 	return pcs.PaymentVaultParams.Load().GlobalRateBinInterval
 }
 

--- a/core/mock/payment_state.go
+++ b/core/mock/payment_state.go
@@ -62,9 +62,9 @@ func (m *MockOnchainPaymentState) GetGlobalSymbolsPerSecond() uint64 {
 	return args.Get(0).(uint64)
 }
 
-func (m *MockOnchainPaymentState) GetGlobalRateBinInterval() uint64 {
+func (m *MockOnchainPaymentState) GetGlobalRateBinInterval() uint32 {
 	args := m.Called()
-	return args.Get(0).(uint64)
+	return args.Get(0).(uint32)
 }
 
 func (m *MockOnchainPaymentState) GetMinNumSymbols() uint32 {

--- a/disperser/apiserver/server_v2_test.go
+++ b/disperser/apiserver/server_v2_test.go
@@ -443,6 +443,7 @@ func newTestServerV2(t *testing.T) *testComponents {
 	mockState.On("GetReservationWindow", tmock.Anything).Return(uint32(1), nil)
 	mockState.On("GetPricePerSymbol", tmock.Anything).Return(uint32(2), nil)
 	mockState.On("GetGlobalSymbolsPerSecond", tmock.Anything).Return(uint64(1009), nil)
+	mockState.On("GetGlobalRateBinInterval", tmock.Anything).Return(uint32(1), nil)
 	mockState.On("GetMinNumSymbols", tmock.Anything).Return(uint32(3), nil)
 
 	now := uint64(time.Now().Unix())


### PR DESCRIPTION
## Why are these changes needed?

Utilize the global rate reservation interval to make relative global index instead of directly using timestamps

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
