### PR TITLE
swap g2 A0, A1 for X and Y

### DIFF
--- a/core/v2/serialization.go
+++ b/core/v2/serialization.go
@@ -132,22 +132,22 @@ func ComputeBlobKey(
 			},
 			LengthCommitment: abiG2Commit{
 				X: [2]*big.Int{
-					blobCommitments.LengthCommitment.X.A0.BigInt(new(big.Int)),
 					blobCommitments.LengthCommitment.X.A1.BigInt(new(big.Int)),
+					blobCommitments.LengthCommitment.X.A0.BigInt(new(big.Int)),
 				},
 				Y: [2]*big.Int{
-					blobCommitments.LengthCommitment.Y.A0.BigInt(new(big.Int)),
 					blobCommitments.LengthCommitment.Y.A1.BigInt(new(big.Int)),
+					blobCommitments.LengthCommitment.Y.A0.BigInt(new(big.Int)),
 				},
 			},
 			LengthProof: abiG2Commit{
 				X: [2]*big.Int{
-					blobCommitments.LengthProof.X.A0.BigInt(new(big.Int)),
 					blobCommitments.LengthProof.X.A1.BigInt(new(big.Int)),
+					blobCommitments.LengthProof.X.A0.BigInt(new(big.Int)),
 				},
 				Y: [2]*big.Int{
-					blobCommitments.LengthProof.Y.A0.BigInt(new(big.Int)),
 					blobCommitments.LengthProof.Y.A1.BigInt(new(big.Int)),
+					blobCommitments.LengthProof.Y.A0.BigInt(new(big.Int)),
 				},
 			},
 			DataLength: uint32(blobCommitments.Length),

--- a/core/v2/serialization.go
+++ b/core/v2/serialization.go
@@ -130,6 +130,10 @@ func ComputeBlobKey(
 				X: blobCommitments.Commitment.X.BigInt(new(big.Int)),
 				Y: blobCommitments.Commitment.Y.BigInt(new(big.Int)),
 			},
