### PR TITLE
Add `AlreadyExists` error from disperser

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -62,6 +62,10 @@ func NewErrorCanceled(msg string) error {
 	return newErrorGRPC(codes.Canceled, msg)
 }
 
+func NewErrorAlreadyExists(msg string) error {
+	return newErrorGRPC(codes.AlreadyExists, msg)
+}
+
 // ErrorFailover is returned by the disperser-client and eigenda-client to signify
 // that eigenda is temporarily unavailable, and suggest to the caller
 // (most likely some rollup batcher via the eigenda-proxy) to failover

--- a/disperser/apiserver/server_v2_test.go
+++ b/disperser/apiserver/server_v2_test.go
@@ -106,6 +106,14 @@ func TestV2DisperseBlob(t *testing.T) {
 	assert.Greater(t, blobMetadata.Expiry, uint64(now.Unix()))
 	assert.Greater(t, blobMetadata.RequestedAt, uint64(now.UnixNano()))
 	assert.Equal(t, blobMetadata.RequestedAt, blobMetadata.UpdatedAt)
+
+	// Try dispersing the same blob
+	reply, err = c.DispersalServerV2.DisperseBlob(ctx, &pbv2.DisperseBlobRequest{
+		Data:       data,
+		BlobHeader: blobHeaderProto,
+	})
+	assert.Nil(t, reply)
+	assert.ErrorContains(t, err, "blob already exists")
 }
 
 func TestV2DisperseBlobRequestValidation(t *testing.T) {

--- a/disperser/common/v2/blobstore/s3_blob_store.go
+++ b/disperser/common/v2/blobstore/s3_blob_store.go
@@ -26,7 +26,13 @@ func NewBlobStore(s3BucketName string, s3Client s3.Client, logger logging.Logger
 
 // StoreBlob adds a blob to the blob store
 func (b *BlobStore) StoreBlob(ctx context.Context, key corev2.BlobKey, data []byte) error {
-	err := b.s3Client.UploadObject(ctx, b.bucketName, s3.ScopedBlobKey(key), data)
+	_, err := b.s3Client.HeadObject(ctx, b.bucketName, s3.ScopedBlobKey(key))
+	if err == nil {
+		b.logger.Warnf("blob already exists in bucket %s: %s", b.bucketName, key)
+		return common.ErrAlreadyExists
+	}
+
+	err = b.s3Client.UploadObject(ctx, b.bucketName, s3.ScopedBlobKey(key), data)
 	if err != nil {
 		b.logger.Errorf("failed to upload blob in bucket %s: %v", b.bucketName, err)
 		return err


### PR DESCRIPTION
## Why are these changes needed?
If storage fails due to `AlreadyExists` error, return the right error code 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
