### PR TITLE
fix: payment metadata invalid if both payment fields empty

### DIFF
--- a/disperser/apiserver/disperse_blob_v2.go
+++ b/disperser/apiserver/disperse_blob_v2.go
@@ -118,7 +118,7 @@ func (s *DispersalServerV2) validateDispersalRequest(ctx context.Context, req *p
 		return api.NewErrorInvalidArg("payment metadata is required")
 	}
 
-	if len(blobHeader.PaymentMetadata.AccountID) == 0 || blobHeader.PaymentMetadata.ReservationPeriod == 0 || blobHeader.PaymentMetadata.CumulativePayment == nil {
+	if len(blobHeader.PaymentMetadata.AccountID) == 0 || (blobHeader.PaymentMetadata.ReservationPeriod == 0 && blobHeader.PaymentMetadata.CumulativePayment.Cmp(big.NewInt(0)) == 0) {
 		return api.NewErrorInvalidArg("invalid payment metadata")
 	}
 

--- a/disperser/apiserver/server_v2_test.go
+++ b/disperser/apiserver/server_v2_test.go
@@ -223,7 +223,7 @@ func TestV2DisperseBlobRequestValidation(t *testing.T) {
 		PaymentHeader: &pbcommon.PaymentHeader{
 			AccountId:         accountID,
 			ReservationPeriod: 0,
-			CumulativePayment: big.NewInt(100).Bytes(),
+			CumulativePayment: big.NewInt(0).Bytes(),
 		},
 	}
 	blobHeader, err := corev2.BlobHeaderFromProtobuf(invalidReqProto)


### PR DESCRIPTION
## Why are these changes needed?

quick fix

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
