### PR TITLE
Add suppport for blob feed API at dataapi

### DIFF
--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -483,6 +483,58 @@ const docTemplateV2 = `{
         "big.Int": {
             "type": "object"
         },
+        "core.BlobHeader": {
+            "type": "object",
+            "properties": {
+                "accountID": {
+                    "description": "AccountID is the account that is paying for the blob to be stored",
+                    "type": "string"
+                },
+                "commitment": {
+                    "$ref": "#/definitions/encoding.G1Commitment"
+                },
+                "length": {
+                    "type": "integer"
+                },
+                "length_commitment": {
+                    "$ref": "#/definitions/encoding.G2Commitment"
+                },
+                "length_proof": {
+                    "$ref": "#/definitions/encoding.LengthProof"
+                },
+                "quorumInfos": {
+                    "description": "QuorumInfos contains the quorum specific parameters for the blob",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/core.BlobQuorumInfo"
+                    }
+                }
+            }
+        },
+        "core.BlobQuorumInfo": {
+            "type": "object",
+            "properties": {
+                "adversaryThreshold": {
+                    "description": "AdversaryThreshold is the maximum amount of stake that can be controlled by an adversary in the quorum as a percentage of the total stake in the quorum",
+                    "type": "integer"
+                },
+                "chunkLength": {
+                    "description": "ChunkLength is the number of symbols in a chunk",
+                    "type": "integer"
+                },
+                "confirmationThreshold": {
+                    "description": "ConfirmationThreshold is the amount of stake that must sign a message for it to be considered valid as a percentage of the total stake in the quorum",
+                    "type": "integer"
+                },
+                "quorumID": {
+                    "type": "integer"
+                },
+                "quorumRate": {
+                    "description": "Rate Limit. This is a temporary measure until the node can derive rates on its own using rollup authentication. This is used\nfor restricting the rate at which retrievers are able to download data from the DA node to a multiple of the rate at which the\ndata was posted to the DA node.",
+                    "type": "integer"
+                }
+            }
+        },
         "core.G1Point": {
             "type": "object",
             "properties": {
@@ -741,6 +793,23 @@ const docTemplateV2 = `{
                 }
             }
         },
