### PR TITLE
Enable disperser-v2 prometheus metrics registry

### DIFF
--- a/disperser/apiserver/metrics_v2.go
+++ b/disperser/apiserver/metrics_v2.go
@@ -133,14 +133,13 @@ func newAPIServerV2Metrics(registry *prometheus.Registry, metricsConfig disperse
 	}
 }
 
-// Start starts the metrics server
+// Start the metrics server
 func (m *metricsV2) Start(ctx context.Context) {
 	m.logger.Info("Starting metrics server at ", "port", m.httpPort)
 	addr := fmt.Sprintf(":%s", m.httpPort)
 	go func() {
 		log := m.logger
 		mux := http.NewServeMux()
-		m.logger.Info("metrics registry", "registry", m.registry)
 		mux.Handle("/metrics", promhttp.HandlerFor(
 			m.registry,
 			promhttp.HandlerOpts{},

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -124,6 +124,11 @@ func NewDispersalServerV2(
 }
 
 func (s *DispersalServerV2) Start(ctx context.Context) error {
+	// Start the metrics server
+	if s.metricsConfig.EnableMetrics {
+		s.metrics.Start(context.Background())
+	}
+
 	// Serve grpc requests
 	addr := fmt.Sprintf("%s:%s", disperser.Localhost, s.serverConfig.GrpcPort)
 	listener, err := net.Listen("tcp", addr)
@@ -168,11 +173,6 @@ func (s *DispersalServerV2) Start(ctx context.Context) error {
 
 	if err := gs.Serve(listener); err != nil {
 		return errors.New("could not start GRPC server")
-	}
-
-	// Start the metrics server
-	if s.metricsConfig.EnableMetrics {
-		s.metrics.Start(context.Background())
 	}
 
 	return nil

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -58,7 +58,8 @@ type DispersalServerV2 struct {
 	maxNumSymbolsPerBlob        uint64
 	onchainStateRefreshInterval time.Duration
 
-	metrics *metricsV2
+	metricsConfig disperser.MetricsConfig
+	metrics       *metricsV2
 }
 
 // NewDispersalServerV2 creates a new Server struct with the provided parameters.
@@ -74,6 +75,7 @@ func NewDispersalServerV2(
 	onchainStateRefreshInterval time.Duration,
 	_logger logging.Logger,
 	registry *prometheus.Registry,
+	metricsConfig disperser.MetricsConfig,
 ) (*DispersalServerV2, error) {
 	if serverConfig.GrpcPort == "" {
 		return nil, errors.New("grpc port is required")
@@ -116,7 +118,8 @@ func NewDispersalServerV2(
 		maxNumSymbolsPerBlob:        maxNumSymbolsPerBlob,
 		onchainStateRefreshInterval: onchainStateRefreshInterval,
 
-		metrics: newAPIServerV2Metrics(registry),
+		metricsConfig: metricsConfig,
+		metrics:       newAPIServerV2Metrics(registry, metricsConfig, logger),
 	}, nil
 }
 
@@ -165,6 +168,11 @@ func (s *DispersalServerV2) Start(ctx context.Context) error {
 
 	if err := gs.Serve(listener); err != nil {
 		return errors.New("could not start GRPC server")
+	}
+
+	// Start the metrics server
+	if s.metricsConfig.EnableMetrics {
+		s.metrics.Start(context.Background())
 	}
 
 	return nil

--- a/disperser/apiserver/server_v2_test.go
+++ b/disperser/apiserver/server_v2_test.go
@@ -517,7 +517,12 @@ func newTestServerV2(t *testing.T) *testComponents {
 		10,
 		time.Hour,
 		logger,
-		prometheus.NewRegistry())
+		prometheus.NewRegistry(),
+		disperser.MetricsConfig{
+			HTTPPort:      "9094",
+			EnableMetrics: false,
+		},
+	)
 	assert.NoError(t, err)
 
 	err = s.RefreshOnchainState(context.Background())

--- a/disperser/cmd/apiserver/main.go
+++ b/disperser/cmd/apiserver/main.go
@@ -182,6 +182,7 @@ func RunDisperserServer(ctx *cli.Context) error {
 			config.OnchainStateRefreshInterval,
 			logger,
 			reg,
+			config.MetricsConfig,
 		)
 		if err != nil {
 			return err
@@ -212,7 +213,6 @@ func RunDisperserServer(ctx *cli.Context) error {
 	// Enable Metrics Block
 	if config.MetricsConfig.EnableMetrics {
 		httpSocket := fmt.Sprintf(":%s", config.MetricsConfig.HTTPPort)
-		// TODO(cody-littley): once we deprecate v1, move all remaining metrics functionality to metrics_v2.go
 		metrics.Start(context.Background())
 		logger.Info("Enabled metrics for Disperser", "socket", httpSocket)
 	}


### PR DESCRIPTION
## Why are these changes needed?

Enables Disperser-v2 to serve metrics registry + endpoint
Enables process collector
Enables go collector

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
