### PR TITLE
KMS client from AWS config

### DIFF
--- a/api/clients/v2/dispersal_request_signer.go
+++ b/api/clients/v2/dispersal_request_signer.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+
 	grpc "github.com/Layr-Labs/eigenda/api/grpc/node/v2"
 	"github.com/Layr-Labs/eigenda/api/hashing"
 	aws2 "github.com/Layr-Labs/eigenda/common/aws"
-	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 )
 
@@ -33,11 +34,16 @@ func NewDispersalRequestSigner(
 	endpoint string,
 	keyID string) (DispersalRequestSigner, error) {
 
-	keyManager := kms.New(kms.Options{
-		Region:       region,
-		BaseEndpoint: aws.String(endpoint),
-	})
+	// Load the AWS SDK configuration, which will automatically detect credentials
+	// from environment variables, IAM roles, or AWS config files
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
 
+	keyManager := kms.NewFromConfig(cfg)
 	key, err := aws2.LoadPublicKeyKMS(ctx, keyManager, keyID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ecdsa public key: %w", err)

--- a/api/clients/v2/dispersal_request_signer.go
+++ b/api/clients/v2/dispersal_request_signer.go
@@ -31,7 +31,6 @@ type requestSigner struct {
 func NewDispersalRequestSigner(
 	ctx context.Context,
 	region string,
-	endpoint string,
 	keyID string) (DispersalRequestSigner, error) {
 
 	// Load the AWS SDK configuration, which will automatically detect credentials

--- a/api/clients/v2/dispersal_request_signer_test.go
+++ b/api/clients/v2/dispersal_request_signer_test.go
@@ -2,6 +2,12 @@ package clients
 
 import (
 	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
 	aws2 "github.com/Layr-Labs/eigenda/common/aws"
 	"github.com/Layr-Labs/eigenda/common/testutils/random"
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
@@ -12,11 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
-	"log"
-	"os"
-	"path/filepath"
-	"runtime"
-	"testing"
 )
 
 var (
@@ -99,7 +100,7 @@ func TestRequestSigning(t *testing.T) {
 			request := auth.RandomStoreChunksRequest(rand)
 			request.Signature = nil
 
-			signer, err := NewDispersalRequestSigner(context.Background(), region, localstackHost, keyID)
+			signer, err := NewDispersalRequestSigner(context.Background(), region, keyID)
 			require.NoError(t, err)
 
 			// Test a valid signature.

--- a/api/clients/v2/dispersal_request_signer_test.go
+++ b/api/clients/v2/dispersal_request_signer_test.go
@@ -100,7 +100,7 @@ func TestRequestSigning(t *testing.T) {
 			request := auth.RandomStoreChunksRequest(rand)
 			request.Signature = nil
 
-			signer, err := NewDispersalRequestSigner(context.Background(), region, keyID)
+			signer, err := NewDispersalRequestSigner(context.Background(), region, localstackHost, keyID)
 			require.NoError(t, err)
 
 			// Test a valid signature.

--- a/disperser/cmd/controller/main.go
+++ b/disperser/cmd/controller/main.go
@@ -158,6 +158,7 @@ func RunController(ctx *cli.Context) error {
 		requestSigner, err = clients.NewDispersalRequestSigner(
 			context.Background(),
 			config.AwsClientConfig.Region,
+			config.AwsClientConfig.EndpointURL,
 			config.DisperserKMSKeyID)
 		if err != nil {
 			return fmt.Errorf("failed to create request signer: %v", err)

--- a/disperser/cmd/controller/main.go
+++ b/disperser/cmd/controller/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenda/api/clients/v2"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"log"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/Layr-Labs/eigenda/api/clients/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/aws/dynamodb"
@@ -157,7 +158,6 @@ func RunController(ctx *cli.Context) error {
 		requestSigner, err = clients.NewDispersalRequestSigner(
 			context.Background(),
 			config.AwsClientConfig.Region,
-			config.AwsClientConfig.EndpointURL,
 			config.DisperserKMSKeyID)
 		if err != nil {
 			return fmt.Errorf("failed to create request signer: %v", err)


### PR DESCRIPTION
## Why are these changes needed?

Need to load KMS client from AWS config so that it can utilize the AWS role based service account.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
