### PR TITLE
fix: Improve error handling in traffic generator main

### DIFF
--- a/tools/traffic/cmd/main.go
+++ b/tools/traffic/cmd/main.go
@@ -34,7 +34,7 @@ func main() {
 func trafficGeneratorMain(ctx *cli.Context) error {
 	config, err := traffic.NewConfig(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create config: %w", err)
 	}
 
 	var signer core.BlobRequestSigner
@@ -45,7 +45,7 @@ func trafficGeneratorMain(ctx *cli.Context) error {
 
 	generator, err := traffic.NewTrafficGenerator(config, signer)
 	if err != nil {
-		panic("failed to create new traffic generator")
+		return fmt.Errorf("failed to create new traffic generator: %w", err)
 	}
 
 	return generator.Run()


### PR DESCRIPTION
## Why are these changes needed?

The current error handling in the traffic generator's main entry point uses panic and lacks proper error context, which makes debugging difficult. These changes:
- Replace panic with proper error propagation
- Add contextual information to errors
- Improve error messages for better debugging
- Make error handling consistent with Go best practices

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(