### PR TITLE
Reachability check against v2 dispersal port

### DIFF
--- a/core/serialization.go
+++ b/core/serialization.go
@@ -535,6 +535,14 @@ func (s OperatorSocket) GetV1DispersalSocket() string {
 	return fmt.Sprintf("%s:%s", ip, v1DispersalPort)
 }
 
+func (s OperatorSocket) GetV2DispersalSocket() string {
+	ip, _, _, v2DispersalPort, err := ParseOperatorSocket(string(s))
+	if err != nil || v2DispersalPort == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%s", ip, v2DispersalPort)
+}
+
 func (s OperatorSocket) GetRetrievalSocket() string {
 	ip, _, retrievalPort, _, err := ParseOperatorSocket(string(s))
 	if err != nil {

--- a/disperser/dataapi/docs/v1/V1_docs.go
+++ b/disperser/dataapi/docs/v1/V1_docs.go
@@ -941,6 +941,15 @@ const docTemplateV1 = `{
                 },
                 "retrieval_status": {
                     "type": "string"
+                },
+                "v2_dispersal_online": {
+                    "type": "boolean"
+                },
+                "v2_dispersal_socket": {
+                    "type": "string"
+                },
+                "v2_dispersal_status": {
+                    "type": "string"
                 }
             }
         },

--- a/disperser/dataapi/docs/v1/V1_docs.go
+++ b/disperser/dataapi/docs/v1/V1_docs.go
@@ -927,6 +927,9 @@ const docTemplateV1 = `{
                 "dispersal_socket": {
                     "type": "string"
                 },
+                "dispersal_status": {
+                    "type": "string"
+                },
                 "operator_id": {
                     "type": "string"
                 },
@@ -934,6 +937,9 @@ const docTemplateV1 = `{
                     "type": "boolean"
                 },
                 "retrieval_socket": {
+                    "type": "string"
+                },
+                "retrieval_status": {
                     "type": "string"
                 }
             }
@@ -1126,6 +1132,12 @@ const docTemplateV1 = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "y": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -1134,6 +1146,9 @@ const docTemplateV1 = `{
             "properties": {
                 "x": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
         },
@@ -1141,6 +1156,9 @@ const docTemplateV1 = `{
             "type": "object",
             "properties": {
                 "x": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -1168,6 +1186,12 @@ const docTemplateV1 = `{
             "type": "object",
             "properties": {
                 "a0": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "a1": {
                     "type": "array",
                     "items": {
                         "type": "integer"

--- a/disperser/dataapi/docs/v1/V1_swagger.json
+++ b/disperser/dataapi/docs/v1/V1_swagger.json
@@ -923,6 +923,9 @@
                 "dispersal_socket": {
                     "type": "string"
                 },
+                "dispersal_status": {
+                    "type": "string"
+                },
                 "operator_id": {
                     "type": "string"
                 },
@@ -930,6 +933,9 @@
                     "type": "boolean"
                 },
                 "retrieval_socket": {
+                    "type": "string"
+                },
+                "retrieval_status": {
                     "type": "string"
                 }
             }
@@ -1122,6 +1128,12 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "y": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -1130,6 +1142,9 @@
             "properties": {
                 "x": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
         },
@@ -1137,6 +1152,9 @@
             "type": "object",
             "properties": {
                 "x": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -1164,6 +1182,12 @@
             "type": "object",
             "properties": {
                 "a0": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "a1": {
                     "type": "array",
                     "items": {
                         "type": "integer"

--- a/disperser/dataapi/docs/v1/V1_swagger.json
+++ b/disperser/dataapi/docs/v1/V1_swagger.json
@@ -937,6 +937,15 @@
                 },
                 "retrieval_status": {
                     "type": "string"
+                },
+                "v2_dispersal_online": {
+                    "type": "boolean"
+                },
+                "v2_dispersal_socket": {
+                    "type": "string"
+                },
+                "v2_dispersal_status": {
+                    "type": "string"
                 }
             }
         },

--- a/disperser/dataapi/docs/v1/V1_swagger.yaml
+++ b/disperser/dataapi/docs/v1/V1_swagger.yaml
@@ -124,11 +124,15 @@ definitions:
         type: boolean
       dispersal_socket:
         type: string
+      dispersal_status:
+        type: string
       operator_id:
         type: string
       retrieval_online:
         type: boolean
       retrieval_socket:
+        type: string
+      retrieval_status:
         type: string
     type: object
   dataapi.OperatorStake:
@@ -253,15 +257,23 @@ definitions:
         items:
           type: integer
         type: array
+      "y":
+        items:
+          type: integer
+        type: array
     type: object
   encoding.G2Commitment:
     properties:
       x:
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
+      "y":
+        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   encoding.LengthProof:
     properties:
       x:
+        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
+      "y":
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   github_com_Layr-Labs_eigenda_disperser.BlobStatus:
@@ -283,6 +295,10 @@ definitions:
   github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2:
     properties:
       a0:
+        items:
+          type: integer
+        type: array
+      a1:
         items:
           type: integer
         type: array

--- a/disperser/dataapi/docs/v1/V1_swagger.yaml
+++ b/disperser/dataapi/docs/v1/V1_swagger.yaml
@@ -134,6 +134,12 @@ definitions:
         type: string
       retrieval_status:
         type: string
+      v2_dispersal_online:
+        type: boolean
+      v2_dispersal_socket:
+        type: string
+      v2_dispersal_status:
+        type: string
     type: object
   dataapi.OperatorStake:
     properties:

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -1260,6 +1260,9 @@ const docTemplateV2 = `{
                 "dispersal_socket": {
                     "type": "string"
                 },
+                "dispersal_status": {
+                    "type": "string"
+                },
                 "operator_id": {
                     "type": "string"
                 },
@@ -1267,6 +1270,18 @@ const docTemplateV2 = `{
                     "type": "boolean"
                 },
                 "retrieval_socket": {
+                    "type": "string"
+                },
+                "retrieval_status": {
+                    "type": "string"
+                },
+                "v2_dispersal_online": {
+                    "type": "boolean"
+                },
+                "v2_dispersal_socket": {
+                    "type": "string"
+                },
+                "v2_dispersal_status": {
                     "type": "string"
                 }
             }

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -663,6 +663,12 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "y": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -670,6 +676,9 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "x": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -703,6 +712,12 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "y": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -731,6 +746,12 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "y": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -739,6 +760,9 @@ const docTemplateV2 = `{
             "properties": {
                 "x": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
         },
@@ -746,6 +770,9 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "x": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -945,6 +972,12 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "a0": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "a1": {
                     "type": "array",
                     "items": {
                         "type": "integer"

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -660,6 +660,12 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "y": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -667,6 +673,9 @@
             "type": "object",
             "properties": {
                 "x": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -700,6 +709,12 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "y": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -728,6 +743,12 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "y": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -736,6 +757,9 @@
             "properties": {
                 "x": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
         },
@@ -743,6 +767,9 @@
             "type": "object",
             "properties": {
                 "x": {
+                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
+                },
+                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -942,6 +969,12 @@
             "type": "object",
             "properties": {
                 "a0": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "a1": {
                     "type": "array",
                     "items": {
                         "type": "integer"

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -1257,6 +1257,9 @@
                 "dispersal_socket": {
                     "type": "string"
                 },
+                "dispersal_status": {
+                    "type": "string"
+                },
                 "operator_id": {
                     "type": "string"
                 },
@@ -1264,6 +1267,18 @@
                     "type": "boolean"
                 },
                 "retrieval_socket": {
+                    "type": "string"
+                },
+                "retrieval_status": {
+                    "type": "string"
+                },
+                "v2_dispersal_online": {
+                    "type": "boolean"
+                },
+                "v2_dispersal_socket": {
+                    "type": "string"
+                },
+                "v2_dispersal_status": {
                     "type": "string"
                 }
             }

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -51,10 +51,16 @@ definitions:
         items:
           type: integer
         type: array
+      "y":
+        items:
+          type: integer
+        type: array
     type: object
   core.G2Point:
     properties:
       x:
+        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
+      "y":
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   core.PaymentMetadata:
@@ -78,6 +84,10 @@ definitions:
         items:
           type: integer
         type: array
+      "y":
+        items:
+          type: integer
+        type: array
     type: object
   encoding.BlobCommitments:
     properties:
@@ -96,15 +106,23 @@ definitions:
         items:
           type: integer
         type: array
+      "y":
+        items:
+          type: integer
+        type: array
     type: object
   encoding.G2Commitment:
     properties:
       x:
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
+      "y":
+        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   encoding.LengthProof:
     properties:
       x:
+        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
+      "y":
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   github_com_Layr-Labs_eigenda_core_v2.Attestation:
@@ -250,6 +268,10 @@ definitions:
   github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2:
     properties:
       a0:
+        items:
+          type: integer
+        type: array
+      a1:
         items:
           type: integer
         type: array

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -463,11 +463,21 @@ definitions:
         type: boolean
       dispersal_socket:
         type: string
+      dispersal_status:
+        type: string
       operator_id:
         type: string
       retrieval_online:
         type: boolean
       retrieval_socket:
+        type: string
+      retrieval_status:
+        type: string
+      v2_dispersal_online:
+        type: boolean
+      v2_dispersal_socket:
+        type: string
+      v2_dispersal_status:
         type: string
     type: object
   v2.OperatorStake:

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -175,13 +175,16 @@ type (
 	}
 
 	OperatorPortCheckResponse struct {
-		OperatorId      string `json:"operator_id"`
-		DispersalSocket string `json:"dispersal_socket"`
-		RetrievalSocket string `json:"retrieval_socket"`
-		DispersalOnline bool   `json:"dispersal_online"`
-		RetrievalOnline bool   `json:"retrieval_online"`
-		DispersalStatus string `json:"dispersal_status"`
-		RetrievalStatus string `json:"retrieval_status"`
+		OperatorId        string `json:"operator_id"`
+		DispersalSocket   string `json:"dispersal_socket"`
+		DispersalOnline   bool   `json:"dispersal_online"`
+		DispersalStatus   string `json:"dispersal_status"`
+		RetrievalSocket   string `json:"retrieval_socket"`
+		RetrievalOnline   bool   `json:"retrieval_online"`
+		RetrievalStatus   string `json:"retrieval_status"`
+		V2DispersalSocket string `json:"v2_dispersal_socket"`
+		V2DispersalOnline bool   `json:"v2_dispersal_online"`
+		V2DispersalStatus string `json:"v2_dispersal_status"`
 	}
 	SemverReportResponse struct {
 		Semver map[string]*semver.SemverMetrics `json:"semver"`

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -122,11 +122,16 @@ type (
 	}
 
 	OperatorPortCheckResponse struct {
-		OperatorId      string `json:"operator_id"`
-		DispersalSocket string `json:"dispersal_socket"`
-		RetrievalSocket string `json:"retrieval_socket"`
-		DispersalOnline bool   `json:"dispersal_online"`
-		RetrievalOnline bool   `json:"retrieval_online"`
+		OperatorId        string `json:"operator_id"`
+		DispersalSocket   string `json:"dispersal_socket"`
+		DispersalOnline   bool   `json:"dispersal_online"`
+		DispersalStatus   string `json:"dispersal_status"`
+		RetrievalSocket   string `json:"retrieval_socket"`
+		RetrievalOnline   bool   `json:"retrieval_online"`
+		RetrievalStatus   string `json:"retrieval_status"`
+		V2DispersalSocket string `json:"v2_dispersal_socket"`
+		V2DispersalOnline bool   `json:"v2_dispersal_online"`
+		V2DispersalStatus string `json:"v2_dispersal_status"`
 	}
 
 	SemverReportResponse struct {


### PR DESCRIPTION
Add v2 dispersal port reachability check

This PR depends on
- https://github.com/Layr-Labs/eigenda/pull/1132 and 
- https://github.com/Layr-Labs/eigenda/pull/1127

## V2 port not registered
```
{
      "operator_id": "feba99a1e3230e2383f5417ded9695f170491eb4bc2e21110d73f7f127e3d835",
      "dispersal_socket": "23.93.87.156:32005",
      "dispersal_online": true,
      "dispersal_status": "node.Dispersal is available",
      "retrieval_socket": "23.93.87.156:32004",
      "retrieval_online": true,
      "retrieval_status": "node.Retrieval is available",
      "v2_dispersal_socket": "",
      "v2_dispersal_online": false,
      "v2_dispersal_status": "v2 dispersal port is not registered"
}
```

## V2 port registered and reachable
```
{
      "operator_id": "feba99a1e3230e2383f5417ded9695f170491eb4bc2e21110d73f7f127e3d835",
      "dispersal_socket": "23.93.87.156:32005",
      "dispersal_online": true,
      "dispersal_status": "node.Dispersal is available",
      "retrieval_socket": "23.93.87.156:32004",
      "retrieval_online": true,
      "retrieval_status": "node.Retrieval is available",
      "v2_dispersal_socket": "23.93.87.156:32006",
      "v2_dispersal_online": true,
      "v2_dispersal_status": "node.v2.Dispersal is available"
    }
```

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
