### PR TITLE
Ignore socket parsing error from dispatcher

### DIFF
--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -150,7 +150,15 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 		op := op
 		host, _, _, v2DispersalPort, _, err := core.ParseOperatorSocket(op.Socket)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse operator socket (%s): %w", op.Socket, err)
+			d.logger.Warn("failed to parse operator socket, check if the socket format is correct", "operator", opID.Hex(), "socket", op.Socket, "err", err)
+			sigChan <- core.SigningMessage{
+				Signature:            nil,
+				Operator:             opID,
+				BatchHeaderHash:      batchData.BatchHeaderHash,
+				AttestationLatencyMs: 0,
+				Err:                  fmt.Errorf("failed to parse operator socket (%s): %w", op.Socket, err),
+			}
+			continue
 		}
 
 		client, err := d.nodeClientManager.GetClient(host, v2DispersalPort)


### PR DESCRIPTION
## Why are these changes needed?
Dispatcher should not return error when a single operator has a malformed socket, it should continue with the rest of the operators. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
