### PR TITLE
Handle nil operator ID in GetChunks()

### DIFF
--- a/relay/auth/authenticator.go
+++ b/relay/auth/authenticator.go
@@ -117,6 +117,10 @@ func (a *requestAuthenticator) AuthenticateGetChunksRequest(
 		return nil
 	}
 
+	if request.OperatorId == nil || len(request.OperatorId) != 32 {
+		return errors.New("invalid operator ID")
+	}
+
 	key, err := a.getOperatorKey(ctx, core.OperatorID(request.OperatorId))
 	if err != nil {
 		return fmt.Errorf("failed to get operator key: %w", err)

--- a/relay/auth/authenticator_test.go
+++ b/relay/auth/authenticator_test.go
@@ -241,3 +241,34 @@ func TestBadSignature(t *testing.T) {
 		now)
 	require.Error(t, err)
 }
+
+func TestMissingOperatorID(t *testing.T) {
+	tu.InitializeRandom()
+
+	ctx := context.Background()
+
+	operatorID := mock.MakeOperatorId(0)
+	stakes := map[core.QuorumID]map[core.OperatorID]int{
+		core.QuorumID(0): {
+			operatorID: 1,
+		},
+	}
+	ics, err := mock.NewChainDataMock(stakes)
+	require.NoError(t, err)
+	ics.Mock.On("GetCurrentBlockNumber").Return(uint(0), nil)
+
+	timeout := 10 * time.Second
+
+	authenticator, err := NewRequestAuthenticator(ctx, ics, 1024, timeout)
+	require.NoError(t, err)
+
+	request := randomGetChunksRequest()
+	request.OperatorId = nil
+
+	err = authenticator.AuthenticateGetChunksRequest(
+		ctx,
+		"foobar",
+		request,
+		time.Now())
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Why are these changes needed?

Without this check, the relay would panic if a `GetChunks()` RPC had a nil operator ID.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
