### PR TITLE
Add BlobAttestaionInfo data type and fetch API support

### DIFF
--- a/disperser/common/v2/blob.go
+++ b/disperser/common/v2/blob.go
@@ -89,3 +89,12 @@ type BlobMetadata struct {
 
 	*encoding.FragmentInfo
 }
+
+// BlobAttestationInfo describes the attestation information for a blob regarding to the batch
+// that the blob belongs to and the validators' attestation to that batch.
+//
+// Note: for a blob, there will be at most one attested/signed batch that contains the blob.
+type BlobAttestationInfo struct {
+	InclusionInfo *corev2.BlobInclusionInfo
+	Attestation   *corev2.Attestation
+}

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -670,7 +670,7 @@ func TestBlobMetadataStoreGetAttestationByAttestedAtPagination(t *testing.T) {
 	// bucket.
 	startBucket, endBucket := blobstore.GetAttestedAtBucketIDRange(firstBatchTs-1, now)
 	if startBucket < endBucket {
-		now -= uint64(25 * time.Hour.Nanoseconds())
+		now -= uint64(time.Hour.Nanoseconds())
 		firstBatchTs = now - uint64(5*time.Minute.Nanoseconds())
 	}
 	startBucket, endBucket = blobstore.GetAttestedAtBucketIDRange(firstBatchTs-1, now)

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -1048,7 +1048,7 @@ func TestBlobMetadataStoreBlobAttestationInfo(t *testing.T) {
 	blobKey := corev2.BlobKey{1, 1, 1}
 	batchHeader := &corev2.BatchHeader{
 		BatchRoot:            [32]byte{1, 2, 3},
-		ReferenceBlockNumber: 100,
+		ReferenceBlockNumber: 1024,
 	}
 	bhh, err := batchHeader.Hash()
 	assert.NoError(t, err)

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -1111,6 +1111,10 @@ func TestBlobMetadataStoreBlobAttestationInfo(t *testing.T) {
 			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
 			"SK": &types.AttributeValueMemberS{Value: "Attestation"},
 		},
+		{
+			"PK": &types.AttributeValueMemberS{Value: "BlobKey#" + blobKey.Hex()},
+			"SK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
+		},
 	})
 }
 

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -1040,6 +1041,64 @@ func TestBlobMetadataStoreDispersals(t *testing.T) {
 			"SK": &types.AttributeValueMemberS{Value: "DispersalResponse#" + opID2.Hex()},
 		},
 	})
+}
+
+func TestBlobMetadataStoreBlobAttestationInfo(t *testing.T) {
+	ctx := context.Background()
+	blobKey := corev2.BlobKey{1, 1, 1}
+	batchHeader := &corev2.BatchHeader{
+		BatchRoot:            [32]byte{1, 2, 3},
+		ReferenceBlockNumber: 100,
+	}
+	err := blobMetadataStore.PutBatchHeader(ctx, batchHeader)
+	assert.NoError(t, err)
+
+	inclusionInfo := &corev2.BlobInclusionInfo{
+		BatchHeader:    batchHeader,
+		BlobKey:        blobKey,
+		BlobIndex:      10,
+		InclusionProof: []byte("proof"),
+	}
+	err = blobMetadataStore.PutBlobInclusionInfo(ctx, inclusionInfo)
+	assert.NoError(t, err)
+
+	// Test 1: the batch isn't signed yet, so there is no attestation info
+	_, err = blobMetadataStore.GetBlobAttestationInfo(ctx, blobKey)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "no attestation info found"))
+
+	keyPair, err := core.GenRandomBlsKeys()
+	assert.NoError(t, err)
+	apk := keyPair.GetPubKeyG2()
+	attestation := &corev2.Attestation{
+		BatchHeader: batchHeader,
+		AttestedAt:  uint64(time.Now().UnixNano()),
+		NonSignerPubKeys: []*core.G1Point{
+			core.NewG1Point(big.NewInt(1), big.NewInt(2)),
+			core.NewG1Point(big.NewInt(3), big.NewInt(4)),
+		},
+		APKG2: apk,
+		QuorumAPKs: map[uint8]*core.G1Point{
+			0: core.NewG1Point(big.NewInt(5), big.NewInt(6)),
+			1: core.NewG1Point(big.NewInt(7), big.NewInt(8)),
+		},
+		Sigma: &core.Signature{
+			G1Point: core.NewG1Point(big.NewInt(9), big.NewInt(10)),
+		},
+		QuorumNumbers: []core.QuorumID{0, 1},
+		QuorumResults: map[uint8]uint8{
+			0: 100,
+			1: 80,
+		},
+	}
+	err = blobMetadataStore.PutAttestation(ctx, attestation)
+	assert.NoError(t, err)
+
+	// Test 2: the batch is signed, so we can fetch blob's attestation info
+	blobAttestationInfo, err := blobMetadataStore.GetBlobAttestationInfo(ctx, blobKey)
+	require.NoError(t, err)
+	assert.Equal(t, inclusionInfo, blobAttestationInfo.InclusionInfo)
+	assert.Equal(t, attestation, blobAttestationInfo.Attestation)
 }
 
 func TestBlobMetadataStoreInclusionInfo(t *testing.T) {

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -1050,7 +1050,9 @@ func TestBlobMetadataStoreBlobAttestationInfo(t *testing.T) {
 		BatchRoot:            [32]byte{1, 2, 3},
 		ReferenceBlockNumber: 100,
 	}
-	err := blobMetadataStore.PutBatchHeader(ctx, batchHeader)
+	bhh, err := batchHeader.Hash()
+	assert.NoError(t, err)
+	err = blobMetadataStore.PutBatchHeader(ctx, batchHeader)
 	assert.NoError(t, err)
 
 	inclusionInfo := &corev2.BlobInclusionInfo{
@@ -1099,6 +1101,17 @@ func TestBlobMetadataStoreBlobAttestationInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, inclusionInfo, blobAttestationInfo.InclusionInfo)
 	assert.Equal(t, attestation, blobAttestationInfo.Attestation)
+
+	deleteItems(t, []commondynamodb.Key{
+		{
+			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
+			"SK": &types.AttributeValueMemberS{Value: "BatchHeader"},
+		},
+		{
+			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
+			"SK": &types.AttributeValueMemberS{Value: "Attestation"},
+		},
+	})
 }
 
 func TestBlobMetadataStoreInclusionInfo(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
The `BlobAttestationInfo` (which includes the batch that contains the blob and the attestation to the batch) will be used to replace the `v2/blobs/inclusion-info` data API.

This provides more complete picture about a blob's dispersal/attestation info and saves users effort to collect it from client side.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
