### PR TITLE
Simplify commitment generation, and choose better name for util file

### DIFF
--- a/api/clients/v2/verification/commitment_utils.go
+++ b/api/clients/v2/verification/commitment_utils.go
@@ -38,9 +38,9 @@ func GenerateBlobCommitment(
 // GenerateAndCompareBlobCommitment generates the kzg-bn254 commitment of the blob, and compares it with a claimed
 // commitment. An error is returned if there is a problem generating the commitment, or if the comparison fails.
 func GenerateAndCompareBlobCommitment(
-	claimedCommitment *encoding.G1Commitment,
 	g1Srs []bn254.G1Affine,
-	blobBytes []byte) error {
+	blobBytes []byte,
+	claimedCommitment *encoding.G1Commitment) error {
 
 	computedCommitment, err := GenerateBlobCommitment(g1Srs, blobBytes)
 	if err != nil {

--- a/api/clients/v2/verification/commitment_utils.go
+++ b/api/clients/v2/verification/commitment_utils.go
@@ -12,9 +12,9 @@ import (
 // GenerateBlobCommitment computes a kzg-bn254 commitment of blob data using SRS
 func GenerateBlobCommitment(
 	g1Srs []bn254.G1Affine,
-	blob []byte) (*encoding.G1Commitment, error) {
+	blobBytes []byte) (*encoding.G1Commitment, error) {
 
-	inputFr, err := rs.ToFrArray(blob)
+	inputFr, err := rs.ToFrArray(blobBytes)
 	if err != nil {
 		return nil, fmt.Errorf("convert bytes to field elements, %w", err)
 	}
@@ -38,8 +38,8 @@ func GenerateBlobCommitment(
 // GenerateAndCompareBlobCommitment generates the kzg-bn254 commitment of the blob, and compares it with a claimed
 // commitment. An error is returned if there is a problem generating the commitment, or if the comparison fails.
 func GenerateAndCompareBlobCommitment(
-	g1Srs []bn254.G1Affine,
 	claimedCommitment *encoding.G1Commitment,
+	g1Srs []bn254.G1Affine,
 	blobBytes []byte) error {
 
 	computedCommitment, err := GenerateBlobCommitment(g1Srs, blobBytes)

--- a/api/clients/v2/verification/commitment_utils_test.go
+++ b/api/clients/v2/verification/commitment_utils_test.go
@@ -33,18 +33,18 @@ func TestComputeAndCompareKzgCommitmentSuccess(t *testing.T) {
 
 	srsNumberToLoad := computeSrsNumber(len(randomBytes))
 
-	s1, err := kzg.ReadG1Points(g1Path, srsNumberToLoad, uint64(runtime.GOMAXPROCS(0)))
-	require.NotNil(t, s1)
+	g1Srs, err := kzg.ReadG1Points(g1Path, srsNumberToLoad, uint64(runtime.GOMAXPROCS(0)))
+	require.NotNil(t, g1Srs)
 	require.NoError(t, err)
 
-	commitment, err := GenerateBlobCommitment(s1, randomBytes)
+	commitment, err := GenerateBlobCommitment(g1Srs, randomBytes)
 	require.NotNil(t, commitment)
 	require.NoError(t, err)
 
 	// make sure the commitment verifies correctly
 	err = GenerateAndCompareBlobCommitment(
-		s1,
 		commitment,
+		g1Srs,
 		randomBytes)
 	require.NoError(t, err)
 }
@@ -55,19 +55,19 @@ func TestComputeAndCompareKzgCommitmentFailure(t *testing.T) {
 
 	srsNumberToLoad := computeSrsNumber(len(randomBytes))
 
-	s1, err := kzg.ReadG1Points(g1Path, srsNumberToLoad, uint64(runtime.GOMAXPROCS(0)))
-	require.NotNil(t, s1)
+	g1Srs, err := kzg.ReadG1Points(g1Path, srsNumberToLoad, uint64(runtime.GOMAXPROCS(0)))
+	require.NotNil(t, g1Srs)
 	require.NoError(t, err)
 
-	commitment, err := GenerateBlobCommitment(s1, randomBytes)
+	commitment, err := GenerateBlobCommitment(g1Srs, randomBytes)
 	require.NotNil(t, commitment)
 	require.NoError(t, err)
 
 	// randomly modify the bytes, and make sure the commitment verification fails
 	randomlyModifyBytes(testRandom, randomBytes)
 	err = GenerateAndCompareBlobCommitment(
-		s1,
 		commitment,
+		g1Srs,
 		randomBytes)
 	require.NotNil(t, err)
 }
@@ -78,15 +78,15 @@ func TestGenerateBlobCommitmentEquality(t *testing.T) {
 
 	srsNumberToLoad := computeSrsNumber(len(randomBytes))
 
-	s1, err := kzg.ReadG1Points(g1Path, srsNumberToLoad, uint64(runtime.GOMAXPROCS(0)))
-	require.NotNil(t, s1)
+	g1Srs, err := kzg.ReadG1Points(g1Path, srsNumberToLoad, uint64(runtime.GOMAXPROCS(0)))
+	require.NotNil(t, g1Srs)
 	require.NoError(t, err)
 
 	// generate two identical commitments
-	commitment1, err := GenerateBlobCommitment(s1, randomBytes)
+	commitment1, err := GenerateBlobCommitment(g1Srs, randomBytes)
 	require.NotNil(t, commitment1)
 	require.NoError(t, err)
-	commitment2, err := GenerateBlobCommitment(s1, randomBytes)
+	commitment2, err := GenerateBlobCommitment(g1Srs, randomBytes)
 	require.NotNil(t, commitment2)
 	require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestGenerateBlobCommitmentEquality(t *testing.T) {
 
 	// randomly modify a byte
 	randomlyModifyBytes(testRandom, randomBytes)
-	commitmentA, err := GenerateBlobCommitment(s1, randomBytes)
+	commitmentA, err := GenerateBlobCommitment(g1Srs, randomBytes)
 	require.NotNil(t, commitmentA)
 	require.NoError(t, err)
 
@@ -106,8 +106,8 @@ func TestGenerateBlobCommitmentEquality(t *testing.T) {
 func TestGenerateBlobCommitmentTooLong(t *testing.T) {
 	srsNumberToLoad := uint64(500)
 
-	s1, err := kzg.ReadG1Points(g1Path, srsNumberToLoad, uint64(runtime.GOMAXPROCS(0)))
-	require.NotNil(t, s1)
+	g1Srs, err := kzg.ReadG1Points(g1Path, srsNumberToLoad, uint64(runtime.GOMAXPROCS(0)))
+	require.NotNil(t, g1Srs)
 	require.NoError(t, err)
 
 	// this is the absolute maximum number of bytes we can handle, given how the verifier was configured
@@ -115,13 +115,13 @@ func TestGenerateBlobCommitmentTooLong(t *testing.T) {
 
 	// an array of exactly this size should be fine
 	almostTooLongBytes := make([]byte, almostTooLongByteCount)
-	commitment1, err := GenerateBlobCommitment(s1, almostTooLongBytes)
+	commitment1, err := GenerateBlobCommitment(g1Srs, almostTooLongBytes)
 	require.NotNil(t, commitment1)
 	require.NoError(t, err)
 
 	// but 1 more byte is more than we can handle
 	tooLongBytes := make([]byte, almostTooLongByteCount+1)
-	commitment2, err := GenerateBlobCommitment(s1, tooLongBytes)
+	commitment2, err := GenerateBlobCommitment(g1Srs, tooLongBytes)
 	require.Nil(t, commitment2)
 	require.NotNil(t, err)
 }

--- a/api/clients/v2/verification/commitment_utils_test.go
+++ b/api/clients/v2/verification/commitment_utils_test.go
@@ -43,9 +43,9 @@ func TestComputeAndCompareKzgCommitmentSuccess(t *testing.T) {
 
 	// make sure the commitment verifies correctly
 	err = GenerateAndCompareBlobCommitment(
-		commitment,
 		g1Srs,
-		randomBytes)
+		randomBytes,
+		commitment)
 	require.NoError(t, err)
 }
 
@@ -66,9 +66,9 @@ func TestComputeAndCompareKzgCommitmentFailure(t *testing.T) {
 	// randomly modify the bytes, and make sure the commitment verification fails
 	randomlyModifyBytes(testRandom, randomBytes)
 	err = GenerateAndCompareBlobCommitment(
-		commitment,
 		g1Srs,
-		randomBytes)
+		randomBytes,
+		commitment)
 	require.NotNil(t, err)
 }
 


### PR DESCRIPTION
## Why are these changes needed?

- This PR slightly reworks the commitment generation utility, to address concerns raised [here](https://github.com/Layr-Labs/eigenda/pull/1051#discussion_r1894261800)
- After further consideration, I decided that constructing a verifier just to compute a commitment is improper code reuse. Commitment generation only requires SRS data, which can be sourced from anywhere.

## Checks

- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [X] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [X] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
