### PR TITLE
fix typo in the file SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,5 +16,5 @@ Audit reports are published in the `docs` folder: https://github.com/Layr-Labs/e
 
 **Please do not file a public ticket** mentioning the vulnerability.
 
-Please report security vulnerabilities to security@eigenlabs.org with the all the relavent details included in the email.
+Please report security vulnerabilities to security@eigenlabs.org with the all the relevant details included in the email.
 


### PR DESCRIPTION

Fixed a spelling mistake in `SECURITY.md`, replacing **"relavent"** with **"relevant"** to ensure correct usage.
