### PR TITLE
fix: properly set fields without onchain correspondance

### DIFF
--- a/api/clients/v2/accountant.go
+++ b/api/clients/v2/accountant.go
@@ -184,7 +184,13 @@ func (a *Accountant) SetPaymentState(paymentState *disperser_rpc.GetPaymentState
 	}
 
 	if paymentState.GetReservation() == nil {
-		a.reservation = core.DummyReservedPayment()
+		a.reservation = &core.ReservedPayment{
+			SymbolsPerSecond: 0,
+			StartTimestamp:   0,
+			EndTimestamp:     0,
+			QuorumNumbers:    []uint8{},
+			QuorumSplits:     []byte{},
+		}
 	} else {
 		a.reservation.SymbolsPerSecond = uint64(paymentState.GetReservation().GetSymbolsPerSecond())
 		a.reservation.StartTimestamp = uint64(paymentState.GetReservation().GetStartTimestamp())

--- a/core/data.go
+++ b/core/data.go
@@ -619,25 +619,9 @@ type ReservedPayment struct {
 	QuorumSplits []byte
 }
 
-func DummyReservedPayment() *ReservedPayment {
-	return &ReservedPayment{
-		SymbolsPerSecond: 0,
-		StartTimestamp:   0,
-		EndTimestamp:     0,
-		QuorumNumbers:    []uint8{},
-		QuorumSplits:     []byte{},
-	}
-}
-
 type OnDemandPayment struct {
 	// Total amount deposited by the user
 	CumulativePayment *big.Int
-}
-
-func DummyOnDemandPayment() *OnDemandPayment {
-	return &OnDemandPayment{
-		CumulativePayment: big.NewInt(0),
-	}
 }
 
 type BlobVersionParameters struct {

--- a/core/data.go
+++ b/core/data.go
@@ -619,9 +619,25 @@ type ReservedPayment struct {
 	QuorumSplits []byte
 }
 
+func DummyReservedPayment() *ReservedPayment {
+	return &ReservedPayment{
+		SymbolsPerSecond: 0,
+		StartTimestamp:   0,
+		EndTimestamp:     0,
+		QuorumNumbers:    []uint8{},
+		QuorumSplits:     []byte{},
+	}
+}
+
 type OnDemandPayment struct {
 	// Total amount deposited by the user
 	CumulativePayment *big.Int
+}
+
+func DummyOnDemandPayment() *OnDemandPayment {
+	return &OnDemandPayment{
+		CumulativePayment: big.NewInt(0),
+	}
 }
 
 type BlobVersionParameters struct {

--- a/core/meterer/offchain_store.go
+++ b/core/meterer/offchain_store.go
@@ -295,7 +295,7 @@ func (s *OffchainStore) GetLargestCumulativePayment(ctx context.Context, account
 	}
 
 	if len(payments) == 0 {
-		return nil, nil
+		return big.NewInt(0), nil
 	}
 
 	var payment *big.Int

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -255,18 +255,17 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 	currentReservationPeriod := meterer.GetReservationPeriod(now, reservationWindow)
 	binRecords, err := s.meterer.OffchainStore.GetBinRecords(ctx, req.AccountId, currentReservationPeriod)
 	if err != nil {
-		s.logger.Debug("failed to get reservation records, use placeholders", err, accountID)
+		s.logger.Debug("failed to get reservation records, use placeholders", "err", err, "accountID", accountID)
 	}
 	largestCumulativePayment, err := s.meterer.OffchainStore.GetLargestCumulativePayment(ctx, req.AccountId)
 	if err != nil {
-		s.logger.Debug("failed to get largest cumulative payment, use zero value", err)
+		s.logger.Debug("failed to get largest cumulative payment, use zero value", "err", err, "accountID", accountID)
 	}
 	// on-Chain account state
-	pbReservation := &pb.Reservation{}
+	var pbReservation *pb.Reservation
 	reservation, err := s.meterer.ChainPaymentState.GetReservedPaymentByAccount(ctx, accountID)
 	if err != nil {
-		s.logger.Debug("failed to get onchain reservation, use zero values", err)
-		pbReservation = nil
+		s.logger.Debug("failed to get onchain reservation, use zero values", "err", err, "accountID", accountID)
 	} else {
 		quorumNumbers := make([]uint32, len(reservation.QuorumNumbers))
 		for i, v := range reservation.QuorumNumbers {
@@ -289,8 +288,7 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 	var onchainCumulativePayment *big.Int
 	onDemandPayment, err := s.meterer.ChainPaymentState.GetOnDemandPaymentByAccount(ctx, accountID)
 	if err != nil {
-		s.logger.Debug("failed to get ondemand payment, use zero value", err)
-		onchainCumulativePayment = nil
+		s.logger.Debug("failed to get ondemand payment, use zero value", "err", err, "accountID", accountID)
 	} else {
 		onchainCumulativePayment = onDemandPayment.CumulativePayment
 	}


### PR DESCRIPTION
## Why are these changes needed?

- do not let server return API errors when some users did not have payment set on-chain
- for the client's accoutant, use default values instead of failing when one of the payments info is missing

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
