### PR TITLE
Relay client should limit max concurrency

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -76,6 +76,8 @@ type Config struct {
 	UseSecureGrpc                  bool
 	ReachabilityPollIntervalSec    uint64
 	DisableNodeInfoResources       bool
+	// The maximum number of concurrent requests to any particular relay server.
+	RelayConcurrency uint
 
 	BlsSignerConfig blssignerTypes.SignerConfig
 
@@ -256,6 +258,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		EnableGnarkBundleEncoding:           ctx.Bool(flags.EnableGnarkBundleEncodingFlag.Name),
 		ClientIPHeader:                      ctx.GlobalString(flags.ClientIPHeaderFlag.Name),
 		UseSecureGrpc:                       ctx.GlobalBoolT(flags.ChurnerUseSecureGRPC.Name),
+		RelayConcurrency:                    ctx.GlobalUint(flags.RelayConcurrencyFlag.Name),
 		DisableNodeInfoResources:            ctx.GlobalBool(flags.DisableNodeInfoResourcesFlag.Name),
 		BlsSignerConfig:                     blsSignerConfig,
 		EnableV2:                            ctx.GlobalBool(flags.EnableV2Flag.Name),

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -148,6 +148,14 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "CHURNER_USE_SECURE_GRPC"),
 	}
+	RelayConcurrencyFlag = cli.UintFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "relay-concurrency"),
+		Usage:    "The maximum number of concurrent relay requests to any particular relay",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "RELAY_CONCURRENCY"),
+		// default value should stay in sync with default value in relay.limiter.Config.MaxConcurrentGetChunkOpsClient
+		Value: 2,
+	}
 	PubIPProviderFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "public-ip-provider"),
 		Usage:    "The ip provider service used to obtain a node's public IP [seeip (default), ipify)",
@@ -415,6 +423,7 @@ var optionalFlags = []cli.Flag{
 	DispersalAuthenticationKeyCacheSizeFlag,
 	DisperserKeyTimeoutFlag,
 	DispersalAuthenticationTimeoutFlag,
+	RelayConcurrencyFlag,
 }
 
 func init() {

--- a/node/node.go
+++ b/node/node.go
@@ -241,10 +241,11 @@ func NewNode(
 
 		logger.Info("Creating relay client", "relayURLs", relayURLs)
 		relayClient, err = clients.NewRelayClient(&clients.RelayClientConfig{
-			Sockets:           relayURLs,
-			UseSecureGrpcFlag: config.UseSecureGrpc,
-			OperatorID:        &config.ID,
-			MessageSigner:     n.SignMessage,
+			Sockets:               relayURLs,
+			UseSecureGrpcFlag:     config.UseSecureGrpc,
+			OperatorID:            &config.ID,
+			MessageSigner:         n.SignMessage,
+			MaxConcurrentRequests: config.RelayConcurrency,
 		}, logger)
 
 		if err != nil {

--- a/relay/cmd/flags/flags.go
+++ b/relay/cmd/flags/flags.go
@@ -199,7 +199,7 @@ var (
 		Usage:    "Max number of concurrent GetChunk operations per client",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "MAX_CONCURRENT_GET_CHUNK_OPS_CLIENT"),
-		Value:    1,
+		Value:    2, // default value should stay in sync with the default value of node.Config.RelayConcurrency
 	}
 	BlsOperatorStateRetrieverAddrFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever-addr"),

--- a/relay/limiter/config.go
+++ b/relay/limiter/config.go
@@ -60,6 +60,6 @@ type Config struct {
 	GetChunkBytesBurstinessClient int
 
 	// MaxConcurrentGetChunkOpsClient is the maximum number of concurrent GetChunk operations that are permitted.
-	// Default is 1.
+	// Default is 2.
 	MaxConcurrentGetChunkOpsClient int
 }


### PR DESCRIPTION
## Why are these changes needed?

In preprod, we observe relays rate limiting concurrent `GetChunks()` requests. This is non-ideal in an environment where the relays are not under intentional attack or high load.

The following screenshot is a histogram of the logs reporting concurrency throttling.

![Screenshot 2025-01-23 at 9 10 50 AM](https://github.com/user-attachments/assets/1eeab188-6032-4d77-8cf0-1cafedc7afc9)

This PR introduces two primary changes:
- increases the maximum permissible concurrency per relay client from 1 to 2
- adds logic to relay clients that causes them to avoid exceeding maximum permissible concurrency
