### PR TITLE
chore(api/clients/v2): Add build function for `PayloadDisperser`

### DIFF
--- a/api/clients/v2/config.go
+++ b/api/clients/v2/config.go
@@ -59,6 +59,9 @@ type PayloadRetrieverConfig struct {
 type PayloadDisperserConfig struct {
 	PayloadClientConfig
 
+	// SignerPaymentKey is the private key used for signing payment authorization headers
+	SignerPaymentKey string
+
 	// DisperseBlobTimeout is the duration after which the PayloadDisperser will time out, when trying to disperse a
 	// blob
 	DisperseBlobTimeout time.Duration


### PR DESCRIPTION
## Why are these changes needed?
More seamless usability within proxy by providing this method which does bulk of dependency injection work - ensuring proxy only has to care about configs. Also added field for `SignerPaymentKey` since this wasn't being tracked in configs before. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
