### PR TITLE
[v2] fix: Ignore chunks outside operator quorums

### DIFF
--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -240,8 +240,14 @@ func (d *ChainDataMock) GetOperatorState(ctx context.Context, blockNumber uint, 
 }
 
 func (d *ChainDataMock) GetOperatorStateByOperator(ctx context.Context, blockNumber uint, operator core.OperatorID) (*core.OperatorState, error) {
+	quorums := make([]core.QuorumID, 0)
+	for quorumID, stake := range d.Stakes {
+		if _, ok := stake[operator]; ok {
+			quorums = append(quorums, quorumID)
+		}
+	}
 
-	state := d.GetTotalOperatorState(ctx, blockNumber)
+	state := d.GetTotalOperatorStateWithQuorums(ctx, blockNumber, quorums)
 
 	return state.OperatorState, nil
 

--- a/core/v2/core_test.go
+++ b/core/v2/core_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gammazero/workerpool"
-	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -42,6 +42,7 @@ var (
 	blobParamsMap = v2.NewBlobVersionParameterMap(map[corev2.BlobVersion]*core.BlobVersionParameters{
 		0: blobParams,
 	})
+	quorumNumbers = []core.QuorumID{0, 1, 2}
 )
 
 func TestMain(m *testing.M) {
@@ -135,7 +136,7 @@ func prepareBlobs(
 	cst, err := mock.MakeChainDataMock(map[uint8]int{
 		0: int(operatorCount),
 		1: int(operatorCount),
-		2: int(operatorCount),
+		2: int(operatorCount) / 2,
 	})
 	assert.NoError(t, err)
 
@@ -146,37 +147,22 @@ func prepareBlobs(
 		header := cert.BlobHeader
 
 		params, err := header.GetEncodingParams(blobParams)
-		if err != nil {
-			t.Fatal(err)
-		}
-
+		require.NoError(t, err)
 		chunks, err := p.GetFrames(blob, params)
-		if err != nil {
-			t.Fatal(err)
-		}
-
+		require.NoError(t, err)
 		state, err := cst.GetOperatorState(context.Background(), uint(referenceBlockNumber), header.QuorumNumbers)
-		if err != nil {
-			t.Fatal(err)
-		}
-
+		require.NoError(t, err)
 		blobMap := make(map[core.QuorumID]map[core.OperatorID][]*encoding.Frame)
 
 		for _, quorum := range header.QuorumNumbers {
-
 			assignments, err := corev2.GetAssignments(state, blobParams, quorum)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			blobMap[quorum] = make(map[core.OperatorID][]*encoding.Frame)
 
 			for opID, assignment := range assignments {
-
 				blobMap[quorum][opID] = chunks[assignment.StartIndex : assignment.StartIndex+assignment.NumChunks]
-
 			}
-
 		}
 
 		blobsMap = append(blobsMap, blobMap)
@@ -201,7 +187,6 @@ func prepareBlobs(
 					continue
 				}
 				inverseMap[operatorID][blobIndex].Bundles[quorum] = append(inverseMap[operatorID][blobIndex].Bundles[quorum], frames...)
-
 			}
 		}
 	}
@@ -213,48 +198,30 @@ func prepareBlobs(
 // checkBatchByUniversalVerifier runs the verification logic for each DA node in the current OperatorState, and returns an error if any of
 // the DA nodes' validation checks fails
 func checkBatchByUniversalVerifier(
+	t *testing.T,
 	cst core.IndexedChainState,
 	packagedBlobs map[core.OperatorID][]*corev2.BlobShard,
 	pool common.WorkerPool,
-) error {
+) {
 
 	ctx := context.Background()
-
-	quorums := []core.QuorumID{0, 1}
-	state, _ := cst.GetIndexedOperatorState(context.Background(), 0, quorums)
-
-	var errList *multierror.Error
+	state, _ := cst.GetIndexedOperatorState(context.Background(), 0, quorumNumbers)
 
 	for id := range state.IndexedOperators {
-
 		val := corev2.NewShardValidator(v, id, testutils.GetLogger())
-
 		blobs := packagedBlobs[id]
-
-		err := val.ValidateBlobs(ctx, blobs, blobParamsMap, pool, state.OperatorState)
-		if err != nil {
-			errList = multierror.Append(errList, err)
-		}
+		st, err := cst.GetOperatorStateByOperator(ctx, 0, id)
+		require.NoError(t, err)
+		err = val.ValidateBlobs(ctx, blobs, blobParamsMap, pool, st)
+		require.NoError(t, err)
 	}
-
-	return errList.ErrorOrNil()
-
 }
 
 func TestValidationSucceeds(t *testing.T) {
 
-	// operatorCounts := []uint{1, 2, 4, 10, 30}
-
-	// numBlob := 3 // must be greater than 0
-	// blobLengths := []int{1, 32, 128}
-
-	operatorCounts := []uint{4}
-
+	operatorCounts := []uint{1, 10}
 	numBlob := 1 // must be greater than 0
 	blobLengths := []int{1, 2}
-
-	quorumNumbers := []core.QuorumID{0, 1}
-
 	bn := uint64(1000)
 
 	version := corev2.BlobVersion(0)
@@ -264,21 +231,20 @@ func TestValidationSucceeds(t *testing.T) {
 	for _, operatorCount := range operatorCounts {
 
 		// batch can only be tested per operatorCount, because the assignment would be wrong otherwise
-		headers := make([]corev2.BlobCertificate, 0)
+		certs := make([]corev2.BlobCertificate, 0)
 		blobs := make([][]byte, 0)
 		for _, blobLength := range blobLengths {
 			for i := 0; i < numBlob; i++ {
-				header, data := makeTestBlob(t, p, version, blobLength, quorumNumbers)
-				headers = append(headers, header)
+				cert, data := makeTestBlob(t, p, version, blobLength, quorumNumbers)
+				certs = append(certs, cert)
 				blobs = append(blobs, data)
 			}
 		}
 
-		packagedBlobs, cst := prepareBlobs(t, operatorCount, headers, blobs, bn)
+		packagedBlobs, cst := prepareBlobs(t, operatorCount, certs, blobs, bn)
 
 		t.Run(fmt.Sprintf("universal verifier operatorCount=%v over %v blobs", operatorCount, len(blobs)), func(t *testing.T) {
-			err := checkBatchByUniversalVerifier(cst, packagedBlobs, pool)
-			assert.NoError(t, err)
+			checkBatchByUniversalVerifier(t, cst, packagedBlobs, pool)
 		})
 
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -21,7 +21,8 @@ import (
 
 var (
 	privateKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-	opID       = [32]byte{0}
+	op0        = [32]byte{0}
+	op3        = [32]byte{3}
 
 	blobParams = &core.BlobVersionParameters{
 		NumChunks:       8192,
@@ -39,7 +40,7 @@ type components struct {
 	relayClient *clientsmock.MockRelayClient
 }
 
-func newComponents(t *testing.T) *components {
+func newComponents(t *testing.T, operatorID [32]byte) *components {
 	dbPath := t.TempDir()
 	keyPair, err := core.GenRandomBlsKeys()
 	if err != nil {
@@ -50,7 +51,7 @@ func newComponents(t *testing.T) *components {
 		ExpirationPollIntervalSec: 1,
 		QuorumIDList:              []core.QuorumID{0},
 		DbPath:                    dbPath,
-		ID:                        opID,
+		ID:                        operatorID,
 		NumBatchValidators:        runtime.GOMAXPROCS(0),
 		EnableNodeApi:             false,
 		EnableMetrics:             false,
@@ -74,7 +75,7 @@ func newComponents(t *testing.T) *components {
 	chainState, _ := coremock.MakeChainDataMock(map[uint8]int{
 		0: 4,
 		1: 4,
-		2: 4,
+		2: 3,
 	})
 
 	store, err := node.NewLevelDBStore(dbPath, logger, nil, 1e9, 1e9)
@@ -101,7 +102,7 @@ func newComponents(t *testing.T) *components {
 }
 
 func TestNodeStartNoAddress(t *testing.T) {
-	c := newComponents(t)
+	c := newComponents(t, op0)
 	c.node.Config.RegisterNodeAtStart = false
 
 	c.tx.On("GetOperatorSocket", mock.Anything).Return("", errors.New("failed to get operator socket"))
@@ -111,7 +112,7 @@ func TestNodeStartNoAddress(t *testing.T) {
 }
 
 func TestNodeStartOperatorIDMatch(t *testing.T) {
-	c := newComponents(t)
+	c := newComponents(t, op0)
 	c.node.Config.RegisterNodeAtStart = true
 	c.node.Config.EthClientConfig = geth.EthClientConfig{
 		RPCURLs:          []string{"http://localhost:8545"},
@@ -127,14 +128,14 @@ func TestNodeStartOperatorIDMatch(t *testing.T) {
 	c.tx.On("GetNumberOfRegisteredOperatorForQuorum", mock.Anything, mock.Anything).Return(uint32(0), nil)
 	c.tx.On("RegisterOperator", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	c.tx.On("OperatorAddressToID", mock.Anything).Return(core.OperatorID(opID), nil)
+	c.tx.On("OperatorAddressToID", mock.Anything).Return(core.OperatorID(op0), nil)
 
 	err := c.node.Start(context.Background())
 	assert.NoError(t, err)
 }
 
 func TestNodeStartOperatorIDDoesNotMatch(t *testing.T) {
-	c := newComponents(t)
+	c := newComponents(t, op0)
 	c.node.Config.RegisterNodeAtStart = true
 	c.node.Config.EthClientConfig = geth.EthClientConfig{
 		RPCURLs:          []string{"http://localhost:8545"},

--- a/node/node_v2.go
+++ b/node/node_v2.go
@@ -71,9 +71,17 @@ func (n *Node) DownloadBundles(ctx context.Context, batch *corev2.Batch, operato
 			if !ok {
 				return nil, nil, fmt.Errorf("blob version %d not found", cert.BlobHeader.BlobVersion)
 			}
+
+			if _, ok := operatorState.Operators[quorum]; !ok {
+				// operator is not part of the quorum or the quorum is not valid
+				n.Logger.Debug("operator is not part of the quorum or the quorum is not valid", "quorum", quorum)
+				continue
+			}
+
 			assgn, err := corev2.GetAssignment(operatorState, blobParams, quorum, n.Config.ID)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get assignments: %v", err)
+				n.Logger.Errorf("failed to get assignment: %v", err)
+				continue
 			}
 
 			req, ok := requests[relayKey]


### PR DESCRIPTION
## Why are these changes needed?
Operator should not download/process chunks outside its participating quorums. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
