### PR TITLE
Don't create V2 server instance in v1-only runtime mode

### DIFF
--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -108,9 +108,13 @@ func NodeMain(ctx *cli.Context) error {
 	// TODO(cody-littley): the metrics server is currently started by eigenmetrics, which is in another repo.
 	//  When we fully remove v1 support, we need to start the metrics server inside the v2 metrics code.
 	server := nodegrpc.NewServer(config, node, logger, ratelimiter)
-	serverV2, err := nodegrpc.NewServerV2(context.Background(), config, node, logger, ratelimiter, reg, reader)
-	if err != nil {
-		return fmt.Errorf("failed to create server v2: %v", err)
+
+	var serverV2 *nodegrpc.ServerV2
+	if config.EnableV2 {
+		serverV2, err = nodegrpc.NewServerV2(context.Background(), config, node, logger, ratelimiter, reg, reader)
+		if err != nil {
+			return fmt.Errorf("failed to create server v2: %v", err)
+		}
 	}
 	err = nodegrpc.RunServers(server, serverV2, config, logger)
 

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -399,9 +399,9 @@ var (
 
 	RuntimeModeFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "runtime-mode"),
-		Usage:    fmt.Sprintf("Node runtime mode (%s (default), %s, or %s)", ModeV1Only, ModeV2Only, ModeV1AndV2),
+		Usage:    fmt.Sprintf("Node runtime mode (%s (default), %s, or %s)", ModeV1AndV2, ModeV1Only, ModeV2Only),
 		Required: false,
-		Value:    ModeV1Only,
+		Value:    ModeV1AndV2,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "RUNTIME_MODE"),
 	}
 )


### PR DESCRIPTION
This handles the case where someone tries to run upcoming v2 release `v0.9.0` in `v1-only` runtime mode against a `v0.8.6` network that lack v2 contracts.

NOTE: This change also promotes `v1-and-v2` as default runtime mode

