### PR TITLE
Rename existing client to PayloadRetriever

### DIFF
--- a/api/clients/v2/payload_retriever.go
+++ b/api/clients/v2/payload_retriever.go
@@ -250,9 +250,12 @@ func (pr *PayloadRetriever) verifyCertWithTimeout(
 //
 // This method should only be called once.
 func (pr *PayloadRetriever) Close() error {
-	relayClientErr := pr.relayClient.Close()
+	err := pr.relayClient.Close()
+	if err != nil {
+		return fmt.Errorf("close relay client: %w", err)
+	}
 
-	return fmt.Errorf("close relay client: %w", relayClientErr)
+	return nil
 }
 
 // createCodec creates the codec based on client config values

--- a/api/clients/v2/payload_retriever.go
+++ b/api/clients/v2/payload_retriever.go
@@ -19,6 +19,9 @@ import (
 
 // PayloadRetriever provides the ability to get payloads from the relay subsystem.
 //
+// In the future, this struct will be expanded to support distributed retrieval directly from DA nodes, if unable
+// to retrieve a payload from the relay subsystem.
+//
 // This struct is goroutine safe.
 type PayloadRetriever struct {
 	log logging.Logger

--- a/api/clients/v2/payload_retriever_config.go
+++ b/api/clients/v2/payload_retriever_config.go
@@ -6,8 +6,8 @@ import (
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
 )
 
-// EigenDAClientConfig contains configuration values for EigenDAClient
-type EigenDAClientConfig struct {
+// PayloadRetrieverConfig contains configuration values for a PayloadRetriever
+type PayloadRetrieverConfig struct {
 	// The blob encoding version to use when writing and reading blobs
 	BlobEncodingVersion codecs.BlobEncodingVersion
 


### PR DESCRIPTION
## Why are these changes needed?

- This PR changes the name of the existing v2 client to `PayloadRetriever`
    - The decision was made to keep `GET` and `PUT` functionality separate, so a more specific name was required for the current struct

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
