### PR TITLE
Add a new relay metric to more accurately describe cache behavior.

### DIFF
--- a/relay/cache/cache_accessor.go
+++ b/relay/cache/cache_accessor.go
@@ -123,7 +123,13 @@ func (c *cacheAccessor[K, V]) Get(ctx context.Context, key K) (V, error) {
 	c.cacheLock.Unlock()
 
 	if c.metrics != nil {
-		c.metrics.ReportCacheMiss()
+		if alreadyLoading {
+			// A lookup is currently in progress. Not a cache hit, but this call won't duplicate the work.
+			c.metrics.ReportCacheNearMiss()
+		} else {
+			// The data is not in the cache and no lookup is in progress. We must fetch the data from the source.
+			c.metrics.ReportCacheMiss()
+		}
 	}
 
 	if alreadyLoading {

--- a/relay/cache/cache_accessor_metrics.go
+++ b/relay/cache/cache_accessor_metrics.go
@@ -13,6 +13,7 @@ const namespace = "eigenda_relay"
 // CacheAccessorMetrics provides metrics for a CacheAccessor.
 type CacheAccessorMetrics struct {
 	cacheHits        *prometheus.CounterVec
+	cacheNearMisses  *prometheus.CounterVec
 	cacheMisses      *prometheus.CounterVec
 	size             *prometheus.GaugeVec
 	weight           *prometheus.GaugeVec
@@ -30,6 +31,15 @@ func NewCacheAccessorMetrics(
 			Namespace: namespace,
 			Name:      fmt.Sprintf("%s_cache_hit_count", cacheName),
 			Help:      "Number of cache hits",
+		},
+		[]string{},
+	)
+
+	cacheNearMisses := promauto.With(registry).NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("%s_cache_near_miss_count", cacheName),
+			Help:      "Number of near cache misses (i.e. a lookup is already in progress)",
 		},
 		[]string{},
 	)
@@ -82,6 +92,7 @@ func NewCacheAccessorMetrics(
 
 	return &CacheAccessorMetrics{
 		cacheHits:        cacheHits,
+		cacheNearMisses:  cacheNearMisses,
 		cacheMisses:      cacheMisses,
 		size:             size,
 		weight:           weight,
@@ -92,6 +103,10 @@ func NewCacheAccessorMetrics(
 
 func (m *CacheAccessorMetrics) ReportCacheHit() {
 	m.cacheHits.WithLabelValues().Inc()
+}
+
+func (m *CacheAccessorMetrics) ReportCacheNearMiss() {
+	m.cacheNearMisses.WithLabelValues().Inc()
 }
 
 func (m *CacheAccessorMetrics) ReportCacheMiss() {


### PR DESCRIPTION
## Why are these changes needed?

Adds a new metric to the relay caches: "cache near miss count". A near miss in this context is defined as a request to the cache for data that is currently being looked up. Such requests are not as good as a cache hit, since a cache hit returns the data with no extra latency. But unlike a true cache miss, a cache near miss does not result in extra network traffic to fetch the data.
