### PR TITLE
Handle unsorted quorum numbers

### DIFF
--- a/api/clients/v2/verification/conversion_utils.go
+++ b/api/clients/v2/verification/conversion_utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
+	"golang.org/x/exp/slices"
 )
 
 func SignedBatchProtoToBinding(inputBatch *disperserv2.SignedBatch) (*contractEigenDACertVerifier.SignedBatch, error) {
@@ -59,32 +60,51 @@ func BatchHeaderProtoToBinding(inputHeader *commonv2.BatchHeader) (*contractEige
 }
 
 func attestationProtoToBinding(inputAttestation *disperserv2.Attestation) (*contractEigenDACertVerifier.Attestation, error) {
+	if len(inputAttestation.QuorumApks) != len(inputAttestation.QuorumNumbers) {
+		return nil, fmt.Errorf(
+			"quorum apks and quorum numbers must have the same length (apks: %d, numbers: %d)",
+			len(inputAttestation.QuorumApks),
+			len(inputAttestation.QuorumNumbers))
+	}
 	nonSignerPubkeys, err := repeatedBytesToBN254G1Points(inputAttestation.GetNonSignerPubkeys())
 	if err != nil {
 		return nil, fmt.Errorf("convert non signer pubkeys to g1 points: %s", err)
 	}
 
-	quorumApks, err := repeatedBytesToBN254G1Points(inputAttestation.GetQuorumApks())
-	if err != nil {
-		return nil, fmt.Errorf("convert quorum apks to g1 points: %s", err)
-	}
-
 	sigma, err := bytesToBN254G1Point(inputAttestation.GetSigma())
 	if err != nil {
-		return nil, fmt.Errorf("convert sigma to g1 point: %s", err)
+		return nil, fmt.Errorf("failed to convert sigma to g1 point: %s", err)
 	}
 
 	apkG2, err := bytesToBN254G2Point(inputAttestation.GetApkG2())
 	if err != nil {
-		return nil, fmt.Errorf("convert apk g2 to g2 point: %s", err)
+		return nil, fmt.Errorf("failed to convert apk g2 to g2 point: %s", err)
 	}
 
+	// contract expects quorum numbers to be sorted in ascending order
+	// and quorum apks to be in the same order as the quorum numbers
+	sortedQuorumNumbers := make([]uint32, len(inputAttestation.GetQuorumNumbers()))
+	copy(sortedQuorumNumbers, inputAttestation.GetQuorumNumbers())
+	slices.Sort(sortedQuorumNumbers)
+	quorumAPKMap := make(map[core.QuorumID]contractEigenDACertVerifier.BN254G1Point, len(inputAttestation.GetQuorumApks()))
+	for i, quorumNumber := range inputAttestation.GetQuorumNumbers() {
+		apkBytes := inputAttestation.GetQuorumApks()[i]
+		g1Point, err := bytesToBN254G1Point(apkBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to deserialize g1 point: %s", err)
+		}
+		quorumAPKMap[core.QuorumID(quorumNumber)] = *g1Point
+	}
+	sortedQuorumAPKs := make([]contractEigenDACertVerifier.BN254G1Point, len(inputAttestation.GetQuorumNumbers()))
+	for i, quorumNumber := range sortedQuorumNumbers {
+		sortedQuorumAPKs[i] = quorumAPKMap[core.QuorumID(quorumNumber)]
+	}
 	convertedAttestation := &contractEigenDACertVerifier.Attestation{
 		NonSignerPubkeys: nonSignerPubkeys,
-		QuorumApks:       quorumApks,
+		QuorumApks:       sortedQuorumAPKs,
 		Sigma:            *sigma,
 		ApkG2:            *apkG2,
-		QuorumNumbers:    inputAttestation.GetQuorumNumbers(),
+		QuorumNumbers:    sortedQuorumNumbers,
 	}
 
 	return convertedAttestation, nil

--- a/api/clients/v2/verification/conversion_utils_test.go
+++ b/api/clients/v2/verification/conversion_utils_test.go
@@ -1,0 +1,103 @@
+package verification
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/core"
+	v2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttestationProtoToBinding(t *testing.T) {
+	var X0, Y0, X1, Y1 fp.Element
+	_, err := X0.SetString("21661178944771197726808973281966770251114553549453983978976194544185382599016")
+	require.NoError(t, err)
+	_, err = Y0.SetString("9207254729396071334325696286939045899948985698134704137261649190717970615186")
+	require.NoError(t, err)
+	_, err = X1.SetString("18730744272503541936633286178165146673834730535090946570310418711896464442549")
+	require.NoError(t, err)
+	_, err = Y1.SetString("15356431458378126778840641829778151778222945686256112821552210070627093656047")
+	require.NoError(t, err)
+
+	pt0 := &core.G1Point{
+		G1Affine: &bn254.G1Affine{
+			X: X0,
+			Y: Y0,
+		},
+	}
+	pt1 := &core.G1Point{
+		G1Affine: &bn254.G1Affine{
+			X: X1,
+			Y: Y1,
+		},
+	}
+
+	var e0, e1, e2, e3 fp.Element
+	_, err = e0.SetString("10857046999023057135944570762232829481370756359578518086990519993285655852781")
+	require.NoError(t, err)
+	_, err = e1.SetString("11559732032986387107991004021392285783925812861821192530917403151452391805634")
+	require.NoError(t, err)
+	_, err = e2.SetString("8495653923123431417604973247489272438418190587263600148770280649306958101930")
+	require.NoError(t, err)
+	_, err = e3.SetString("4082367875863433681332203403145435568316851327593401208105741076214120093531")
+	require.NoError(t, err)
+
+	var apk bn254.G2Affine
+	apk.X.A0 = e0
+	apk.X.A1 = e1
+	apk.Y.A0 = e2
+	apk.Y.A1 = e3
+
+	inputAttestation := &v2.Attestation{
+		NonSignerPubKeys: []*core.G1Point{pt0, pt1},
+		APKG2: &core.G2Point{
+			G2Affine: &apk,
+		},
+		QuorumAPKs: map[uint8]*core.G1Point{
+			0: pt0,
+			3: pt0,
+			2: pt1,
+		},
+		Sigma: &core.Signature{
+			G1Point: pt0,
+		},
+		QuorumNumbers: []core.QuorumID{3, 0, 2},
+		QuorumResults: map[uint8]uint8{
+			0: 100,
+			3: 50,
+			2: 25,
+		},
+	}
+	attestationProtobuf, err := inputAttestation.ToProtobuf()
+	require.NoError(t, err)
+
+	bindingAttestation, err := attestationProtoToBinding(attestationProtobuf)
+	require.NoError(t, err)
+
+	require.Equal(t, len(inputAttestation.NonSignerPubKeys), len(bindingAttestation.NonSignerPubkeys))
+	for i := range inputAttestation.NonSignerPubKeys {
+		require.Equal(t, inputAttestation.NonSignerPubKeys[i].G1Affine.X.BigInt(new(big.Int)).Bytes(), bindingAttestation.NonSignerPubkeys[i].X.Bytes())
+		require.Equal(t, inputAttestation.NonSignerPubKeys[i].G1Affine.Y.BigInt(new(big.Int)).Bytes(), bindingAttestation.NonSignerPubkeys[i].Y.Bytes())
+	}
+
+	require.Equal(t, inputAttestation.APKG2.G2Affine.X.A0.BigInt(new(big.Int)).Bytes(), bindingAttestation.ApkG2.X[1].Bytes())
+	require.Equal(t, inputAttestation.APKG2.G2Affine.X.A1.BigInt(new(big.Int)).Bytes(), bindingAttestation.ApkG2.X[0].Bytes())
+	require.Equal(t, inputAttestation.APKG2.G2Affine.Y.A0.BigInt(new(big.Int)).Bytes(), bindingAttestation.ApkG2.Y[1].Bytes())
+	require.Equal(t, inputAttestation.APKG2.G2Affine.Y.A1.BigInt(new(big.Int)).Bytes(), bindingAttestation.ApkG2.Y[0].Bytes())
+
+	require.Equal(t, len(inputAttestation.QuorumAPKs), len(bindingAttestation.QuorumApks))
+	require.Equal(t, bindingAttestation.QuorumApks[0].X.Bytes(), pt0.G1Affine.X.BigInt(new(big.Int)).Bytes())
+	require.Equal(t, bindingAttestation.QuorumApks[0].Y.Bytes(), pt0.G1Affine.Y.BigInt(new(big.Int)).Bytes())
+	require.Equal(t, bindingAttestation.QuorumApks[1].X.Bytes(), pt1.G1Affine.X.BigInt(new(big.Int)).Bytes())
+	require.Equal(t, bindingAttestation.QuorumApks[1].Y.Bytes(), pt1.G1Affine.Y.BigInt(new(big.Int)).Bytes())
+	require.Equal(t, bindingAttestation.QuorumApks[2].X.Bytes(), pt0.G1Affine.X.BigInt(new(big.Int)).Bytes())
+	require.Equal(t, bindingAttestation.QuorumApks[2].Y.Bytes(), pt0.G1Affine.Y.BigInt(new(big.Int)).Bytes())
+
+	require.Equal(t, inputAttestation.Sigma.G1Point.G1Affine.X.BigInt(new(big.Int)).Bytes(), bindingAttestation.Sigma.X.Bytes())
+	require.Equal(t, inputAttestation.Sigma.G1Point.G1Affine.Y.BigInt(new(big.Int)).Bytes(), bindingAttestation.Sigma.Y.Bytes())
+
+	require.Equal(t, bindingAttestation.QuorumNumbers, []uint32{0, 2, 3})
+}

--- a/core/v2/serialization.go
+++ b/core/v2/serialization.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/encoding"
@@ -42,7 +43,6 @@ func ComputeBlobKey(
 	paymentMetadataHash [32]byte,
 	salt uint32,
 ) ([32]byte, error) {
-
 	versionType, err := abi.NewType("uint16", "", nil)
 	if err != nil {
 		return [32]byte{}, err
@@ -121,10 +121,13 @@ func ComputeBlobKey(
 			Type: saltType,
 		},
 	}
-
+	// Sort the quorum numbers to ensure the hash is consistent
+	sortedQuorums := make([]core.QuorumID, len(quorumNumbers))
+	copy(sortedQuorums, quorumNumbers)
+	slices.Sort(sortedQuorums)
 	packedBytes, err := arguments.Pack(
 		blobVersion,
-		quorumNumbers,
+		sortedQuorums,
 		abiBlobCommitments{
 			Commitment: abiG1Commit{
 				X: blobCommitments.Commitment.X.BigInt(new(big.Int)),

--- a/core/v2/serialization_test.go
+++ b/core/v2/serialization_test.go
@@ -54,6 +54,23 @@ func TestBlobKeyFromHeader(t *testing.T) {
 	assert.NoError(t, err)
 	// 0x2bac85c7fc4c21ad02538a7eb44b120efbc64d25b1691470273f84c8cf82187a has verified in solidity  with chisel
 	assert.Equal(t, "2bac85c7fc4c21ad02538a7eb44b120efbc64d25b1691470273f84c8cf82187a", blobKey.Hex())
+
+	// same blob key should be generated for the blob header with shuffled quorum numbers
+	bh2 := v2.BlobHeader{
+		BlobVersion:     0,
+		BlobCommitments: commitments,
+		QuorumNumbers:   []core.QuorumID{1, 0},
+		PaymentMetadata: core.PaymentMetadata{
+			AccountID:         "0x123",
+			ReservationPeriod: 5,
+			CumulativePayment: big.NewInt(100),
+		},
+		Salt: 42,
+	}
+
+	blobKey2, err := bh2.BlobKey()
+	assert.NoError(t, err)
+	assert.Equal(t, blobKey2.Hex(), blobKey.Hex())
 }
 
 func TestBatchHeaderHash(t *testing.T) {

--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	commonpb "github.com/Layr-Labs/eigenda/api/grpc/common/v2"
@@ -107,6 +108,7 @@ func BlobHeaderFromProtobuf(proto *commonpb.BlobHeader) (*BlobHeader, error) {
 		}
 		quorumNumbers[i] = core.QuorumID(q)
 	}
+	slices.Sort(quorumNumbers)
 
 	paymentMetadata := core.ConvertToPaymentMetadata(proto.GetPaymentHeader())
 	if paymentMetadata == nil {

--- a/core/v2/types_test.go
+++ b/core/v2/types_test.go
@@ -8,14 +8,13 @@ import (
 	v2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertBatchToFromProtobuf(t *testing.T) {
 	data := codec.ConvertByPaddingEmptyByte(GETTYSBURG_ADDRESS_BYTES)
 	commitments, err := p.GetCommitmentsForPaddedLength(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	bh0 := &v2.BlobHeader{
 		BlobVersion:     0,
@@ -69,9 +68,7 @@ func TestConvertBatchToFromProtobuf(t *testing.T) {
 func TestConvertBlobHeaderToFromProtobuf(t *testing.T) {
 	data := codec.ConvertByPaddingEmptyByte(GETTYSBURG_ADDRESS_BYTES)
 	commitments, err := p.GetCommitmentsForPaddedLength(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	bh := &v2.BlobHeader{
 		BlobVersion:     0,
@@ -96,9 +93,7 @@ func TestConvertBlobHeaderToFromProtobuf(t *testing.T) {
 func TestConvertBlobCertToFromProtobuf(t *testing.T) {
 	data := codec.ConvertByPaddingEmptyByte(GETTYSBURG_ADDRESS_BYTES)
 	commitments, err := p.GetCommitmentsForPaddedLength(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	bh := &v2.BlobHeader{
 		BlobVersion:     0,

--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
@@ -311,6 +312,7 @@ func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData,
 		}
 		return fmt.Errorf("all quorums received no attestation for batch %s", batchHeaderHash)
 	}
+	slices.Sort(nonZeroQuorums)
 
 	aggSig, err := d.aggregator.AggregateSignatures(ctx, d.chainState, uint(batchData.Batch.BatchHeader.ReferenceBlockNumber), quorumAttestation, nonZeroQuorums)
 	aggregateSignaturesFinished := time.Now()


### PR DESCRIPTION
## Why are these changes needed?
Sort quorum numbers for internal storage and for CertVerifier contract call
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
