### PR TITLE
init once accountant

### DIFF
--- a/api/clients/v2/accountant.go
+++ b/api/clients/v2/accountant.go
@@ -39,6 +39,13 @@ type BinRecord struct {
 	Usage uint64
 }
 
+func DummyBinRecord() *BinRecord {
+	return &BinRecord{
+		Index: 0,
+		Usage: 0,
+	}
+}
+
 func NewAccountant(accountID string, reservation *core.ReservedPayment, onDemand *core.OnDemandPayment, reservationWindow uint32, pricePerSymbol uint32, minNumSymbols uint32, numBins uint32) *Accountant {
 	//TODO: client storage; currently every instance starts fresh but on-chain or a small store makes more sense
 	// Also client is currently responsible for supplying network params, we need to add RPC in order to be automatic

--- a/api/clients/v2/accountant.go
+++ b/api/clients/v2/accountant.go
@@ -172,9 +172,13 @@ func (a *Accountant) SetPaymentState(paymentState *disperser_rpc.GetPaymentState
 	a.reservationWindow = uint32(paymentState.GetPaymentGlobalParams().GetReservationWindow())
 
 	if paymentState.GetOnchainCumulativePayment() == nil {
-		a.onDemand.CumulativePayment = big.NewInt(0)
+		a.onDemand = &core.OnDemandPayment{
+			CumulativePayment: big.NewInt(0),
+		}
 	} else {
-		a.onDemand.CumulativePayment = new(big.Int).SetBytes(paymentState.GetOnchainCumulativePayment())
+		a.onDemand = &core.OnDemandPayment{
+			CumulativePayment: new(big.Int).SetBytes(paymentState.GetOnchainCumulativePayment()),
+		}
 	}
 
 	if paymentState.GetCumulativePayment() == nil {
@@ -192,20 +196,21 @@ func (a *Accountant) SetPaymentState(paymentState *disperser_rpc.GetPaymentState
 			QuorumSplits:     []byte{},
 		}
 	} else {
-		a.reservation.SymbolsPerSecond = uint64(paymentState.GetReservation().GetSymbolsPerSecond())
-		a.reservation.StartTimestamp = uint64(paymentState.GetReservation().GetStartTimestamp())
-		a.reservation.EndTimestamp = uint64(paymentState.GetReservation().GetEndTimestamp())
 		quorumNumbers := make([]uint8, len(paymentState.GetReservation().GetQuorumNumbers()))
 		for i, quorum := range paymentState.GetReservation().GetQuorumNumbers() {
 			quorumNumbers[i] = uint8(quorum)
 		}
-		a.reservation.QuorumNumbers = quorumNumbers
-
 		quorumSplits := make([]uint8, len(paymentState.GetReservation().GetQuorumSplits()))
 		for i, quorum := range paymentState.GetReservation().GetQuorumSplits() {
 			quorumSplits[i] = uint8(quorum)
 		}
-		a.reservation.QuorumSplits = quorumSplits
+		a.reservation = &core.ReservedPayment{
+			SymbolsPerSecond: uint64(paymentState.GetReservation().GetSymbolsPerSecond()),
+			StartTimestamp:   uint64(paymentState.GetReservation().GetStartTimestamp()),
+			EndTimestamp:     uint64(paymentState.GetReservation().GetEndTimestamp()),
+			QuorumNumbers:    quorumNumbers,
+			QuorumSplits:     quorumSplits,
+		}
 	}
 
 	binRecords := make([]BinRecord, len(paymentState.GetBinRecords()))

--- a/api/clients/v2/accountant.go
+++ b/api/clients/v2/accountant.go
@@ -39,13 +39,6 @@ type BinRecord struct {
 	Usage uint64
 }
 
-func DummyBinRecord() *BinRecord {
-	return &BinRecord{
-		Index: 0,
-		Usage: 0,
-	}
-}
-
 func NewAccountant(accountID string, reservation *core.ReservedPayment, onDemand *core.OnDemandPayment, reservationWindow uint32, pricePerSymbol uint32, minNumSymbols uint32, numBins uint32) *Accountant {
 	//TODO: client storage; currently every instance starts fresh but on-chain or a small store makes more sense
 	// Also client is currently responsible for supplying network params, we need to add RPC in order to be automatic

--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -87,6 +87,14 @@ func NewDisperserClient(config *DisperserClientConfig, signer corev2.BlobRequest
 
 // PopulateAccountant populates the accountant with the payment state from the disperser.
 func (c *disperserClient) PopulateAccountant(ctx context.Context) error {
+	if c.accountant == nil {
+		accountId, err := c.signer.GetAccountID()
+		if err != nil {
+			return fmt.Errorf("error getting account ID: %w", err)
+		}
+		c.accountant = NewAccountant(accountId, nil, nil, 0, 0, 0, 0)
+	}
+
 	paymentState, err := c.GetPaymentState(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting payment state for initializing accountant: %w", err)

--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -30,13 +30,14 @@ type DisperserClient interface {
 }
 
 type disperserClient struct {
-	config     *DisperserClientConfig
-	signer     corev2.BlobRequestSigner
-	initOnce   sync.Once
-	conn       *grpc.ClientConn
-	client     disperser_rpc.DisperserClient
-	prover     encoding.Prover
-	accountant *Accountant
+	config             *DisperserClientConfig
+	signer             corev2.BlobRequestSigner
+	initOnceGrpc       sync.Once
+	initOnceAccountant sync.Once
+	conn               *grpc.ClientConn
+	client             disperser_rpc.DisperserClient
+	prover             encoding.Prover
+	accountant         *Accountant
 }
 
 var _ DisperserClient = &disperserClient{}
@@ -118,6 +119,10 @@ func (c *disperserClient) DisperseBlob(
 	salt uint32,
 ) (*dispv2.BlobStatus, corev2.BlobKey, error) {
 	err := c.initOnceGrpcConnection()
+	if err != nil {
+		return nil, [32]byte{}, api.NewErrorFailover(err)
+	}
+	err = c.initOncePopulateAccountant(ctx)
 	if err != nil {
 		return nil, [32]byte{}, api.NewErrorFailover(err)
 	}
@@ -273,7 +278,7 @@ func (c *disperserClient) GetBlobCommitment(ctx context.Context, data []byte) (*
 // If initialization fails, it caches the error and will return it on every subsequent call.
 func (c *disperserClient) initOnceGrpcConnection() error {
 	var initErr error
-	c.initOnce.Do(func() {
+	c.initOnceGrpc.Do(func() {
 		addr := fmt.Sprintf("%v:%v", c.config.Hostname, c.config.Port)
 		dialOptions := getGrpcDialOptions(c.config.UseSecureGrpcFlag)
 		conn, err := grpc.NewClient(addr, dialOptions...)
@@ -286,6 +291,25 @@ func (c *disperserClient) initOnceGrpcConnection() error {
 	})
 	if initErr != nil {
 		return fmt.Errorf("initializing grpc connection: %w", initErr)
+	}
+	return nil
+}
+
+// initOncePopulateAccountant initializes the accountant if it is not already initialized.
+// If initialization fails, it caches the error and will return it on every subsequent call.
+func (c *disperserClient) initOncePopulateAccountant(ctx context.Context) error {
+	var initErr error
+	c.initOnceAccountant.Do(func() {
+		if c.accountant == nil {
+			err := c.PopulateAccountant(ctx)
+			if err != nil {
+				initErr = err
+				return
+			}
+		}
+	})
+	if initErr != nil {
+		return fmt.Errorf("populating accountant: %w", initErr)
 	}
 	return nil
 }

--- a/core/data.go
+++ b/core/data.go
@@ -619,25 +619,9 @@ type ReservedPayment struct {
 	QuorumSplits []byte
 }
 
-func DummyReservedPayment() *ReservedPayment {
-	return &ReservedPayment{
-		SymbolsPerSecond: 0,
-		StartTimestamp:   0,
-		EndTimestamp:     0,
-		QuorumNumbers:    []uint8{},
-		QuorumSplits:     []byte{},
-	}
-}
-
 type OnDemandPayment struct {
 	// Total amount deposited by the user
 	CumulativePayment *big.Int
-}
-
-func DummyOnDemandPayment() *OnDemandPayment {
-	return &OnDemandPayment{
-		CumulativePayment: big.NewInt(0),
-	}
 }
 
 type BlobVersionParameters struct {

--- a/core/data.go
+++ b/core/data.go
@@ -619,9 +619,25 @@ type ReservedPayment struct {
 	QuorumSplits []byte
 }
 
+func DummyReservedPayment() *ReservedPayment {
+	return &ReservedPayment{
+		SymbolsPerSecond: 0,
+		StartTimestamp:   0,
+		EndTimestamp:     0,
+		QuorumNumbers:    []uint8{},
+		QuorumSplits:     []byte{},
+	}
+}
+
 type OnDemandPayment struct {
 	// Total amount deposited by the user
 	CumulativePayment *big.Int
+}
+
+func DummyOnDemandPayment() *OnDemandPayment {
+	return &OnDemandPayment{
+		CumulativePayment: big.NewInt(0),
+	}
 }
 
 type BlobVersionParameters struct {

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"net"
 	"sync/atomic"
 	"time"
@@ -285,9 +284,13 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 	if err != nil {
 		s.logger.Debug("failed to get reservation records, use placeholders", "err", err, "accountID", accountID)
 	}
+	var largestCumulativePaymentBytes []byte
 	largestCumulativePayment, err := s.meterer.OffchainStore.GetLargestCumulativePayment(ctx, req.AccountId)
 	if err != nil {
 		s.logger.Debug("failed to get largest cumulative payment, use zero value", "err", err, "accountID", accountID)
+
+	} else {
+		largestCumulativePaymentBytes = largestCumulativePayment.Bytes()
 	}
 	// on-Chain account state
 	var pbReservation *pb.Reservation
@@ -313,13 +316,12 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 		}
 	}
 
-	var onchainCumulativePayment *big.Int
+	var onchainCumulativePaymentBytes []byte
 	onDemandPayment, err := s.meterer.ChainPaymentState.GetOnDemandPaymentByAccount(ctx, accountID)
 	if err != nil {
 		s.logger.Debug("failed to get ondemand payment, use zero value", "err", err, "accountID", accountID)
-		onchainCumulativePayment = 
 	} else {
-		onchainCumulativePayment = onDemandPayment.CumulativePayment
+		onchainCumulativePaymentBytes = onDemandPayment.CumulativePayment.Bytes()
 	}
 
 	paymentGlobalParams := pb.PaymentGlobalParams{
@@ -334,8 +336,8 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 		PaymentGlobalParams:      &paymentGlobalParams,
 		BinRecords:               binRecords[:],
 		Reservation:              pbReservation,
-		CumulativePayment:        largestCumulativePayment.Bytes(),
-		OnchainCumulativePayment: onchainCumulativePayment.Bytes(),
+		CumulativePayment:        largestCumulativePaymentBytes,
+		OnchainCumulativePayment: onchainCumulativePaymentBytes,
 	}
 	return reply, nil
 }

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -317,6 +317,7 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 	onDemandPayment, err := s.meterer.ChainPaymentState.GetOnDemandPaymentByAccount(ctx, accountID)
 	if err != nil {
 		s.logger.Debug("failed to get ondemand payment, use zero value", "err", err, "accountID", accountID)
+		onchainCumulativePayment = 
 	} else {
 		onchainCumulativePayment = onDemandPayment.CumulativePayment
 	}

--- a/inabox/deploy/config.go
+++ b/inabox/deploy/config.go
@@ -225,7 +225,11 @@ func (env *Config) generateDisperserV2Vars(ind int, logPath, dbPath, grpcPort st
 		DISPERSER_SERVER_BLS_OPERATOR_STATE_RETRIVER: env.EigenDA.OperatorStateRetreiver,
 		DISPERSER_SERVER_EIGENDA_SERVICE_MANAGER:     env.EigenDA.ServiceManager,
 		DISPERSER_SERVER_DISPERSER_VERSION:           "2",
-		DISPERSER_SERVER_ENABLE_PAYMENT_METERER:      "true",
+
+		DISPERSER_SERVER_ENABLE_PAYMENT_METERER:  "true",
+		DISPERSER_SERVER_RESERVATIONS_TABLE_NAME: "e2e_v2_reservation",
+		DISPERSER_SERVER_ON_DEMAND_TABLE_NAME:    "e2e_v2_ondemand",
+		DISPERSER_SERVER_GLOBAL_RATE_TABLE_NAME:  "e2e_v2_global_reservation",
 	}
 
 	env.applyDefaults(&v, "DISPERSER_SERVER", "dis", ind)

--- a/inabox/deploy/config.go
+++ b/inabox/deploy/config.go
@@ -225,6 +225,7 @@ func (env *Config) generateDisperserV2Vars(ind int, logPath, dbPath, grpcPort st
 		DISPERSER_SERVER_BLS_OPERATOR_STATE_RETRIVER: env.EigenDA.OperatorStateRetreiver,
 		DISPERSER_SERVER_EIGENDA_SERVICE_MANAGER:     env.EigenDA.ServiceManager,
 		DISPERSER_SERVER_DISPERSER_VERSION:           "2",
+		DISPERSER_SERVER_ENABLE_PAYMENT_METERER:      "true",
 	}
 
 	env.applyDefaults(&v, "DISPERSER_SERVER", "dis", ind)

--- a/inabox/deploy/localstack.go
+++ b/inabox/deploy/localstack.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/common/aws"
 	"github.com/Layr-Labs/eigenda/common/store"
+	"github.com/Layr-Labs/eigenda/core/meterer"
 	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
 	blobstorev2 "github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
 	"github.com/ory/dockertest/v3"
@@ -140,6 +141,24 @@ func DeployResources(
 		if err != nil {
 			return err
 		}
+	}
+
+	v2PaymentName := "e2e_v2_"
+	// create payment related tables
+	err = meterer.CreateReservationTable(cfg, v2PaymentName+"reservation")
+	if err != nil {
+		fmt.Println("err", err)
+		return err
+	}
+	err = meterer.CreateOnDemandTable(cfg, v2PaymentName+"ondemand")
+	if err != nil {
+		fmt.Println("err", err)
+		return err
+	}
+	err = meterer.CreateGlobalReservationTable(cfg, v2PaymentName+"global_reservation")
+	if err != nil {
+		fmt.Println("err", err)
+		return err
 	}
 
 	return err


### PR DESCRIPTION
## Why are these changes needed?

Instead of relying on disperser client to call populate accountant before dispersing blobs, we add an init once function that automatically populate the accountant if it isn't constructed at the beginning 

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
