### PR TITLE
Add support for operator responses APIs

### DIFF
--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -425,6 +425,58 @@ const docTemplateV2 = `{
                     }
                 }
             }
+        },
+        "/operators/{batch_header_hash}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Fetch operator attestation response for a batch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Operator ID in hex string",
+                        "name": "operator_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -439,12 +491,6 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -452,9 +498,6 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "x": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -492,12 +535,6 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -526,12 +563,6 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -540,9 +571,6 @@ const docTemplateV2 = `{
             "properties": {
                 "x": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
         },
@@ -550,9 +578,6 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "x": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -735,12 +760,6 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
-                },
-                "a1": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -817,6 +836,54 @@ const docTemplateV2 = `{
                 }
             }
         },
+        "v2.DispersalResponse": {
+            "type": "object",
+            "properties": {
+                "batchRoot": {
+                    "description": "BatchRoot is the root of a Merkle tree whose leaves are the keys of the blobs in the batch",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "core.OperatorID": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "dispersedAt": {
+                    "type": "integer"
+                },
+                "error": {
+                    "description": "Error is the error message if the dispersal failed",
+                    "type": "string"
+                },
+                "operatorAddress": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "referenceBlockNumber": {
+                    "description": "ReferenceBlockNumber is the block number at which all operator information (stakes, indexes, etc.) is taken from",
+                    "type": "integer"
+                },
+                "respondedAt": {
+                    "type": "integer"
+                },
+                "signature": {
+                    "description": "Signature is the signature of the response by the operator",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "socket": {
+                    "type": "string"
+                }
+            }
+        },
         "v2.ErrorResponse": {
             "type": "object",
             "properties": {
@@ -847,6 +914,14 @@ const docTemplateV2 = `{
                     "additionalProperties": {
                         "$ref": "#/definitions/big.Int"
                     }
+                }
+            }
+        },
+        "v2.OperatorDispersalResponse": {
+            "type": "object",
+            "properties": {
+                "operator_dispersal_response": {
+                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -422,6 +422,58 @@
                     }
                 }
             }
+        },
+        "/operators/{batch_header_hash}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Fetch operator attestation response for a batch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Operator ID in hex string",
+                        "name": "operator_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -436,12 +488,6 @@
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -449,9 +495,6 @@
             "type": "object",
             "properties": {
                 "x": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -489,12 +532,6 @@
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -523,12 +560,6 @@
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -537,9 +568,6 @@
             "properties": {
                 "x": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
         },
@@ -547,9 +575,6 @@
             "type": "object",
             "properties": {
                 "x": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -732,12 +757,6 @@
                     "items": {
                         "type": "integer"
                     }
-                },
-                "a1": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -814,6 +833,54 @@
                 }
             }
         },
+        "v2.DispersalResponse": {
+            "type": "object",
+            "properties": {
+                "batchRoot": {
+                    "description": "BatchRoot is the root of a Merkle tree whose leaves are the keys of the blobs in the batch",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "core.OperatorID": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "dispersedAt": {
+                    "type": "integer"
+                },
+                "error": {
+                    "description": "Error is the error message if the dispersal failed",
+                    "type": "string"
+                },
+                "operatorAddress": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "referenceBlockNumber": {
+                    "description": "ReferenceBlockNumber is the block number at which all operator information (stakes, indexes, etc.) is taken from",
+                    "type": "integer"
+                },
+                "respondedAt": {
+                    "type": "integer"
+                },
+                "signature": {
+                    "description": "Signature is the signature of the response by the operator",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "socket": {
+                    "type": "string"
+                }
+            }
+        },
         "v2.ErrorResponse": {
             "type": "object",
             "properties": {
@@ -844,6 +911,14 @@
                     "additionalProperties": {
                         "$ref": "#/definitions/big.Int"
                     }
+                }
+            }
+        },
+        "v2.OperatorDispersalResponse": {
+            "type": "object",
+            "properties": {
+                "operator_dispersal_response": {
+                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -8,16 +8,10 @@ definitions:
         items:
           type: integer
         type: array
-      "y":
-        items:
-          type: integer
-        type: array
     type: object
   core.G2Point:
     properties:
       x:
-        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
-      "y":
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   core.PaymentMetadata:
@@ -46,10 +40,6 @@ definitions:
         items:
           type: integer
         type: array
-      "y":
-        items:
-          type: integer
-        type: array
     type: object
   encoding.BlobCommitments:
     properties:
@@ -68,23 +58,15 @@ definitions:
         items:
           type: integer
         type: array
-      "y":
-        items:
-          type: integer
-        type: array
     type: object
   encoding.G2Commitment:
     properties:
       x:
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
-      "y":
-        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   encoding.LengthProof:
     properties:
       x:
-        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
-      "y":
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   github_com_Layr-Labs_eigenda_core_v2.Attestation:
@@ -214,10 +196,6 @@ definitions:
         items:
           type: integer
         type: array
-      a1:
-        items:
-          type: integer
-        type: array
     type: object
   semver.SemverMetrics:
     properties:
@@ -266,6 +244,41 @@ definitions:
       blob_verification_info:
         $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo'
     type: object
+  v2.DispersalResponse:
+    properties:
+      batchRoot:
+        description: BatchRoot is the root of a Merkle tree whose leaves are the keys
+          of the blobs in the batch
+        items:
+          type: integer
+        type: array
+      core.OperatorID:
+        items:
+          type: integer
+        type: array
+      dispersedAt:
+        type: integer
+      error:
+        description: Error is the error message if the dispersal failed
+        type: string
+      operatorAddress:
+        items:
+          type: integer
+        type: array
+      referenceBlockNumber:
+        description: ReferenceBlockNumber is the block number at which all operator
+          information (stakes, indexes, etc.) is taken from
+        type: integer
+      respondedAt:
+        type: integer
+      signature:
+        description: Signature is the signature of the response by the operator
+        items:
+          type: integer
+        type: array
+      socket:
+        type: string
+    type: object
   v2.ErrorResponse:
     properties:
       error:
@@ -286,6 +299,11 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/big.Int'
         type: object
+    type: object
+  v2.OperatorDispersalResponse:
+    properties:
+      operator_dispersal_response:
+        $ref: '#/definitions/v2.DispersalResponse'
     type: object
   v2.OperatorPortCheckResponse:
     properties:
@@ -533,6 +551,40 @@ paths:
       summary: Fetch throughput time series
       tags:
       - Metrics
+  /operators/{batch_header_hash}:
+    get:
+      parameters:
+      - description: Batch header hash in hex string
+        in: path
+        name: batch_header_hash
+        required: true
+        type: string
+      - description: Operator ID in hex string
+        in: query
+        name: operator_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.OperatorDispersalResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+      summary: Fetch operator attestation response for a batch
+      tags:
+      - Operators
   /operators/nodeinfo:
     get:
       produces:


### PR DESCRIPTION
## Why are these changes needed?
Implementing dataapi v2 (https://github.com/Layr-Labs/eigenda/pull/955)

Note: the operator's dispersal request is already included in response

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
