### PR TITLE
Reduce `MaxRecvMsgSize` for v2 node endpoints

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -86,6 +86,7 @@ type Config struct {
 	EnableV2                    bool
 	OnchainStateRefreshInterval time.Duration
 	ChunkDownloadTimeout        time.Duration
+	GRPCMsgSizeLimitV2          int
 
 	PprofHttpPort string
 	EnablePprof   bool
@@ -261,6 +262,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		EnableV2:                            ctx.GlobalBool(flags.EnableV2Flag.Name),
 		OnchainStateRefreshInterval:         ctx.GlobalDuration(flags.OnchainStateRefreshIntervalFlag.Name),
 		ChunkDownloadTimeout:                ctx.GlobalDuration(flags.ChunkDownloadTimeoutFlag.Name),
+		GRPCMsgSizeLimitV2:                  ctx.GlobalInt(flags.GRPCMsgSizeLimitV2Flag.Name),
 		PprofHttpPort:                       ctx.GlobalString(flags.PprofHttpPort.Name),
 		EnablePprof:                         ctx.GlobalBool(flags.EnablePprof.Name),
 		DisableDispersalAuthentication:      ctx.GlobalBool(flags.DisableDispersalAuthenticationFlag.Name),

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -238,6 +238,13 @@ var (
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "CHUNK_DOWNLOAD_TIMEOUT"),
 		Value:    20 * time.Second,
 	}
+	GRPCMsgSizeLimitV2Flag = cli.IntFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "grpc-msg-size-limit-v2"),
+		Usage:    "The maximum message size in bytes the V2 dispersal endpoint can receive from the client. This flag is only relevant in v2 (default: 1MB)",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "GRPC_MSG_SIZE_LIMIT_V2"),
+		Value:    1024 * 1024,
+	}
 	DisableDispersalAuthenticationFlag = cli.BoolFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "disable-dispersal-authentication"),
 		Usage:    "Disable authentication for StoreChunks() calls from the disperser",
@@ -409,6 +416,7 @@ var optionalFlags = []cli.Flag{
 	EnableV2Flag,
 	OnchainStateRefreshIntervalFlag,
 	ChunkDownloadTimeoutFlag,
+	GRPCMsgSizeLimitV2Flag,
 	PprofHttpPort,
 	EnablePprof,
 	DisableDispersalAuthenticationFlag,

--- a/node/grpc/run.go
+++ b/node/grpc/run.go
@@ -59,7 +59,7 @@ func RunServers(serverV1 *Server, serverV2 *ServerV2, config *node.Config, logge
 				logger.Fatalf("Could not start tcp listener: %v", err)
 			}
 
-			opt := grpc.MaxRecvMsgSize(1024 * 1024 * 300) // 300 MiB
+			opt := grpc.MaxRecvMsgSize(config.GRPCMsgSizeLimitV2)
 			gs := grpc.NewServer(opt, serverV2.metrics.GetGRPCServerOption())
 
 			// Register reflection service on gRPC server


### PR DESCRIPTION
## Why are these changes needed?
v2 requests to nodes should be a lot smaller (<30 KiB for a dispersal request with 100 blobs)
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
