### PR TITLE
fix: inabox flaky test

### DIFF
--- a/api/clients/v2/relay_client.go
+++ b/api/clients/v2/relay_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+
 	relaygrpc "github.com/Layr-Labs/eigenda/api/grpc/relay"
 	"github.com/Layr-Labs/eigenda/api/hashing"
 	"github.com/Layr-Labs/eigenda/core"
@@ -11,7 +13,6 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc"
-	"sync"
 )
 
 // MessageSigner is a function that signs a message with a private BLS key.
@@ -74,7 +75,7 @@ func NewRelayClient(config *RelayClientConfig, logger logging.Logger) (RelayClie
 		return nil, fmt.Errorf("invalid config: %v", config)
 	}
 
-	logger.Info("creating relay client", "config", config)
+	logger.Info("creating relay client", "urls", config.Sockets)
 
 	initOnce := sync.Map{}
 	for key := range config.Sockets {

--- a/inabox/deploy/deploy.go
+++ b/inabox/deploy/deploy.go
@@ -179,12 +179,6 @@ func (env *Config) RegisterBlobVersionAndRelays(ethClient common.EthClient) map[
 	if err != nil {
 		log.Panicf("Error: %s", err)
 	}
-	fmt.Println("thresholds reigstry address", thresholdRegistryAddr.Hex())
-	defaultThes, err := contractThresholdRegistry.GetDefaultSecurityThresholdsV2(&bind.CallOpts{})
-	if err != nil {
-		log.Panicf("Error: %s", err)
-	}
-	fmt.Println("thresholds", defaultThes.AdversaryThreshold, defaultThes.ConfirmationThreshold)
 	for _, blobVersionParam := range env.BlobVersionParams {
 		txn, err := contractThresholdRegistry.AddVersionedBlobParams(opts, thresholdreg.VersionedBlobParams{
 			MaxNumOperators: blobVersionParam.MaxNumOperators,

--- a/inabox/tests/integration_v2_test.go
+++ b/inabox/tests/integration_v2_test.go
@@ -132,24 +132,13 @@ var _ = Describe("Inabox v2 Integration", func() {
 				attestation = reply2.GetSignedBatch().GetAttestation()
 				Expect(attestation).To(Not(BeNil()))
 
-				if bytes.Equal(batchHeader2.BatchRoot, batchHeader1.BatchRoot) {
-					// same batch
-					attestation2 := reply2.GetSignedBatch().GetAttestation()
-					Expect(attestation2).To(Not(BeNil()))
-					Expect(attestation2.QuorumNumbers).To(Equal(attestation.QuorumNumbers))
-					Expect(len(attestation2.NonSignerPubkeys)).To(Equal(len(attestation.NonSignerPubkeys)))
-					Expect(attestation2.ApkG2).To(Equal(attestation.ApkG2))
-					Expect(len(attestation2.QuorumApks)).To(Equal(len(attestation.QuorumApks)))
-					Expect(attestation2.QuorumSignedPercentages).To(Equal(attestation.QuorumSignedPercentages))
-				} else {
-					attestation = reply2.GetSignedBatch().GetAttestation()
-					Expect(attestation).To(Not(BeNil()))
-					Expect(attestation.QuorumNumbers).To(ConsistOf([]uint32{0}))
-					Expect(len(attestation.NonSignerPubkeys)).To(Equal(0))
-					Expect(attestation.ApkG2).To(Not(BeNil()))
-					Expect(len(attestation.QuorumApks)).To(Equal(1))
-					Expect(attestation.QuorumSignedPercentages).To(Equal([]byte{100}))
-				}
+				attestation2 := reply2.GetSignedBatch().GetAttestation()
+				Expect(attestation2).To(Not(BeNil()))
+				Expect(attestation2.QuorumNumbers).To(Equal(attestation.QuorumNumbers))
+				Expect(len(attestation2.NonSignerPubkeys)).To(Equal(len(attestation.NonSignerPubkeys)))
+				Expect(attestation2.ApkG2).To(Equal(attestation.ApkG2))
+				Expect(len(attestation2.QuorumApks)).To(Equal(len(attestation.QuorumApks)))
+				Expect(attestation2.QuorumSignedPercentages).To(Equal(attestation.QuorumSignedPercentages))
 
 				blobVerification2 = reply2.GetBlobVerificationInfo()
 				Expect(blobVerification2).To(Not(BeNil()))


### PR DESCRIPTION
## Why are these changes needed?
Not both blobs are dispersed to both quorums, attestation from 2nd blob should have both quorums regardless of whether both blobs are in the same batch or not. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
