### PR TITLE
Update download-artifact version

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -37,7 +37,7 @@ runs:
         go-version: ${{inputs.go-version}}
 
     - name: Download coverage artifact
-      uses: actions/download-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: coverage
         path: .


### PR DESCRIPTION
## Why are these changes needed?
The[ previous fix ](https://github.com/Layr-Labs/eigenda/pull/1141)had wrong download artifact version (used same version as upload artifact) 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
