### PR TITLE
Disable auth cache

### DIFF
--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -277,7 +277,7 @@ var (
 		Usage:    "The duration for which a disperser authentication is valid",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "DISPERSAL_AUTHENTICATION_TIMEOUT"),
-		Value:    time.Minute,
+		Value:    0, // TODO (cody-littley) remove this feature
 	}
 	RelayMaxGRPCMessageSizeFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "relay-max-grpc-message-size"),

--- a/relay/cmd/flags/flags.go
+++ b/relay/cmd/flags/flags.go
@@ -231,7 +231,7 @@ var (
 	AuthenticationDisabledFlag = cli.BoolFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "authentication-disabled"),
 		Usage:    "Disable GetChunks() authentication",
-		Required: false,
+		Required: true, // TODO(cody-littley) remove this feature
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "AUTHENTICATION_DISABLED"),
 	}
 	GetChunksTimeoutFlag = cli.DurationFlag{

--- a/relay/cmd/flags/flags.go
+++ b/relay/cmd/flags/flags.go
@@ -226,12 +226,12 @@ var (
 		Usage:    "Duration to keep authentication results",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "AUTHENTICATION_TIMEOUT"),
-		Value:    5 * time.Minute,
+		Value:    0, // TODO(cody-littley) remove this feature
 	}
 	AuthenticationDisabledFlag = cli.BoolFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "authentication-disabled"),
 		Usage:    "Disable GetChunks() authentication",
-		Required: true, // TODO(cody-littley) remove this feature
+		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "AUTHENTICATION_DISABLED"),
 	}
 	GetChunksTimeoutFlag = cli.DurationFlag{


### PR DESCRIPTION
## Why are these changes needed?

In testing, I found that auth caching does not work as we intended. This is because traffic is sometimes routed through things like load balancers, which make the IP addresses of different requesters appear to be the same.
