### PR TITLE
fix: typos in documentation files

### DIFF
--- a/api/docs/node.md
+++ b/api/docs/node.md
@@ -90,7 +90,7 @@ BatchHeader (see core/data.go#BatchHeader)
 <a name="node-Blob"></a>
 
 ### Blob
-In EigenDA, the original blob to disperse is encoded as a polynomial via taking
+In EigenDA, the original blob to disperse is encoded as a polynomial via
 taking different point evaluations (i.e. erasure coding). These points are split
 into disjoint subsets which are assigned to different operator nodes in the EigenDA
 network.

--- a/api/proto/node/node.proto
+++ b/api/proto/node/node.proto
@@ -15,7 +15,7 @@ service Dispersal {
 	// for the protocol-defined length of custody. It will return a signature at the
 	// end to attest to the data in this request it has processed.
 	rpc StoreChunks(StoreChunksRequest) returns (StoreChunksReply) {}
-	// StoreBlobs is simiar to StoreChunks, but it stores the blobs using a different storage schema
+	// StoreBlobs is similar to StoreChunks, but it stores the blobs using a different storage schema
 	// so that the stored blobs can later be aggregated by AttestBatch method to a bigger batch.
 	// StoreBlobs + AttestBatch will eventually replace and deprecate StoreChunks method.
 	// DEPRECATED: StoreBlobs method is not used

--- a/api/proto/node/node.proto
+++ b/api/proto/node/node.proto
@@ -59,7 +59,7 @@ message StoreBlobsRequest {
 }
 
 message StoreBlobsReply {
-	// The operator's BLS sgnature signed on the blob header hashes.
+	// The operator's BLS signature signed on the blob header hashes.
 	// The ordering of the signatures must match the ordering of the blobs sent
 	// in the request, with empty signatures in the places for discarded blobs.
 	repeated google.protobuf.BytesValue signatures = 1;
@@ -131,7 +131,7 @@ message MerkleProof {
 // Types
 
 // In EigenDA, the original blob to disperse is encoded as a polynomial via taking
-// taking different point evaluations (i.e. erasure coding). These points are split
+// different point evaluations (i.e. erasure coding). These points are split
 // into disjoint subsets which are assigned to different operator nodes in the EigenDA
 // network.
 // The data in this message is a subset of these points that are assigned to a

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -166,7 +166,7 @@ var (
 
 	// This flag is used to control if the DA Node registers itself when it starts.
 	// This is useful for testing and for hosted node where we don't want to have
-	// mannual operation with CLI to register.
+	// manual operation with CLI to register.
 	// By default, it will not register itself at start.
 	RegisterAtNodeStartFlag = cli.BoolFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "register-at-node-start"),


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `via taking taking` to `via taking`
Corrected `mannual` to `manual`

Please review the changes and let me know if any additional changes are needed.