### PR TITLE
Gracefully shut down relay GRPC server.

### DIFF
--- a/relay/server.go
+++ b/relay/server.go
@@ -523,7 +523,7 @@ func (s *Server) RefreshOnchainState(ctx context.Context) error {
 // Stop stops the server.
 func (s *Server) Stop() error {
 	if s.grpcServer != nil {
-		s.grpcServer.Stop()
+		s.grpcServer.GracefulStop()
 	}
 
 	err := s.metrics.Stop()


### PR DESCRIPTION
## Why are these changes needed?

When the relay GRPC server needs to be stopped, gracefully shut it down. According to the docs, this SHOULD wait until the relay server is actually dead prior to returning.
