### PR TITLE
Make choosing relay IDs thread safe.

### DIFF
--- a/disperser/controller/encoding_manager.go
+++ b/disperser/controller/encoding_manager.go
@@ -291,7 +291,8 @@ func GetRelayKeys(numAssignment uint16, availableRelays []corev2.RelayKey) ([]co
 	if int(numAssignment) > len(availableRelays) {
 		return nil, fmt.Errorf("numAssignment (%d) cannot be greater than numRelays (%d)", numAssignment, len(availableRelays))
 	}
-	relayKeys := availableRelays
+	relayKeys := make([]corev2.RelayKey, len(availableRelays))
+	copy(relayKeys, availableRelays)
 	// shuffle relay keys
 	for i := len(relayKeys) - 1; i > 0; i-- {
 		j := rand.Intn(i + 1)

--- a/disperser/controller/encoding_manager_test.go
+++ b/disperser/controller/encoding_manager_test.go
@@ -57,6 +57,12 @@ func TestGetRelayKeys(t *testing.T) {
 			err:             nil,
 		},
 		{
+			name:            "All relays",
+			numRelays:       2,
+			availableRelays: []corev2.RelayKey{0, 1},
+			err:             nil,
+		},
+		{
 			name:            "Choose 1 from multiple relays",
 			numRelays:       3,
 			availableRelays: []corev2.RelayKey{0, 1, 2, 3},
@@ -78,6 +84,10 @@ func TestGetRelayKeys(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
+			availableRelaysCopy := make([]corev2.RelayKey, len(tt.availableRelays))
+			copy(availableRelaysCopy, tt.availableRelays)
+
 			got, err := controller.GetRelayKeys(tt.numRelays, tt.availableRelays)
 			if err != nil {
 				require.Error(t, err)
@@ -90,6 +100,8 @@ func TestGetRelayKeys(t *testing.T) {
 					seen[relay] = struct{}{}
 				}
 				require.Equal(t, len(seen), len(got))
+				// GetRelayKeys should not modify the original list of available relays.
+				require.Equal(t, availableRelaysCopy, tt.availableRelays)
 			}
 		})
 	}


### PR DESCRIPTION
## Why are these changes needed?

Fixes a race condition for relay selection.
