### PR TITLE
CertVerifier fix

### DIFF
--- a/contracts/src/core/EigenDACertVerifier.sol
+++ b/contracts/src/core/EigenDACertVerifier.sol
@@ -98,11 +98,13 @@ contract EigenDACertVerifier is IEigenDACertVerifier {
      * @param batchHeader The batch header of the blob 
      * @param blobInclusionInfo The inclusion proof for the blob cert
      * @param nonSignerStakesAndSignature The nonSignerStakesAndSignature to verify the blob cert against
+     * @param signedQuorumNumbers The signed quorum numbers corresponding to the nonSignerStakesAndSignature
      */
     function verifyDACertV2(
         BatchHeaderV2 calldata batchHeader,
         BlobInclusionInfo calldata blobInclusionInfo,
-        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature
+        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature,
+        bytes memory signedQuorumNumbers
     ) external view {
         EigenDACertVerificationUtils._verifyDACertV2ForQuorums(
             eigenDAThresholdRegistry,
@@ -112,7 +114,8 @@ contract EigenDACertVerifier is IEigenDACertVerifier {
             blobInclusionInfo,
             nonSignerStakesAndSignature,
             securityThresholdsV2,
-            quorumNumbersRequiredV2
+            quorumNumbersRequiredV2,
+            signedQuorumNumbers
         );
     }
 
@@ -145,11 +148,13 @@ contract EigenDACertVerifier is IEigenDACertVerifier {
      * @param batchHeader The batch header of the blob 
      * @param blobInclusionInfo The inclusion proof for the blob cert
      * @param nonSignerStakesAndSignature The nonSignerStakesAndSignature to verify the blob cert against
+     * @param signedQuorumNumbers The signed quorum numbers corresponding to the nonSignerStakesAndSignature
      */
     function verifyDACertV2ForZKProof(
         BatchHeaderV2 calldata batchHeader,
         BlobInclusionInfo calldata blobInclusionInfo,
-        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature
+        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature,
+        bytes memory signedQuorumNumbers
     ) external view returns (bool) {
         try EigenDACertVerificationUtils.verifyDACertV2ForQuorumsExternal(
             eigenDAThresholdRegistry,
@@ -159,7 +164,8 @@ contract EigenDACertVerifier is IEigenDACertVerifier {
             blobInclusionInfo,
             nonSignerStakesAndSignature,
             securityThresholdsV2,
-            quorumNumbersRequiredV2
+            quorumNumbersRequiredV2,
+            signedQuorumNumbers
         ) {
             return true;
         } catch {
@@ -175,7 +181,7 @@ contract EigenDACertVerifier is IEigenDACertVerifier {
      */
     function getNonSignerStakesAndSignature(
         SignedBatch calldata signedBatch
-    ) external view returns (NonSignerStakesAndSignature memory) {
+    ) external view returns (NonSignerStakesAndSignature memory, bytes memory) {
         return EigenDACertVerificationUtils._getNonSignerStakesAndSignature(
             operatorStateRetriever, 
             registryCoordinator, 

--- a/contracts/src/interfaces/IEigenDACertVerifier.sol
+++ b/contracts/src/interfaces/IEigenDACertVerifier.sol
@@ -32,11 +32,13 @@ interface IEigenDACertVerifier is IEigenDAThresholdRegistry {
      * @param batchHeader The batch header of the blob 
      * @param blobInclusionInfo The inclusion proof for the blob cert
      * @param nonSignerStakesAndSignature The nonSignerStakesAndSignature to verify the blob cert against
+     * @param signedQuorumNumbers The signed quorum numbers corresponding to the nonSignerStakesAndSignature
      */
     function verifyDACertV2(
         BatchHeaderV2 calldata batchHeader,
         BlobInclusionInfo calldata blobInclusionInfo,
-        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature
+        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature,
+        bytes memory signedQuorumNumbers
     ) external view;
 
     /**
@@ -50,12 +52,28 @@ interface IEigenDACertVerifier is IEigenDAThresholdRegistry {
     ) external view;
 
     /**
+     * @notice Thin try/catch wrapper around verifyDACertV2 that returns false instead of panicing
+     * @dev The Steel library (https://github.com/risc0/risc0-ethereum/tree/main/crates/steel) 
+     *      currently has a limitation that it can only create zk proofs for functions that return a value
+     * @param batchHeader The batch header of the blob 
+     * @param blobInclusionInfo The inclusion proof for the blob cert
+     * @param nonSignerStakesAndSignature The nonSignerStakesAndSignature to verify the blob cert against
+     * @param signedQuorumNumbers The signed quorum numbers corresponding to the nonSignerStakesAndSignature
+     */
+    function verifyDACertV2ForZKProof(
+        BatchHeaderV2 calldata batchHeader,
+        BlobInclusionInfo calldata blobInclusionInfo,
+        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature,
+        bytes memory signedQuorumNumbers
+    ) external view returns (bool);
+
+    /**
      * @notice Returns the nonSignerStakesAndSignature for a given blob cert and signed batch
      * @param signedBatch The signed batch to get the nonSignerStakesAndSignature for
      */
     function getNonSignerStakesAndSignature(
         SignedBatch calldata signedBatch
-    ) external view returns (NonSignerStakesAndSignature memory);
+    ) external view returns (NonSignerStakesAndSignature memory, bytes memory);
 
     /**
      * @notice Verifies the security parameters for a blob cert

--- a/contracts/test/unit/EigenDACertVerifierV2Unit.t.sol
+++ b/contracts/test/unit/EigenDACertVerifierV2Unit.t.sol
@@ -36,10 +36,8 @@ contract EigenDACertVerifierV2Unit is MockEigenDADeployer {
 
         eigenDACertVerifier.verifyDACertV2FromSignedBatch(signedBatch, blobInclusionInfo);
 
-        eigenDACertVerifier.verifyDACertV2(signedBatch.batchHeader, blobInclusionInfo, nonSignerStakesAndSignature);
-
-        NonSignerStakesAndSignature memory _nonSignerStakesAndSignature = eigenDACertVerifier.getNonSignerStakesAndSignature(signedBatch);
-        eigenDACertVerifier.verifyDACertV2(signedBatch.batchHeader, blobInclusionInfo, _nonSignerStakesAndSignature);
+        (NonSignerStakesAndSignature memory _nonSignerStakesAndSignature, bytes memory signedQuorumNumbers) = eigenDACertVerifier.getNonSignerStakesAndSignature(signedBatch);
+        eigenDACertVerifier.verifyDACertV2(signedBatch.batchHeader, blobInclusionInfo, _nonSignerStakesAndSignature, signedQuorumNumbers);
     }
 
     function test_verifyDACertV2ZK_True(uint256 pseudoRandomNumber) public {
@@ -61,8 +59,8 @@ contract EigenDACertVerifierV2Unit is MockEigenDADeployer {
 
         _registerRelayKeys();
 
-        NonSignerStakesAndSignature memory _nonSignerStakesAndSignature = eigenDACertVerifier.getNonSignerStakesAndSignature(signedBatch);
-        bool zk = eigenDACertVerifier.verifyDACertV2ForZKProof(signedBatch.batchHeader, blobInclusionInfo, _nonSignerStakesAndSignature);
+        (NonSignerStakesAndSignature memory _nonSignerStakesAndSignature, bytes memory signedQuorumNumbers) = eigenDACertVerifier.getNonSignerStakesAndSignature(signedBatch);
+        bool zk = eigenDACertVerifier.verifyDACertV2ForZKProof(signedBatch.batchHeader, blobInclusionInfo, _nonSignerStakesAndSignature, signedQuorumNumbers);
         assert(zk);
     }
 
@@ -83,8 +81,8 @@ contract EigenDACertVerifierV2Unit is MockEigenDADeployer {
         nonSignerStakesAndSignature.totalStakeIndices = nssas.totalStakeIndices;
         nonSignerStakesAndSignature.nonSignerStakeIndices = nssas.nonSignerStakeIndices;
 
-        NonSignerStakesAndSignature memory _nonSignerStakesAndSignature = eigenDACertVerifier.getNonSignerStakesAndSignature(signedBatch);
-        bool zk = eigenDACertVerifier.verifyDACertV2ForZKProof(signedBatch.batchHeader, blobInclusionInfo, _nonSignerStakesAndSignature);
+        (NonSignerStakesAndSignature memory _nonSignerStakesAndSignature, bytes memory signedQuorumNumbers) = eigenDACertVerifier.getNonSignerStakesAndSignature(signedBatch);
+        bool zk = eigenDACertVerifier.verifyDACertV2ForZKProof(signedBatch.batchHeader, blobInclusionInfo, _nonSignerStakesAndSignature, signedQuorumNumbers);
         assert(!zk);
     }
 


### PR DESCRIPTION
Fixes edge case when blob quorums are subset of batch quorums
- Signature check within v2 cert verification now uses the batch level quorum numbers ("signedQuorums") specified in the Attestation of the SignedBatch instead of blob level quorum numbers
- getNonSignerStakesAndSignatures now returns NonSignerStakesAndSignatures and corresponding batch level signedQuroums
- signedQuorums must now be passed to verifyCertV2() and the corresponding ZK wrapper