### PR TITLE
Use payload clients in preprod tests

### DIFF
--- a/api/clients/v2/config.go
+++ b/api/clients/v2/config.go
@@ -14,9 +14,6 @@ type PayloadClientConfig struct {
 	// The blob encoding version to use when writing and reading blobs
 	BlobEncodingVersion codecs.BlobEncodingVersion
 
-	// The Ethereum RPC URL to use for querying an Ethereum network
-	EthRpcUrl string
-
 	// The address of the EigenDACertVerifier contract
 	EigenDACertVerifierAddr string
 
@@ -112,8 +109,8 @@ type PayloadDisperserConfig struct {
 
 // GetDefaultPayloadClientConfig creates a PayloadClientConfig with default values
 //
-// NOTE: EthRpcUrl and EigenDACertVerifierAddr do not have defined defaults. These must always be specifically configured.
-func getDefaultPayloadClientConfig() *PayloadClientConfig {
+// NOTE: EigenDACertVerifierAddr does not have a defined default. It must always be specifically configured.
+func GetDefaultPayloadClientConfig() *PayloadClientConfig {
 	return &PayloadClientConfig{
 		BlobEncodingVersion:     codecs.DefaultBlobEncoding,
 		PayloadPolynomialForm:   codecs.PolynomialFormEval,
@@ -131,17 +128,13 @@ func getDefaultPayloadClientConfig() *PayloadClientConfig {
 func (cc *PayloadClientConfig) checkAndSetDefaults() error {
 	// BlobEncodingVersion may be 0, so don't do anything
 
-	if cc.EthRpcUrl == "" {
-		return errors.New("EthRpcUrl is required")
-	}
-
 	if cc.EigenDACertVerifierAddr == "" {
 		return errors.New("EigenDACertVerifierAddr is required")
 	}
 
 	// Nothing to do for PayloadPolynomialForm
 
-	defaultConfig := getDefaultPayloadClientConfig()
+	defaultConfig := GetDefaultPayloadClientConfig()
 
 	if cc.ContractCallTimeout == 0 {
 		cc.ContractCallTimeout = defaultConfig.ContractCallTimeout
@@ -156,10 +149,10 @@ func (cc *PayloadClientConfig) checkAndSetDefaults() error {
 
 // GetDefaultRelayPayloadRetrieverConfig creates a RelayPayloadRetrieverConfig with default values
 //
-// NOTE: EthRpcUrl and EigenDACertVerifierAddr do not have defined defaults. These must always be specifically configured.
+// NOTE: EigenDACertVerifierAddr does not have a defined default. It must always be specifically configured.
 func GetDefaultRelayPayloadRetrieverConfig() *RelayPayloadRetrieverConfig {
 	return &RelayPayloadRetrieverConfig{
-		PayloadClientConfig: *getDefaultPayloadClientConfig(),
+		PayloadClientConfig: *GetDefaultPayloadClientConfig(),
 		RelayTimeout:        5 * time.Second,
 	}
 }
@@ -186,13 +179,12 @@ func (rc *RelayPayloadRetrieverConfig) checkAndSetDefaults() error {
 // GetDefaultValidatorPayloadRetrieverConfig creates a ValidatorPayloadRetrieverConfig with default values
 //
 // NOTE: The following fields do not have defined defaults and must always be specifically configured:
-// - EthRpcUrl
 // - EigenDACertVerifierAddr
 // - BlsOperatorStateRetrieverAddr
 // - EigenDAServiceManagerAddr
 func GetDefaultValidatorPayloadRetrieverConfig() *ValidatorPayloadRetrieverConfig {
 	return &ValidatorPayloadRetrieverConfig{
-		PayloadClientConfig: *getDefaultPayloadClientConfig(),
+		PayloadClientConfig: *GetDefaultPayloadClientConfig(),
 		RetrievalTimeout:    30 * time.Second,
 		MaxConnectionCount:  100,
 	}
@@ -230,10 +222,10 @@ func (rc *ValidatorPayloadRetrieverConfig) checkAndSetDefaults() error {
 
 // GetDefaultPayloadDisperserConfig creates a PayloadDisperserConfig with default values
 //
-// NOTE: EthRpcUrl and EigenDACertVerifierAddr do not have defined defaults. These must always be specifically configured.
+// NOTE: EigenDACertVerifierAddr does not have a defined default. It must always be specifically configured.
 func GetDefaultPayloadDisperserConfig() *PayloadDisperserConfig {
 	return &PayloadDisperserConfig{
-		PayloadClientConfig:    *getDefaultPayloadClientConfig(),
+		PayloadClientConfig:    *GetDefaultPayloadClientConfig(),
 		DisperseBlobTimeout:    5 * time.Second,
 		BlobCertifiedTimeout:   10 * time.Second,
 		BlobStatusPollInterval: 1 * time.Second,

--- a/api/clients/v2/payload_disperser.go
+++ b/api/clients/v2/payload_disperser.go
@@ -165,7 +165,7 @@ func (pd *PayloadDisperser) SendPayload(
 
 	timeoutCtx, cancel = context.WithTimeout(ctx, pd.config.BlobCertifiedTimeout)
 	defer cancel()
-	blobStatusReply, err := pd.PollBlobStatusUntilCertified(timeoutCtx, blobKey, blobStatus.ToProfobuf())
+	blobStatusReply, err := pd.pollBlobStatusUntilCertified(timeoutCtx, blobKey, blobStatus.ToProfobuf())
 	if err != nil {
 		return nil, fmt.Errorf("poll blob status until certified: %w", err)
 	}
@@ -203,11 +203,11 @@ func (pd *PayloadDisperser) Close() error {
 	return nil
 }
 
-// PollBlobStatusUntilCertified polls the disperser for the status of a blob that has been dispersed
+// pollBlobStatusUntilCertified polls the disperser for the status of a blob that has been dispersed
 //
 // This method will only return a non-nil BlobStatusReply if the blob is reported to be CERTIFIED prior to the timeout.
 // In all other cases, this method will return a nil BlobStatusReply, along with an error describing the failure.
-func (pd *PayloadDisperser) PollBlobStatusUntilCertified(
+func (pd *PayloadDisperser) pollBlobStatusUntilCertified(
 	ctx context.Context,
 	blobKey core.BlobKey,
 	initialStatus dispgrpc.BlobStatus,

--- a/api/clients/v2/payload_disperser.go
+++ b/api/clients/v2/payload_disperser.go
@@ -223,8 +223,8 @@ func (pd *PayloadDisperser) pollBlobStatusUntilCertified(
 		case <-ctx.Done():
 			return nil, fmt.Errorf(
 				"timed out waiting for %v blob status, final status was %v: %w",
-				dispgrpc.BlobStatus_COMPLETE.Descriptor(),
-				previousStatus.Descriptor(),
+				dispgrpc.BlobStatus_COMPLETE.String(),
+				previousStatus.String(),
 				ctx.Err())
 		case <-ticker.C:
 			// This call to the disperser doesn't have a dedicated timeout configured.
@@ -240,8 +240,8 @@ func (pd *PayloadDisperser) pollBlobStatusUntilCertified(
 				pd.logger.Debug(
 					"Blob status changed",
 					"blob key", blobKey.Hex(),
-					"previous status", previousStatus.Descriptor(),
-					"new status", newStatus.Descriptor())
+					"previous status", previousStatus.String(),
+					"new status", newStatus.String())
 				previousStatus = newStatus
 			}
 
@@ -255,7 +255,7 @@ func (pd *PayloadDisperser) pollBlobStatusUntilCertified(
 				return nil, fmt.Errorf(
 					"terminal dispersal failure for blobKey %v. blob status: %v",
 					blobKey.Hex(),
-					newStatus.Descriptor())
+					newStatus.String())
 			}
 		}
 	}

--- a/api/clients/v2/payload_disperser.go
+++ b/api/clients/v2/payload_disperser.go
@@ -165,7 +165,7 @@ func (pd *PayloadDisperser) SendPayload(
 
 	timeoutCtx, cancel = context.WithTimeout(ctx, pd.config.BlobCertifiedTimeout)
 	defer cancel()
-	blobStatusReply, err := pd.pollBlobStatusUntilCertified(timeoutCtx, blobKey, blobStatus.ToProfobuf())
+	blobStatusReply, err := pd.PollBlobStatusUntilCertified(timeoutCtx, blobKey, blobStatus.ToProfobuf())
 	if err != nil {
 		return nil, fmt.Errorf("poll blob status until certified: %w", err)
 	}
@@ -203,11 +203,11 @@ func (pd *PayloadDisperser) Close() error {
 	return nil
 }
 
-// pollBlobStatusUntilCertified polls the disperser for the status of a blob that has been dispersed
+// PollBlobStatusUntilCertified polls the disperser for the status of a blob that has been dispersed
 //
 // This method will only return a non-nil BlobStatusReply if the blob is reported to be CERTIFIED prior to the timeout.
 // In all other cases, this method will return a nil BlobStatusReply, along with an error describing the failure.
-func (pd *PayloadDisperser) pollBlobStatusUntilCertified(
+func (pd *PayloadDisperser) PollBlobStatusUntilCertified(
 	ctx context.Context,
 	blobKey core.BlobKey,
 	initialStatus dispgrpc.BlobStatus,

--- a/api/clients/v2/test/relay_payload_retriever_test.go
+++ b/api/clients/v2/test/relay_payload_retriever_test.go
@@ -45,13 +45,12 @@ func buildRelayPayloadRetrieverTester(t *testing.T) RelayPayloadRetrieverTester 
 
 	// the constructor checks that these values aren't empty. we don't need them, though, since we're using mocks
 	payloadClientConfig := clients.PayloadClientConfig{
-		EthRpcUrl:               "x",
-		EigenDACertVerifierAddr: "y",
+		EigenDACertVerifierAddr: "x",
 	}
 
 	clientConfig := clients.RelayPayloadRetrieverConfig{
 		PayloadClientConfig: payloadClientConfig,
-		RelayTimeout: 50 * time.Millisecond,
+		RelayTimeout:        50 * time.Millisecond,
 	}
 
 	mockRelayClient := clientsmock.MockRelayClient{}

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -305,21 +305,24 @@ func (c *TestClient) DisperseAndVerify(
 	blobKey, err := eigenDACert.ComputeBlobKey()
 	require.NoError(c.T, err)
 
+	// read blob from a single relay (assuming success, otherwise will retry)
 	payloadBytesFromRelayRetriever, err := c.RelayPayloadRetriever.GetPayload(ctx, eigenDACert)
 	require.NoError(c.T, err)
 	require.Equal(c.T, payload, payloadBytesFromRelayRetriever)
 
+	// read blob from a single quorum (assuming success, otherwise will retry)
 	payloadBytesFromValidatorRetriever, err := c.ValidatorPayloadRetriever.GetPayload(ctx, eigenDACert)
 	require.NoError(c.T, err)
 	require.Equal(c.T, payload, payloadBytesFromValidatorRetriever)
 
-	// Read the blob from the relays and validators
+	// read blob from ALL relays
 	c.ReadBlobFromRelays(ctx, *blobKey, eigenDACert.BlobInclusionInfo.BlobCertificate.RelayKeys, payload)
 
 	blobHeader := eigenDACert.BlobInclusionInfo.BlobCertificate.BlobHeader
 	commitment, err := verification.BlobCommitmentsBindingToInternal(&blobHeader.Commitment)
 	require.NoError(c.T, err)
 
+	// read blob from ALL quorums
 	c.ReadBlobFromValidators(
 		ctx,
 		*blobKey,

--- a/test/v2/correctness/correctness_test.go
+++ b/test/v2/correctness/correctness_test.go
@@ -43,17 +43,23 @@ func testBasicDispersal(
 	return nil
 }
 
-// Disperse a 0 byte payload.
+// Disperse a 0 byte blob.
 // Empty blobs are not allowed by the disperser
 func TestEmptyBlobDispersal(t *testing.T) {
 	rand := random.NewTestRandom(t)
-	payload := []byte{}
+	blobBytes := []byte{}
+	quorums := []core.QuorumID{0, 1}
+
+	c := client.GetClient(t, quorums)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// We have to use the disperser client directly, since it's not possible for the PayloadDisperser to
+	// attempt dispersal of an empty blob
 	// This should fail with "data is empty" error
-	err := testBasicDispersal(t, rand, payload, []core.QuorumID{0, 1})
+	_, _, err := c.DisperserClient.DisperseBlob(ctx, blobBytes, 0, quorums, rand.Uint32())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "data is empty")
-
-	// TODO: blob no longer empty after payload is processed, this is definitely broken
 }
 
 // Disperse a 1 byte payload (no padding).

--- a/test/v2/load/load_test.go
+++ b/test/v2/load/load_test.go
@@ -1,16 +1,18 @@
 package load
 
 import (
-	"github.com/Layr-Labs/eigenda/common/testutils/random"
-	"github.com/Layr-Labs/eigenda/test/v2/client"
-	"github.com/docker/go-units"
 	"os"
 	"testing"
+
+	"github.com/Layr-Labs/eigenda/common/testutils/random"
+	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/test/v2/client"
+	"github.com/docker/go-units"
 )
 
 func TestLightLoad(t *testing.T) {
 	rand := random.NewTestRandom(t)
-	c := client.GetClient(t)
+	c := client.GetClient(t, []core.QuorumID{0, 1})
 
 	config := DefaultLoadGeneratorConfig()
 	config.AverageBlobSize = 100 * units.KiB


### PR DESCRIPTION
## Why are these changes needed?

- This PR uses the new payload clients in the preprod e2e tests
- This PR is still rough, since holesky is down. WIP

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
