### PR TITLE
fix(api/clients): Update v1 client to take in eigen-sdk logger

### DIFF
--- a/api/clients/eigenda_client.go
+++ b/api/clients/eigenda_client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/Layr-Labs/eigenda/api"
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
@@ -21,6 +20,7 @@ import (
 	edasm "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDAServiceManager"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/auth"
+	"github.com/Layr-Labs/eigensdk-go/logging"
 )
 
 // IEigenDAClient is a wrapper around the DisperserClient interface which
@@ -40,7 +40,7 @@ type EigenDAClient struct {
 	// TODO: all of these should be private, to prevent users from using them directly,
 	// which breaks encapsulation and makes it hard for us to do refactors or changes
 	Config      EigenDAClientConfig
-	Log         log.Logger
+	Log         logging.Logger
 	Client      DisperserClient
 	ethClient   *ethclient.Client
 	edasmCaller *edasm.ContractEigenDAServiceManagerCaller
@@ -76,7 +76,7 @@ var _ IEigenDAClient = &EigenDAClient{}
 //	if err != nil {
 //	  return err
 //	}
-func NewEigenDAClient(log log.Logger, config EigenDAClientConfig) (*EigenDAClient, error) {
+func NewEigenDAClient(log logging.Logger, config EigenDAClientConfig) (*EigenDAClient, error) {
 	err := config.CheckAndSetDefaults()
 	if err != nil {
 		return nil, err
@@ -326,7 +326,7 @@ func (m *EigenDAClient) putBlob(ctxFinality context.Context, rawData []byte, res
 				// Some quorum failed to sign the blob, indicating that the whole network is having issues.
 				// We hence return api.ErrorFailover to let the batcher failover to ethda. This could however be a very unlucky
 				// temporary issue, so the caller should retry at least one more time before failing over.
-				errChan <- api.NewErrorFailover(fmt.Errorf("blob dispersal (requestID=%s) failed with insufficient signatures. eigenda nodes are probably down.", base64RequestID))
+				errChan <- api.NewErrorFailover(fmt.Errorf("blob dispersal (requestID=%s) failed with insufficient signatures. eigenda nodes are probably down", base64RequestID))
 				return
 			case grpcdisperser.BlobStatus_CONFIRMED:
 				if m.Config.WaitForFinalization {

--- a/api/clients/eigenda_client_e2e_test.go
+++ b/api/clients/eigenda_client_e2e_test.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"flag"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
+	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +28,9 @@ func TestClientUsingTestnet(t *testing.T) {
 
 	t.Run("PutBlobWaitForConfirmationDepth0AndGetBlob", func(t *testing.T) {
 		t.Parallel()
-		logger := log.NewLogger(log.NewTerminalHandler(os.Stdout, true))
+		logger, err := logging.NewZapLogger(logging.Development)
+		assert.NoError(t, err)
+
 		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
 			RPC: "disperser-holesky.eigenda.xyz:443",
 			// Should need way less than 20 minutes, but we set it to 20 minutes to be safe
@@ -58,7 +59,9 @@ func TestClientUsingTestnet(t *testing.T) {
 	t.Run("PutBlobWaitForConfirmationDepth3AndGetBlob", func(t *testing.T) {
 		t.Parallel()
 		confDepth := uint64(3)
-		logger := log.NewLogger(log.NewTerminalHandler(os.Stdout, true))
+		logger, err := logging.NewZapLogger(logging.Development)
+		assert.NoError(t, err)
+
 		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
 			RPC: "disperser-holesky.eigenda.xyz:443",
 			// Should need way less than 20 minutes, but we set it to 20 minutes to be safe

--- a/api/clients/eigenda_client_e2e_test.go
+++ b/api/clients/eigenda_client_e2e_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/Layr-Labs/eigenda/common/testutils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,10 +28,8 @@ func TestClientUsingTestnet(t *testing.T) {
 
 	t.Run("PutBlobWaitForConfirmationDepth0AndGetBlob", func(t *testing.T) {
 		t.Parallel()
-		logger, err := logging.NewZapLogger(logging.Development)
-		assert.NoError(t, err)
 
-		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
+		client, err := NewEigenDAClient(testutils.GetLogger(), EigenDAClientConfig{
 			RPC: "disperser-holesky.eigenda.xyz:443",
 			// Should need way less than 20 minutes, but we set it to 20 minutes to be safe
 			// In worst case we had 10 min batching interval + some time for the tx to land onchain,
@@ -59,10 +57,8 @@ func TestClientUsingTestnet(t *testing.T) {
 	t.Run("PutBlobWaitForConfirmationDepth3AndGetBlob", func(t *testing.T) {
 		t.Parallel()
 		confDepth := uint64(3)
-		logger, err := logging.NewZapLogger(logging.Development)
-		assert.NoError(t, err)
 
-		client, err := NewEigenDAClient(logger, EigenDAClientConfig{
+		client, err := NewEigenDAClient(testutils.GetLogger(), EigenDAClientConfig{
 			RPC: "disperser-holesky.eigenda.xyz:443",
 			// Should need way less than 20 minutes, but we set it to 20 minutes to be safe
 			// In worst case we had 10 min batching interval + some time for the tx to land onchain,

--- a/api/clients/eigenda_client_test.go
+++ b/api/clients/eigenda_client_test.go
@@ -11,8 +11,8 @@ import (
 	clientsmock "github.com/Layr-Labs/eigenda/api/clients/mock"
 	"github.com/Layr-Labs/eigenda/api/grpc/common"
 	grpcdisperser "github.com/Layr-Labs/eigenda/api/grpc/disperser"
+	"github.com/Layr-Labs/eigenda/common/testutils"
 	"github.com/Layr-Labs/eigenda/disperser"
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -55,10 +55,8 @@ func TestPutRetrieveBlobIFFTSuccess(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
 	(disperserClient.On("RetrieveBlob", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).Once()) // pass nil in as the return blob to tell the mock to return the corresponding blob
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                          "localhost:51001",
 			StatusQueryTimeout:           10 * time.Minute,
@@ -122,11 +120,10 @@ func TestPutRetrieveBlobIFFTNoDecodeSuccess(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
 	(disperserClient.On("RetrieveBlob", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).Once()) // pass nil in as the return blob to tell the mock to return the corresponding blob
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
+
 	ifftCodec := codecs.NewIFFTCodec(codecs.NewDefaultBlobCodec())
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                          "localhost:51001",
 			StatusQueryTimeout:           10 * time.Minute,
@@ -195,10 +192,8 @@ func TestPutRetrieveBlobNoIFFTSuccess(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
 	(disperserClient.On("RetrieveBlob", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).Once()) // pass nil in as the return blob to tell the mock to return the corresponding blob
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                          "localhost:51001",
 			StatusQueryTimeout:           10 * time.Minute,
@@ -229,10 +224,8 @@ func TestPutBlobFailDispersal(t *testing.T) {
 	disperserClient := clientsmock.NewMockDisperserClient()
 	(disperserClient.On("DisperseBlobAuthenticated", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil, fmt.Errorf("error dispersing")))
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                      "localhost:51001",
 			StatusQueryTimeout:       10 * time.Minute,
@@ -263,10 +256,8 @@ func TestPutBlobFailureInsufficentSignatures(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_DISPERSING}, nil).Once())
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_INSUFFICIENT_SIGNATURES}, nil).Once())
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                      "localhost:51001",
 			StatusQueryTimeout:       10 * time.Minute,
@@ -297,10 +288,8 @@ func TestPutBlobFailureGeneral(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_DISPERSING}, nil).Once())
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FAILED}, nil).Once())
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                      "localhost:51001",
 			StatusQueryTimeout:       10 * time.Minute,
@@ -331,10 +320,8 @@ func TestPutBlobFailureUnknown(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_DISPERSING}, nil).Once())
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_UNKNOWN}, nil).Once())
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                      "localhost:51001",
 			StatusQueryTimeout:       10 * time.Minute,
@@ -367,10 +354,8 @@ func TestPutBlobFinalizationTimeout(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_PROCESSING}, nil).Once())
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_PROCESSING}, nil).Once())
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                      "localhost:51001",
 			StatusQueryTimeout:       200 * time.Millisecond,
@@ -428,10 +413,8 @@ func TestPutBlobIndividualRequestTimeout(t *testing.T) {
 	}
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                      "localhost:51001",
 			StatusQueryTimeout:       10 * time.Minute,
@@ -492,10 +475,8 @@ func TestPutBlobTotalTimeout(t *testing.T) {
 	}
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
-	logger, err := logging.NewZapLogger(logging.Development)
-	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
-		Log: logger,
+		Log: testutils.GetLogger(),
 		Config: clients.EigenDAClientConfig{
 			RPC:                      "localhost:51001",
 			StatusQueryTimeout:       100 * time.Millisecond, // low total timeout

--- a/api/clients/eigenda_client_test.go
+++ b/api/clients/eigenda_client_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/api/grpc/common"
 	grpcdisperser "github.com/Layr-Labs/eigenda/api/grpc/disperser"
 	"github.com/Layr-Labs/eigenda/disperser"
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -55,7 +55,8 @@ func TestPutRetrieveBlobIFFTSuccess(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
 	(disperserClient.On("RetrieveBlob", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).Once()) // pass nil in as the return blob to tell the mock to return the corresponding blob
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{
@@ -121,7 +122,8 @@ func TestPutRetrieveBlobIFFTNoDecodeSuccess(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
 	(disperserClient.On("RetrieveBlob", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).Once()) // pass nil in as the return blob to tell the mock to return the corresponding blob
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	ifftCodec := codecs.NewIFFTCodec(codecs.NewDefaultBlobCodec())
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
@@ -193,7 +195,8 @@ func TestPutRetrieveBlobNoIFFTSuccess(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
 	(disperserClient.On("RetrieveBlob", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).Once()) // pass nil in as the return blob to tell the mock to return the corresponding blob
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{
@@ -226,7 +229,8 @@ func TestPutBlobFailDispersal(t *testing.T) {
 	disperserClient := clientsmock.NewMockDisperserClient()
 	(disperserClient.On("DisperseBlobAuthenticated", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil, fmt.Errorf("error dispersing")))
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{
@@ -259,7 +263,8 @@ func TestPutBlobFailureInsufficentSignatures(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_DISPERSING}, nil).Once())
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_INSUFFICIENT_SIGNATURES}, nil).Once())
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{
@@ -292,7 +297,8 @@ func TestPutBlobFailureGeneral(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_DISPERSING}, nil).Once())
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FAILED}, nil).Once())
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{
@@ -325,7 +331,8 @@ func TestPutBlobFailureUnknown(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_DISPERSING}, nil).Once())
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_UNKNOWN}, nil).Once())
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{
@@ -360,7 +367,8 @@ func TestPutBlobFinalizationTimeout(t *testing.T) {
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_PROCESSING}, nil).Once())
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_PROCESSING}, nil).Once())
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{
@@ -420,7 +428,8 @@ func TestPutBlobIndividualRequestTimeout(t *testing.T) {
 	}
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{
@@ -483,7 +492,8 @@ func TestPutBlobTotalTimeout(t *testing.T) {
 	}
 	(disperserClient.On("GetBlobStatus", mock.Anything, mock.Anything).
 		Return(&grpcdisperser.BlobStatusReply{Status: grpcdisperser.BlobStatus_FINALIZED, Info: finalizedBlobInfo}, nil).Once())
-	logger := log.NewLogger(log.DiscardHandler())
+	logger, err := logging.NewZapLogger(logging.Development)
+	require.NoError(t, err)
 	eigendaClient := clients.EigenDAClient{
 		Log: logger,
 		Config: clients.EigenDAClientConfig{


### PR DESCRIPTION
## Why are these changes needed?
V2 clients take in the `eigensdk/logger` while v1 uses `go-ethereum/log`. We'll need to consolidate a single one within proxy or update the SDK's log interface to be interoperable with `go-ethereum/log`.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
