### PR TITLE
Add better error reporting for relay rate limits

### DIFF
--- a/relay/limiter/blob_rate_limiter.go
+++ b/relay/limiter/blob_rate_limiter.go
@@ -112,8 +112,13 @@ func (l *BlobRateLimiter) RequestGetBlobBandwidth(now time.Time, bytes uint32) e
 		if l.relayMetrics != nil {
 			l.relayMetrics.ReportBlobRateLimited("global bandwidth")
 		}
-		return fmt.Errorf("global rate limit %dMib/s exceeded for getBlob bandwidth, try again later",
-			int(l.config.MaxGetBlobBytesPerSecond/1024/1024))
+
+		rateLimit := l.config.MaxGetBlobBytesPerSecond / 1024 / 1024
+		burstiness := l.config.GetBlobBytesBurstiness / 1024 / 1024
+
+		return fmt.Errorf(
+			"global rate limit %0.1fMiB/s (burstiness %dMiB) exceeded for getBlob bandwidth, try again later",
+			rateLimit, burstiness)
 	}
 	return nil
 }

--- a/relay/limiter/chunk_rate_limiter.go
+++ b/relay/limiter/chunk_rate_limiter.go
@@ -162,8 +162,13 @@ func (l *ChunkRateLimiter) RequestGetChunkBandwidth(now time.Time, requesterID s
 		if l.relayMetrics != nil {
 			l.relayMetrics.ReportChunkRateLimited("global bandwidth")
 		}
-		return fmt.Errorf("global rate limit %dMiB exceeded for GetChunk bandwidth, try again later",
-			int(l.config.MaxGetChunkBytesPerSecond/1024/1024))
+
+		rateLimit := l.config.MaxGetChunkBytesPerSecond / 1024 / 1024
+		burstiness := l.config.GetChunkBytesBurstiness / 1024 / 1024
+
+		return fmt.Errorf(
+			"global rate limit %0.1fMiB (burstiness %dMIB) exceeded for GetChunk bandwidth, try again later",
+			rateLimit, burstiness)
 	}
 
 	limiter, ok := l.perClientBandwidthLimiter[requesterID]
@@ -176,8 +181,13 @@ func (l *ChunkRateLimiter) RequestGetChunkBandwidth(now time.Time, requesterID s
 		if l.relayMetrics != nil {
 			l.relayMetrics.ReportChunkRateLimited("client bandwidth")
 		}
-		return fmt.Errorf("client rate limit %dMiB exceeded for GetChunk bandwidth, try again later",
-			int(l.config.MaxGetChunkBytesPerSecondClient/1024/1024))
+
+		rateLimit := l.config.MaxGetChunkBytesPerSecondClient / 1024 / 1024
+		burstiness := l.config.GetChunkBytesBurstinessClient / 1024 / 1024
+
+		return fmt.Errorf(
+			"client rate limit %0.1fMiB (bustiness %dMiB) exceeded for GetChunk bandwidth, try again later",
+			rateLimit, burstiness)
 	}
 
 	return nil

--- a/relay/limiter/chunk_rate_limiter.go
+++ b/relay/limiter/chunk_rate_limiter.go
@@ -167,7 +167,7 @@ func (l *ChunkRateLimiter) RequestGetChunkBandwidth(now time.Time, requesterID s
 		burstiness := l.config.GetChunkBytesBurstiness / 1024 / 1024
 
 		return fmt.Errorf(
-			"global rate limit %0.1fMiB (burstiness %dMIB) exceeded for GetChunk bandwidth, try again later",
+			"global rate limit %0.1fMiB (burstiness %dMiB) exceeded for GetChunk bandwidth, try again later",
 			rateLimit, burstiness)
 	}
 


### PR DESCRIPTION
## Why are these changes needed?

I am currently investigating a relay rate limiting issue. This PR adds more informative error messages when we hit a relay rate limit.
