### PR TITLE
fix: Add salt to blob header conversion util

### DIFF
--- a/api/clients/v2/verification/conversion_utils.go
+++ b/api/clients/v2/verification/conversion_utils.go
@@ -153,6 +153,7 @@ func blobHeaderProtoToBinding(inputHeader *commonv2.BlobHeader) (*contractEigenD
 		QuorumNumbers:     quorumNumbers,
 		Commitment:        *convertedBlobCommitment,
 		PaymentHeaderHash: paymentHeaderHash,
+		Salt:              inputHeader.GetSalt(),
 	}, nil
 }
 
@@ -176,7 +177,7 @@ func blobCommitmentProtoToBinding(inputCommitment *common.BlobCommitment) (*cont
 		Commitment:       *convertedCommitment,
 		LengthCommitment: *convertedLengthCommitment,
 		LengthProof:      *convertedLengthProof,
-		Length:       inputCommitment.GetLength(),
+		Length:           inputCommitment.GetLength(),
 	}, nil
 }
 


### PR DESCRIPTION
## Why are these changes needed?

- The blob header was changed, but salt wasn't added to the conversion util

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
