### PR TITLE
Return blobkey in the blob feed response

### DIFF
--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -273,7 +273,7 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/blobs/{blob_key}/verification-info": {
+        "/blobs/{blob_key}/inclusion-info": {
             "get": {
                 "produces": [
                     "application/json"
@@ -281,7 +281,7 @@ const docTemplateV2 = `{
                 "tags": [
                     "Blob"
                 ],
-                "summary": "Fetch blob verification info by blob key and batch header hash",
+                "summary": "Fetch blob inclusion info by blob key and batch header hash",
                 "parameters": [
                     {
                         "type": "string",
@@ -302,7 +302,7 @@ const docTemplateV2 = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.BlobVerificationInfoResponse"
+                            "$ref": "#/definitions/v2.BlobInclusionInfoResponse"
                         }
                     },
                     "400": {
@@ -663,12 +663,6 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -676,9 +670,6 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "x": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -712,12 +703,6 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -746,12 +731,6 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -760,9 +739,6 @@ const docTemplateV2 = `{
             "properties": {
                 "x": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
         },
@@ -770,9 +746,6 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "x": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -869,6 +842,13 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "signature": {
+                    "description": "Signature is an ECDSA signature signed by the blob request signer's account ID over the blob key,\nwhich is a keccak hash of the serialized BlobHeader, and used to verify against blob dispersal request's account ID",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -899,17 +879,10 @@ const docTemplateV2 = `{
                 "salt": {
                     "description": "Salt is used to make blob intentionally unique when everything else is the same",
                     "type": "integer"
-                },
-                "signature": {
-                    "description": "Signature is an ECDSA signature signed by the blob request signer's account ID over the BlobHeader's blobKey,\nwhich is a keccak hash of the serialized BlobHeader, and used to verify against blob dispersal request's account ID",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
-        "github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo": {
+        "github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo": {
             "type": "object",
             "properties": {
                 "BlobKey": {
@@ -972,12 +945,6 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "a0": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "a1": {
                     "type": "array",
                     "items": {
                         "type": "integer"
@@ -1054,10 +1021,10 @@ const docTemplateV2 = `{
                 "batch_header_hash": {
                     "type": "string"
                 },
-                "blob_verification_infos": {
+                "blob_inclusion_infos": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo"
+                        "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo"
                     }
                 },
                 "signed_batch": {
@@ -1079,11 +1046,30 @@ const docTemplateV2 = `{
                 "blobs": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.BlobMetadata"
+                        "$ref": "#/definitions/v2.BlobInfo"
                     }
                 },
                 "pagination_token": {
                     "type": "string"
+                }
+            }
+        },
+        "v2.BlobInclusionInfoResponse": {
+            "type": "object",
+            "properties": {
+                "blob_inclusion_info": {
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo"
+                }
+            }
+        },
+        "v2.BlobInfo": {
+            "type": "object",
+            "properties": {
+                "blob_key": {
+                    "type": "string"
+                },
+                "blob_metadata": {
+                    "$ref": "#/definitions/v2.BlobMetadata"
                 }
             }
         },
@@ -1121,6 +1107,12 @@ const docTemplateV2 = `{
                     "description": "RequestedAt is the Unix timestamp of when the blob was requested in seconds",
                     "type": "integer"
                 },
+                "signature": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "totalChunkSizeBytes": {
                     "description": "TotalChunkSizeBytes is the total size of the file containing all chunk coefficients for the blob.",
                     "type": "integer"
@@ -1148,14 +1140,6 @@ const docTemplateV2 = `{
                 },
                 "status": {
                     "type": "string"
-                }
-            }
-        },
-        "v2.BlobVerificationInfoResponse": {
-            "type": "object",
-            "properties": {
-                "blob_verification_info": {
-                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -270,7 +270,7 @@
                 }
             }
         },
-        "/blobs/{blob_key}/verification-info": {
+        "/blobs/{blob_key}/inclusion-info": {
             "get": {
                 "produces": [
                     "application/json"
@@ -278,7 +278,7 @@
                 "tags": [
                     "Blob"
                 ],
-                "summary": "Fetch blob verification info by blob key and batch header hash",
+                "summary": "Fetch blob inclusion info by blob key and batch header hash",
                 "parameters": [
                     {
                         "type": "string",
@@ -299,7 +299,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.BlobVerificationInfoResponse"
+                            "$ref": "#/definitions/v2.BlobInclusionInfoResponse"
                         }
                     },
                     "400": {
@@ -660,12 +660,6 @@
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -673,9 +667,6 @@
             "type": "object",
             "properties": {
                 "x": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -709,12 +700,6 @@
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -743,12 +728,6 @@
                     "items": {
                         "type": "integer"
                     }
-                },
-                "y": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
@@ -757,9 +736,6 @@
             "properties": {
                 "x": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
         },
@@ -767,9 +743,6 @@
             "type": "object",
             "properties": {
                 "x": {
-                    "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
-                },
-                "y": {
                     "$ref": "#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2"
                 }
             }
@@ -866,6 +839,13 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "signature": {
+                    "description": "Signature is an ECDSA signature signed by the blob request signer's account ID over the blob key,\nwhich is a keccak hash of the serialized BlobHeader, and used to verify against blob dispersal request's account ID",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             }
         },
@@ -896,17 +876,10 @@
                 "salt": {
                     "description": "Salt is used to make blob intentionally unique when everything else is the same",
                     "type": "integer"
-                },
-                "signature": {
-                    "description": "Signature is an ECDSA signature signed by the blob request signer's account ID over the BlobHeader's blobKey,\nwhich is a keccak hash of the serialized BlobHeader, and used to verify against blob dispersal request's account ID",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         },
-        "github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo": {
+        "github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo": {
             "type": "object",
             "properties": {
                 "BlobKey": {
@@ -969,12 +942,6 @@
             "type": "object",
             "properties": {
                 "a0": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "a1": {
                     "type": "array",
                     "items": {
                         "type": "integer"
@@ -1051,10 +1018,10 @@
                 "batch_header_hash": {
                     "type": "string"
                 },
-                "blob_verification_infos": {
+                "blob_inclusion_infos": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo"
+                        "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo"
                     }
                 },
                 "signed_batch": {
@@ -1076,11 +1043,30 @@
                 "blobs": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.BlobMetadata"
+                        "$ref": "#/definitions/v2.BlobInfo"
                     }
                 },
                 "pagination_token": {
                     "type": "string"
+                }
+            }
+        },
+        "v2.BlobInclusionInfoResponse": {
+            "type": "object",
+            "properties": {
+                "blob_inclusion_info": {
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo"
+                }
+            }
+        },
+        "v2.BlobInfo": {
+            "type": "object",
+            "properties": {
+                "blob_key": {
+                    "type": "string"
+                },
+                "blob_metadata": {
+                    "$ref": "#/definitions/v2.BlobMetadata"
                 }
             }
         },
@@ -1118,6 +1104,12 @@
                     "description": "RequestedAt is the Unix timestamp of when the blob was requested in seconds",
                     "type": "integer"
                 },
+                "signature": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "totalChunkSizeBytes": {
                     "description": "TotalChunkSizeBytes is the total size of the file containing all chunk coefficients for the blob.",
                     "type": "integer"
@@ -1145,14 +1137,6 @@
                 },
                 "status": {
                     "type": "string"
-                }
-            }
-        },
-        "v2.BlobVerificationInfoResponse": {
-            "type": "object",
-            "properties": {
-                "blob_verification_info": {
-                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -51,16 +51,10 @@ definitions:
         items:
           type: integer
         type: array
-      "y":
-        items:
-          type: integer
-        type: array
     type: object
   core.G2Point:
     properties:
       x:
-        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
-      "y":
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   core.PaymentMetadata:
@@ -84,10 +78,6 @@ definitions:
         items:
           type: integer
         type: array
-      "y":
-        items:
-          type: integer
-        type: array
     type: object
   encoding.BlobCommitments:
     properties:
@@ -106,23 +96,15 @@ definitions:
         items:
           type: integer
         type: array
-      "y":
-        items:
-          type: integer
-        type: array
     type: object
   encoding.G2Commitment:
     properties:
       x:
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
-      "y":
-        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   encoding.LengthProof:
     properties:
       x:
-        $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
-      "y":
         $ref: '#/definitions/github_com_consensys_gnark-crypto_ecc_bn254_internal_fptower.E2'
     type: object
   github_com_Layr-Labs_eigenda_core_v2.Attestation:
@@ -193,6 +175,13 @@ definitions:
         items:
           type: integer
         type: array
+      signature:
+        description: |-
+          Signature is an ECDSA signature signed by the blob request signer's account ID over the blob key,
+          which is a keccak hash of the serialized BlobHeader, and used to verify against blob dispersal request's account ID
+        items:
+          type: integer
+        type: array
     type: object
   github_com_Layr-Labs_eigenda_core_v2.BlobHeader:
     properties:
@@ -213,15 +202,8 @@ definitions:
         description: Salt is used to make blob intentionally unique when everything
           else is the same
         type: integer
-      signature:
-        description: |-
-          Signature is an ECDSA signature signed by the blob request signer's account ID over the BlobHeader's blobKey,
-          which is a keccak hash of the serialized BlobHeader, and used to verify against blob dispersal request's account ID
-        items:
-          type: integer
-        type: array
     type: object
-  github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo:
+  github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo:
     properties:
       BlobKey:
         items:
@@ -271,10 +253,6 @@ definitions:
         items:
           type: integer
         type: array
-      a1:
-        items:
-          type: integer
-        type: array
     type: object
   semver.SemverMetrics:
     properties:
@@ -321,9 +299,9 @@ definitions:
     properties:
       batch_header_hash:
         type: string
-      blob_verification_infos:
+      blob_inclusion_infos:
         items:
-          $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo'
+          $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo'
         type: array
       signed_batch:
         $ref: '#/definitions/github_com_Layr-Labs_eigenda_disperser_dataapi_v2.SignedBatch'
@@ -337,10 +315,22 @@ definitions:
     properties:
       blobs:
         items:
-          $ref: '#/definitions/v2.BlobMetadata'
+          $ref: '#/definitions/v2.BlobInfo'
         type: array
       pagination_token:
         type: string
+    type: object
+  v2.BlobInclusionInfoResponse:
+    properties:
+      blob_inclusion_info:
+        $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobInclusionInfo'
+    type: object
+  v2.BlobInfo:
+    properties:
+      blob_key:
+        type: string
+      blob_metadata:
+        $ref: '#/definitions/v2.BlobMetadata'
     type: object
   v2.BlobMetadata:
     properties:
@@ -367,6 +357,10 @@ definitions:
         description: RequestedAt is the Unix timestamp of when the blob was requested
           in seconds
         type: integer
+      signature:
+        items:
+          type: integer
+        type: array
       totalChunkSizeBytes:
         description: TotalChunkSizeBytes is the total size of the file containing
           all chunk coefficients for the blob.
@@ -388,11 +382,6 @@ definitions:
         type: integer
       status:
         type: string
-    type: object
-  v2.BlobVerificationInfoResponse:
-    properties:
-      blob_verification_info:
-        $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobVerificationInfo'
     type: object
   v2.DispersalResponse:
     properties:
@@ -650,7 +639,7 @@ paths:
       summary: Fetch blob certificate by blob key v2
       tags:
       - Blob
-  /blobs/{blob_key}/verification-info:
+  /blobs/{blob_key}/inclusion-info:
     get:
       parameters:
       - description: Blob key in hex string
@@ -669,7 +658,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/v2.BlobVerificationInfoResponse'
+            $ref: '#/definitions/v2.BlobInclusionInfoResponse'
         "400":
           description: 'error: Bad request'
           schema:
@@ -682,7 +671,7 @@ paths:
           description: 'error: Server error'
           schema:
             $ref: '#/definitions/v2.ErrorResponse'
-      summary: Fetch blob verification info by blob key and batch header hash
+      summary: Fetch blob inclusion info by blob key and batch header hash
       tags:
       - Blob
   /blobs/feed:

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -429,8 +429,8 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		response := decodeResponseBody[serverv2.BlobFeedResponse](t, w)
 		require.Equal(t, 20, len(response.Blobs))
 		for i := 0; i < 20; i++ {
-			checkBlobKeyEqual(t, keys[43+i], response.Blobs[i].BlobHeader)
-			assert.Equal(t, requestedAt[43+i], response.Blobs[i].RequestedAt)
+			checkBlobKeyEqual(t, keys[43+i], response.Blobs[i].BlobMetadata.BlobHeader)
+			assert.Equal(t, requestedAt[43+i], response.Blobs[i].BlobMetadata.RequestedAt)
 		}
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[62], keys[62])
@@ -443,8 +443,8 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		response := decodeResponseBody[serverv2.BlobFeedResponse](t, w)
 		require.Equal(t, 60, len(response.Blobs))
 		for i := 0; i < 60; i++ {
-			checkBlobKeyEqual(t, keys[43+i], response.Blobs[i].BlobHeader)
-			assert.Equal(t, requestedAt[43+i], response.Blobs[i].RequestedAt)
+			checkBlobKeyEqual(t, keys[43+i], response.Blobs[i].BlobMetadata.BlobHeader)
+			assert.Equal(t, requestedAt[43+i], response.Blobs[i].BlobMetadata.RequestedAt)
 		}
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[102], keys[102])
@@ -455,12 +455,12 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		response = decodeResponseBody[serverv2.BlobFeedResponse](t, w)
 		require.Equal(t, numBlobs, len(response.Blobs))
 		// First 3 blobs ordered by key due to same timestamp
-		checkBlobKeyEqual(t, firstBlobKeys[0], response.Blobs[0].BlobHeader)
-		checkBlobKeyEqual(t, firstBlobKeys[1], response.Blobs[1].BlobHeader)
-		checkBlobKeyEqual(t, firstBlobKeys[2], response.Blobs[2].BlobHeader)
+		checkBlobKeyEqual(t, firstBlobKeys[0], response.Blobs[0].BlobMetadata.BlobHeader)
+		checkBlobKeyEqual(t, firstBlobKeys[1], response.Blobs[1].BlobMetadata.BlobHeader)
+		checkBlobKeyEqual(t, firstBlobKeys[2], response.Blobs[2].BlobMetadata.BlobHeader)
 		for i := 3; i < numBlobs; i++ {
-			checkBlobKeyEqual(t, keys[i], response.Blobs[i].BlobHeader)
-			assert.Equal(t, requestedAt[i], response.Blobs[i].RequestedAt)
+			checkBlobKeyEqual(t, keys[i], response.Blobs[i].BlobMetadata.BlobHeader)
+			assert.Equal(t, requestedAt[i], response.Blobs[i].BlobMetadata.RequestedAt)
 		}
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[102], keys[102])
@@ -474,8 +474,8 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		response = decodeResponseBody[serverv2.BlobFeedResponse](t, w)
 		require.Equal(t, 60, len(response.Blobs))
 		for i := 0; i < 60; i++ {
-			checkBlobKeyEqual(t, keys[41+i], response.Blobs[i].BlobHeader)
-			assert.Equal(t, requestedAt[41+i], response.Blobs[i].RequestedAt)
+			checkBlobKeyEqual(t, keys[41+i], response.Blobs[i].BlobMetadata.BlobHeader)
+			assert.Equal(t, requestedAt[41+i], response.Blobs[i].BlobMetadata.RequestedAt)
 		}
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[100], keys[100])
@@ -495,8 +495,8 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		response := decodeResponseBody[serverv2.BlobFeedResponse](t, w)
 		require.Equal(t, 20, len(response.Blobs))
 		for i := 0; i < 20; i++ {
-			checkBlobKeyEqual(t, keys[43+i], response.Blobs[i].BlobHeader)
-			assert.Equal(t, requestedAt[43+i], response.Blobs[i].RequestedAt)
+			checkBlobKeyEqual(t, keys[43+i], response.Blobs[i].BlobMetadata.BlobHeader)
+			assert.Equal(t, requestedAt[43+i], response.Blobs[i].BlobMetadata.RequestedAt)
 		}
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[62], keys[62])
@@ -507,8 +507,8 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		response = decodeResponseBody[serverv2.BlobFeedResponse](t, w)
 		require.Equal(t, 20, len(response.Blobs))
 		for i := 0; i < 20; i++ {
-			checkBlobKeyEqual(t, keys[63+i], response.Blobs[i].BlobHeader)
-			assert.Equal(t, requestedAt[63+i], response.Blobs[i].RequestedAt)
+			checkBlobKeyEqual(t, keys[63+i], response.Blobs[i].BlobMetadata.BlobHeader)
+			assert.Equal(t, requestedAt[63+i], response.Blobs[i].BlobMetadata.RequestedAt)
 		}
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[82], keys[82])
@@ -527,10 +527,10 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		w := executeRequest(t, r, http.MethodGet, reqUrl)
 		response := decodeResponseBody[serverv2.BlobFeedResponse](t, w)
 		require.Equal(t, 2, len(response.Blobs))
-		checkBlobKeyEqual(t, firstBlobKeys[0], response.Blobs[0].BlobHeader)
-		checkBlobKeyEqual(t, firstBlobKeys[1], response.Blobs[1].BlobHeader)
-		assert.Equal(t, firstBlobTime, response.Blobs[0].RequestedAt)
-		assert.Equal(t, firstBlobTime, response.Blobs[1].RequestedAt)
+		checkBlobKeyEqual(t, firstBlobKeys[0], response.Blobs[0].BlobMetadata.BlobHeader)
+		checkBlobKeyEqual(t, firstBlobKeys[1], response.Blobs[1].BlobMetadata.BlobHeader)
+		assert.Equal(t, firstBlobTime, response.Blobs[0].BlobMetadata.RequestedAt)
+		assert.Equal(t, firstBlobTime, response.Blobs[1].BlobMetadata.RequestedAt)
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[1], firstBlobKeys[1])
 
@@ -542,12 +542,12 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		// 1. Last same-timestamp blob
 		// 2. Following blobs with sequential timestamps
 		require.Equal(t, 3, len(response.Blobs))
-		checkBlobKeyEqual(t, firstBlobKeys[2], response.Blobs[0].BlobHeader)
-		checkBlobKeyEqual(t, keys[3], response.Blobs[1].BlobHeader)
-		checkBlobKeyEqual(t, keys[4], response.Blobs[2].BlobHeader)
-		assert.Equal(t, firstBlobTime, response.Blobs[0].RequestedAt)
-		assert.Equal(t, requestedAt[3], response.Blobs[1].RequestedAt)
-		assert.Equal(t, requestedAt[4], response.Blobs[2].RequestedAt)
+		checkBlobKeyEqual(t, firstBlobKeys[2], response.Blobs[0].BlobMetadata.BlobHeader)
+		checkBlobKeyEqual(t, keys[3], response.Blobs[1].BlobMetadata.BlobHeader)
+		checkBlobKeyEqual(t, keys[4], response.Blobs[2].BlobMetadata.BlobHeader)
+		assert.Equal(t, firstBlobTime, response.Blobs[0].BlobMetadata.RequestedAt)
+		assert.Equal(t, requestedAt[3], response.Blobs[1].BlobMetadata.RequestedAt)
+		assert.Equal(t, requestedAt[4], response.Blobs[2].BlobMetadata.RequestedAt)
 		assert.True(t, len(response.PaginationToken) > 0)
 		checkPaginationToken(t, response.PaginationToken, requestedAt[4], keys[4])
 	})


### PR DESCRIPTION
## Why are these changes needed?
Blobkey is needed by the clients. If we don't provide, they will have to re-compute by duplicating this function https://github.com/Layr-Labs/eigenda/blob/master/core/v2/serialization.go#L30

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
