### PR TITLE
Do not panic when a quorum has zero stake.

### DIFF
--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -357,9 +357,13 @@ func GetStakeThreshold(state *OperatorState, quorum QuorumID, quorumThreshold ui
 }
 
 func GetSignedPercentage(state *OperatorState, quorum QuorumID, stakeAmount *big.Int) uint8 {
+	totalStake := state.Totals[quorum].Stake
+	if totalStake.Cmp(big.NewInt(0)) == 0 {
+		return 0
+	}
 
 	stakeAmount = stakeAmount.Mul(stakeAmount, new(big.Int).SetUint64(percentMultiplier))
-	quorumThresholdBig := stakeAmount.Div(stakeAmount, state.Totals[quorum].Stake)
+	quorumThresholdBig := stakeAmount.Div(stakeAmount, totalStake)
 
 	quorumThreshold := uint8(quorumThresholdBig.Uint64())
 


### PR DESCRIPTION
## Why are these changes needed?

Do not panic when a quorum has zero stake. Observed on preprod.
