### PR TITLE
Add service verification to reachability check

### DIFF
--- a/disperser/dataapi/operator_handler.go
+++ b/disperser/dataapi/operator_handler.go
@@ -48,14 +48,14 @@ func (oh *OperatorHandler) ProbeOperatorHosts(ctx context.Context, operatorId st
 	operatorSocket := core.OperatorSocket(operatorInfo.Socket)
 	retrievalSocket := operatorSocket.GetRetrievalSocket()
 	retrievalPortOpen := checkIsOperatorPortOpen(retrievalSocket, 3, oh.logger)
-	retrievalOnline, retrievalStatus := false, "port closed"
+	retrievalOnline, retrievalStatus := false, fmt.Sprintf("port closed or unreachable for %s", retrievalSocket)
 	if retrievalPortOpen {
 		retrievalOnline, retrievalStatus = checkServiceOnline(ctx, "node.Retrieval", retrievalSocket, 3*time.Second)
 	}
 
 	dispersalSocket := operatorSocket.GetDispersalSocket()
 	dispersalPortOpen := checkIsOperatorPortOpen(dispersalSocket, 3, oh.logger)
-	dispersalOnline, dispersalStatus := false, "port closed"
+	dispersalOnline, dispersalStatus := false, fmt.Sprintf("port closed or unreachable for %s", dispersalSocket)
 	if dispersalPortOpen {
 		dispersalOnline, dispersalStatus = checkServiceOnline(ctx, "node.Dispersal", dispersalSocket, 3*time.Second)
 	}
@@ -115,11 +115,11 @@ func checkServiceOnline(ctx context.Context, serviceName string, socket string, 
 	if list := r.GetListServicesResponse(); list != nil {
 		for _, service := range list.GetService() {
 			if service.GetName() == serviceName {
-				return true, "available"
+				return true, fmt.Sprintf("%s is available", serviceName)
 			}
 		}
 	}
-	return false, "unavailable"
+	return false, fmt.Sprintf("grpc available but %s service not found at %s", serviceName, socket)
 }
 
 func (oh *OperatorHandler) GetOperatorsStake(ctx context.Context, operatorId string) (*OperatorsStakeResponse, error) {

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -199,7 +199,7 @@ func checkIsOnlineAndProcessOperator(operatorStatus OperatorOnlineStatus, operat
 	var socket string
 	if operatorStatus.IndexedOperatorInfo != nil {
 		socket = core.OperatorSocket(operatorStatus.IndexedOperatorInfo.Socket).GetRetrievalSocket()
-		isOnline = checkIsOperatorOnline(socket, 10, logger)
+		isOnline = checkIsOperatorPortOpen(socket, 10, logger)
 	}
 
 	// Log the online status
@@ -245,8 +245,8 @@ func ValidOperatorIP(address string, logger logging.Logger) bool {
 	return isValid
 }
 
-// method to check if operator is online via socket dial
-func checkIsOperatorOnline(socket string, timeoutSecs int, logger logging.Logger) bool {
+// method to check if operator port is open
+func checkIsOperatorPortOpen(socket string, timeoutSecs int, logger logging.Logger) bool {
 	if !ValidOperatorIP(socket, logger) {
 		logger.Error("port check blocked invalid operator IP", "socket", socket)
 		return false

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -180,6 +180,8 @@ type (
 		RetrievalSocket string `json:"retrieval_socket"`
 		DispersalOnline bool   `json:"dispersal_online"`
 		RetrievalOnline bool   `json:"retrieval_online"`
+		DispersalStatus string `json:"dispersal_status"`
+		RetrievalStatus string `json:"retrieval_status"`
 	}
 	SemverReportResponse struct {
 		Semver map[string]*semver.SemverMetrics `json:"semver"`


### PR DESCRIPTION
Current reachability check only confirms that the port is open. 

This new logic performs additional validation using grpc reflection to ensure we do not mislead operators when there are configuration issues preventing us from connecting to the node.

If port is open, we now verify the expected service is available based on port specification using grpc reflection. This will catch situations where port is open, but service backend is configured wrong or unreachable.

We now include a status message for dispersal and retrieval checks to help operators debug any reachability check failures.

## all services available
```
{
  "operator_id": "39638352822b2eecf33f2ea0e6893a576edbcc202b4925c3ab2875677945bf58",
  "dispersal_socket": "98.84.160.141:32007",
  "retrieval_socket": "98.84.160.141:32008",
  "dispersal_online": true,
  "retrieval_online": true,
  "dispersal_status": "node.Dispersal is available",
  "retrieval_status": "node.Retrieval is available"
}
```

## ports closed or unreachable
```
{
  "operator_id": "39638352822b2eecf33f2ea0e6893a576edbcc202b4925c3ab2875677945bf58",
  "dispersal_socket": "98.84.160.141:32002",
  "retrieval_socket": "98.84.160.141:32001",
  "dispersal_online": false,
  "retrieval_online": false,
  "dispersal_status": "port closed or unreachable for 98.84.160.141:32002",
  "retrieval_status": "port closed or unreachable for 98.84.160.141:32001"
}
```

## port open but grpc fails to connect
previously this would return `dispersal_online: true`
```
{
  "operator_id": "39638352822b2eecf33f2ea0e6893a576edbcc202b4925c3ab2875677945bf58",
  "dispersal_socket": "98.84.160.141:32001",
  "retrieval_socket": "98.84.160.141:32008",
  "dispersal_online": false,
  "retrieval_online": true,
  "dispersal_status": "rpc error: code = DeadlineExceeded desc = received context error while waiting for new LB policy update: context deadline exceeded",
  "retrieval_status": "available"
}
```

## ports open but serving wrong grpc services
previously this would return `dispersal_online: true` and `retrieval_online: true`
```
{
  "operator_id": "39638352822b2eecf33f2ea0e6893a576edbcc202b4925c3ab2875677945bf58",
  "dispersal_socket": "98.84.160.141:32007",
  "retrieval_socket": "98.84.160.141:32008",
  "dispersal_online": false,
  "retrieval_online": false,
  "dispersal_status": "grpc available but node.Dispersal service not found at 98.84.160.141:32007",
  "retrieval_status": "grpc available but node.Retrieval service not found at 98.84.160.141:32008"
}
```

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(
