### PR TITLE
fix: make the api path naming plural

### DIFF
--- a/disperser/dataapi/docs/docs.go
+++ b/disperser/dataapi/docs/docs.go
@@ -15,7 +15,7 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/batch/{batch_header_hash}": {
+        "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -61,7 +61,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/blob/{blob_key}": {
+        "/blobs/{blob_key}": {
             "get": {
                 "produces": [
                     "application/json"

--- a/disperser/dataapi/docs/swagger.json
+++ b/disperser/dataapi/docs/swagger.json
@@ -11,7 +11,7 @@
         "version": "1"
     },
     "paths": {
-        "/batch/{batch_header_hash}": {
+        "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -57,7 +57,7 @@
                 }
             }
         },
-        "/blob/{blob_key}": {
+        "/blobs/{blob_key}": {
             "get": {
                 "produces": [
                     "application/json"

--- a/disperser/dataapi/docs/swagger.yaml
+++ b/disperser/dataapi/docs/swagger.yaml
@@ -361,7 +361,7 @@ info:
   title: EigenDA Data Access API
   version: "1"
 paths:
-  /batch/{batch_header_hash}:
+  /batches/{batch_header_hash}:
     get:
       parameters:
       - description: Batch header hash in hex string
@@ -391,7 +391,7 @@ paths:
       summary: Fetch batch by the batch header hash
       tags:
       - Feed
-  /blob/{blob_key}:
+  /blobs/{blob_key}:
     get:
       parameters:
       - description: Blob key in hex string

--- a/disperser/dataapi/server_v2.go
+++ b/disperser/dataapi/server_v2.go
@@ -105,13 +105,13 @@ func (s *ServerV2) Start() error {
 	{
 		blob := v2.Group("/blob")
 		{
-			blob.GET("/blob/feed", s.FetchBlobFeedHandler)
-			blob.GET("/blob/:blob_key", s.FetchBlobHandler)
+			blob.GET("/blobs/feed", s.FetchBlobFeedHandler)
+			blob.GET("/blobs/:blob_key", s.FetchBlobHandler)
 		}
 		batch := v2.Group("/batch")
 		{
-			batch.GET("/batch/feed", s.FetchBatchFeedHandler)
-			batch.GET("/batch/:batch_header_hash", s.FetchBatchHandler)
+			batch.GET("/batches/feed", s.FetchBatchFeedHandler)
+			batch.GET("/batches/:batch_header_hash", s.FetchBatchHandler)
 		}
 		operators := v2.Group("/operators")
 		{
@@ -180,7 +180,7 @@ func (s *ServerV2) FetchBlobFeedHandler(c *gin.Context) {
 //	@Failure	400			{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404			{object}	ErrorResponse	"error: Not found"
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"
-//	@Router		/blob/{blob_key} [get]
+//	@Router		/blobs/{blob_key} [get]
 func (s *ServerV2) FetchBlobHandler(c *gin.Context) {
 	start := time.Now()
 	blobKey, err := corev2.HexToBlobKey(c.Param("blob_key"))
@@ -221,7 +221,7 @@ func (s *ServerV2) FetchBatchFeedHandler(c *gin.Context) {
 //	@Failure	400					{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404					{object}	ErrorResponse	"error: Not found"
 //	@Failure	500					{object}	ErrorResponse	"error: Server error"
-//	@Router		/batch/{batch_header_hash} [get]
+//	@Router		/batches/{batch_header_hash} [get]
 func (s *ServerV2) FetchBatchHandler(c *gin.Context) {
 	start := time.Now()
 	batchHeaderHashHex := c.Param("batch_header_hash")

--- a/disperser/dataapi/server_v2_test.go
+++ b/disperser/dataapi/server_v2_test.go
@@ -174,9 +174,9 @@ func TestFetchBlobHandlerV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, err)
 
-	r.GET("/v2/blob/:blob_key", testDataApiServerV2.FetchBlobHandler)
+	r.GET("/v2/blobs/:blob_key", testDataApiServerV2.FetchBlobHandler)
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/v2/blob/"+blobKey.Hex(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/v2/blobs/"+blobKey.Hex(), nil)
 	r.ServeHTTP(w, req)
 	res := w.Result()
 	defer res.Body.Close()
@@ -232,9 +232,9 @@ func TestFetchBatchHandlerV2(t *testing.T) {
 	err = blobMetadataStore.PutAttestation(context.Background(), attestation)
 	require.NoError(t, err)
 
-	r.GET("/v2/batch/:batch_header_hash", testDataApiServerV2.FetchBatchHandler)
+	r.GET("/v2/batches/:batch_header_hash", testDataApiServerV2.FetchBatchHandler)
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/v2/batch/"+batchHeaderHash, nil)
+	req := httptest.NewRequest(http.MethodGet, "/v2/batches/"+batchHeaderHash, nil)
 	r.ServeHTTP(w, req)
 	res := w.Result()
 	defer res.Body.Close()


### PR DESCRIPTION
## Why are these changes needed?
To be consistent with `/operators/...` (and plural seems more usual in such case)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
