### PR TITLE
Remove unused `NumConnectionsToNodesFlag`

### DIFF
--- a/disperser/cmd/controller/flags/flags.go
+++ b/disperser/cmd/controller/flags/flags.go
@@ -130,12 +130,6 @@ var (
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "NODE_REQUEST_TIMEOUT"),
 	}
-	NumConnectionsToNodesFlag = cli.IntFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "num-connections-to-nodes"),
-		Usage:    "Max number of connections to nodes",
-		Required: true,
-		EnvVar:   common.PrefixEnvVar(envVarPrefix, "NUM_CONNECTIONS_TO_NODES"),
-	}
 	FinalizationBlockDelayFlag = cli.Uint64Flag{
 		Name:     common.PrefixFlag(FlagPrefix, "finalization-block-delay"),
 		Usage:    "Number of blocks to wait before finalizing",
@@ -203,7 +197,6 @@ var requiredFlags = []cli.Flag{
 
 	DispatcherPullIntervalFlag,
 	NodeRequestTimeoutFlag,
-	NumConnectionsToNodesFlag,
 }
 
 var optionalFlags = []cli.Flag{


### PR DESCRIPTION
## Why are these changes needed?
Removing an unused flag from controller
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
