### PR TITLE
fix(clients/v2): Update blob verifier to not reference client interface via pointer

### DIFF
--- a/api/clients/v2/verification/blob_verifier.go
+++ b/api/clients/v2/verification/blob_verifier.go
@@ -24,13 +24,13 @@ type BlobVerifier struct {
 
 // NewBlobVerifier constructs a BlobVerifier
 func NewBlobVerifier(
-	ethClient *common.EthClient, // the eth client, which should already be set up
+	ethClient common.EthClient, // the eth client, which should already be set up
 	blobVerifierAddress string, // the hex address of the EigenDABlobVerifier contract
 ) (*BlobVerifier, error) {
 
 	verifierCaller, err := verifierBindings.NewContractEigenDABlobVerifierCaller(
 		gethcommon.HexToAddress(blobVerifierAddress),
-		*ethClient)
+		ethClient)
 
 	if err != nil {
 		return nil, fmt.Errorf("bind to verifier contract at %s: %s", blobVerifierAddress, err)


### PR DESCRIPTION
## Why are these changes needed?
Referencing the ethereum client by interface creates an additional layer of indirection - meaning that structs who implement the interface don't adhere since its not expecting a concrete type. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
