### PR TITLE
Check type assertion for dynamo types

### DIFF
--- a/core/data.go
+++ b/core/data.go
@@ -559,13 +559,25 @@ func (pm *PaymentMetadata) UnmarshalDynamoDBAttributeValue(av types.AttributeVal
 	if !ok {
 		return fmt.Errorf("expected *types.AttributeValueMemberM, got %T", av)
 	}
-	pm.AccountID = m.Value["AccountID"].(*types.AttributeValueMemberS).Value
-	reservationPeriod, err := strconv.ParseUint(m.Value["ReservationPeriod"].(*types.AttributeValueMemberN).Value, 10, 32)
+	accountID, ok := m.Value["AccountID"].(*types.AttributeValueMemberS)
+	if !ok {
+		return fmt.Errorf("expected *types.AttributeValueMemberS for AccountID, got %T", m.Value["AccountID"])
+	}
+	pm.AccountID = accountID.Value
+	rp, ok := m.Value["ReservationPeriod"].(*types.AttributeValueMemberN)
+	if !ok {
+		return fmt.Errorf("expected *types.AttributeValueMemberN for ReservationPeriod, got %T", m.Value["ReservationPeriod"])
+	}
+	reservationPeriod, err := strconv.ParseUint(rp.Value, 10, 32)
 	if err != nil {
 		return fmt.Errorf("failed to parse ReservationPeriod: %w", err)
 	}
 	pm.ReservationPeriod = uint32(reservationPeriod)
-	pm.CumulativePayment, _ = new(big.Int).SetString(m.Value["CumulativePayment"].(*types.AttributeValueMemberN).Value, 10)
+	cp, ok := m.Value["CumulativePayment"].(*types.AttributeValueMemberN)
+	if !ok {
+		return fmt.Errorf("expected *types.AttributeValueMemberN for CumulativePayment, got %T", m.Value["CumulativePayment"])
+	}
+	pm.CumulativePayment, _ = new(big.Int).SetString(cp.Value, 10)
 	return nil
 }
 

--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -157,6 +157,13 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 		client, err := d.nodeClientManager.GetClient(host, v2DispersalPort)
 		if err != nil {
 			d.logger.Error("failed to get node client", "operator", opID.Hex(), "err", err)
+			sigChan <- core.SigningMessage{
+				Signature:            nil,
+				Operator:             opID,
+				BatchHeaderHash:      batchData.BatchHeaderHash,
+				AttestationLatencyMs: 0,
+				Err:                  err,
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Why are these changes needed?
Type assertions should be validated before being accessed
Also, adding a fix in controller to return error to signature channel in case node client fails to initialize
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
