### PR TITLE
Add e2e latency metrics in controller

### DIFF
--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -50,6 +50,7 @@ type batchData struct {
 	Batch           *corev2.Batch
 	BatchHeaderHash [32]byte
 	BlobKeys        []corev2.BlobKey
+	Metadata        map[corev2.BlobKey]*v2.BlobMetadata
 	OperatorState   *core.IndexedOperatorState
 }
 
@@ -351,6 +352,7 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 	}
 
 	keys := make([]corev2.BlobKey, len(blobMetadatas))
+	metadataMap := make(map[corev2.BlobKey]*v2.BlobMetadata, len(blobMetadatas))
 	for i, metadata := range blobMetadatas {
 		if metadata == nil || metadata.BlobHeader == nil {
 			return nil, fmt.Errorf("invalid blob metadata")
@@ -360,6 +362,7 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 			return nil, fmt.Errorf("failed to get blob key: %w", err)
 		}
 		keys[i] = blobKey
+		metadataMap[blobKey] = metadata
 	}
 
 	certs, _, err := d.blobMetadataStore.GetBlobCertificates(ctx, keys)
@@ -471,6 +474,7 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 		},
 		BatchHeaderHash: batchHeaderHash,
 		BlobKeys:        keys,
+		Metadata:        metadataMap,
 		OperatorState:   state,
 	}, nil
 }
@@ -540,6 +544,10 @@ func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, qu
 		err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Certified)
 		if err != nil {
 			multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to certified: %w", blobKey.Hex(), err))
+		}
+		if metadata, ok := batch.Metadata[blobKey]; ok {
+			requestedAt := time.Unix(0, int64(metadata.RequestedAt))
+			d.metrics.reportE2EDispersalLatency(time.Since(requestedAt))
 		}
 	}
 

--- a/disperser/controller/dispatcher_metrics.go
+++ b/disperser/controller/dispatcher_metrics.go
@@ -32,6 +32,8 @@ type dispatcherMetrics struct {
 	aggregateSignaturesLatency *prometheus.SummaryVec
 	putAttestationLatency      *prometheus.SummaryVec
 	updateBatchStatusLatency   *prometheus.SummaryVec
+
+	blobE2EDispersalLatency *prometheus.SummaryVec
 }
 
 // NewDispatcherMetrics sets up metrics for the dispatcher.
@@ -228,6 +230,16 @@ func newDispatcherMetrics(registry *prometheus.Registry) *dispatcherMetrics {
 		[]string{},
 	)
 
+	blobE2EDispersalLatency := promauto.With(registry).NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace:  encodingManagerNamespace,
+			Name:       "e2e_dispersal_latency_ms",
+			Help:       "The time required to disperse a blob end-to-end.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		},
+		[]string{},
+	)
+
 	return &dispatcherMetrics{
 		handleBatchLatency:          handleBatchLatency,
 		newBatchLatency:             newBatchLatency,
@@ -248,6 +260,7 @@ func newDispatcherMetrics(registry *prometheus.Registry) *dispatcherMetrics {
 		aggregateSignaturesLatency:  aggregateSignaturesLatency,
 		putAttestationLatency:       putAttestationLatency,
 		updateBatchStatusLatency:    updateBatchStatusLatency,
+		blobE2EDispersalLatency:     blobE2EDispersalLatency,
 	}
 }
 
@@ -325,4 +338,8 @@ func (m *dispatcherMetrics) reportPutAttestationLatency(duration time.Duration) 
 
 func (m *dispatcherMetrics) reportUpdateBatchStatusLatency(duration time.Duration) {
 	m.updateBatchStatusLatency.WithLabelValues().Observe(common.ToMilliseconds(duration))
+}
+
+func (m *dispatcherMetrics) reportE2EDispersalLatency(duration time.Duration) {
+	m.blobE2EDispersalLatency.WithLabelValues().Observe(common.ToMilliseconds(duration))
 }

--- a/disperser/controller/encoding_manager.go
+++ b/disperser/controller/encoding_manager.go
@@ -246,6 +246,9 @@ func (e *EncodingManager) HandleBatch(ctx context.Context) error {
 				e.metrics.reportUpdateBlobStatusLatency(
 					finishedUpdateBlobStatusTime.Sub(finishedPutBlobCertificateTime))
 				e.metrics.reportBlobHandleLatency(time.Since(start))
+
+				requestedAt := time.Unix(0, int64(blob.RequestedAt))
+				e.metrics.reportE2EEncodingLatency(time.Since(requestedAt))
 			} else {
 				e.metrics.reportFailedSubmission()
 				storeCtx, cancel := context.WithTimeout(ctx, e.StoreTimeout)


### PR DESCRIPTION
## Why are these changes needed?
Adding end to end latency metrics for encoding/dispersals
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