+			// Most crypptography library serializes a G2 point by having
+			// A0 followed by A1 for both X, Y field of G2. However, ethereum
+			// precompile assumes an ordering of A1, A0. Currently, we choose
+			// to conform with Ethereum order when serializing a blobHeaderV2
 			LengthCommitment: abiG2Commit{
 				X: [2]*big.Int{
 					blobCommitments.LengthCommitment.X.A1.BigInt(new(big.Int)),
@@ -140,6 +144,7 @@ func ComputeBlobKey(
 					blobCommitments.LengthCommitment.Y.A0.BigInt(new(big.Int)),
 				},
 			},
+			// Same as above
 			LengthProof: abiG2Commit{
 				X: [2]*big.Int{
 					blobCommitments.LengthProof.X.A1.BigInt(new(big.Int)),

--- a/core/v2/serialization.go
+++ b/core/v2/serialization.go
@@ -130,10 +130,12 @@ func ComputeBlobKey(
 				X: blobCommitments.Commitment.X.BigInt(new(big.Int)),
 				Y: blobCommitments.Commitment.Y.BigInt(new(big.Int)),
 			},
-			// Most crypptography library serializes a G2 point by having
+			// Most cryptography library serializes a G2 point by having
 			// A0 followed by A1 for both X, Y field of G2. However, ethereum
-			// precompile assumes an ordering of A1, A0. Currently, we choose
+			// precompile assumes an ordering of A1, A0. We choose
 			// to conform with Ethereum order when serializing a blobHeaderV2
+			// for instance, gnark, https://github.com/Consensys/gnark-crypto/blob/de0d77f2b4d520350bc54c612828b19ce2146eee/ecc/bn254/marshal.go#L1078
+			// Ethereum, https://eips.ethereum.org/EIPS/eip-197#definition-of-the-groups
 			LengthCommitment: abiG2Commit{
 				X: [2]*big.Int{
 					blobCommitments.LengthCommitment.X.A1.BigInt(new(big.Int)),

--- a/core/v2/serialization_test.go
+++ b/core/v2/serialization_test.go
@@ -2,7 +2,6 @@ package v2_test
 
 import (
 	"encoding/hex"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestBlobKeyFromHeader(t *testing.T) {
 	}
 	blobKey, err := bh.BlobKey()
 	assert.NoError(t, err)
-	// 0x2bac85c7fc4c21ad02538a7eb44b120efbc64d25b1691470273f84c8cf82187a has not verified in solidity
+	// 0x2bac85c7fc4c21ad02538a7eb44b120efbc64d25b1691470273f84c8cf82187a has verified in solidity  with chisel
 	assert.Equal(t, "2bac85c7fc4c21ad02538a7eb44b120efbc64d25b1691470273f84c8cf82187a", blobKey.Hex())
 }
 
@@ -112,8 +111,7 @@ func TestBlobCertHash(t *testing.T) {
 	hash, err := blobCert.Hash()
 	assert.NoError(t, err)
 
-	fmt.Printf("%x", hash)
-	// afa39b4c45197f0254f7e8e2127c797c74578357e9f077eab7a8aa62e1402bec has not verified in solidity
+	// afa39b4c45197f0254f7e8e2127c797c74578357e9f077eab7a8aa62e1402bec has verified in solidity with chisel
 	assert.Equal(t, "afa39b4c45197f0254f7e8e2127c797c74578357e9f077eab7a8aa62e1402bec", hex.EncodeToString(hash[:]))
 }
 

--- a/core/v2/serialization_test.go
+++ b/core/v2/serialization_test.go
@@ -2,6 +2,7 @@ package v2_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -52,8 +53,8 @@ func TestBlobKeyFromHeader(t *testing.T) {
 	}
 	blobKey, err := bh.BlobKey()
 	assert.NoError(t, err)
-	// 0xac17ec01189d04e827ea282f49077b138f0aefa5177be146a74ae51135868c57 verified in solidity
-	assert.Equal(t, "ac17ec01189d04e827ea282f49077b138f0aefa5177be146a74ae51135868c57", blobKey.Hex())
+	// 0x2bac85c7fc4c21ad02538a7eb44b120efbc64d25b1691470273f84c8cf82187a has not verified in solidity
+	assert.Equal(t, "2bac85c7fc4c21ad02538a7eb44b120efbc64d25b1691470273f84c8cf82187a", blobKey.Hex())
 }
 
 func TestBatchHeaderHash(t *testing.T) {
@@ -110,8 +111,10 @@ func TestBlobCertHash(t *testing.T) {
 
 	hash, err := blobCert.Hash()
 	assert.NoError(t, err)
-	// 0x1db857aeead06422b8d727dc3972db6ceb04ceb87e194cb6c2389ac3015eda49 verified in solidity
-	assert.Equal(t, "1db857aeead06422b8d727dc3972db6ceb04ceb87e194cb6c2389ac3015eda49", hex.EncodeToString(hash[:]))
+
+	fmt.Printf("%x", hash)
+	// afa39b4c45197f0254f7e8e2127c797c74578357e9f077eab7a8aa62e1402bec has not verified in solidity
+	assert.Equal(t, "afa39b4c45197f0254f7e8e2127c797c74578357e9f077eab7a8aa62e1402bec", hex.EncodeToString(hash[:]))
 }
 
 func TestBlobCertSerialization(t *testing.T) {

--- a/inabox/tests/integration_v2_test.go
+++ b/inabox/tests/integration_v2_test.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"github.com/docker/go-units"
 	"math/big"
 	"time"
+
+	"github.com/docker/go-units"
 
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
 	commonpb "github.com/Layr-Labs/eigenda/api/grpc/common/v2"
@@ -303,12 +304,12 @@ func convertBlobInclusionInfo(inclusionInfo *disperserpb.BlobInclusionInfo) (*ve
 						Y: commitY,
 					},
 					LengthCommitment: verifierbindings.BN254G2Point{
-						X: [2]*big.Int{lengthCommitX0, lengthCommitX1},
-						Y: [2]*big.Int{lengthCommitY0, lengthCommitY1},
+						X: [2]*big.Int{lengthCommitX1, lengthCommitX0},
+						Y: [2]*big.Int{lengthCommitY1, lengthCommitY0},
 					},
 					LengthProof: verifierbindings.BN254G2Point{
-						X: [2]*big.Int{lengthProofX0, lengthProofX1},
-						Y: [2]*big.Int{lengthProofY0, lengthProofY1},
+						X: [2]*big.Int{lengthProofX1, lengthProofX0},
+						Y: [2]*big.Int{lengthProofY1, lengthProofY0},
 					},
 					Length: uint32(blobCertificate.BlobHeader.BlobCommitments.Length),
 				},

--- a/inabox/tests/integration_v2_test.go
+++ b/inabox/tests/integration_v2_test.go
@@ -303,6 +303,10 @@ func convertBlobInclusionInfo(inclusionInfo *disperserpb.BlobInclusionInfo) (*ve
 						X: commitX,
 						Y: commitY,
 					},
+					// Most crypptography library serializes a G2 point by having
+					// A0 followed by A1 for both X, Y field of G2. However, ethereum
+					// precompile assumes an ordering of A1, A0. Currently, we choose
+					// to conform with Ethereum order when serializing a blobHeaderV2
 					LengthCommitment: verifierbindings.BN254G2Point{
 						X: [2]*big.Int{lengthCommitX1, lengthCommitX0},
 						Y: [2]*big.Int{lengthCommitY1, lengthCommitY0},

--- a/inabox/tests/integration_v2_test.go
+++ b/inabox/tests/integration_v2_test.go
@@ -305,8 +305,10 @@ func convertBlobInclusionInfo(inclusionInfo *disperserpb.BlobInclusionInfo) (*ve
 					},
 					// Most crypptography library serializes a G2 point by having
 					// A0 followed by A1 for both X, Y field of G2. However, ethereum
-					// precompile assumes an ordering of A1, A0. Currently, we choose
+					// precompile assumes an ordering of A1, A0. We choose
 					// to conform with Ethereum order when serializing a blobHeaderV2
+					// for instance, gnark, https://github.com/Consensys/gnark-crypto/blob/de0d77f2b4d520350bc54c612828b19ce2146eee/ecc/bn254/marshal.go#L1078
+					// Ethereum, https://eips.ethereum.org/EIPS/eip-197#definition-of-the-groups
 					LengthCommitment: verifierbindings.BN254G2Point{
 						X: [2]*big.Int{lengthCommitX1, lengthCommitX0},
 						Y: [2]*big.Int{lengthCommitY1, lengthCommitY0},


### PR DESCRIPTION
This PR addresses the inconsistency issue when serializing the blobHeader at the controller side and at the client side. 

When the controller computes a merkle tree for a batch, it serialize all Blobheader into leaves in the tree, and generate merkle proof for each blob. The merkle proof is given to the client, who computes the leaf locally and query the smart contract for the merkle verification.

Because two serialization are different, the merkle proof won't verify.

Note, the G2 serialization only affect G2 inside the blobCommitment. Not the one inside attestation.ApkG2 . The serialization in attestation.[ApkG2](https://github.com/bxue-l2/eigenda/blob/ba85f0bfb2c64644722fa47a6d637ed85c5e6035/inabox/tests/integration_v2_test.go#L192) is A1, A0. 

The BlobCommitments is not used for computation at all. So it is purely just standardizing the serialization format for G2. As it will be weird that we do both serialization in the codebase.

In the current integration test, it called VerifyDACertV2FromSignedBatch. 
But in the client, we used an upgraded version called VerifyDACertV2.
