### PR TITLE
Ignore .DS_Store files, which are generated by the OSX Finder app.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ lightnode/docker/args.sh
 .vscode
 
 icicle/*
+
+# OSX specific
+.DS_Store


### PR DESCRIPTION
## Why are these changes needed?

OSX likes to drop annoying `.DS_Store` files in directories visited by Finder. Ignore these files.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
