### PR TITLE
Add trivial PR warning to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> We do not accept trivial/documentation fixes from first-time contributors. These PRs will be closed without review.
+
 ## Why are these changes needed?
 
 <!-- Please give a short summary of the change and the problem this solves. -->


### PR DESCRIPTION
Adds warning to PR template to discourage Github reputation farming bots

<img width="1587" alt="image" src="https://github.com/user-attachments/assets/7592ea65-0105-4acd-b3f4-45658eecc3b9" />