### PR TITLE
Don't log relay config.

### DIFF
--- a/relay/cmd/main.go
+++ b/relay/cmd/main.go
@@ -54,7 +54,6 @@ func RunRelay(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
-	logger.Info(fmt.Sprintf("Relay configuration: %#v", config))
 
 	dynamoClient, err := dynamodb.NewClient(config.AWS, logger)
 	if err != nil {


### PR DESCRIPTION
## Why are these changes needed?

Logging configuration may be a security issue. This log is not super critical, better to just not do it.
