### PR TITLE
Fix swagger doc gen to resolve v2.BlobHeader

### DIFF
--- a/disperser/common/v2/blob.go
+++ b/disperser/common/v2/blob.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	pb "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
-	core "github.com/Layr-Labs/eigenda/core/v2"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/encoding"
 )
 
@@ -71,7 +71,7 @@ func BlobStatusFromProtobuf(s pb.BlobStatus) (BlobStatus, error) {
 
 // BlobMetadata is an internal representation of a blob's metadata.
 type BlobMetadata struct {
-	BlobHeader *core.BlobHeader
+	BlobHeader *corev2.BlobHeader
 	Signature  []byte
 
 	// BlobStatus indicates the current status of the blob

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -603,58 +603,6 @@ const docTemplateV2 = `{
         "big.Int": {
             "type": "object"
         },
-        "core.BlobHeader": {
-            "type": "object",
-            "properties": {
-                "accountID": {
-                    "description": "AccountID is the account that is paying for the blob to be stored",
-                    "type": "string"
-                },
-                "commitment": {
-                    "$ref": "#/definitions/encoding.G1Commitment"
-                },
-                "length": {
-                    "type": "integer"
-                },
-                "length_commitment": {
-                    "$ref": "#/definitions/encoding.G2Commitment"
-                },
-                "length_proof": {
-                    "$ref": "#/definitions/encoding.LengthProof"
-                },
-                "quorumInfos": {
-                    "description": "QuorumInfos contains the quorum specific parameters for the blob",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/core.BlobQuorumInfo"
-                    }
-                }
-            }
-        },
-        "core.BlobQuorumInfo": {
-            "type": "object",
-            "properties": {
-                "adversaryThreshold": {
-                    "description": "AdversaryThreshold is the maximum amount of stake that can be controlled by an adversary in the quorum as a percentage of the total stake in the quorum",
-                    "type": "integer"
-                },
-                "chunkLength": {
-                    "description": "ChunkLength is the number of symbols in a chunk",
-                    "type": "integer"
-                },
-                "confirmationThreshold": {
-                    "description": "ConfirmationThreshold is the amount of stake that must sign a message for it to be considered valid as a percentage of the total stake in the quorum",
-                    "type": "integer"
-                },
-                "quorumID": {
-                    "type": "integer"
-                },
-                "quorumRate": {
-                    "description": "Rate Limit. This is a temporary measure until the node can derive rates on its own using rollup authentication. This is used\nfor restricting the rate at which retrievers are able to download data from the DA node to a multiple of the rate at which the\ndata was posted to the DA node.",
-                    "type": "integer"
-                }
-            }
-        },
         "core.G1Point": {
             "type": "object",
             "properties": {
@@ -1110,7 +1058,7 @@ const docTemplateV2 = `{
             "type": "object",
             "properties": {
                 "blobHeader": {
-                    "$ref": "#/definitions/core.BlobHeader"
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobHeader"
                 },
                 "blobSize": {
                     "description": "BlobSize is the size of the blob in bytes",

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -600,58 +600,6 @@
         "big.Int": {
             "type": "object"
         },
-        "core.BlobHeader": {
-            "type": "object",
-            "properties": {
-                "accountID": {
-                    "description": "AccountID is the account that is paying for the blob to be stored",
-                    "type": "string"
-                },
-                "commitment": {
-                    "$ref": "#/definitions/encoding.G1Commitment"
-                },
-                "length": {
-                    "type": "integer"
-                },
-                "length_commitment": {
-                    "$ref": "#/definitions/encoding.G2Commitment"
-                },
-                "length_proof": {
-                    "$ref": "#/definitions/encoding.LengthProof"
-                },
-                "quorumInfos": {
-                    "description": "QuorumInfos contains the quorum specific parameters for the blob",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/core.BlobQuorumInfo"
-                    }
-                }
-            }
-        },
-        "core.BlobQuorumInfo": {
-            "type": "object",
-            "properties": {
-                "adversaryThreshold": {
-                    "description": "AdversaryThreshold is the maximum amount of stake that can be controlled by an adversary in the quorum as a percentage of the total stake in the quorum",
-                    "type": "integer"
-                },
-                "chunkLength": {
-                    "description": "ChunkLength is the number of symbols in a chunk",
-                    "type": "integer"
-                },
-                "confirmationThreshold": {
-                    "description": "ConfirmationThreshold is the amount of stake that must sign a message for it to be considered valid as a percentage of the total stake in the quorum",
-                    "type": "integer"
-                },
-                "quorumID": {
-                    "type": "integer"
-                },
-                "quorumRate": {
-                    "description": "Rate Limit. This is a temporary measure until the node can derive rates on its own using rollup authentication. This is used\nfor restricting the rate at which retrievers are able to download data from the DA node to a multiple of the rate at which the\ndata was posted to the DA node.",
-                    "type": "integer"
-                }
-            }
-        },
         "core.G1Point": {
             "type": "object",
             "properties": {
@@ -1107,7 +1055,7 @@
             "type": "object",
             "properties": {
                 "blobHeader": {
-                    "$ref": "#/definitions/core.BlobHeader"
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobHeader"
                 },
                 "blobSize": {
                     "description": "BlobSize is the size of the blob in bytes",

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -2,49 +2,6 @@ basePath: /api/v2
 definitions:
   big.Int:
     type: object
-  core.BlobHeader:
-    properties:
-      accountID:
-        description: AccountID is the account that is paying for the blob to be stored
-        type: string
-      commitment:
-        $ref: '#/definitions/encoding.G1Commitment'
-      length:
-        type: integer
-      length_commitment:
-        $ref: '#/definitions/encoding.G2Commitment'
-      length_proof:
-        $ref: '#/definitions/encoding.LengthProof'
-      quorumInfos:
-        description: QuorumInfos contains the quorum specific parameters for the blob
-        items:
-          $ref: '#/definitions/core.BlobQuorumInfo'
-        type: array
-    type: object
-  core.BlobQuorumInfo:
-    properties:
-      adversaryThreshold:
-        description: AdversaryThreshold is the maximum amount of stake that can be
-          controlled by an adversary in the quorum as a percentage of the total stake
-          in the quorum
-        type: integer
-      chunkLength:
-        description: ChunkLength is the number of symbols in a chunk
-        type: integer
-      confirmationThreshold:
-        description: ConfirmationThreshold is the amount of stake that must sign a
-          message for it to be considered valid as a percentage of the total stake
-          in the quorum
-        type: integer
-      quorumID:
-        type: integer
-      quorumRate:
-        description: |-
-          Rate Limit. This is a temporary measure until the node can derive rates on its own using rollup authentication. This is used
-          for restricting the rate at which retrievers are able to download data from the DA node to a multiple of the rate at which the
-          data was posted to the DA node.
-        type: integer
-    type: object
   core.G1Point:
     properties:
       x:
@@ -358,7 +315,7 @@ definitions:
   v2.BlobMetadata:
     properties:
       blobHeader:
-        $ref: '#/definitions/core.BlobHeader'
+        $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BlobHeader'
       blobSize:
         description: BlobSize is the size of the blob in bytes
         type: integer


### PR DESCRIPTION
Swagger was including the (v1) `core.BlobHeader` instead of the `v2.BlobHeader` in the `v2.BlobFeedResponse`

```
v2.BlobFeedResponse{
blobs	[v2.BlobInfo{
blob_key	[...]
blob_metadata	v2.BlobMetadata{
blobHeader	core.BlobHeader{
accountID	[...] <-- accountID is inside the BlobHeader object
```

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
