### PR TITLE
feat: add basic logging in disperser meterer

### DIFF
--- a/core/meterer/meterer.go
+++ b/core/meterer/meterer.go
@@ -74,6 +74,7 @@ func (m *Meterer) Start(ctx context.Context) {
 // TODO: return error if there's a rejection (with reasoning) or internal error (should be very rare)
 func (m *Meterer) MeterRequest(ctx context.Context, header core.PaymentMetadata, numSymbols uint, quorumNumbers []uint8) error {
 	accountID := gethcommon.HexToAddress(header.AccountID)
+	m.logger.Info("Validating incoming request's payment metadata", "paymentMetadata", header, "numSymbols", numSymbols, "quorumNumbers", quorumNumbers)
 	// Validate against the payment method
 	if header.CumulativePayment.Sign() == 0 {
 		reservation, err := m.ChainPaymentState.GetReservedPaymentByAccount(ctx, accountID)
@@ -98,6 +99,7 @@ func (m *Meterer) MeterRequest(ctx context.Context, header core.PaymentMetadata,
 
 // ServeReservationRequest handles the rate limiting logic for incoming requests
 func (m *Meterer) ServeReservationRequest(ctx context.Context, header core.PaymentMetadata, reservation *core.ReservedPayment, numSymbols uint, quorumNumbers []uint8) error {
+	m.logger.Info("Recording and validating reservation usage", "reservation", reservation)
 	if !reservation.IsActive(uint64(time.Now().Unix())) {
 		return fmt.Errorf("reservation not active")
 	}
@@ -186,6 +188,7 @@ func GetReservationPeriod(timestamp uint64, binInterval uint32) uint32 {
 // On-demand requests doesn't have additional quorum settings and should only be
 // allowed by ETH and EIGEN quorums
 func (m *Meterer) ServeOnDemandRequest(ctx context.Context, header core.PaymentMetadata, onDemandPayment *core.OnDemandPayment, numSymbols uint, headerQuorums []uint8) error {
+	m.logger.Info("Recording and validating on-demand usage", "onDemandPayment", onDemandPayment)
 	quorumNumbers, err := m.ChainPaymentState.GetOnDemandQuorumNumbers(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get on-demand quorum numbers: %w", err)

--- a/core/meterer/meterer.go
+++ b/core/meterer/meterer.go
@@ -99,7 +99,7 @@ func (m *Meterer) MeterRequest(ctx context.Context, header core.PaymentMetadata,
 
 // ServeReservationRequest handles the rate limiting logic for incoming requests
 func (m *Meterer) ServeReservationRequest(ctx context.Context, header core.PaymentMetadata, reservation *core.ReservedPayment, numSymbols uint, quorumNumbers []uint8) error {
-	m.logger.Info("Recording and validating reservation usage", "reservation", reservation)
+	m.logger.Info("Recording and validating reservation usage", "header", header, "reservation", reservation)
 	if !reservation.IsActive(uint64(time.Now().Unix())) {
 		return fmt.Errorf("reservation not active")
 	}
@@ -188,7 +188,7 @@ func GetReservationPeriod(timestamp uint64, binInterval uint32) uint32 {
 // On-demand requests doesn't have additional quorum settings and should only be
 // allowed by ETH and EIGEN quorums
 func (m *Meterer) ServeOnDemandRequest(ctx context.Context, header core.PaymentMetadata, onDemandPayment *core.OnDemandPayment, numSymbols uint, headerQuorums []uint8) error {
-	m.logger.Info("Recording and validating on-demand usage", "onDemandPayment", onDemandPayment)
+	m.logger.Info("Recording and validating on-demand usage", "header", header, "onDemandPayment", onDemandPayment)
 	quorumNumbers, err := m.ChainPaymentState.GetOnDemandQuorumNumbers(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get on-demand quorum numbers: %w", err)


### PR DESCRIPTION
## Why are these changes needed?

There's no logging for meterer at all. Added 3 basic lines to log the general flow of meterer processing 

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
