### PR TITLE
fix: make password as non required field

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -165,8 +165,8 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	if blsRemoteSignerEnabled && (ctx.GlobalString(flags.BLSRemoteSignerUrlFlag.Name) == "" || ctx.GlobalString(flags.BLSPublicKeyHexFlag.Name) == "") {
 		return nil, fmt.Errorf("BLS remote signer URL and Public Key Hex is required if BLS remote signer is enabled")
 	}
-	if !blsRemoteSignerEnabled && (ctx.GlobalString(flags.BlsKeyFileFlag.Name) == "" || ctx.GlobalString(flags.BlsKeyPasswordFlag.Name) == "") {
-		return nil, fmt.Errorf("BLS key file and password is required if BLS remote signer is disabled")
+	if !blsRemoteSignerEnabled && ctx.GlobalString(flags.BlsKeyFileFlag.Name) == "" {
+		return nil, fmt.Errorf("BLS key file is required if BLS remote signer is disabled")
 	}
 
 	// Decrypt BLS key


### PR DESCRIPTION
## Why are these changes needed?

Fixes #1021 

- Makes password as not required since folks do testing with no password encrypted keys.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
