### PR TITLE
Refactor the operator quorum interval computing

### DIFF
--- a/disperser/dataapi/nonsigner_handler.go
+++ b/disperser/dataapi/nonsigner_handler.go
@@ -49,10 +49,10 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTi
 	}
 
 	// Create a mapping from address to operatorID.
-	operatorSet := NewOperatorSet()
+	operatorList := NewOperatorList()
 	for i := range nonsigners {
 		addr := strings.ToLower(nonsignerAddresses[i].Hex())
-		operatorSet.Add(nonsigners[i], addr)
+		operatorList.Add(nonsigners[i], addr)
 	}
 
 	operatorQuorumEvents, err := s.operatorHandler.subgraphClient.QueryOperatorQuorumEvent(ctx, startBlock+1, endBlock)
@@ -61,7 +61,7 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTi
 	}
 
 	// Create operators' quorum intervals.
-	operatorQuorumIntervals, quorumIDs, err := s.operatorHandler.CreateOperatorQuorumIntervals(ctx, operatorSet, operatorQuorumEvents, startBlock, endBlock)
+	operatorQuorumIntervals, quorumIDs, err := s.operatorHandler.CreateOperatorQuorumIntervals(ctx, operatorList, operatorQuorumEvents, startBlock, endBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTi
 					continue
 				}
 
-				addr, exist := operatorSet.GetAddress(op)
+				addr, exist := operatorList.GetAddress(op)
 				if !exist {
 					// This should never happen, but we don't fail the entire request, just
 					// mark error for the address field.

--- a/disperser/dataapi/nonsigner_handler.go
+++ b/disperser/dataapi/nonsigner_handler.go
@@ -49,16 +49,19 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTi
 	}
 
 	// Create a mapping from address to operatorID.
-	nonsignerAddressToId := make(map[string]core.OperatorID)
-	nonsignerIdToAddress := make(map[string]string)
+	operatorSet := NewOperatorSet()
 	for i := range nonsigners {
 		addr := strings.ToLower(nonsignerAddresses[i].Hex())
-		nonsignerAddressToId[addr] = nonsigners[i]
-		nonsignerIdToAddress[nonsigners[i].Hex()] = addr
+		operatorSet.Add(nonsigners[i], addr)
+	}
+
+	operatorQuorumEvents, err := s.operatorHandler.subgraphClient.QueryOperatorQuorumEvent(ctx, startBlock+1, endBlock)
+	if err != nil {
+		return nil, err
 	}
 
 	// Create operators' quorum intervals.
