### PR TITLE
Fix relay cache sizes.

### DIFF
--- a/relay/cmd/flags/flags.go
+++ b/relay/cmd/flags/flags.go
@@ -67,7 +67,7 @@ var (
 		Usage:    "The size of the blob cache, in bytes.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "BLOB_CACHE_SIZE"),
-		Value:    8 * units.GiB,
+		Value:    units.GiB,
 	}
 	BlobMaxConcurrencyFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "blob-max-concurrency"),
@@ -81,7 +81,7 @@ var (
 		Usage:    "Size of the chunk cache, in bytes.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "CHUNK_CACHE_BYTES"),
-		Value:    units.GiB,
+		Value:    8 * units.GiB,
 	}
 	ChunkMaxConcurrencyFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "chunk-max-concurrency"),


### PR DESCRIPTION
## Why are these changes needed?

In a prior PR, I intended to make the chunk cache size `8gb`. Instead, I accidentally increased the size of the blob cache instead. This reverts the change to the blob cache size, and applies the intended change to the chunk cache.
