### PR TITLE
[ejector] Don't create txn when there's no one to eject

### DIFF
--- a/operators/ejector/ejector.go
+++ b/operators/ejector/ejector.go
@@ -24,6 +24,9 @@ const (
 	queryTickerDuration     = 3 * time.Second
 )
 
+// EjectionResponse encapsulates the response of an ejection request.
+// It contains the transaction hash of the ejection transaction.
+// If the ejection resulted in no transaction due to no operators to eject (without any errors), the transaction hash will be empty.
 type EjectionResponse struct {
 	TransactionHash string `json:"transaction_hash"`
 }
@@ -114,6 +117,14 @@ func (e *Ejector) Eject(ctx context.Context, nonsignerMetrics []*NonSignerMetric
 		if metric.Percentage/100.0 > 1-stakeShareToSLA(metric.StakePercentage/100.0) {
 			nonsigners = append(nonsigners, metric)
 		}
+	}
+
+	if len(nonsigners) == 0 {
+		e.logger.Info("No operators to eject")
+		e.metrics.IncrementEjectionRequest(mode, codes.OK)
+		return &EjectionResponse{
+			TransactionHash: "",
+		}, nil
 	}
 
 	// Rank the operators for each quorum by the operator performance score.


### PR DESCRIPTION
## Why are these changes needed?
It should exit early when there is no one to eject
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
