### PR TITLE
fix: V2 merkle check

### DIFF
--- a/contracts/src/libraries/EigenDABlobVerificationUtils.sol
+++ b/contracts/src/libraries/EigenDABlobVerificationUtils.sol
@@ -173,7 +173,7 @@ library EigenDABlobVerificationUtils {
             Merkle.verifyInclusionKeccak(
                 blobVerificationProof.inclusionProof, 
                 batchHeader.batchRoot, 
-                keccak256(abi.encodePacked(EigenDAHasher.hashBlobHeaderV2(blobVerificationProof.blobCertificate.blobHeader))),
+                EigenDAHasher.hashBlobCertificate(blobVerificationProof.blobCertificate),
                 blobVerificationProof.blobIndex
             ),
             "EigenDABlobVerificationUtils._verifyBlobV2ForQuorums: inclusion proof is invalid"
@@ -242,7 +242,7 @@ library EigenDABlobVerificationUtils {
             Merkle.verifyInclusionKeccak(
                 blobVerificationProof.inclusionProof, 
                 batchHeader.batchRoot, 
-                keccak256(abi.encodePacked(EigenDAHasher.hashBlobHeaderV2(blobVerificationProof.blobCertificate.blobHeader))),
+                EigenDAHasher.hashBlobCertificate(blobVerificationProof.blobCertificate),
                 blobVerificationProof.blobIndex
             ),
             "EigenDABlobVerificationUtils._verifyBlobV2ForQuorums: inclusion proof is invalid"

--- a/contracts/src/libraries/EigenDABlobVerificationUtils.sol
+++ b/contracts/src/libraries/EigenDABlobVerificationUtils.sol
@@ -173,7 +173,7 @@ library EigenDABlobVerificationUtils {
             Merkle.verifyInclusionKeccak(
                 blobVerificationProof.inclusionProof, 
                 batchHeader.batchRoot, 
-                EigenDAHasher.hashBlobCertificate(blobVerificationProof.blobCertificate),
+                keccak256(abi.encodePacked(EigenDAHasher.hashBlobCertificate(blobVerificationProof.blobCertificate))),
                 blobVerificationProof.blobIndex
             ),
             "EigenDABlobVerificationUtils._verifyBlobV2ForQuorums: inclusion proof is invalid"
@@ -242,7 +242,7 @@ library EigenDABlobVerificationUtils {
             Merkle.verifyInclusionKeccak(
                 blobVerificationProof.inclusionProof, 
                 batchHeader.batchRoot, 
-                EigenDAHasher.hashBlobCertificate(blobVerificationProof.blobCertificate),
+                keccak256(abi.encodePacked(EigenDAHasher.hashBlobCertificate(blobVerificationProof.blobCertificate))),
                 blobVerificationProof.blobIndex
             ),
             "EigenDABlobVerificationUtils._verifyBlobV2ForQuorums: inclusion proof is invalid"

--- a/contracts/src/libraries/EigenDAHasher.sol
+++ b/contracts/src/libraries/EigenDAHasher.sol
@@ -130,4 +130,17 @@ library EigenDAHasher {
             )
         );
     }
+
+    /**
+     * @notice hashes the given V2 blob certificate
+     * @param blobCertificate the V2 blob certificate to hash
+     */
+    function hashBlobCertificate(BlobCertificate memory blobCertificate) internal pure returns(bytes32) {
+        return keccak256(
+            abi.encode(
+                hashBlobHeaderV2(blobCertificate.blobHeader),
+                blobCertificate.relayKeys
+            )
+        );
+    }
 }


### PR DESCRIPTION
changes leaf from blob header hash to blob cert hash 