Prior to this fix, the node would fail to run in `v1-only` mode with the following error
```
eigenda-native-node  | 2025/02/05 05:17:43 Initializing Node
eigenda-native-node  | Feb  5 05:17:44.092 INF pubip/pubip.go:78 Using IP provider 'seeip'
eigenda-native-node  | Feb  5 05:17:45.722 DBG eth/reader.go:149 Addresses component=Reader blsOperatorStateRetrieverAddr=0xB4baAfee917fb4449f5ec64804217bccE9f46C67 eigenDAServiceManagerAddr=0xD4A7E1Bd8015057293f0D0A557088c286942e84b registryCoordinatorAddr=0x53012C69A189cfA2D9d29eb6F19B32e0A2EA3490 blsPubkeyRegistryAddr=0x066cF95c1bf0927124DFB8B02B401bc23A79730D
eigenda-native-node  | Feb  5 05:17:46.483 ERR eth/reader.go:198 Failed to fetch IEigenDARelayRegistry contract component=Reader err="execution reverted"
eigenda-native-node  | Feb  5 05:17:46.665 ERR eth/reader.go:210 Failed to fetch EigenDAThresholdRegistry contract component=Reader err="execution reverted"
eigenda-native-node  | Feb  5 05:17:46.984 ERR eth/reader.go:222 Failed to fetch PaymentVault address component=Reader err="execution reverted"
eigenda-native-node  | Feb  5 05:17:47.175 ERR eth/reader.go:236 Failed to fetch EigenDADisperserRegistry address component=Reader err="execution reverted"
eigenda-native-node  | Feb  5 05:17:47.861 DBG eth/reader.go:149 Addresses component=Reader blsOperatorStateRetrieverAddr=0xB4baAfee917fb4449f5ec64804217bccE9f46C67 eigenDAServiceManagerAddr=0xD4A7E1Bd8015057293f0D0A557088c286942e84b registryCoordinatorAddr=0x53012C69A189cfA2D9d29eb6F19B32e0A2EA3490 blsPubkeyRegistryAddr=0x066cF95c1bf0927124DFB8B02B401bc23A79730D
eigenda-native-node  | Feb  5 05:17:48.303 ERR eth/reader.go:198 Failed to fetch IEigenDARelayRegistry contract component=Reader err="execution reverted"
eigenda-native-node  | Feb  5 05:17:48.490 ERR eth/reader.go:210 Failed to fetch EigenDAThresholdRegistry contract component=Reader err="execution reverted"
eigenda-native-node  | Feb  5 05:17:48.669 ERR eth/reader.go:222 Failed to fetch PaymentVault address component=Reader err="execution reverted"
eigenda-native-node  | Feb  5 05:17:48.851 ERR eth/reader.go:236 Failed to fetch EigenDADisperserRegistry address component=Reader err="execution reverted"
eigenda-native-node  | 2025/02/05 05:17:49     Reading G1 points (4194304 bytes) takes 633.334µs
eigenda-native-node  | Feb  5 05:17:50.750 INF node/node.go:189 Creating node component=Node chainID=17000 operatorID=feba99a1e3230e2383f5417ded9695f170491eb4bc2e21110d73f7f127e3d835 dispersalPort=32005 v2DispersalPort="" retrievalPort=32004 v2RetrievalPort="" churnerUrl=churner-holesky.eigenda.xyz:443 quorumIDs=[0] registerNodeAtStart=false pubIPCheckInterval=10s eigenDAServiceManagerAddr=0xD4A7E1Bd8015057293f0D0A557088c286942e84b blockStaleMeasure=300 storeDurationBlocks=100800 enableGnarkBundleEncoding=false
eigenda-native-node  | Feb  5 05:17:50.750 INF metrics/eigenmetrics.go:86 Starting metrics server at port :9092 component=EigenMetrics
eigenda-native-node  | Feb  5 05:17:50.750 INF node/node.go:275 Enabled metrics component=Node socket=:9092
eigenda-native-node  | Feb  5 05:17:50.750 INF nodeapi/nodeapi.go:104 Starting node api server at address :9091 component=NodeApi
eigenda-native-node  | Feb  5 05:17:50.750 INF node/node.go:279 Enabled node api component=Node port=9091
eigenda-native-node  | Feb  5 05:17:50.750 INF node/node.go:361 Start expireLoop goroutine in background to periodically remove expired batches on the node component=Node
eigenda-native-node  | Feb  5 05:17:50.750 INF nodeapi/nodeapi.go:227 node api server running component=NodeApi addr=:9091
eigenda-native-node  | Feb  5 05:17:50.750 INF node/node.go:701 Start nodeReachabilityCheck goroutine in background to check the reachability of the operator node component=Node
eigenda-native-node  | Feb  5 05:17:51.069 INF node/node.go:332 The node has successfully started. Note: if it's not opted in on https://holesky.eigenlayer.xyz/avs/eigenda, then please follow the EigenDA operator guide section in docs.eigenlayer.xyz to register component=Node
eigenda-native-node  | Feb  5 05:17:51.069 INF node/node.go:627 Start checkRegisteredNodeIpOnChain goroutine in background to subscribe the operator socket change events onchain component=Node
eigenda-native-node  | Feb  5 05:17:51.069 INF node/node.go:650 Start checkCurrentNodeIp goroutine in background to detect the current public IP of the operator node component=Node
eigenda-native-node  | 2025/02/05 05:17:51 application failed: failed to create server v2: failed to create authenticator: failed to preload cache: failed to get operator key: failed to get disperser address: disperser registry not deployed
eigenda-native-node exited with code 0
```

With this fix, the node is able to startup and serve v1 batch requests.
```
Feb  5 22:10:56.902 INF node/node.go:332 The node has successfully started. Note: if it's not opted in on https://holesky.eigenlayer.xyz/avs/eigenda, then please follow the EigenDA operator guide section in docs.eigenlayer.xyz to register component=Node
Feb  5 22:10:56.902 WRN grpc/run.go:125 v2 is not enabled, skipping v2 retrieval server startup
Feb  5 22:10:56.902 WRN grpc/run.go:64 v2 is not enabled, skipping v2 dispersal server startup
Feb  5 22:10:56.902 INF node/node.go:627 Start checkRegisteredNodeIpOnChain goroutine in background to subscribe the operator socket change events onchain component=Node
Feb  5 22:10:56.902 INF node/node.go:650 Start checkCurrentNodeIp goroutine in background to detect the current public IP of the operator node component=Node
Feb  5 22:10:56.902 INF grpc/run.go:54 v1 dispersal enabled on port 32005=address [::]:32005="GRPC Listening"
Feb  5 22:10:56.902 INF grpc/run.go:115 v1 retrieval enabled on port 32004=address [::]:32004="GRPC Listening"
```

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
