### PR TITLE
feat: metrics on meterer usage

### DIFF
--- a/disperser/apiserver/disperse_blob_v2.go
+++ b/disperser/apiserver/disperse_blob_v2.go
@@ -121,7 +121,7 @@ func (s *DispersalServerV2) checkPaymentMeter(ctx context.Context, req *pb.Dispe
 		return api.NewErrorResourceExhausted(err.Error())
 	}
 	symbolsCharged := s.meterer.SymbolsCharged(blobLength)
-	s.metrics.reportDisperseBlobSymbolsCharged(int(symbolsCharged))
+	s.metrics.reportDisperseMeteredBytes(int(symbolsCharged) * encoding.BYTES_PER_SYMBOL)
 
 	return nil
 }

--- a/disperser/apiserver/metrics_v2.go
+++ b/disperser/apiserver/metrics_v2.go
@@ -27,6 +27,7 @@ type metricsV2 struct {
 	getPaymentStateLatency          *prometheus.SummaryVec
 	disperseBlobLatency             *prometheus.SummaryVec
 	disperseBlobSize                *prometheus.GaugeVec
+	disperseBlobSymbolsCharged      *prometheus.GaugeVec
 	validateDispersalRequestLatency *prometheus.SummaryVec
 	storeBlobLatency                *prometheus.SummaryVec
 	getBlobStatusLatency            *prometheus.SummaryVec
@@ -88,6 +89,15 @@ func newAPIServerV2Metrics(registry *prometheus.Registry, metricsConfig disperse
 		[]string{},
 	)
 
+	disperseBlobSymbolsCharged := promauto.With(registry).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "disperse_blob_symbols_charged",
+			Help:      "The number of symbols charged for the blob.",
+		},
+		[]string{},
+	)
+
 	validateDispersalRequestLatency := promauto.With(registry).NewSummaryVec(
 		prometheus.SummaryOpts{
 			Namespace:  namespace,
@@ -124,6 +134,7 @@ func newAPIServerV2Metrics(registry *prometheus.Registry, metricsConfig disperse
 		getPaymentStateLatency:          getPaymentStateLatency,
 		disperseBlobLatency:             disperseBlobLatency,
 		disperseBlobSize:                disperseBlobSize,
+		disperseBlobSymbolsCharged:      disperseBlobSymbolsCharged,
 		validateDispersalRequestLatency: validateDispersalRequestLatency,
 		storeBlobLatency:                storeBlobLatency,
 		getBlobStatusLatency:            getBlobStatusLatency,
@@ -163,6 +174,10 @@ func (m *metricsV2) reportDisperseBlobLatency(duration time.Duration) {
 
 func (m *metricsV2) reportDisperseBlobSize(size int) {
 	m.disperseBlobSize.WithLabelValues().Set(float64(size))
+}
+
+func (m *metricsV2) reportDisperseBlobSymbolsCharged(symbolsCharged int) {
+	m.disperseBlobSymbolsCharged.WithLabelValues().Set(float64(symbolsCharged))
 }
 
 func (m *metricsV2) reportValidateDispersalRequestLatency(duration time.Duration) {

--- a/disperser/apiserver/metrics_v2.go
+++ b/disperser/apiserver/metrics_v2.go
@@ -27,7 +27,7 @@ type metricsV2 struct {
 	getPaymentStateLatency          *prometheus.SummaryVec
 	disperseBlobLatency             *prometheus.SummaryVec
 	disperseBlobSize                *prometheus.GaugeVec
-	disperseBlobSymbolsCharged      *prometheus.GaugeVec
+	disperseBlobMeteredBytes        *prometheus.GaugeVec
 	validateDispersalRequestLatency *prometheus.SummaryVec
 	storeBlobLatency                *prometheus.SummaryVec
 	getBlobStatusLatency            *prometheus.SummaryVec
@@ -89,11 +89,11 @@ func newAPIServerV2Metrics(registry *prometheus.Registry, metricsConfig disperse
 		[]string{},
 	)
 
-	disperseBlobSymbolsCharged := promauto.With(registry).NewGaugeVec(
+	disperseBlobMeteredBytes := promauto.With(registry).NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
-			Name:      "disperse_blob_symbols_charged",
-			Help:      "The number of symbols charged for the blob.",
+			Name:      "disperse_blob_metered_bytes",
+			Help:      "The number of bytes charged for the blob.",
 		},
 		[]string{},
 	)
@@ -134,7 +134,7 @@ func newAPIServerV2Metrics(registry *prometheus.Registry, metricsConfig disperse
 		getPaymentStateLatency:          getPaymentStateLatency,
 		disperseBlobLatency:             disperseBlobLatency,
 		disperseBlobSize:                disperseBlobSize,
-		disperseBlobSymbolsCharged:      disperseBlobSymbolsCharged,
+		disperseBlobMeteredBytes:        disperseBlobMeteredBytes,
 		validateDispersalRequestLatency: validateDispersalRequestLatency,
 		storeBlobLatency:                storeBlobLatency,
 		getBlobStatusLatency:            getBlobStatusLatency,
@@ -176,8 +176,8 @@ func (m *metricsV2) reportDisperseBlobSize(size int) {
 	m.disperseBlobSize.WithLabelValues().Set(float64(size))
 }
 
-func (m *metricsV2) reportDisperseBlobSymbolsCharged(symbolsCharged int) {
-	m.disperseBlobSymbolsCharged.WithLabelValues().Set(float64(symbolsCharged))
+func (m *metricsV2) reportDisperseMeteredBytes(usageInBytes int) {
+	m.disperseBlobMeteredBytes.WithLabelValues().Set(float64(usageInBytes))
 }
 
 func (m *metricsV2) reportValidateDispersalRequestLatency(duration time.Duration) {


### PR DESCRIPTION
## Why are these changes needed?

added a `disperseBlobSymbolsCharged` gauge vector metrics, to be compared against the normal disperseBlobSize (we expect `disperseBlobSymbolsCharged` to round up and be multiple of 128kb for each dispersal

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
