### PR TITLE
fix typo disperser.pb.go

### DIFF
--- a/api/grpc/disperser/disperser.pb.go
+++ b/api/grpc/disperser/disperser.pb.go
@@ -24,7 +24,7 @@ const (
 // BlobStatus represents the status of a blob.
 // The status of a blob is updated as the blob is processed by the disperser.
 // The status of a blob can be queried by the client using the GetBlobStatus API.
-// Intermediate states are states that the blob can be in while being processed, and it can be updated to a differet state:
+// Intermediate states are states that the blob can be in while being processed, and it can be updated to a different state:
 // - PROCESSING
 // - DISPERSING
 // - CONFIRMED


### PR DESCRIPTION
# Fix Typo in `disperser.pb.go`

## Description
This pull request fixes a typo in the `api/grpc/disperser/disperser.pb.go` file, changing "differet" to "different" for improved clarity and accuracy.

## Change Details
- **File:** `api/grpc/disperser/disperser.pb.go`
- **Changes:** Corrected a typo in the word "different."

## Context
Fixing typos ensures clear and professional documentation, enhancing code readability and maintainability. This change has no impact on functionality.

Let me know if further modifications are needed!
