### PR TITLE
update download-artifact to v4

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -37,7 +37,7 @@ runs:
         go-version: ${{inputs.go-version}}
 
     - name: Download coverage artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage
         path: .

--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Download coverage artifact
       uses: actions/download-artifact@v4
       with:
-        name: coverage
+        name: coverage-*
         path: .
 
     - name: Generate coverage report


### PR DESCRIPTION
## Why are these changes needed?

fix CI per: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
