### PR TITLE
fix: global symbols per period and interval

### DIFF
--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -222,7 +222,6 @@ func (t *Reader) updateContractBindings(blsOperatorStateRetrieverAddr, eigenDASe
 			t.logger.Error("Failed to fetch PaymentVault contract", "err", err)
 			return err
 		}
-
 	}
 
 	t.bindings = &ContractBindings{
@@ -791,7 +790,7 @@ func (t *Reader) GetGlobalSymbolsPerSecond(ctx context.Context) (uint64, error) 
 	if t.bindings.PaymentVault == nil {
 		return 0, errors.New("payment vault not deployed")
 	}
-	globalSymbolsPerSecond, err := t.bindings.PaymentVault.GlobalRatePeriodInterval(&bind.CallOpts{
+	globalSymbolsPerSecond, err := t.bindings.PaymentVault.GlobalSymbolsPerPeriod(&bind.CallOpts{
 		Context: ctx,
 	})
 	if err != nil {
@@ -812,6 +811,7 @@ func (t *Reader) GetGlobalRatePeriodInterval(ctx context.Context) (uint32, error
 	}
 	return uint32(globalRateBinInterval), nil
 }
+
 func (t *Reader) GetMinNumSymbols(ctx context.Context) (uint32, error) {
 	if t.bindings.PaymentVault == nil {
 		return 0, errors.New("payment vault not deployed")

--- a/core/meterer/meterer.go
+++ b/core/meterer/meterer.go
@@ -176,6 +176,9 @@ func (m *Meterer) IncrementBinUsage(ctx context.Context, header core.PaymentMeta
 // GetReservationPeriod returns the current reservation period by chunking time by the bin interval;
 // bin interval used by the disperser should be public information
 func GetReservationPeriod(timestamp uint64, binInterval uint32) uint32 {
+	if binInterval == 0 {
+		return 0
+	}
 	return uint32(timestamp) / binInterval
 }
 
@@ -207,11 +210,11 @@ func (m *Meterer) ServeOnDemandRequest(ctx context.Context, header core.PaymentM
 	// Update bin usage atomically and check against bin capacity
 	if err := m.IncrementGlobalBinUsage(ctx, uint64(symbolsCharged)); err != nil {
 		//TODO: conditionally remove the payment based on the error type (maybe if the error is store-op related)
-		err := m.OffchainStore.RemoveOnDemandPayment(ctx, header.AccountID, header.CumulativePayment)
-		if err != nil {
-			return err
+		db_err := m.OffchainStore.RemoveOnDemandPayment(ctx, header.AccountID, header.CumulativePayment)
+		if db_err != nil {
+			return db_err
 		}
-		return fmt.Errorf("failed global rate limiting")
+		return fmt.Errorf("failed global rate limiting: %w", err)
 	}
 
 	return nil

--- a/core/meterer/meterer.go
+++ b/core/meterer/meterer.go
@@ -210,9 +210,9 @@ func (m *Meterer) ServeOnDemandRequest(ctx context.Context, header core.PaymentM
 	// Update bin usage atomically and check against bin capacity
 	if err := m.IncrementGlobalBinUsage(ctx, uint64(symbolsCharged)); err != nil {
 		//TODO: conditionally remove the payment based on the error type (maybe if the error is store-op related)
-		db_err := m.OffchainStore.RemoveOnDemandPayment(ctx, header.AccountID, header.CumulativePayment)
-		if db_err != nil {
-			return db_err
+		dbErr := m.OffchainStore.RemoveOnDemandPayment(ctx, header.AccountID, header.CumulativePayment)
+		if dbErr != nil {
+			return dbErr
 		}
 		return fmt.Errorf("failed global rate limiting: %w", err)
 	}

--- a/core/meterer/onchain_state.go
+++ b/core/meterer/onchain_state.go
@@ -77,6 +77,11 @@ func (pcs *OnchainPaymentState) GetPaymentVaultParams(ctx context.Context) (*Pay
 		return nil, err
 	}
 
+	globalRatePeriodInterval, err := pcs.tx.GetGlobalRatePeriodInterval(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	minNumSymbols, err := pcs.tx.GetMinNumSymbols(ctx)
 	if err != nil {
 		return nil, err
@@ -93,11 +98,12 @@ func (pcs *OnchainPaymentState) GetPaymentVaultParams(ctx context.Context) (*Pay
 	}
 
 	return &PaymentVaultParams{
-		OnDemandQuorumNumbers:  quorumNumbers,
-		GlobalSymbolsPerSecond: globalSymbolsPerSecond,
-		MinNumSymbols:          minNumSymbols,
-		PricePerSymbol:         pricePerSymbol,
-		ReservationWindow:      reservationWindow,
+		OnDemandQuorumNumbers:    quorumNumbers,
+		GlobalSymbolsPerSecond:   globalSymbolsPerSecond,
+		GlobalRatePeriodInterval: globalRatePeriodInterval,
+		MinNumSymbols:            minNumSymbols,
+		PricePerSymbol:           pricePerSymbol,
+		ReservationWindow:        reservationWindow,
 	}, nil
 }
 


### PR DESCRIPTION
## Why are these changes needed?

quick fixes related to global reservations

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