-	operatorQuorumIntervals, quorumIDs, err := s.operatorHandler.CreateOperatorQuorumIntervals(ctx, nonsigners, nonsignerAddressToId, startBlock, endBlock)
+	operatorQuorumIntervals, quorumIDs, err := s.operatorHandler.CreateOperatorQuorumIntervals(ctx, operatorSet, operatorQuorumEvents, startBlock, endBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -106,9 +109,15 @@ func (s *server) getOperatorNonsigningRate(ctx context.Context, startTime, endTi
 					continue
 				}
 
+				addr, exist := operatorSet.GetAddress(op)
+				if !exist {
+					// This should never happen, but we don't fail the entire request, just
+					// mark error for the address field.
+					addr = "Unexpected internal error"
+				}
 				nonsignerMetric := OperatorNonsigningPercentageMetrics{
 					OperatorId:           fmt.Sprintf("0x%s", op),
-					OperatorAddress:      nonsignerIdToAddress[op],
+					OperatorAddress:      addr,
 					QuorumId:             q,
 					TotalUnsignedBatches: unsignedCount,
 					TotalBatches:         totalCount,

--- a/disperser/dataapi/operator_handler.go
+++ b/disperser/dataapi/operator_handler.go
@@ -28,6 +28,52 @@ type OperatorHandler struct {
 	subgraphClient    SubgraphClient
 }
 
+// OperatorSet wraps a set of operators with their IDs and addresses.
+type OperatorSet struct {
+	// The addressToId and idToAddress provide 1:1 mapping of operator ID and address.
+	// They always have the same length and same operator IDs/addresses.
+	addressToId map[string]core.OperatorID
+	idToAddress map[core.OperatorID]string
+
+	// operatorIds always has the same IDs as implied by the two maps.
+	operatorIds []core.OperatorID
+}
+
+func NewOperatorSet() *OperatorSet {
+	return &OperatorSet{
+		addressToId: make(map[string]core.OperatorID),
+		idToAddress: make(map[core.OperatorID]string),
+		operatorIds: make([]core.OperatorID, 0),
+	}
+}
+
+func (o *OperatorSet) Add(id core.OperatorID, address string) {
+	if _, exists := o.idToAddress[id]; exists {
+		return
+	}
+	if _, exists := o.addressToId[address]; exists {
+		return
+	}
+
+	o.addressToId[address] = id
+	o.idToAddress[id] = address
+	o.operatorIds = append(o.operatorIds, id)
+}
+
+func (o *OperatorSet) GetAddress(id string) (string, bool) {
+	opID, err := core.OperatorIDFromHex(id)
+	if err != nil {
+		return "", false
+	}
+	address, exists := o.idToAddress[opID]
+	return address, exists
+}
+
+func (o *OperatorSet) GetID(address string) (core.OperatorID, bool) {
+	id, exists := o.addressToId[address]
+	return id, exists
+}
+
 func NewOperatorHandler(logger logging.Logger, metrics *Metrics, chainReader core.Reader, chainState core.ChainState, indexedChainState core.IndexedChainState, subgraphClient SubgraphClient) *OperatorHandler {
 	return &OperatorHandler{
 		logger:            logger,
@@ -229,18 +275,29 @@ func (s *OperatorHandler) ScanOperatorsHostInfo(ctx context.Context) (*SemverRep
 
 }
 
-func (oh *OperatorHandler) CreateOperatorQuorumIntervals(ctx context.Context, nonsigners []core.OperatorID, nonsignerAddressToId map[string]core.OperatorID, startBlock, endBlock uint32) (OperatorQuorumIntervals, []uint8, error) {
-	// Get operators' initial quorums (at startBlock).
+// CreateOperatorQuorumIntervals creates OperatorQuorumIntervals that are within the
+// the block interval [startBlock, endBlock] for operators specified in OperatorSet.
+//
+// Note: the returned result OperatorQuorumIntervals[op][q] means a sequence of increasing
+// and non-overlapping block intervals during which the operator "op" is registered in
+// quorum "q".
+func (oh *OperatorHandler) CreateOperatorQuorumIntervals(
+	ctx context.Context,
+	operatorSet *OperatorSet,
+	operatorQuorumEvents *OperatorQuorumEvents,
+	startBlock, endBlock uint32,
+) (OperatorQuorumIntervals, []uint8, error) {
+	// Get operators' quorums at startBlock.
 	quorumSeen := make(map[uint8]struct{}, 0)
 
-	bitmaps, err := oh.chainReader.GetQuorumBitmapForOperatorsAtBlockNumber(ctx, nonsigners, startBlock)
+	bitmaps, err := oh.chainReader.GetQuorumBitmapForOperatorsAtBlockNumber(ctx, operatorSet.operatorIds, startBlock)
 	if err != nil {
 		return nil, nil, err
 	}
 	operatorInitialQuorum := make(map[string][]uint8)
 	for i := range bitmaps {
 		opQuorumIDs := eth.BitmapToQuorumIds(bitmaps[i])
-		operatorInitialQuorum[nonsigners[i].Hex()] = opQuorumIDs
+		operatorInitialQuorum[operatorSet.operatorIds[i].Hex()] = opQuorumIDs
 		for _, q := range opQuorumIDs {
 			quorumSeen[q] = struct{}{}
 		}
@@ -252,8 +309,8 @@ func (oh *OperatorHandler) CreateOperatorQuorumIntervals(ctx context.Context, no
 		allQuorums = append(allQuorums, q)
 	}
 
-	// Get operators' quorum change events from [startBlock+1, endBlock].
-	addedToQuorum, removedFromQuorum, err := oh.getOperatorQuorumEvents(ctx, startBlock, endBlock, nonsignerAddressToId)
+	// Get quorum change events from [startBlock+1, endBlock] for operators in operator set.
+	addedToQuorum, removedFromQuorum, err := oh.getOperatorQuorumEvents(ctx, operatorQuorumEvents, operatorSet)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -267,25 +324,22 @@ func (oh *OperatorHandler) CreateOperatorQuorumIntervals(ctx context.Context, no
 	return operatorQuorumIntervals, allQuorums, nil
 }
 
-func (oh *OperatorHandler) getOperatorQuorumEvents(ctx context.Context, startBlock, endBlock uint32, nonsignerAddressToId map[string]core.OperatorID) (map[string][]*OperatorQuorum, map[string][]*OperatorQuorum, error) {
+func (oh *OperatorHandler) getOperatorQuorumEvents(
+	ctx context.Context,
+	operatorQuorumEvents *OperatorQuorumEvents,
+	operatorSet *OperatorSet,
+) (map[string][]*OperatorQuorum, map[string][]*OperatorQuorum, error) {
 	addedToQuorum := make(map[string][]*OperatorQuorum)
 	removedFromQuorum := make(map[string][]*OperatorQuorum)
-	if startBlock == endBlock {
-		return addedToQuorum, removedFromQuorum, nil
-	}
-	operatorQuorumEvents, err := oh.subgraphClient.QueryOperatorQuorumEvent(ctx, startBlock+1, endBlock)
-	if err != nil {
-		return nil, nil, err
-	}
 	// Make quorum events organize by operatorID (instead of address) and drop those who
-	// are not nonsigners.
+	// are not in the operator set.
 	for op, events := range operatorQuorumEvents.AddedToQuorum {
-		if id, ok := nonsignerAddressToId[op]; ok {
+		if id, ok := operatorSet.GetID(op); ok {
 			addedToQuorum[id.Hex()] = events
 		}
 	}
 	for op, events := range operatorQuorumEvents.RemovedFromQuorum {
-		if id, ok := nonsignerAddressToId[op]; ok {
+		if id, ok := operatorSet.GetID(op); ok {
 			removedFromQuorum[id.Hex()] = events
 		}
 	}


### PR DESCRIPTION
## Why are these changes needed?
To make it shareable for v1 and v2
- v1: compute quorum intervals for nonsigners (and nonsigning rate) in the specified time range
- v2: compute quorum intervals for all operators that are live (and signing rate) in the specified time range

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
