### PR TITLE
Move SRS initialization logic into SRS constructor

### DIFF
--- a/encoding/kzg/prover/gnark/commitments.go
+++ b/encoding/kzg/prover/gnark/commitments.go
@@ -10,9 +10,8 @@ import (
 )
 
 type KzgCommitmentsGnarkBackend struct {
-	KzgConfig  *kzg.KzgConfig
-	Srs        *kzg.SRS
-	G2Trailing []bn254.G2Affine
+	KzgConfig *kzg.KzgConfig
+	Srs       *kzg.SRS
 }
 
 func (p *KzgCommitmentsGnarkBackend) ComputeLengthProof(coeffs []fr.Element) (*bn254.G2Affine, error) {
@@ -26,7 +25,7 @@ func (p *KzgCommitmentsGnarkBackend) ComputeLengthProofForLength(coeffs []fr.Ele
 	}
 
 	start := p.KzgConfig.SRSNumberToLoad - length
-	shiftedSecret := p.G2Trailing[start : start+uint64(len(coeffs))]
+	shiftedSecret := p.Srs.G2Trailing[start : start+uint64(len(coeffs))]
 	config := ecc.MultiExpConfig{}
 
 	//The proof of low degree is commitment of the polynomial shifted to the largest srs degree

--- a/encoding/kzg/srs.go
+++ b/encoding/kzg/srs.go
@@ -25,21 +25,83 @@
 package kzg
 
 import (
+	"errors"
+	"fmt"
+	"math"
+
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 )
 
 type SRS struct {
-
 	// [b.multiply(b.G1, pow(s, i, MODULUS)) for i in range(WIDTH+1)],
 	G1 []bn254.G1Affine
 	// [b.multiply(b.G2, pow(s, i, MODULUS)) for i in range(WIDTH+1)],
 	G2 []bn254.G2Affine
+	// TODO: is there a nice way to represent this field mathematically, as above?
+	G2Trailing []bn254.G2Affine
 }
 
-func NewSrs(G1 []bn254.G1Affine, G2 []bn254.G2Affine) (*SRS, error) {
+// NewSrs initializes the SRS struct using the configuration specified in a KzgConfig
+func NewSrs(kzgConfig *KzgConfig) (*SRS, error) {
+	if kzgConfig.SRSNumberToLoad > kzgConfig.SRSOrder {
+		return nil, fmt.Errorf(
+			"SRSOrder (%d) is less than srsNumberToLoad (%d)",
+			kzgConfig.SRSOrder,
+			kzgConfig.SRSNumberToLoad)
+	}
+
+	// read the whole order, and treat it as entire SRS for low degree proof
+	s1, err := ReadG1Points(kzgConfig.G1Path, kzgConfig.SRSNumberToLoad, kzgConfig.NumWorker)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %d G1 points from %s: %v", kzgConfig.SRSNumberToLoad, kzgConfig.G1Path, err)
+	}
+
+	s2 := make([]bn254.G2Affine, 0)
+	g2Trailing := make([]bn254.G2Affine, 0)
+
+	if kzgConfig.LoadG2Points {
+		if len(kzgConfig.G2Path) == 0 {
+			return nil, errors.New("G2Path is empty. However, object needs to load G2Points")
+		}
+
+		s2, err = ReadG2Points(kzgConfig.G2Path, kzgConfig.SRSNumberToLoad, kzgConfig.NumWorker)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %d G2 points from %s: %v", kzgConfig.SRSNumberToLoad, kzgConfig.G2Path, err)
+		}
+
+		g2Trailing, err = ReadG2PointSection(
+			kzgConfig.G2Path,
+			kzgConfig.SRSOrder-kzgConfig.SRSNumberToLoad,
+			kzgConfig.SRSOrder, // last exclusive
+			kzgConfig.NumWorker,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read trailing G2 points from %s: %v", kzgConfig.G2Path, err)
+		}
+	} else {
+		if len(kzgConfig.G2PowerOf2Path) == 0 && len(kzgConfig.G2Path) == 0 {
+			return nil, errors.New("both G2Path and G2PowerOf2Path are empty. However, object needs to load G2Points")
+		}
+
+		if len(kzgConfig.G2PowerOf2Path) != 0 {
+			if kzgConfig.SRSOrder == 0 {
+				return nil, errors.New("SRS order cannot be 0")
+			}
+
+			maxPower := uint64(math.Log2(float64(kzgConfig.SRSOrder)))
+			_, err := ReadG2PointSection(kzgConfig.G2PowerOf2Path, 0, maxPower, 1)
+			if err != nil {
+				return nil, fmt.Errorf("file located at %v is invalid", kzgConfig.G2PowerOf2Path)
+			}
+		} else {
+			return nil, fmt.Errorf(`G2PowerOf2Path is empty. However, object needs to load G2Points.
+						For most operators, this likely indicates that G2_POWER_OF_2_PATH is improperly configured.`)
+		}
+	}
 
 	return &SRS{
-		G1: G1,
-		G2: G2,
+		G1:         s1,
+		G2:         s2,
+		G2Trailing: g2Trailing,
 	}, nil
 }

--- a/encoding/kzg/srs.go
+++ b/encoding/kzg/srs.go
@@ -37,7 +37,7 @@ type SRS struct {
 	G1 []bn254.G1Affine
 	// [b.multiply(b.G2, pow(s, i, MODULUS)) for i in range(WIDTH+1)],
 	G2 []bn254.G2Affine
-	// TODO: is there a nice way to represent this field mathematically, as above?
+	// [b.multiply(b.G2, pow(s, i, MODULUS)) for i in range(SRS_ORDER - WIDTH -1, SRS_ORDER)],
 	G2Trailing []bn254.G2Affine
 }
 


### PR DESCRIPTION
## Changes

- Add `G2Trailing` SRS data into `SRS` struct
    - Discussed with @bxue-l2, since these points are SRS, it makes sense to include them in the struct directly
    - This change enabled the SRS initialization simplifications
- Extract SRS initialization from `Prover` and `Verifier`
    - The code in these two locations was nearly identical
    - This abstraction allows me to avoid an additional duplication of this logic, while implementing a [further](https://github.com/Layr-Labs/eigenda/pull/1051#discussion_r1894274288) utility which requires SRS


