### PR TITLE
V2 Retrieval Isolation

### DIFF
--- a/api/clients/node_client.go
+++ b/api/clients/node_client.go
@@ -41,7 +41,7 @@ func (c client) GetBlobHeader(
 	blobIndex uint32,
 ) (*core.BlobHeader, *merkletree.Proof, error) {
 	conn, err := grpc.NewClient(
-		core.OperatorSocket(socket).GetRetrievalSocket(),
+		core.OperatorSocket(socket).GetV1RetrievalSocket(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
@@ -86,7 +86,7 @@ func (c client) GetChunks(
 	chunksChan chan RetrievedChunks,
 ) {
 	conn, err := grpc.NewClient(
-		core.OperatorSocket(opInfo.Socket).GetRetrievalSocket(),
+		core.OperatorSocket(opInfo.Socket).GetV1RetrievalSocket(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/api/clients/v2/retrieval_client.go
+++ b/api/clients/v2/retrieval_client.go
@@ -157,7 +157,7 @@ func (r *retrievalClient) getChunksFromOperator(
 	chunksChan chan clients.RetrievedChunks,
 ) {
 	conn, err := grpc.NewClient(
-		core.OperatorSocket(opInfo.Socket).GetRetrievalSocket(),
+		core.OperatorSocket(opInfo.Socket).GetV2RetrievalSocket(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	defer func() {

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -32,6 +32,7 @@ type PrivateOperatorInfo struct {
 	DispersalPort   string
 	RetrievalPort   string
 	V2DispersalPort string
+	V2RetrievalPort string
 }
 
 type PrivateOperatorState struct {
@@ -140,7 +141,8 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 		dispersalPort := fmt.Sprintf("3%03v", 2*i)
 		retrievalPort := fmt.Sprintf("3%03v", 2*i+1)
 		v2DispersalPort := fmt.Sprintf("3%03v", 2*i+2)
-		socket := core.MakeOperatorSocket(host, dispersalPort, retrievalPort, v2DispersalPort)
+		v2RetrievalPort := fmt.Sprintf("3%03v", 2*i+3)
+		socket := core.MakeOperatorSocket(host, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
 
 		indexed := &core.IndexedOperatorInfo{
 			Socket:   string(socket),
@@ -161,6 +163,7 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 			DispersalPort:       dispersalPort,
 			RetrievalPort:       retrievalPort,
 			V2DispersalPort:     v2DispersalPort,
+			V2RetrievalPort:     v2RetrievalPort,
 		}
 
 		indexedOperators[id] = indexed

--- a/core/serialization.go
+++ b/core/serialization.go
@@ -528,7 +528,7 @@ func decode(data []byte, obj any) error {
 }
 
 func (s OperatorSocket) GetV1DispersalSocket() string {
-	ip, v1DispersalPort, _, _, err := ParseOperatorSocket(string(s))
+	ip, v1DispersalPort, _, _, _, err := ParseOperatorSocket(string(s))
 	if err != nil {
 		return ""
 	}
@@ -536,17 +536,25 @@ func (s OperatorSocket) GetV1DispersalSocket() string {
 }
 
 func (s OperatorSocket) GetV2DispersalSocket() string {
-	ip, _, _, v2DispersalPort, err := ParseOperatorSocket(string(s))
+	ip, _, _, v2DispersalPort, _, err := ParseOperatorSocket(string(s))
 	if err != nil || v2DispersalPort == "" {
 		return ""
 	}
 	return fmt.Sprintf("%s:%s", ip, v2DispersalPort)
 }
 
-func (s OperatorSocket) GetRetrievalSocket() string {
-	ip, _, retrievalPort, _, err := ParseOperatorSocket(string(s))
+func (s OperatorSocket) GetV1RetrievalSocket() string {
+	ip, _, v1retrievalPort, _, _, err := ParseOperatorSocket(string(s))
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s", ip, retrievalPort)
+	return fmt.Sprintf("%s:%s", ip, v1retrievalPort)
+}
+
+func (s OperatorSocket) GetV2RetrievalSocket() string {
+	ip, _, _, _, v2RetrievalPort, err := ParseOperatorSocket(string(s))
+	if err != nil || v2RetrievalPort == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%s", ip, v2RetrievalPort)
 }

--- a/core/serialization_test.go
+++ b/core/serialization_test.go
@@ -195,36 +195,37 @@ func TestHashPubKeyG1(t *testing.T) {
 }
 
 func TestParseOperatorSocket(t *testing.T) {
-	operatorSocket := "localhost:1234;5678;9999"
-	host, dispersalPort, retrievalPort, v2DispersalPort, err := core.ParseOperatorSocket(operatorSocket)
+	operatorSocket := "localhost:1234;5678;9999;10001"
+	host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort, err := core.ParseOperatorSocket(operatorSocket)
 	assert.NoError(t, err)
 	assert.Equal(t, "localhost", host)
-	assert.Equal(t, "1234", dispersalPort)
-	assert.Equal(t, "5678", retrievalPort)
+	assert.Equal(t, "1234", v1DispersalPort)
+	assert.Equal(t, "5678", v1RetrievalPort)
 	assert.Equal(t, "9999", v2DispersalPort)
+	assert.Equal(t, "10001", v2RetrievalPort)
 
-	host, dispersalPort, retrievalPort, v2DispersalPort, err = core.ParseOperatorSocket("localhost:1234;5678")
+	host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, _, err = core.ParseOperatorSocket("localhost:1234;5678")
 	assert.NoError(t, err)
 	assert.Equal(t, "localhost", host)
-	assert.Equal(t, "1234", dispersalPort)
-	assert.Equal(t, "5678", retrievalPort)
+	assert.Equal(t, "1234", v1DispersalPort)
+	assert.Equal(t, "5678", v1RetrievalPort)
 	assert.Equal(t, "", v2DispersalPort)
 
-	_, _, _, _, err = core.ParseOperatorSocket("localhost;1234;5678")
+	_, _, _, _, _, err = core.ParseOperatorSocket("localhost;1234;5678")
 	assert.NotNil(t, err)
-	assert.ErrorContains(t, err, "invalid socket address format")
+	assert.ErrorContains(t, err, "invalid host address format")
 
-	_, _, _, _, err = core.ParseOperatorSocket("localhost:12345678")
+	_, _, _, _, _, err = core.ParseOperatorSocket("localhost:12345678")
 	assert.NotNil(t, err)
-	assert.ErrorContains(t, err, "invalid socket address format")
+	assert.ErrorContains(t, err, "invalid v1 dispersal port format")
 
-	_, _, _, _, err = core.ParseOperatorSocket("localhost1234;5678")
+	_, _, _, _, _, err = core.ParseOperatorSocket("localhost1234;5678")
 	assert.NotNil(t, err)
-	assert.ErrorContains(t, err, "invalid socket address format")
+	assert.ErrorContains(t, err, "invalid host address format")
 }
 
 func TestGetV1DispersalSocket(t *testing.T) {
-	operatorSocket := core.OperatorSocket("localhost:1234;5678;9999")
+	operatorSocket := core.OperatorSocket("localhost:1234;5678;9999;1025")
 	socket := operatorSocket.GetV1DispersalSocket()
 	assert.Equal(t, "localhost:1234", socket)
 
@@ -234,28 +235,84 @@ func TestGetV1DispersalSocket(t *testing.T) {
 
 	operatorSocket = core.OperatorSocket("localhost:1234;5678;")
 	socket = operatorSocket.GetV1DispersalSocket()
-	assert.Equal(t, "localhost:1234", socket)
+	assert.Equal(t, "", socket)
 
 	operatorSocket = core.OperatorSocket("localhost:1234")
 	socket = operatorSocket.GetV1DispersalSocket()
 	assert.Equal(t, "", socket)
 }
 
-func TestGetRetrievalSocket(t *testing.T) {
-	operatorSocket := core.OperatorSocket("localhost:1234;5678;9999")
-	socket := operatorSocket.GetRetrievalSocket()
+func TestGetV1RetrievalSocket(t *testing.T) {
+	// Valid v1/v2 socket
+	operatorSocket := core.OperatorSocket("localhost:1234;5678;9999;10001")
+	socket := operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "localhost:5678", socket)
 
+	// Valid v1 socket
 	operatorSocket = core.OperatorSocket("localhost:1234;5678")
-	socket = operatorSocket.GetRetrievalSocket()
+	socket = operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "localhost:5678", socket)
+
+	// Invalid socket testcases
+	operatorSocket = core.OperatorSocket("localhost:1234;5678;9999;10001;")
+	socket = operatorSocket.GetV1RetrievalSocket()
+	assert.Equal(t, "", socket)
 
 	operatorSocket = core.OperatorSocket("localhost:1234;5678;")
-	socket = operatorSocket.GetRetrievalSocket()
-	assert.Equal(t, "localhost:5678", socket)
+	socket = operatorSocket.GetV1RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	operatorSocket = core.OperatorSocket("localhost:;1234;5678;")
+	socket = operatorSocket.GetV1RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	operatorSocket = core.OperatorSocket("localhost:1234;:;5678;")
+	socket = operatorSocket.GetV1RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	operatorSocket = core.OperatorSocket("localhost:;;;")
+	socket = operatorSocket.GetV1RetrievalSocket()
+	assert.Equal(t, "", socket)
 
 	operatorSocket = core.OperatorSocket("localhost:1234")
-	socket = operatorSocket.GetRetrievalSocket()
+	socket = operatorSocket.GetV1RetrievalSocket()
+	assert.Equal(t, "", socket)
+}
+
+func TestGetV2RetrievalSocket(t *testing.T) {
+	// Valid v1/v2 socket
+	operatorSocket := core.OperatorSocket("localhost:1234;5678;9999;10001")
+	socket := operatorSocket.GetV2RetrievalSocket()
+	assert.Equal(t, "localhost:10001", socket)
+
+	// Invalid v2 socket
+	operatorSocket = core.OperatorSocket("localhost:1234;5678")
+	socket = operatorSocket.GetV2RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	// Invalid socket testcases
+	operatorSocket = core.OperatorSocket("localhost:1234;5678;9999;10001;")
+	socket = operatorSocket.GetV2RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	operatorSocket = core.OperatorSocket("localhost:1234;5678;")
+	socket = operatorSocket.GetV2RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	operatorSocket = core.OperatorSocket("localhost:;1234;5678;")
+	socket = operatorSocket.GetV2RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	operatorSocket = core.OperatorSocket("localhost:1234;:;5678;")
+	socket = operatorSocket.GetV2RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	operatorSocket = core.OperatorSocket("localhost:;;;")
+	socket = operatorSocket.GetV2RetrievalSocket()
+	assert.Equal(t, "", socket)
+
+	operatorSocket = core.OperatorSocket("localhost:1234")
+	socket = operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "", socket)
 }
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -1,8 +1,10 @@
 package core
 
 import (
+	"fmt"
 	"math"
 	"math/big"
+	"strconv"
 
 	"golang.org/x/exp/constraints"
 )
@@ -22,4 +24,16 @@ func RoundUpDivide[T constraints.Integer](a, b T) T {
 func NextPowerOf2[T constraints.Integer](d T) T {
 	nextPower := math.Ceil(math.Log2(float64(d)))
 	return T(math.Pow(2.0, nextPower))
+}
+
+func ValidatePort(portStr string) error {
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fmt.Errorf("port is not a valid number: %v", err)
+	}
+
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("port number out of valid range (1-65535)")
+	}
+	return err
 }

--- a/disperser/common/semver/semver.go
+++ b/disperser/common/semver/semver.go
@@ -31,7 +31,7 @@ func ScanOperators(operators map[core.OperatorID]*core.IndexedOperatorInfo, oper
 			operatorSocket := core.OperatorSocket(operators[operatorId].Socket)
 			var socket string
 			if useRetrievalSocket {
-				socket = operatorSocket.GetRetrievalSocket()
+				socket = operatorSocket.GetV1RetrievalSocket()
 			} else {
 				socket = operatorSocket.GetV1DispersalSocket()
 			}

--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -148,7 +148,7 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 	for opID, op := range state.IndexedOperators {
 		opID := opID
 		op := op
-		host, _, _, v2DispersalPort, err := core.ParseOperatorSocket(op.Socket)
+		host, _, _, v2DispersalPort, _, err := core.ParseOperatorSocket(op.Socket)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse operator socket (%s): %w", op.Socket, err)
 		}

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -198,7 +198,7 @@ func checkIsOnlineAndProcessOperator(operatorStatus OperatorOnlineStatus, operat
 	var isOnline bool
 	var socket string
 	if operatorStatus.IndexedOperatorInfo != nil {
-		socket = core.OperatorSocket(operatorStatus.IndexedOperatorInfo.Socket).GetRetrievalSocket()
+		socket = core.OperatorSocket(operatorStatus.IndexedOperatorInfo.Socket).GetV1RetrievalSocket()
 		isOnline = checkIsOperatorPortOpen(socket, 10, logger)
 	}
 

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -185,6 +185,9 @@ type (
 		V2DispersalSocket string `json:"v2_dispersal_socket"`
 		V2DispersalOnline bool   `json:"v2_dispersal_online"`
 		V2DispersalStatus string `json:"v2_dispersal_status"`
+		V2RetrievalSocket string `json:"v2_retrieval_socket"`
+		V2RetrievalOnline bool   `json:"v2_retrieval_online"`
+		V2RetrievalStatus string `json:"v2_retrieval_status"`
 	}
 	SemverReportResponse struct {
 		Semver map[string]*semver.SemverMetrics `json:"semver"`

--- a/disperser/dataapi/subgraph_client_test.go
+++ b/disperser/dataapi/subgraph_client_test.go
@@ -330,7 +330,7 @@ var (
 		},
 		SocketUpdates: []subgraph.SocketUpdates{
 			{
-				Socket: "localhost:32008;32009;32010",
+				Socket: "localhost:32008;32009;32010;32011",
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.28.6
 	github.com/consensys/gnark-crypto v0.12.1
+	github.com/docker/go-units v0.5.0
 	github.com/emirpasic/gods v1.18.1
 	github.com/ethereum/go-ethereum v1.14.8
 	github.com/fxamacker/cbor/v2 v2.5.0
@@ -85,7 +86,6 @@ require (
 	github.com/docker/cli v25.0.3+incompatible // indirect
 	github.com/docker/docker v25.0.6+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ethereum/c-kzg-4844 v1.0.0 // indirect
 	github.com/ethereum/go-verkle v0.1.1-0.20240306133620-7d920df305f0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect

--- a/inabox/deploy/config.go
+++ b/inabox/deploy/config.go
@@ -385,7 +385,7 @@ func (env *Config) generateRelayVars(ind int, graphUrl, grpcPort string) RelayVa
 }
 
 // Generates DA node .env
-func (env *Config) generateOperatorVars(ind int, name, key, churnerUrl, logPath, dbPath, dispersalPort, retrievalPort, v2DispersalPort, metricsPort, nodeApiPort string) OperatorVars {
+func (env *Config) generateOperatorVars(ind int, name, key, churnerUrl, logPath, dbPath, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort, metricsPort, nodeApiPort string) OperatorVars {
 
 	max, _ := new(big.Int).SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
 	// max.Exp(big.NewInt(2), big.NewInt(130), nil).Sub(max, big.NewInt(1))
@@ -412,6 +412,7 @@ func (env *Config) generateOperatorVars(ind int, name, key, churnerUrl, logPath,
 		NODE_INTERNAL_DISPERSAL_PORT:          dispersalPort,
 		NODE_INTERNAL_RETRIEVAL_PORT:          retrievalPort,
 		NODE_V2_DISPERSAL_PORT:                v2DispersalPort,
+		NODE_V2_RETRIEVAL_PORT:                v2RetrievalPort,
 		NODE_ENABLE_METRICS:                   "true",
 		NODE_METRICS_PORT:                     metricsPort,
 		NODE_ENABLE_NODE_API:                  "true",
@@ -653,8 +654,9 @@ func (env *Config) GenerateAllVariables() {
 		dispersalPort := fmt.Sprint(port + 2)
 		retrievalPort := fmt.Sprint(port + 3)
 		v2DispersalPort := fmt.Sprint(port + 4)
-		nodeApiPort := fmt.Sprint(port + 5)
-		port += 6
+		v2RetrievalPort := fmt.Sprint(port + 5)
+		nodeApiPort := fmt.Sprint(port + 6)
+		port += 7
 
 		name := fmt.Sprintf("opr%v", i)
 		logPath, dbPath, filename, envFile := env.getPaths(name)
@@ -662,7 +664,7 @@ func (env *Config) GenerateAllVariables() {
 
 		// Convert key to address
 
-		operatorConfig := env.generateOperatorVars(i, name, key, churnerUrl, logPath, dbPath, dispersalPort, retrievalPort, v2DispersalPort, fmt.Sprint(metricsPort), nodeApiPort)
+		operatorConfig := env.generateOperatorVars(i, name, key, churnerUrl, logPath, dbPath, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort, fmt.Sprint(metricsPort), nodeApiPort)
 		writeEnv(operatorConfig.getEnvMap(), envFile)
 		env.Operators = append(env.Operators, operatorConfig)
 

--- a/inabox/deploy/deploy.go
+++ b/inabox/deploy/deploy.go
@@ -365,7 +365,7 @@ func (env *Config) StopAnvil() {
 func (env *Config) RunNodePluginBinary(operation string, operator OperatorVars) {
 	changeDirectory(filepath.Join(env.rootPath, "inabox"))
 
-	socket := string(core.MakeOperatorSocket(operator.NODE_HOSTNAME, operator.NODE_DISPERSAL_PORT, operator.NODE_RETRIEVAL_PORT, operator.NODE_V2_DISPERSAL_PORT))
+	socket := string(core.MakeOperatorSocket(operator.NODE_HOSTNAME, operator.NODE_DISPERSAL_PORT, operator.NODE_RETRIEVAL_PORT, operator.NODE_V2_DISPERSAL_PORT, operator.NODE_V2_RETRIEVAL_PORT))
 
 	envVars := []string{
 		"NODE_OPERATION=" + operation,

--- a/inabox/deploy/env_vars.go
+++ b/inabox/deploy/env_vars.go
@@ -346,6 +346,8 @@ type OperatorVars struct {
 
 	NODE_V2_DISPERSAL_PORT string
 
+	NODE_V2_RETRIEVAL_PORT string
+
 	NODE_ENABLE_METRICS string
 
 	NODE_METRICS_PORT string

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -54,6 +54,12 @@ var (
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "V2_DISPERSAL_PORT"),
 	}
+	V2RetrievalPortFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "v2-retrieval-port"),
+		Usage:    "Port at which node registers to listen for v2 retrieval calls",
+		Required: true,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "V2_RETRIEVAL_PORT"),
+	}
 	EnableNodeApiFlag = cli.BoolFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "enable-node-api"),
 		Usage:    "enable node-api to serve eigenlayer-cli node-api calls",
@@ -438,6 +444,7 @@ var optionalFlags = []cli.Flag{
 	BLSSignerAPIKeyFlag,
 	EnableV2Flag,
 	V2DispersalPortFlag,
+	V2RetrievalPortFlag,
 	OnchainStateRefreshIntervalFlag,
 	ChunkDownloadTimeoutFlag,
 	GRPCMsgSizeLimitV2Flag,

--- a/node/node.go
+++ b/node/node.go
@@ -184,7 +184,7 @@ func NewNode(
 	}
 
 	nodeLogger.Info("Creating node", "chainID", chainID.String(), "operatorID", config.ID.Hex(),
-		"dispersalPort", config.DispersalPort, "v2DispersalPort", config.V2DispersalPort, "retrievalPort", config.RetrievalPort, "churnerUrl", config.ChurnerUrl,
+		"dispersalPort", config.DispersalPort, "v2DispersalPort", config.V2DispersalPort, "retrievalPort", config.RetrievalPort, "v2RetrievalPort", config.V2RetrievalPort, "churnerUrl", config.ChurnerUrl,
 		"quorumIDs", fmt.Sprint(config.QuorumIDList), "registerNodeAtStart", config.RegisterNodeAtStart, "pubIPCheckInterval", config.PubIPCheckInterval,
 		"eigenDAServiceManagerAddr", config.EigenDAServiceManagerAddr, "blockStaleMeasure", blockStaleMeasure, "storeDurationBlocks", storeDurationBlocks, "enableGnarkBundleEncoding", config.EnableGnarkBundleEncoding)
 
@@ -286,12 +286,12 @@ func (n *Node) Start(ctx context.Context) error {
 	}
 
 	// Build the socket based on the hostname/IP provided in the CLI
-	socket := string(core.MakeOperatorSocket(n.Config.Hostname, n.Config.DispersalPort, n.Config.RetrievalPort, n.Config.V2DispersalPort))
+	socket := string(core.MakeOperatorSocket(n.Config.Hostname, n.Config.DispersalPort, n.Config.RetrievalPort, n.Config.V2DispersalPort, n.Config.V2RetrievalPort))
 	var operator *Operator
 	if n.Config.RegisterNodeAtStart {
 		n.Logger.Info("Registering node on chain with the following parameters:", "operatorId",
 			n.Config.ID.Hex(), "hostname", n.Config.Hostname, "dispersalPort", n.Config.DispersalPort, "v2DispersalPort", n.Config.V2DispersalPort,
-			"retrievalPort", n.Config.RetrievalPort, "churnerUrl", n.Config.ChurnerUrl, "quorumIds", fmt.Sprint(n.Config.QuorumIDList))
+			"retrievalPort", n.Config.RetrievalPort, "v2RetrievalPort", n.Config.V2RetrievalPort, "churnerUrl", n.Config.ChurnerUrl, "quorumIds", fmt.Sprint(n.Config.QuorumIDList))
 		privateKey, err := crypto.HexToECDSA(n.Config.EthClientConfig.PrivateKeyString)
 		if err != nil {
 			return fmt.Errorf("NewClient: cannot parse private key: %w", err)
@@ -649,7 +649,7 @@ func (n *Node) checkCurrentNodeIp(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			newSocketAddr, err := SocketAddress(ctx, n.PubIPProvider, n.Config.DispersalPort, n.Config.RetrievalPort, n.Config.V2DispersalPort)
+			newSocketAddr, err := SocketAddress(ctx, n.PubIPProvider, n.Config.DispersalPort, n.Config.RetrievalPort, n.Config.V2DispersalPort, n.Config.V2RetrievalPort)
 			if err != nil {
 				n.Logger.Error("failed to get socket address", "err", err)
 				continue

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -135,7 +135,7 @@ func pluginOps(ctx *cli.Context) {
 		return
 	}
 
-	_, dispersalPort, retrievalPort, v2DispersalPort, err := core.ParseOperatorSocket(config.Socket)
+	_, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort, err := core.ParseOperatorSocket(config.Socket)
 	if err != nil {
 		log.Printf("Error: failed to parse operator socket: %v", err)
 		return
@@ -144,7 +144,7 @@ func pluginOps(ctx *cli.Context) {
 	socket := config.Socket
 	if isLocalhost(socket) {
 		pubIPProvider := pubip.ProviderOrDefault(logger, config.PubIPProvider)
-		socket, err = node.SocketAddress(context.Background(), pubIPProvider, dispersalPort, retrievalPort, v2DispersalPort)
+		socket, err = node.SocketAddress(context.Background(), pubIPProvider, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
 		if err != nil {
 			log.Printf("Error: failed to get socket address from ip provider: %v", err)
 			return

--- a/node/utils.go
+++ b/node/utils.go
@@ -121,12 +121,12 @@ func ValidatePointsFromBlobHeader(h *pb.BlobHeader) error {
 	return nil
 }
 
-func SocketAddress(ctx context.Context, provider pubip.Provider, dispersalPort, retrievalPort, v2DispersalPort string) (string, error) {
+func SocketAddress(ctx context.Context, provider pubip.Provider, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort string) (string, error) {
 	ip, err := provider.PublicIPAddress(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get public ip address from IP provider: %w", err)
 	}
-	socket := core.MakeOperatorSocket(ip, dispersalPort, retrievalPort, v2DispersalPort)
+	socket := core.MakeOperatorSocket(ip, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
 	return socket.String(), nil
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -359,6 +359,7 @@ func mustMakeOperators(t *testing.T, cst *coremock.ChainDataMock, logger logging
 			InternalRetrievalPort:               op.RetrievalPort,
 			InternalDispersalPort:               op.DispersalPort,
 			V2DispersalPort:                     op.V2DispersalPort,
+			V2RetrievalPort:                     op.V2RetrievalPort,
 			EnableMetrics:                       false,
 			Timeout:                             10,
 			ExpirationPollIntervalSec:           10,
@@ -383,7 +384,7 @@ func mustMakeOperators(t *testing.T, cst *coremock.ChainDataMock, logger logging
 		tx.On("GetBlockStaleMeasure").Return(nil)
 		tx.On("GetStoreDurationBlocks").Return(nil)
 		tx.On("OperatorIDToAddress").Return(gethcommon.Address{1}, nil)
-		socket := core.MakeOperatorSocket(config.Hostname, config.DispersalPort, config.RetrievalPort, config.V2DispersalPort)
+		socket := core.MakeOperatorSocket(config.Hostname, config.DispersalPort, config.RetrievalPort, config.V2DispersalPort, config.V2RetrievalPort)
 		tx.On("GetOperatorSocket", mock.Anything, mock.Anything).Return(socket.String(), nil)
 
 		noopMetrics := metrics.NewNoopMetrics()


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
- Updates operator socket format to `host:v1DispersalPort;v1RetrievalPort;v2DispersalPort;V2RetrievalPort`
- Refactors parseOperatorSocket to handle v2 retrieval socket with strict port validation
- Adds ValidatePort() to core utils  
- Adds stricter validation for operator sockets. Valid formats:
    - `host:v1DispersalPort;v1RetrievalPort`
    - `host:v1DispersalPort;v1RetrievalPort;v2DispersalPort;V2RetrievalPort`
- Adds host validation supporting both FQDN and IP addr
- Registers node for the new V2 retrieval service


## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
  
