### PR TITLE
chore: better logs in txn_manager

### DIFF
--- a/disperser/batcher/txn_manager.go
+++ b/disperser/batcher/txn_manager.go
@@ -241,9 +241,10 @@ func (t *txnManager) ensureAnyTransactionEvaled(ctx context.Context, txs []*tran
 				chainTip, err := t.ethClient.BlockNumber(ctx)
 				if err == nil {
 					if receipt.BlockNumber.Uint64()+uint64(t.numConfirmations) > chainTip {
-						t.logger.Debug("transaction has been mined but don't have enough confirmations at current chain tip", "txnBlockNumber", receipt.BlockNumber.Uint64(), "numConfirmations", t.numConfirmations, "chainTip", chainTip)
+						t.logger.Debug("transaction has been mined but don't have enough confirmations at current chain tip", "nonce", tx.Nonce(), "txnBlockNumber", receipt.BlockNumber.Uint64(), "numConfirmations", t.numConfirmations, "chainTip", chainTip)
 						break
 					} else {
+						t.logger.Info("transaction has been mined and has enough confirmations", "nonce", tx.Nonce(), "txnBlockNumber", receipt.BlockNumber.Uint64(), "numConfirmations", t.numConfirmations, "chainTip", chainTip)
 						return receipt, nil
 					}
 				} else {


### PR DESCRIPTION
1. add info log when tx is confirmed and we exit the monitoring loop
2. add txn nonce to monitoring log lines to track which nonce the log line is referring to

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
