### PR TITLE
Fix CORs support in dataAPI

### DIFF
--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -210,9 +210,33 @@ func (s *ServerV2) Start() error {
 	}
 
 	router := gin.New()
+
+	// Add recovery middleware (best practice according to Cursor)
+	router.Use(gin.Recovery())
+
 	basePath := "/api/v2"
 	docsv2.SwaggerInfoV2.BasePath = basePath
 	docsv2.SwaggerInfoV2.Host = os.Getenv("SWAGGER_HOST")
+
+	// Configure CORS
+	config := cors.DefaultConfig()
+	config.AllowOrigins = s.allowOrigins
+	config.AllowCredentials = true
+	config.AllowMethods = []string{"GET", "POST", "HEAD", "OPTIONS"}
+	config.AllowHeaders = []string{"Origin", "Content-Type", "Accept", "Authorization"}
+	config.ExposeHeaders = []string{"Content-Length"}
+
+	if s.serverMode != gin.ReleaseMode {
+		config.AllowOrigins = []string{"*"}
+	}
+
+	// Apply CORS middleware before routes
+	router.Use(cors.New(config))
+
+	// Add OPTIONS handlers for all routes
+	router.OPTIONS("/*path", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
 
 	v2 := router.Group(basePath)
 	{
@@ -255,16 +279,6 @@ func (s *ServerV2) Start() error {
 	router.Use(logger.SetLogger(
 		logger.WithSkipPath([]string{"/"}),
 	))
-
-	config := cors.DefaultConfig()
-	config.AllowOrigins = s.allowOrigins
-	config.AllowCredentials = true
-	config.AllowMethods = []string{"GET", "POST", "HEAD", "OPTIONS"}
-
-	if s.serverMode != gin.ReleaseMode {
-		config.AllowOrigins = []string{"*"}
-	}
-	router.Use(cors.New(config))
 
 	srv := &http.Server{
 		Addr:              s.socketAddr,


### PR DESCRIPTION
This change adds `OPTIONS` request support to DataAPI gin router to allow CORS requests.

DataAPI was not setup to respond to `HTTP:OPTIONS` request which is used by browser to determine CORS options before it actually attempts the CORS request. Effectively dataAPI CORS support was broken and any CORS request was rejected.

Configure allowed CORS origin
```
DATA_ACCESS_API_ALLOW_ORIGINS=https://blob-explorer-v2-preprod.vercel.app
DATA_ACCESS_API_SERVER_MODE=release
```

Verify `HTTP:OPTIONS` request succeeds for origin `https://blob-explorer-v2-preprod.vercel.app`
```
curl -v -X OPTIONS "http://localhost:8080/api/v2/blobs/feed?limit=10" -H "Origin: https://blob-explorer-v2-preprod.vercel.app"
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> OPTIONS /api/v2/blobs/feed?limit=10 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.6.0
> Accept: */*
> Origin: https://blob-explorer-v2-preprod.vercel.app
>
< HTTP/1.1 204 No Content
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Headers: Origin,Content-Type,Accept,Authorization
< Access-Control-Allow-Methods: GET,POST,HEAD,OPTIONS
< Access-Control-Allow-Origin: https://blob-explorer-v2-preprod.vercel.app
< Access-Control-Max-Age: 43200
< Vary: Origin
< Vary: Access-Control-Request-Method
< Vary: Access-Control-Request-Headers
< Date: Wed, 29 Jan 2025 03:59:01 GMT
```

Verify `HTTP:OPTIONS` request BLOCKED for origin `https://foobar.com:1234`
```
curl -v -X OPTIONS "http://localhost:8080/api/v2/blobs/feed?limit=10" -H "Origin: http://foobar.com:1234"
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> OPTIONS /api/v2/blobs/feed?limit=10 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.6.0
> Accept: */*
> Origin: http://foobar.com:1234
>
< HTTP/1.1 403 Forbidden
< Date: Wed, 29 Jan 2025 03:58:54 GMT
< Content-Length: 0
```