### PR TITLE
Handle signature aggregation failure in dispatcher

### DIFF
--- a/disperser/common/v2/blob.go
+++ b/disperser/common/v2/blob.go
@@ -15,7 +15,7 @@ const (
 	Encoded
 	Certified
 	Failed
-	INSUFFICIENT_SIGNATURES
+	InsufficientSignatures
 )
 
 func (s BlobStatus) String() string {
@@ -28,7 +28,7 @@ func (s BlobStatus) String() string {
 		return "Certified"
 	case Failed:
 		return "Failed"
-	case INSUFFICIENT_SIGNATURES:
+	case InsufficientSignatures:
 		return "Insufficient Signatures"
 	default:
 		return "Unknown"
@@ -45,7 +45,7 @@ func (s BlobStatus) ToProfobuf() pb.BlobStatus {
 		return pb.BlobStatus_CERTIFIED
 	case Failed:
 		return pb.BlobStatus_FAILED
-	case INSUFFICIENT_SIGNATURES:
+	case InsufficientSignatures:
 		return pb.BlobStatus_INSUFFICIENT_SIGNATURES
 	default:
 		return pb.BlobStatus_UNKNOWN
@@ -63,7 +63,7 @@ func BlobStatusFromProtobuf(s pb.BlobStatus) (BlobStatus, error) {
 	case pb.BlobStatus_FAILED:
 		return Failed, nil
 	case pb.BlobStatus_INSUFFICIENT_SIGNATURES:
-		return INSUFFICIENT_SIGNATURES, nil
+		return InsufficientSignatures, nil
 	default:
 		return 0, fmt.Errorf("unknown blob status: %v", s)
 	}

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -42,11 +42,11 @@ const (
 
 var (
 	statusUpdatePrecondition = map[v2.BlobStatus][]v2.BlobStatus{
-		v2.Queued:                  {},
-		v2.Encoded:                 {v2.Queued},
-		v2.Certified:               {v2.Encoded},
-		v2.Failed:                  {v2.Queued, v2.Encoded},
-		v2.INSUFFICIENT_SIGNATURES: {v2.Encoded},
+		v2.Queued:                 {},
+		v2.Encoded:                {v2.Queued},
+		v2.Certified:              {v2.Encoded},
+		v2.Failed:                 {v2.Queued, v2.Encoded},
+		v2.InsufficientSignatures: {v2.Encoded},
 	}
 	ErrInvalidStateTransition = errors.New("invalid state transition")
 )


### PR DESCRIPTION
## Why are these changes needed?
Blob statuses should be properly updated before `HandleSignatures` returns
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