+        "github_com_Layr-Labs_eigenda_disperser_common_v2.BlobStatus": {
+            "type": "integer",
+            "enum": [
+                0,
+                1,
+                2,
+                3,
+                4
+            ],
+            "x-enum-varnames": [
+                "Queued",
+                "Encoded",
+                "Certified",
+                "Failed",
+                "InsufficientSignatures"
+            ]
+        },
         "github_com_Layr-Labs_eigenda_disperser_dataapi_v2.SignedBatch": {
             "type": "object",
             "properties": {
@@ -808,6 +877,64 @@ const docTemplateV2 = `{
             "properties": {
                 "blob_certificate": {
                     "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobCertificate"
+                }
+            }
+        },
+        "v2.BlobFeedResponse": {
+            "type": "object",
+            "properties": {
+                "blobs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.BlobMetadata"
+                    }
+                },
+                "pagination_token": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.BlobMetadata": {
+            "type": "object",
+            "properties": {
+                "blobHeader": {
+                    "$ref": "#/definitions/core.BlobHeader"
+                },
+                "blobSize": {
+                    "description": "BlobSize is the size of the blob in bytes",
+                    "type": "integer"
+                },
+                "blobStatus": {
+                    "description": "BlobStatus indicates the current status of the blob",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_Layr-Labs_eigenda_disperser_common_v2.BlobStatus"
+                        }
+                    ]
+                },
+                "expiry": {
+                    "description": "Expiry is Unix timestamp of the blob expiry in seconds from epoch",
+                    "type": "integer"
+                },
+                "fragmentSizeBytes": {
+                    "description": "FragmentSizeBytes is the maximum fragment size used to store the chunk coefficients.",
+                    "type": "integer"
+                },
+                "numRetries": {
+                    "description": "NumRetries is the number of times the blob has been retried",
+                    "type": "integer"
+                },
+                "requestedAt": {
+                    "description": "RequestedAt is the Unix timestamp of when the blob was requested in seconds",
+                    "type": "integer"
+                },
+                "totalChunkSizeBytes": {
+                    "description": "TotalChunkSizeBytes is the total size of the file containing all chunk coefficients for the blob.",
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "description": "UpdatedAt is the Unix timestamp of when the blob was last updated in _nanoseconds_",
+                    "type": "integer"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -480,6 +480,58 @@
         "big.Int": {
             "type": "object"
         },
+        "core.BlobHeader": {
+            "type": "object",
+            "properties": {
+                "accountID": {
+                    "description": "AccountID is the account that is paying for the blob to be stored",
+                    "type": "string"
+                },
+                "commitment": {
+                    "$ref": "#/definitions/encoding.G1Commitment"
+                },
+                "length": {
+                    "type": "integer"
+                },
+                "length_commitment": {
+                    "$ref": "#/definitions/encoding.G2Commitment"
+                },
+                "length_proof": {
+                    "$ref": "#/definitions/encoding.LengthProof"
+                },
+                "quorumInfos": {
+                    "description": "QuorumInfos contains the quorum specific parameters for the blob",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/core.BlobQuorumInfo"
+                    }
+                }
+            }
+        },
+        "core.BlobQuorumInfo": {
+            "type": "object",
+            "properties": {
+                "adversaryThreshold": {
+                    "description": "AdversaryThreshold is the maximum amount of stake that can be controlled by an adversary in the quorum as a percentage of the total stake in the quorum",
+                    "type": "integer"
+                },
+                "chunkLength": {
+                    "description": "ChunkLength is the number of symbols in a chunk",
+                    "type": "integer"
+                },
+                "confirmationThreshold": {
+                    "description": "ConfirmationThreshold is the amount of stake that must sign a message for it to be considered valid as a percentage of the total stake in the quorum",
+                    "type": "integer"
+                },
+                "quorumID": {
+                    "type": "integer"
+                },
+                "quorumRate": {
+                    "description": "Rate Limit. This is a temporary measure until the node can derive rates on its own using rollup authentication. This is used\nfor restricting the rate at which retrievers are able to download data from the DA node to a multiple of the rate at which the\ndata was posted to the DA node.",
+                    "type": "integer"
+                }
+            }
+        },
         "core.G1Point": {
             "type": "object",
             "properties": {
@@ -738,6 +790,23 @@
                 }
             }
         },
+        "github_com_Layr-Labs_eigenda_disperser_common_v2.BlobStatus": {
+            "type": "integer",
+            "enum": [
+                0,
+                1,
+                2,
+                3,
+                4
+            ],
+            "x-enum-varnames": [
+                "Queued",
+                "Encoded",
+                "Certified",
+                "Failed",
+                "InsufficientSignatures"
+            ]
+        },
         "github_com_Layr-Labs_eigenda_disperser_dataapi_v2.SignedBatch": {
             "type": "object",
             "properties": {
@@ -805,6 +874,64 @@
             "properties": {
                 "blob_certificate": {
                     "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobCertificate"
+                }
+            }
+        },
+        "v2.BlobFeedResponse": {
+            "type": "object",
+            "properties": {
+                "blobs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.BlobMetadata"
+                    }
+                },
+                "pagination_token": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.BlobMetadata": {
+            "type": "object",
+            "properties": {
+                "blobHeader": {
+                    "$ref": "#/definitions/core.BlobHeader"
+                },
+                "blobSize": {
+                    "description": "BlobSize is the size of the blob in bytes",
+                    "type": "integer"
+                },
+                "blobStatus": {
+                    "description": "BlobStatus indicates the current status of the blob",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_Layr-Labs_eigenda_disperser_common_v2.BlobStatus"
+                        }
+                    ]
+                },
+                "expiry": {
+                    "description": "Expiry is Unix timestamp of the blob expiry in seconds from epoch",
+                    "type": "integer"
+                },
+                "fragmentSizeBytes": {
+                    "description": "FragmentSizeBytes is the maximum fragment size used to store the chunk coefficients.",
+                    "type": "integer"
+                },
+                "numRetries": {
+                    "description": "NumRetries is the number of times the blob has been retried",
+                    "type": "integer"
+                },
+                "requestedAt": {
+                    "description": "RequestedAt is the Unix timestamp of when the blob was requested in seconds",
+                    "type": "integer"
+                },
+                "totalChunkSizeBytes": {
+                    "description": "TotalChunkSizeBytes is the total size of the file containing all chunk coefficients for the blob.",
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "description": "UpdatedAt is the Unix timestamp of when the blob was last updated in _nanoseconds_",
+                    "type": "integer"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -2,6 +2,49 @@ basePath: /api/v2
 definitions:
   big.Int:
     type: object
+  core.BlobHeader:
+    properties:
+      accountID:
+        description: AccountID is the account that is paying for the blob to be stored
+        type: string
+      commitment:
+        $ref: '#/definitions/encoding.G1Commitment'
+      length:
+        type: integer
+      length_commitment:
+        $ref: '#/definitions/encoding.G2Commitment'
+      length_proof:
+        $ref: '#/definitions/encoding.LengthProof'
+      quorumInfos:
+        description: QuorumInfos contains the quorum specific parameters for the blob
+        items:
+          $ref: '#/definitions/core.BlobQuorumInfo'
+        type: array
+    type: object
+  core.BlobQuorumInfo:
+    properties:
+      adversaryThreshold:
+        description: AdversaryThreshold is the maximum amount of stake that can be
+          controlled by an adversary in the quorum as a percentage of the total stake
+          in the quorum
+        type: integer
+      chunkLength:
+        description: ChunkLength is the number of symbols in a chunk
+        type: integer
+      confirmationThreshold:
+        description: ConfirmationThreshold is the amount of stake that must sign a
+          message for it to be considered valid as a percentage of the total stake
+          in the quorum
+        type: integer
+      quorumID:
+        type: integer
+      quorumRate:
+        description: |-
+          Rate Limit. This is a temporary measure until the node can derive rates on its own using rollup authentication. This is used
+          for restricting the rate at which retrievers are able to download data from the DA node to a multiple of the rate at which the
+          data was posted to the DA node.
+        type: integer
+    type: object
   core.G1Point:
     properties:
       x:
@@ -183,6 +226,20 @@ definitions:
           information (stakes, indexes, etc.) is taken from
         type: integer
     type: object
+  github_com_Layr-Labs_eigenda_disperser_common_v2.BlobStatus:
+    enum:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    type: integer
+    x-enum-varnames:
+    - Queued
+    - Encoded
+    - Certified
+    - Failed
+    - InsufficientSignatures
   github_com_Layr-Labs_eigenda_disperser_dataapi_v2.SignedBatch:
     properties:
       attestation:
@@ -227,6 +284,49 @@ definitions:
     properties:
       blob_certificate:
         $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobCertificate'
+    type: object
+  v2.BlobFeedResponse:
+    properties:
+      blobs:
+        items:
+          $ref: '#/definitions/v2.BlobMetadata'
+        type: array
+      pagination_token:
+        type: string
+    type: object
+  v2.BlobMetadata:
+    properties:
+      blobHeader:
+        $ref: '#/definitions/core.BlobHeader'
+      blobSize:
+        description: BlobSize is the size of the blob in bytes
+        type: integer
+      blobStatus:
+        allOf:
+        - $ref: '#/definitions/github_com_Layr-Labs_eigenda_disperser_common_v2.BlobStatus'
+        description: BlobStatus indicates the current status of the blob
+      expiry:
+        description: Expiry is Unix timestamp of the blob expiry in seconds from epoch
+        type: integer
+      fragmentSizeBytes:
+        description: FragmentSizeBytes is the maximum fragment size used to store
+          the chunk coefficients.
+        type: integer
+      numRetries:
+        description: NumRetries is the number of times the blob has been retried
+        type: integer
+      requestedAt:
+        description: RequestedAt is the Unix timestamp of when the blob was requested
+          in seconds
+        type: integer
+      totalChunkSizeBytes:
+        description: TotalChunkSizeBytes is the total size of the file containing
+          all chunk coefficients for the blob.
+        type: integer
+      updatedAt:
+        description: UpdatedAt is the Unix timestamp of when the blob was last updated
+          in _nanoseconds_
+        type: integer
     type: object
   v2.BlobResponse:
     properties:

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/disperser/common/semver"
+	disperserv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
 	"github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi"
 	docsv2 "github.com/Layr-Labs/eigenda/disperser/dataapi/docs/v2"
@@ -64,6 +65,11 @@ type (
 
 	BlobVerificationInfoResponse struct {
 		VerificationInfo *corev2.BlobVerificationInfo `json:"blob_verification_info"`
+	}
+
+	BlobFeedResponse struct {
+		Blobs           []*disperserv2.BlobMetadata `json:"blobs"`
+		PaginationToken string                      `json:"pagination_token"`
 	}
 
 	BatchResponse struct {
@@ -255,6 +261,13 @@ func errorResponse(c *gin.Context, err error) {
 	})
 }
 
+func invalidParamsErrorResponse(c *gin.Context, err error) {
+	_ = c.Error(err)
+	c.JSON(http.StatusBadRequest, ErrorResponse{
+		Error: err.Error(),
+	})
+}
+
 func run(logger logging.Logger, httpServer *http.Server) <-chan error {
 	errChan := make(chan error, 1)
 	ctx, stop := signal.NotifyContext(
@@ -294,8 +307,95 @@ func (s *ServerV2) Shutdown() error {
 	return nil
 }
 
+// FetchBlobFeedHandler godoc
+//
+// @Summary      Fetch blob feed
+// @Tags         Blob
+// @Produce      json
+// @Param        end               query    string  false  "Fetch blobs up to the end time (ISO 8601 format: 2006-01-02T15:04:05Z) [default: now]"
+// @Param        interval          query    int     false  "Fetch blobs starting from an interval (in seconds) before the end time [default: 3600]"
+// @Param        pagination_token  query    string  false  "Fetch blobs starting from the pagination token (exclusively). Overrides the interval param if specified [default: empty]"
+// @Param        limit             query    int     false  "The maximum number of blobs to fetch. Unlimited if limit <= 0 [default: 20]"
+// @Success      200               {object} BlobFeedResponse
+// @Failure      400               {object} ErrorResponse  "error: Bad request"
+// @Failure      404               {object} ErrorResponse  "error: Not found"
+// @Failure      500               {object} ErrorResponse  "error: Server error"
 func (s *ServerV2) FetchBlobFeedHandler(c *gin.Context) {
-	errorResponse(c, errors.New("FetchBlobFeedHandler unimplemented"))
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
+		s.metrics.ObserveLatency("FetchBlobFeedHandler", f*1000) // make milliseconds
+	}))
+	defer timer.ObserveDuration()
+
+	var err error
+
+	endTime := time.Now()
+	if c.Query("end") != "" {
+		endTime, err = time.Parse("2006-01-02T15:04:05Z", c.Query("end"))
+		if err != nil {
+			s.metrics.IncrementInvalidArgRequestNum("FetchBlobFeedHandler")
+			invalidParamsErrorResponse(c, fmt.Errorf("failed to parse end param: %w", err))
+			return
+		}
+	}
+
+	interval := 3600
+	if c.Query("interval") != "" {
+		interval, err = strconv.Atoi(c.Query("interval"))
+		if err != nil {
+			s.metrics.IncrementInvalidArgRequestNum("FetchBlobFeedHandler")
+			invalidParamsErrorResponse(c, fmt.Errorf("failed to parse interval param: %w", err))
+			return
+		}
+	}
+
+	limit, err := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	if err != nil {
+		s.metrics.IncrementInvalidArgRequestNum("FetchBlobFeedHandler")
+		invalidParamsErrorResponse(c, fmt.Errorf("failed to parse limit param: %w", err))
+		return
+	}
+
+	paginationCursor := blobstore.BlobFeedCursor{
+		RequestedAt: 0,
+	}
+	if c.Query("pagination_token") != "" {
+		cursor, err := paginationCursor.FromCursorKey(c.Query("pagination_token"))
+		if err != nil {
+			s.metrics.IncrementInvalidArgRequestNum("FetchBlobFeedHandler")
+			invalidParamsErrorResponse(c, fmt.Errorf("failed to parse the pagination token: %w", err))
+			return
+		}
+		paginationCursor = *cursor
+	}
+
+	startTime := endTime.Add(-time.Duration(interval) * time.Second)
+	startCursor := blobstore.BlobFeedCursor{
+		RequestedAt: uint64(startTime.UnixNano()),
+	}
+	if startCursor.LessThan(&paginationCursor) {
+		startCursor = paginationCursor
+	}
+	endCursor := blobstore.BlobFeedCursor{
+		RequestedAt: uint64(endTime.UnixNano()),
+	}
+
+	blobs, paginationToken, err := s.blobMetadataStore.GetBlobMetadataByRequestedAt(c.Request.Context(), startCursor, endCursor, limit)
+	if err != nil {
+		s.metrics.IncrementFailedRequestNum("FetchBlobFeedHandler")
+		errorResponse(c, fmt.Errorf("failed to fetch feed from blob metadata store: %w", err))
+	}
+
+	token := ""
+	if paginationToken != nil {
+		token = paginationToken.ToCursorKey()
+	}
+	response := &BlobFeedResponse{
+		Blobs:           blobs,
+		PaginationToken: token,
+	}
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxFeedBlobAge))
+	s.metrics.IncrementSuccessfulRequestNum("FetchBlobFeedHandler")
+	c.JSON(http.StatusOK, response)
 }
 
 // FetchBlobHandler godoc

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -309,17 +309,17 @@ func (s *ServerV2) Shutdown() error {
 
 // FetchBlobFeedHandler godoc
 //
-// @Summary      Fetch blob feed
-// @Tags         Blob
-// @Produce      json
-// @Param        end               query    string  false  "Fetch blobs up to the end time (ISO 8601 format: 2006-01-02T15:04:05Z) [default: now]"
-// @Param        interval          query    int     false  "Fetch blobs starting from an interval (in seconds) before the end time [default: 3600]"
-// @Param        pagination_token  query    string  false  "Fetch blobs starting from the pagination token (exclusively). Overrides the interval param if specified [default: empty]"
-// @Param        limit             query    int     false  "The maximum number of blobs to fetch. Unlimited if limit <= 0 [default: 20]"
-// @Success      200               {object} BlobFeedResponse
-// @Failure      400               {object} ErrorResponse  "error: Bad request"
-// @Failure      404               {object} ErrorResponse  "error: Not found"
-// @Failure      500               {object} ErrorResponse  "error: Server error"
+//	@Summary	Fetch blob feed
+//	@Tags		Blob
+//	@Produce	json
+//	@Param		end					query		string	false	"Fetch blobs up to the end time (ISO 8601 format: 2006-01-02T15:04:05Z) [default: now]"
+//	@Param		interval			query		int		false	"Fetch blobs starting from an interval (in seconds) before the end time [default: 3600]"
+//	@Param		pagination_token	query		string	false	"Fetch blobs starting from the pagination token (exclusively). Overrides the interval param if specified [default: empty]"
+//	@Param		limit				query		int		false	"The maximum number of blobs to fetch. Unlimited if limit <= 0 [default: 20]"
+//	@Success	200					{object}	BlobFeedResponse
+//	@Failure	400					{object}	ErrorResponse	"error: Bad request"
+//	@Failure	404					{object}	ErrorResponse	"error: Not found"
+//	@Failure	500					{object}	ErrorResponse	"error: Server error"
 func (s *ServerV2) FetchBlobFeedHandler(c *gin.Context) {
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
 		s.metrics.ObserveLatency("FetchBlobFeedHandler", f*1000) // make milliseconds

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -347,18 +347,18 @@ func (s *ServerV2) FetchBlobFeedHandler(c *gin.Context) {
 		interval, err = strconv.Atoi(c.Query("interval"))
 		if err != nil {
 			s.metrics.IncrementInvalidArgRequestNum("FetchBlobFeedHandler")
-			invalidParamsErrorResponse(c, fmt.Errorf("interval param is invalid: %w", err))
+			invalidParamsErrorResponse(c, fmt.Errorf("failed to parse interval param: %w", err))
 			return
 		}
 	}
 
 	limit, err := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	if err != nil || limit > maxBlobFeedNumBlobs {
+	if err != nil {
 		s.metrics.IncrementInvalidArgRequestNum("FetchBlobFeedHandler")
-		invalidParamsErrorResponse(c, fmt.Errorf("limit param is invalid: %w", err))
+		invalidParamsErrorResponse(c, fmt.Errorf("failed to parse limit param: %w", err))
 		return
 	}
-	if limit <= 0 {
+	if limit <= 0 || limit > maxBlobFeedNumBlobs {
 		limit = maxBlobFeedNumBlobs
 	}
 

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -417,6 +417,10 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		r.ServeHTTP(w, req)
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 
+		req = httptest.NewRequest(http.MethodGet, "/v2/blobs/feed?interval=14401", nil)
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+
 		req = httptest.NewRequest(http.MethodGet, "/v2/blobs/feed?end=2006-01-02T15:04:05", nil)
 		r.ServeHTTP(w, req)
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -407,8 +407,8 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		reqUrls := []string{
 			"/v2/blobs/feed?pagination_token=abc",
 			"/v2/blobs/feed?limit=abc",
+			"/v2/blobs/feed?limit=1001",
 			"/v2/blobs/feed?interval=abc",
-			"/v2/blobs/feed?interval=14401",
 			"/v2/blobs/feed?end=2006-01-02T15:04:05",
 		}
 		for _, url := range reqUrls {

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -404,26 +404,19 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 	r.GET("/v2/blobs/feed", testDataApiServerV2.FetchBlobFeedHandler)
 
 	t.Run("invalid params", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/v2/blobs/feed?pagination_token=abc", nil)
-		r.ServeHTTP(w, req)
-		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
-
-		req = httptest.NewRequest(http.MethodGet, "/v2/blobs/feed?limit=abc", nil)
-		r.ServeHTTP(w, req)
-		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
-
-		req = httptest.NewRequest(http.MethodGet, "/v2/blobs/feed?interval=abc", nil)
-		r.ServeHTTP(w, req)
-		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
-
-		req = httptest.NewRequest(http.MethodGet, "/v2/blobs/feed?interval=14401", nil)
-		r.ServeHTTP(w, req)
-		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
-
-		req = httptest.NewRequest(http.MethodGet, "/v2/blobs/feed?end=2006-01-02T15:04:05", nil)
-		r.ServeHTTP(w, req)
-		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		reqUrls := []string{
+			"/v2/blobs/feed?pagination_token=abc",
+			"/v2/blobs/feed?limit=abc",
+			"/v2/blobs/feed?interval=abc",
+			"/v2/blobs/feed?interval=14401",
+			"/v2/blobs/feed?end=2006-01-02T15:04:05",
+		}
+		for _, url := range reqUrls {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			r.ServeHTTP(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		}
 	})
 
 	t.Run("default params", func(t *testing.T) {

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -472,10 +472,10 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BlobFeedResponse](t, w)
 		require.Equal(t, 60, len(response.Blobs))
-		// for i := 0; i < 60; i++ {
-		// 	checkBlobKeyEqual(t, keys[41+i], response.Blobs[i].BlobHeader)
-		// 	assert.Equal(t, requestedAt[41+i], response.Blobs[i].RequestedAt)
-		// }
+		for i := 0; i < 60; i++ {
+			checkBlobKeyEqual(t, keys[41+i], response.Blobs[i].BlobHeader)
+			assert.Equal(t, requestedAt[41+i], response.Blobs[i].RequestedAt)
+		}
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[100], keys[100])
 	})
@@ -484,7 +484,7 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		// Querying the blobs in the past hour, with limit=20
 		// It should return keys[43], ..., keys[62].
 		tm := time.Unix(0, time.Now().UnixNano()).UTC()
-		endTime := tm.Format("2006-01-02T15:04:05.999999999Z")
+		endTime := tm.Format("2006-01-02T15:04:05.999999999Z") // nano precision format
 		reqUrl := fmt.Sprintf("/v2/blobs/feed?end=%s&limit=20", endTime)
 		w := executeRequest(t, r, http.MethodGet, reqUrl)
 		response := decodeResponseBody[serverv2.BlobFeedResponse](t, w)

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -407,7 +407,6 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		reqUrls := []string{
 			"/v2/blobs/feed?pagination_token=abc",
 			"/v2/blobs/feed?limit=abc",
-			"/v2/blobs/feed?limit=1001",
 			"/v2/blobs/feed?interval=abc",
 			"/v2/blobs/feed?end=2006-01-02T15:04:05",
 		}


### PR DESCRIPTION
## Why are these changes needed?
Implementing dataapi v2 (https://github.com/Layr-Labs/eigenda/pull/955)

This supports the blob feed API where clients can query stream of blobs in the past N seconds, with pagination.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
