### PR TITLE
Wait for internal eth client to reach block num

### DIFF
--- a/api/clients/v2/config.go
+++ b/api/clients/v2/config.go
@@ -38,6 +38,13 @@ type PayloadClientConfig struct {
 	// The timeout duration for contract calls
 	ContractCallTimeout time.Duration
 
+	// BlockNumberPollInterval is how frequently to check latest block number when waiting for the internal eth client
+	// to advance to a certain block.
+	//
+	// If this is configured to be <= 0, then contract calls which require the internal eth client to have reached a
+	// certain block height will fail if the internal client is behind.
+	BlockNumberPollInterval time.Duration
+
 	// The BlobVersion to use when creating new blobs, or interpreting blob bytes.
 	//
 	// BlobVersion needs to point to a version defined in the threshold registry contract.
@@ -89,10 +96,11 @@ type PayloadDisperserConfig struct {
 // NOTE: EthRpcUrl and EigenDACertVerifierAddr do not have defined defaults. These must always be specifically configured.
 func getDefaultPayloadClientConfig() *PayloadClientConfig {
 	return &PayloadClientConfig{
-		BlobEncodingVersion:   codecs.DefaultBlobEncoding,
-		PayloadPolynomialForm: codecs.PolynomialFormEval,
-		ContractCallTimeout:   5 * time.Second,
-		BlobVersion:           0,
+		BlobEncodingVersion:     codecs.DefaultBlobEncoding,
+		PayloadPolynomialForm:   codecs.PolynomialFormEval,
+		ContractCallTimeout:     5 * time.Second,
+		BlockNumberPollInterval: 1 * time.Second,
+		BlobVersion:             0,
 	}
 }
 
@@ -119,6 +127,8 @@ func (cc *PayloadClientConfig) checkAndSetDefaults() error {
 	if cc.ContractCallTimeout == 0 {
 		cc.ContractCallTimeout = defaultConfig.ContractCallTimeout
 	}
+
+	// BlockNumberPollInterval may be 0, so don't do anything
 
 	// BlobVersion may be 0, so don't do anything
 

--- a/api/clients/v2/payload_disperser.go
+++ b/api/clients/v2/payload_disperser.go
@@ -78,7 +78,7 @@ func BuildPayloadDisperser(log logging.Logger, payloadDispCfg PayloadDisperserCo
 
 	certVerifier, err := verification.NewCertVerifier(
 		log,
-		*ethClient,
+		ethClient,
 		payloadDispCfg.EigenDACertVerifierAddr,
 		payloadDispCfg.BlockNumberPollInterval,
 	)

--- a/api/clients/v2/payload_disperser.go
+++ b/api/clients/v2/payload_disperser.go
@@ -30,11 +30,11 @@ type PayloadDisperser struct {
 }
 
 // BuildPayloadDisperser builds a PayloadDisperser from config structs.
-func BuildPayloadDisperser(log logging.Logger, payloadDispCfg PayloadDisperserConfig, 
+func BuildPayloadDisperser(log logging.Logger, payloadDispCfg PayloadDisperserConfig,
 	dispClientCfg *DisperserClientConfig,
 	ethCfg *geth.EthClientConfig,
 	kzgConfig *kzg.KzgConfig, encoderCfg *encoding.Config) (*PayloadDisperser, error) {
-	
+
 	// 1 - verify key semantics and create signer
 	signer, err := auth.NewLocalBlobRequestSigner(payloadDispCfg.SignerPaymentKey)
 	if err != nil {
@@ -42,7 +42,7 @@ func BuildPayloadDisperser(log logging.Logger, payloadDispCfg PayloadDisperserCo
 	}
 
 	// 2 - create prover (if applicable)
-	
+
 	var kzgProver *prover.Prover
 	if kzgConfig != nil {
 		if encoderCfg == nil {
@@ -77,8 +77,10 @@ func BuildPayloadDisperser(log logging.Logger, payloadDispCfg PayloadDisperserCo
 	}
 
 	certVerifier, err := verification.NewCertVerifier(
+		log,
 		*ethClient,
 		payloadDispCfg.EigenDACertVerifierAddr,
+		payloadDispCfg.BlockNumberPollInterval,
 	)
 
 	if err != nil {

--- a/api/clients/v2/relay_payload_retriever.go
+++ b/api/clients/v2/relay_payload_retriever.go
@@ -53,7 +53,11 @@ func BuildRelayPayloadRetriever(
 		return nil, fmt.Errorf("new eth client: %w", err)
 	}
 
-	certVerifier, err := verification.NewCertVerifier(*ethClient, relayPayloadRetrieverConfig.EigenDACertVerifierAddr)
+	certVerifier, err := verification.NewCertVerifier(
+		log,
+		*ethClient,
+		relayPayloadRetrieverConfig.EigenDACertVerifierAddr,
+		relayPayloadRetrieverConfig.BlockNumberPollInterval)
 	if err != nil {
 		return nil, fmt.Errorf("new cert verifier: %w", err)
 	}

--- a/api/clients/v2/relay_payload_retriever.go
+++ b/api/clients/v2/relay_payload_retriever.go
@@ -55,7 +55,7 @@ func BuildRelayPayloadRetriever(
 
 	certVerifier, err := verification.NewCertVerifier(
 		log,
-		*ethClient,
+		ethClient,
 		relayPayloadRetrieverConfig.EigenDACertVerifierAddr,
 		relayPayloadRetrieverConfig.BlockNumberPollInterval)
 	if err != nil {

--- a/api/clients/v2/test/cert_verifier_test.go
+++ b/api/clients/v2/test/cert_verifier_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
+	"github.com/Layr-Labs/eigenda/common"
+	commonmock "github.com/Layr-Labs/eigenda/common/mock"
+	testrandom "github.com/Layr-Labs/eigenda/common/testutils/random"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForBlockNumber(t *testing.T) {
+	mockEthClient := commonmock.MockEthClient{}
+
+	logger, err := common.NewLogger(common.DefaultLoggerConfig())
+	require.NoError(t, err)
+
+	pollRate := time.Millisecond * 50
+
+	certVerifier, err := verification.NewCertVerifier(
+		logger,
+		&mockEthClient,
+		"",
+		pollRate)
+	require.NoError(t, err)
+	require.NotNil(t, certVerifier)
+
+	// number of goroutines to start, each of which will call MaybeWaitForBlockNumber
+	callCount := 5
+
+	for i := uint64(0); i < uint64(callCount); i++ {
+		// BlockNumber will increment its return value each time it's called, up to callCount-1
+		mockEthClient.On("BlockNumber").Return(i).Once()
+	}
+	// then, all subsequent calls will yield callCount -1
+	mockEthClient.On("BlockNumber").Return(uint64(callCount - 1))
+
+	// give plenty of time on the timeout, to get the necessary number of polls in
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), pollRate*time.Duration(callCount*2))
+	defer cancel()
+
+	waitGroup := sync.WaitGroup{}
+
+	// start these goroutines in random order, so that it isn't always the same sequence of polling handoffs that gets exercised
+	indices := testrandom.NewTestRandom(t).Perm(callCount)
+	for _, index := range indices {
+		waitGroup.Add(1)
+
+		go func(i int) {
+			defer waitGroup.Done()
+
+			if i == callCount-1 {
+				// the last call is set up to fail, by setting the target block to a number that will never be attained
+				err := certVerifier.MaybeWaitForBlockNumber(timeoutCtx, uint64(i)+1)
+				require.Error(t, err)
+			} else {
+				// all calls except the final call wait for a block number corresponding to their index
+				err := certVerifier.MaybeWaitForBlockNumber(timeoutCtx, uint64(i))
+				require.NoError(t, err)
+			}
+		}(index)
+	}
+
+	waitGroup.Wait()
+	mockEthClient.AssertExpectations(t)
+}

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -40,9 +40,9 @@ type CertVerifier struct {
 	ethClient          *geth.EthClient
 	pollInterval       time.Duration
 	// storage shared between goroutines, containing the most recent block number observed by calling ethClient.BlockNumber()
-	latestBlockNumber *atomic.Uint64
+	latestBlockNumber atomic.Uint64
 	// atomic bool, so that only a single goroutine is polling the internal client with BlockNumber() calls at any given time
-	pollingActive *atomic.Bool
+	pollingActive atomic.Bool
 }
 
 var _ ICertVerifier = &CertVerifier{}
@@ -79,16 +79,11 @@ func NewCertVerifier(
 			"pollInterval", pollInterval)
 	}
 
-	latestBlockNumber := atomic.Uint64{}
-	pollingActive := atomic.Bool{}
-
 	return &CertVerifier{
 		logger:             logger,
 		certVerifierCaller: verifierCaller,
 		ethClient:          ethClient,
 		pollInterval:       pollInterval,
-		latestBlockNumber:  &latestBlockNumber,
-		pollingActive:      &pollingActive,
 	}, nil
 }
 

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	disperser "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
-	"github.com/Layr-Labs/eigenda/common/geth"
+	"github.com/Layr-Labs/eigenda/common"
 	verifierBindings "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifier"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -37,7 +37,7 @@ type CertVerifier struct {
 	logger logging.Logger
 	// go binding around the EigenDACertVerifier ethereum contract
 	certVerifierCaller *verifierBindings.ContractEigenDACertVerifierCaller
-	ethClient          *geth.EthClient
+	ethClient          common.EthClient
 	pollInterval       time.Duration
 	// storage shared between goroutines, containing the most recent block number observed by calling ethClient.BlockNumber()
 	latestBlockNumber atomic.Uint64
@@ -51,7 +51,7 @@ var _ ICertVerifier = &CertVerifier{}
 func NewCertVerifier(
 	logger logging.Logger,
 	// the eth client, which should already be set up
-	ethClient *geth.EthClient,
+	ethClient common.EthClient,
 	// the hex address of the EigenDACertVerifier contract
 	certVerifierAddress string,
 	// pollInterval is how frequently to check latest block number when waiting for the internal eth client to advance

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -33,11 +33,11 @@ type ICertVerifier interface {
 //
 // The cert verifier contract is located at https://github.com/Layr-Labs/eigenda/blob/master/contracts/src/core/EigenDACertVerifier.sol
 type CertVerifier struct {
+	logger logging.Logger
 	// go binding around the EigenDACertVerifier ethereum contract
 	certVerifierCaller *verifierBindings.ContractEigenDACertVerifierCaller
 	ethClient          geth.EthClient
 	pollInterval       time.Duration
-	logger             logging.Logger
 }
 
 var _ ICertVerifier = &CertVerifier{}

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -230,13 +230,12 @@ func (cv *CertVerifier) MaybeWaitForBlockNumber(ctx context.Context, targetBlock
 		defer cv.pollingActive.Store(false)
 	}
 
-	var actualBlockNumber uint64
 	for {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf(
 				"timed out waiting for block number %d (latest block number observed was %d): %w",
-				targetBlockNumber, actualBlockNumber, ctx.Err())
+				targetBlockNumber, cv.latestBlockNumber.Load(), ctx.Err())
 		case <-ticker.C:
 			if cv.latestBlockNumber.Load() >= targetBlockNumber {
 				return nil
@@ -263,7 +262,7 @@ func (cv *CertVerifier) MaybeWaitForBlockNumber(ctx context.Context, targetBlock
 			cv.logger.Debug(
 				"local client is behind the reference block number",
 				"targetBlockNumber", targetBlockNumber,
-				"actualBlockNumber", actualBlockNumber)
+				"actualBlockNumber", cv.latestBlockNumber.Load())
 		}
 	}
 }

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -245,7 +245,14 @@ func (cv *CertVerifier) MaybeWaitForBlockNumber(ctx context.Context, targetBlock
 			if polling {
 				actualBlockNumber, err := cv.ethClient.BlockNumber(ctx)
 				if err != nil {
-					return fmt.Errorf("get block number: %w", err)
+					cv.logger.Debug(
+						"ethClient.BlockNumber returned an error",
+						"targetBlockNumber", targetBlockNumber,
+						"latestBlockNumber", cv.latestBlockNumber.Load(),
+						"error", err)
+
+					// tolerate some failures here. if failure continues for too long, it will be caught by the timeout
+					continue
 				}
 
 				cv.latestBlockNumber.Store(actualBlockNumber)

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -36,7 +36,7 @@ type CertVerifier struct {
 	logger logging.Logger
 	// go binding around the EigenDACertVerifier ethereum contract
 	certVerifierCaller *verifierBindings.ContractEigenDACertVerifierCaller
-	ethClient          geth.EthClient
+	ethClient *geth.EthClient
 	pollInterval       time.Duration
 }
 
@@ -46,7 +46,7 @@ var _ ICertVerifier = &CertVerifier{}
 func NewCertVerifier(
 	logger logging.Logger,
 	// the eth client, which should already be set up
-	ethClient geth.EthClient,
+	ethClient *geth.EthClient,
 	// the hex address of the EigenDACertVerifier contract
 	certVerifierAddress string,
 	// pollInterval is how frequently to check latest block number when waiting for the internal eth client to advance

--- a/test/v2/test_client.go
+++ b/test/v2/test_client.go
@@ -198,7 +198,7 @@ func NewTestClient(t *testing.T, config *TestClientConfig) *TestClient {
 	require.NoError(t, err)
 	certVerifier, err := verification.NewCertVerifier(
 		logger,
-		*gethClient,
+		gethClient,
 		config.EigenDACertVerifierAddress,
 		time.Second)
 	require.NoError(t, err)


### PR DESCRIPTION
## Why are these changes needed?

- Verification calls previously assumed that the internal eth client was advanced far enough that the most recent block number > the block number in the cert
- This isn't necessarily the case, which can cause verification failures
- This PR introduces logic to wait for the internal eth client to catch up to the necessary block to perform the verification

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
