### PR TITLE
A round of misc improvements to dataapi

### DIFF
--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -424,7 +424,52 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/operators/nodeinfo": {
+        "/operators/liveness": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Check operator v2 node liveness",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operator ID in hex string [default: all operators if unspecified]",
+                        "name": "operator_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorLivenessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/operators/node-info": {
             "get": {
                 "produces": [
                     "application/json"
@@ -438,51 +483,6 @@ const docTemplateV2 = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/v2.SemverReportResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/operators/reachability": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Operators"
-                ],
-                "summary": "Operator v2 node reachability check",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Operator ID in hex string [default: all operators if unspecified]",
-                        "name": "operator_id",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.OperatorPortCheckResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
                         }
                     },
                     "500": {
@@ -1215,25 +1215,8 @@ const docTemplateV2 = `{
         "v2.Metric": {
             "type": "object",
             "properties": {
-                "cost_in_gas": {
-                    "type": "number"
-                },
                 "throughput": {
                     "type": "number"
-                },
-                "total_stake": {
-                    "description": "deprecated: use TotalStakePerQuorum instead. Remove when the frontend is updated.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/big.Int"
-                        }
-                    ]
-                },
-                "total_stake_per_quorum": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/big.Int"
-                    }
                 }
             }
         },
@@ -1248,7 +1231,7 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "v2.OperatorPortCheckResponse": {
+        "v2.OperatorLivenessResponse": {
             "type": "object",
             "properties": {
                 "dispersal_online": {

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -421,7 +421,52 @@
                 }
             }
         },
-        "/operators/nodeinfo": {
+        "/operators/liveness": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Check operator v2 node liveness",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operator ID in hex string [default: all operators if unspecified]",
+                        "name": "operator_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorLivenessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/operators/node-info": {
             "get": {
                 "produces": [
                     "application/json"
@@ -435,51 +480,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/v2.SemverReportResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/operators/reachability": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Operators"
-                ],
-                "summary": "Operator v2 node reachability check",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Operator ID in hex string [default: all operators if unspecified]",
-                        "name": "operator_id",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.OperatorPortCheckResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
                         }
                     },
                     "500": {
@@ -1212,25 +1212,8 @@
         "v2.Metric": {
             "type": "object",
             "properties": {
-                "cost_in_gas": {
-                    "type": "number"
-                },
                 "throughput": {
                     "type": "number"
-                },
-                "total_stake": {
-                    "description": "deprecated: use TotalStakePerQuorum instead. Remove when the frontend is updated.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/big.Int"
-                        }
-                    ]
-                },
-                "total_stake_per_quorum": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/big.Int"
-                    }
                 }
             }
         },
@@ -1245,7 +1228,7 @@
                 }
             }
         },
-        "v2.OperatorPortCheckResponse": {
+        "v2.OperatorLivenessResponse": {
             "type": "object",
             "properties": {
                 "dispersal_online": {

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -389,19 +389,8 @@ definitions:
     type: object
   v2.Metric:
     properties:
-      cost_in_gas:
-        type: number
       throughput:
         type: number
-      total_stake:
-        allOf:
-        - $ref: '#/definitions/big.Int'
-        description: 'deprecated: use TotalStakePerQuorum instead. Remove when the
-          frontend is updated.'
-      total_stake_per_quorum:
-        additionalProperties:
-          $ref: '#/definitions/big.Int'
-        type: object
     type: object
   v2.OperatorDispersalResponses:
     properties:
@@ -410,7 +399,7 @@ definitions:
           $ref: '#/definitions/v2.DispersalResponse'
         type: array
     type: object
-  v2.OperatorPortCheckResponse:
+  v2.OperatorLivenessResponse:
     properties:
       dispersal_online:
         type: boolean
@@ -800,7 +789,36 @@ paths:
       summary: Fetch operator attestation response for a batch
       tags:
       - Operators
-  /operators/nodeinfo:
+  /operators/liveness:
+    get:
+      parameters:
+      - description: 'Operator ID in hex string [default: all operators if unspecified]'
+        in: query
+        name: operator_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.OperatorLivenessResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+      summary: Check operator v2 node liveness
+      tags:
+      - Operators
+  /operators/node-info:
     get:
       produces:
       - application/json
@@ -814,35 +832,6 @@ paths:
           schema:
             $ref: '#/definitions/v2.ErrorResponse'
       summary: Active operator semver
-      tags:
-      - Operators
-  /operators/reachability:
-    get:
-      parameters:
-      - description: 'Operator ID in hex string [default: all operators if unspecified]'
-        in: query
-        name: operator_id
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/v2.OperatorPortCheckResponse'
-        "400":
-          description: 'error: Bad request'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "404":
-          description: 'error: Not found'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "500":
-          description: 'error: Server error'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-      summary: Operator v2 node reachability check
       tags:
       - Operators
   /operators/signing-info:

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -118,8 +118,8 @@ func NewMetrics(serverVersion uint, blobMetadataStore interface{}, httpPort stri
 }
 
 // ObserveLatency observes the latency of a stage in 'stage
-func (g *Metrics) ObserveLatency(method string, latencyMs float64) {
-	g.Latency.WithLabelValues(method).Observe(latencyMs)
+func (g *Metrics) ObserveLatency(method string, duration time.Duration) {
+	g.Latency.WithLabelValues(method).Observe(float64(duration.Milliseconds()))
 }
 
 // IncrementSuccessfulRequestNum increments the number of successful requests

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/logger"
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus"
 	swaggerfiles "github.com/swaggo/files"     // swagger embed files
 	ginswagger "github.com/swaggo/gin-swagger" // gin-swagger middleware
 )
@@ -372,10 +371,10 @@ func (s *server) Shutdown() error {
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"
 //	@Router		/feed/blobs/{blob_key} [get]
 func (s *server) FetchBlobHandler(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchBlob", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchBlob", time.Since(handlerStart))
+	}()
 
 	blobKey := c.Param("blob_key")
 
@@ -405,10 +404,10 @@ func (s *server) FetchBlobHandler(c *gin.Context) {
 //	@Failure	500					{object}	ErrorResponse	"error: Server error"
 //	@Router		/feed/batches/{batch_header_hash}/blobs [get]
 func (s *server) FetchBlobsFromBatchHeaderHash(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchBlobsFromBatchHeaderHash", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchBlobsFromBatchHeaderHash", time.Since(handlerStart))
+	}()
 
 	batchHeaderHash := c.Param("batch_header_hash")
 	batchHeaderHashBytes, err := ConvertHexadecimalToBytes([]byte(batchHeaderHash))
@@ -511,10 +510,10 @@ func encodeNextToken(key *disperser.BatchIndexExclusiveStartKey) (string, error)
 //	@Failure	500		{object}	ErrorResponse	"error: Server error"
 //	@Router		/feed/blobs [get]
 func (s *server) FetchBlobsHandler(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchBlobs", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchBlobs", time.Since(handlerStart))
+	}()
 
 	limit, err := strconv.Atoi(c.DefaultQuery("limit", "10"))
 	if err != nil {
@@ -559,10 +558,10 @@ func (s *server) FetchBlobsHandler(c *gin.Context) {
 //	@Failure	500		{object}	ErrorResponse	"error: Server error"
 //	@Router		/metrics  [get]
 func (s *server) FetchMetricsHandler(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchMetrics", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchMetrics", time.Since(handlerStart))
+	}()
 
 	now := time.Now()
 	start, err := strconv.ParseInt(c.DefaultQuery("start", "0"), 10, 64)
@@ -600,10 +599,10 @@ func (s *server) FetchMetricsHandler(c *gin.Context) {
 //	@Failure	500		{object}	ErrorResponse	"error: Server error"
 //	@Router		/metrics/throughput  [get]
 func (s *server) FetchMetricsThroughputHandler(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchMetricsTroughput", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchMetricsTroughput", time.Since(handlerStart))
+	}()
 
 	now := time.Now()
 	start, err := strconv.ParseInt(c.DefaultQuery("start", "0"), 10, 64)
@@ -640,10 +639,10 @@ func (s *server) FetchMetricsThroughputHandler(c *gin.Context) {
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"
 //	@Router		/metrics/non-signers  [get]
 func (s *server) FetchNonSigners(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchNonSigners", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchNonSigners", time.Since(handlerStart))
+	}()
 
 	interval, err := strconv.ParseInt(c.DefaultQuery("interval", "3600"), 10, 64)
 	if err != nil || interval == 0 {
@@ -675,10 +674,10 @@ func (s *server) FetchNonSigners(c *gin.Context) {
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"
 //	@Router		/metrics/operator-nonsigning-percentage  [get]
 func (s *server) FetchOperatorsNonsigningPercentageHandler(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchOperatorsNonsigningPercentageHandler", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchOperatorsNonsigningPercentageHandler", time.Since(handlerStart))
+	}()
 
 	endTime := time.Now()
 	if c.Query("end") != "" {
@@ -731,10 +730,10 @@ func (s *server) FetchOperatorsNonsigningPercentageHandler(c *gin.Context) {
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"
 //	@Router		/operators-info/operators-stake [get]
 func (s *server) OperatorsStake(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("OperatorsStake", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("OperatorsStake", time.Since(handlerStart))
+	}()
 
 	operatorId := c.DefaultQuery("operator_id", "")
 	s.logger.Info("getting operators stake distribution", "operatorId", operatorId)
@@ -762,10 +761,10 @@ func (s *server) OperatorsStake(c *gin.Context) {
 //	@Failure	500	{object}	ErrorResponse	"error: Server error"
 //	@Router		/operators-info/deregistered-operators [get]
 func (s *server) FetchDeregisteredOperators(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchDeregisteredOperators", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchDeregisteredOperators", time.Since(handlerStart))
+	}()
 
 	// Get query parameters
 	// Default Value 14 days
@@ -812,10 +811,10 @@ func (s *server) FetchDeregisteredOperators(c *gin.Context) {
 //	@Failure	500	{object}	ErrorResponse	"error: Server error"
 //	@Router		/operators-info/registered-operators [get]
 func (s *server) FetchRegisteredOperators(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchRegisteredOperators", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchRegisteredOperators", time.Since(handlerStart))
+	}()
 
 	// Get query parameters
 	// Default Value 14 days
@@ -865,10 +864,10 @@ func (s *server) FetchRegisteredOperators(c *gin.Context) {
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"
 //	@Router		/operators-info/operator-ejections [get]
 func (s *server) FetchOperatorEjections(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchOperatorEjections", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchOperatorEjections", time.Since(handlerStart))
+	}()
 
 	operatorId := c.DefaultQuery("operator_id", "") // If not specified, defaults to all operators
 
@@ -923,10 +922,10 @@ func (s *server) FetchOperatorEjections(c *gin.Context) {
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"
 //	@Router		/operators-info/port-check [get]
 func (s *server) OperatorPortCheck(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("OperatorPortCheck", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("OperatorPortCheck", time.Since(handlerStart))
+	}()
 
 	operatorId := c.DefaultQuery("operator_id", "")
 	s.logger.Info("checking operator ports", "operatorId", operatorId)
@@ -957,10 +956,10 @@ func (s *server) OperatorPortCheck(c *gin.Context) {
 //	@Failure	500	{object}	ErrorResponse	"error: Server error"
 //	@Router		/operators-info/semver-scan [get]
 func (s *server) SemverScan(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("SemverScan", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("SemverScan", time.Since(handlerStart))
+	}()
 
 	report, err := s.operatorHandler.ScanOperatorsHostInfo(c.Request.Context())
 	if err != nil {
@@ -983,10 +982,10 @@ func (s *server) SemverScan(c *gin.Context) {
 //	@Failure	500	{object}	ErrorResponse	"error: Server error"
 //	@Router		/metrics/disperser-service-availability [get]
 func (s *server) FetchDisperserServiceAvailability(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchDisperserServiceAvailability", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchDisperserServiceAvailability", time.Since(handlerStart))
+	}()
 
 	// Check Disperser
 	services := []string{"Disperser"}
@@ -1037,10 +1036,10 @@ func (s *server) FetchDisperserServiceAvailability(c *gin.Context) {
 //	@Failure	500	{object}	ErrorResponse	"error: Server error"
 //	@Router		/metrics/churner-service-availability [get]
 func (s *server) FetchChurnerServiceAvailability(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchChurnerServiceAvailability", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchChurnerServiceAvailability", time.Since(handlerStart))
+	}()
 
 	// Check Disperser
 	services := []string{"Churner"}
@@ -1091,10 +1090,10 @@ func (s *server) FetchChurnerServiceAvailability(c *gin.Context) {
 //	@Failure	500	{object}	ErrorResponse	"error: Server error"
 //	@Router		/metrics/batcher-service-availability [get]
 func (s *server) FetchBatcherAvailability(c *gin.Context) {
-	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(f float64) {
-		s.metrics.ObserveLatency("FetchBatcherAvailability", f*1000) // make milliseconds
-	}))
-	defer timer.ObserveDuration()
+	handlerStart := time.Now()
+	defer func() {
+		s.metrics.ObserveLatency("FetchBatcherAvailability", time.Since(handlerStart))
+	}()
 
 	// Check Batcher
 	services := []HttpServiceAvailabilityCheck{{"Batcher", s.batcherHealthEndpt}}

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -373,10 +373,10 @@ func (s *ServerV2) Shutdown() error {
 //	@Summary	Fetch blob feed
 //	@Tags		Blobs
 //	@Produce	json
-//	@Param		end					query		string	false	"Fetch blobs up to the end time (ISO  8601 format: 2006-01-02T15:04:05Z) [default: now]"
-//	@Param		interval			query		int		false	"Fetch blobs starting from an         interval (in seconds) before the end time [default: 3600]"
-//	@Param		pagination_token	query		string	false	"Fetch blobs starting from the        pagination token (exclusively). Overrides the interval param if specified [default: empty]"
-//	@Param		limit				query		int		false	"The maximum number of blobs to       fetch. System max (1000) if limit <= 0 [default: 20; max: 1000]"
+//	@Param		end					query		string	false	"Fetch blobs up to the end time (ISO 8601 format: 2006-01-02T15:04:05Z) [default: now]"
+//	@Param		interval			query		int		false	"Fetch blobs starting from an interval (in seconds) before the end time [default: 3600]"
+//	@Param		pagination_token	query		string	false	"Fetch blobs starting from the pagination token (exclusively). Overrides the interval param if specified [default: empty]"
+//	@Param		limit				query		int		false	"The maximum number of blobs to fetch. System max (1000) if limit <= 0 [default: 20; max: 1000]"
 //	@Success	200					{object}	BlobFeedResponse
 //	@Failure	400					{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404					{object}	ErrorResponse	"error: Not found"
@@ -987,7 +987,7 @@ func (s *ServerV2) FetchOperatorsResponses(c *gin.Context) {
 //	@Tags		Operators
 //	@Produce	json
 //	@Param		operator_id	query		string	false	"Operator ID in hex string [default: all operators if unspecified]"
-//	@Success	200			{object}    OperatorLivenessResponse
+//	@Success	200			{object}	OperatorLivenessResponse
 //	@Failure	400			{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404			{object}	ErrorResponse	"error: Not found"
 //	@Failure	500			{object}	ErrorResponse	"error: Server error"

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	coremock "github.com/Layr-Labs/eigenda/core/mock"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
-	"github.com/Layr-Labs/eigenda/disperser/common/inmem"
 	commonv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
 	v2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
 	blobstorev2 "github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
@@ -78,7 +77,6 @@ var (
 
 	serverVersion     = uint(2)
 	mockLogger        = testutils.GetLogger()
-	blobstore         = inmem.NewBlobStore()
 	mockPrometheusApi = &prommock.MockPrometheusApi{}
 	prometheusClient  = dataapi.NewPrometheusClient(mockPrometheusApi, "test-cluster")
 	mockSubgraphApi   = &subgraphmock.MockSubgraphApi{}
@@ -104,7 +102,6 @@ var (
 		1: 10,
 		2: 10,
 	})
-	testDataApiServer = dataapi.NewServer(config, blobstore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger), &MockGRPCConnection{}, nil, nil)
 
 	operatorInfoV1 = &subgraph.IndexedOperatorInfo{
 		Id:         "0xa96bfb4a7ca981ad365220f336dc5a3de0816ebd5130b79bbc85aca94bc9b6ac",
@@ -335,7 +332,7 @@ func deleteItems(t *testing.T, keys []commondynamodb.Key) {
 	assert.Len(t, failed, 0)
 }
 
-func TestFetchBlobHandlerV2(t *testing.T) {
+func TestFetchBlob(t *testing.T) {
 	r := setUpRouter()
 
 	// Set up blob metadata in metadata store
@@ -354,7 +351,7 @@ func TestFetchBlobHandlerV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, err)
 
-	r.GET("/v2/blobs/:blob_key", testDataApiServerV2.FetchBlobHandler)
+	r.GET("/v2/blobs/:blob_key", testDataApiServerV2.FetchBlob)
 
 	w := executeRequest(t, r, http.MethodGet, "/v2/blobs/"+blobKey.Hex())
 	response := decodeResponseBody[serverv2.BlobResponse](t, w)
@@ -366,7 +363,7 @@ func TestFetchBlobHandlerV2(t *testing.T) {
 	assert.Equal(t, blobHeader.PaymentMetadata.CumulativePayment, response.BlobHeader.PaymentMetadata.CumulativePayment)
 }
 
-func TestFetchBlobCertificateHandler(t *testing.T) {
+func TestFetchBlobCertificate(t *testing.T) {
 	r := setUpRouter()
 
 	// Set up blob certificate in metadata store
@@ -385,7 +382,7 @@ func TestFetchBlobCertificateHandler(t *testing.T) {
 	err = blobMetadataStore.PutBlobCertificate(context.Background(), blobCert, fragmentInfo)
 	require.NoError(t, err)
 
-	r.GET("/v2/blobs/:blob_key/certificate", testDataApiServerV2.FetchBlobCertificateHandler)
+	r.GET("/v2/blobs/:blob_key/certificate", testDataApiServerV2.FetchBlobCertificate)
 
 	w := executeRequest(t, r, http.MethodGet, "/v2/blobs/"+blobKey.Hex()+"/certificate")
 	response := decodeResponseBody[serverv2.BlobCertificateResponse](t, w)
@@ -395,7 +392,7 @@ func TestFetchBlobCertificateHandler(t *testing.T) {
 	assert.Equal(t, blobCert.Signature, response.Certificate.Signature)
 }
 
-func TestFetchBlobFeedHandler(t *testing.T) {
+func TestFetchBlobFeed(t *testing.T) {
 	r := setUpRouter()
 	ctx := context.Background()
 
@@ -443,7 +440,7 @@ func TestFetchBlobFeedHandler(t *testing.T) {
 		return bytes.Compare(firstBlobKeys[i][:], firstBlobKeys[j][:]) < 0
 	})
 
-	r.GET("/v2/blobs/feed", testDataApiServerV2.FetchBlobFeedHandler)
+	r.GET("/v2/blobs/feed", testDataApiServerV2.FetchBlobFeed)
 
 	t.Run("invalid params", func(t *testing.T) {
 		reqUrls := []string{
@@ -685,7 +682,7 @@ func TestFetchBlobAttestationInfo(t *testing.T) {
 	})
 }
 
-func TestFetchBatchHandlerV2(t *testing.T) {
+func TestFetchBatch(t *testing.T) {
 	r := setUpRouter()
 
 	// Set up batch header in metadata store
@@ -725,7 +722,7 @@ func TestFetchBatchHandlerV2(t *testing.T) {
 	}
 	defer deleteItems(t, []commondynamodb.Key{dk})
 
-	r.GET("/v2/batches/:batch_header_hash", testDataApiServerV2.FetchBatchHandler)
+	r.GET("/v2/batches/:batch_header_hash", testDataApiServerV2.FetchBatch)
 
 	w := executeRequest(t, r, http.MethodGet, "/v2/batches/"+batchHeaderHash)
 	response := decodeResponseBody[serverv2.BatchResponse](t, w)
@@ -737,7 +734,7 @@ func TestFetchBatchHandlerV2(t *testing.T) {
 	assert.Equal(t, attestation.QuorumNumbers, response.SignedBatch.Attestation.QuorumNumbers)
 }
 
-func TestFetchBatchFeedHandler(t *testing.T) {
+func TestFetchBatchFeed(t *testing.T) {
 	r := setUpRouter()
 	ctx := context.Background()
 
@@ -790,7 +787,7 @@ func TestFetchBatchFeedHandler(t *testing.T) {
 	}
 	defer deleteItems(t, dynamoKeys)
 
-	r.GET("/v2/batches/feed", testDataApiServerV2.FetchBatchFeedHandler)
+	r.GET("/v2/batches/feed", testDataApiServerV2.FetchBatchFeed)
 
 	t.Run("invalid params", func(t *testing.T) {
 		reqUrls := []string{
@@ -1540,7 +1537,7 @@ func TestFetchOperatorsStake(t *testing.T) {
 	assert.Equal(t, opId0.Hex(), ops[1].OperatorId)
 }
 
-func TestFetchMetricsSummaryHandler(t *testing.T) {
+func TestFetchMetricsSummary(t *testing.T) {
 	r := setUpRouter()
 
 	s := new(model.SampleStream)
@@ -1551,7 +1548,7 @@ func TestFetchMetricsSummaryHandler(t *testing.T) {
 	matrix = append(matrix, s)
 	mockPrometheusApi.On("QueryRange").Return(matrix, nil, nil).Once()
 
-	r.GET("/v2/metrics/summary", testDataApiServerV2.FetchMetricsSummaryHandler)
+	r.GET("/v2/metrics/summary", testDataApiServerV2.FetchMetricsSummary)
 
 	w := executeRequest(t, r, http.MethodGet, "/v2/metrics/summary")
 	response := decodeResponseBody[serverv2.MetricSummary](t, w)
@@ -1559,7 +1556,7 @@ func TestFetchMetricsSummaryHandler(t *testing.T) {
 	assert.Equal(t, 16555.555555555555, response.AvgThroughput)
 }
 
-func TestFetchMetricsThroughputTimeseriesHandler(t *testing.T) {
+func TestFetchMetricsThroughputTimeseries(t *testing.T) {
 	r := setUpRouter()
 
 	s := new(model.SampleStream)
@@ -1570,7 +1567,7 @@ func TestFetchMetricsThroughputTimeseriesHandler(t *testing.T) {
 	matrix = append(matrix, s)
 	mockPrometheusApi.On("QueryRange").Return(matrix, nil, nil).Once()
 
-	r.GET("/v2/metrics/timeseries/throughput", testDataApiServer.FetchMetricsThroughputHandler)
+	r.GET("/v2/metrics/timeseries/throughput", testDataApiServerV2.FetchMetricsThroughputTimeseries)
 
 	w := executeRequest(t, r, http.MethodGet, "/v2/metrics/timeseries/throughput")
 	response := decodeResponseBody[[]*dataapi.Throughput](t, w)

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -1385,7 +1385,7 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 
 }
 
-func TestCheckOperatorsReachability(t *testing.T) {
+func TestCheckOperatorsLiveness(t *testing.T) {
 	r := setUpRouter()
 
 	mockSubgraphApi.ExpectedCalls = nil
@@ -1394,9 +1394,9 @@ func TestCheckOperatorsReachability(t *testing.T) {
 	operatorId := "0xa96bfb4a7ca981ad365220f336dc5a3de0816ebd5130b79bbc85aca94bc9b6ab"
 	mockSubgraphApi.On("QueryOperatorInfoByOperatorIdAtBlockNumber").Return(operatorInfoV2, nil)
 
-	r.GET("/v2/operators/reachability", testDataApiServerV2.CheckOperatorsReachability)
+	r.GET("/v2/operators/liveness", testDataApiServerV2.CheckOperatorsLiveness)
 
-	reqStr := fmt.Sprintf("/v2/operators/reachability?operator_id=%v", operatorId)
+	reqStr := fmt.Sprintf("/v2/operators/liveness?operator_id=%v", operatorId)
 	w := executeRequest(t, r, http.MethodGet, reqStr)
 	response := decodeResponseBody[dataapi.OperatorPortCheckResponse](t, w)
 
@@ -1411,7 +1411,7 @@ func TestCheckOperatorsReachability(t *testing.T) {
 	mockSubgraphApi.Calls = nil
 }
 
-func TestCheckOperatorsReachabilityLegacyV1SocketRegistration(t *testing.T) {
+func TestCheckOperatorsLivenessLegacyV1SocketRegistration(t *testing.T) {
 	r := setUpRouter()
 
 	mockSubgraphApi.ExpectedCalls = nil
@@ -1420,9 +1420,9 @@ func TestCheckOperatorsReachabilityLegacyV1SocketRegistration(t *testing.T) {
 	operatorId := "0xa96bfb4a7ca981ad365220f336dc5a3de0816ebd5130b79bbc85aca94bc9b6ab"
 	mockSubgraphApi.On("QueryOperatorInfoByOperatorIdAtBlockNumber").Return(operatorInfoV1, nil)
 
-	r.GET("/v2/operators/reachability", testDataApiServerV2.CheckOperatorsReachability)
+	r.GET("/v2/operators/liveness", testDataApiServerV2.CheckOperatorsLiveness)
 
-	reqStr := fmt.Sprintf("/v2/operators/reachability?operator_id=%v", operatorId)
+	reqStr := fmt.Sprintf("/v2/operators/liveness?operator_id=%v", operatorId)
 	w := executeRequest(t, r, http.MethodGet, reqStr)
 	response := decodeResponseBody[dataapi.OperatorPortCheckResponse](t, w)
 

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -294,45 +294,6 @@ var (
 		Value:    units.GiB, // intentionally large for the time being
 	}
 
-	// Test only, DO NOT USE the following flags in production
-
-	// This flag controls whether other test flags can take effect.
-	// By default, it is not test mode.
-	EnableTestModeFlag = cli.BoolFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "enable-test-mode"),
-		Usage:    "Whether to run as test mode. This flag needs to be enabled for other test flags to take effect",
-		Required: false,
-		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "ENABLE_TEST_MODE"),
-	}
-
-	// Corresponding to the BLOCK_STALE_MEASURE defined onchain in
-	// contracts/src/core/EigenDAServiceManagerStorage.sol
-	// This flag is used to override the value from the chain. The target use case is testing.
-	OverrideBlockStaleMeasureFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "override-block-stale-measure"),
-		Usage:    "The maximum amount of blocks in the past that the service will consider stake amounts to still be valid. This is used to override the value set on chain. <=0 means no override",
-		Required: false,
-		Value:    "-1",
-		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "OVERRIDE_BLOCK_STALE_MEASURE"),
-	}
-	// Corresponding to the STORE_DURATION_BLOCKS defined onchain in
-	// contracts/src/core/EigenDAServiceManagerStorage.sol
-	// This flag is used to override the value from the chain. The target use case is testing.
-	OverrideStoreDurationBlocksFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "override-store-duration-blocks"),
-		Usage:    "Unit of measure (in blocks) for which data will be stored for after confirmation. This is used to override the value set on chain. <=0 means no override",
-		Required: false,
-		Value:    "-1",
-		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "OVERRIDE_STORE_DURATION_BLOCKS"),
-	}
-	// DO NOT set plain private key in flag in production.
-	// When test mode is enabled, the DA Node will take private BLS key from this flag.
-	TestPrivateBlsFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "test-private-bls"),
-		Usage:    "Test BLS private key for node operator",
-		Required: false,
-		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "TEST_PRIVATE_BLS"),
-	}
 	ClientIPHeaderFlag = cli.StringFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "client-ip-header"),
 		Usage:    "The name of the header used to get the client IP address. If set to empty string, the IP address will be taken from the connection. The rightmost value of the header will be used.",
@@ -404,6 +365,64 @@ var (
 		Value:    ModeV1AndV2,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "RUNTIME_MODE"),
 	}
+
+	/////////////////////////////////////////////////////////////////////////////
+	// TEST FLAGS SECTION
+	//
+	// WARNING: These flags are for testing purposes only.
+	// They must be disabled in production environments as they may:
+	//   - Break protocol requirements
+	//   - Expose sensitive information
+	//   - Bypass security checks
+	//   - Degrade performance
+	/////////////////////////////////////////////////////////////////////////////
+
+	// This flag controls whether other test flags can take effect.
+	// By default, it is not test mode.
+	EnableTestModeFlag = cli.BoolFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "enable-test-mode"),
+		Usage:    "Whether to run as test mode. This flag needs to be enabled for other test flags to take effect",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "ENABLE_TEST_MODE"),
+	}
+
+	// Corresponding to the BLOCK_STALE_MEASURE defined onchain in
+	// contracts/src/core/EigenDAServiceManagerStorage.sol
+	// This flag is used to override the value from the chain. The target use case is testing.
+	OverrideBlockStaleMeasureFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "override-block-stale-measure"),
+		Usage:    "The maximum amount of blocks in the past that the service will consider stake amounts to still be valid. This is used to override the value set on chain. <=0 means no override",
+		Required: false,
+		Value:    "-1",
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "OVERRIDE_BLOCK_STALE_MEASURE"),
+	}
+	// Corresponding to the STORE_DURATION_BLOCKS defined onchain in
+	// contracts/src/core/EigenDAServiceManagerStorage.sol
+	// This flag is used to override the value from the chain. The target use case is testing.
+	OverrideStoreDurationBlocksFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "override-store-duration-blocks"),
+		Usage:    "Unit of measure (in blocks) for which data will be stored for after confirmation. This is used to override the value set on chain. <=0 means no override",
+		Required: false,
+		Value:    "-1",
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "OVERRIDE_STORE_DURATION_BLOCKS"),
+	}
+	// DO NOT set plain private key in flag in production.
+	// When test mode is enabled, the DA Node will take private BLS key from this flag.
+	TestPrivateBlsFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "test-private-bls"),
+		Usage:    "Test BLS private key for node operator",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "TEST_PRIVATE_BLS"),
+	}
+
+	/////////////////////////////////////////////////////////////////////////////
+	// END TEST FLAGS SECTION
+	//
+	// If you need to add new test flags:
+	// 1. Place them within this section above
+	// 2. Document their purpose and impact
+	/////////////////////////////////////////////////////////////////////////////
+
 )
 
 var requiredFlags = []cli.Flag{

--- a/node/node.go
+++ b/node/node.go
@@ -49,7 +49,7 @@ const (
 	gcPercentageTime = 0.1
 
 	v1CheckPath = "api/v1/operators-info/port-check"
-	v2CheckPath = "api/v2/operators/reachability"
+	v2CheckPath = "api/v2/operators/liveness"
 )
 
 var (

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -3,11 +3,12 @@ package node_test
 import (
 	"context"
 	"errors"
-	"github.com/docker/go-units"
 	"os"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/docker/go-units"
 
 	clientsmock "github.com/Layr-Labs/eigenda/api/clients/v2/mock"
 	"github.com/Layr-Labs/eigenda/common"
@@ -165,8 +166,8 @@ func TestGetReachabilityURL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://dataapi.eigenda.xyz/api/v1/operators-info/port-check?operator_id=123123123", url)
 
-	v2CheckPath := "api/v2/operators/reachability"
+	v2CheckPath := "api/v2/operators/liveness"
 	url, err = node.GetReachabilityURL("https://dataapi.eigenda.xyz", v2CheckPath, "123123123")
 	assert.NoError(t, err)
-	assert.Equal(t, "https://dataapi.eigenda.xyz/api/v2/operators/reachability?operator_id=123123123", url)
+	assert.Equal(t, "https://dataapi.eigenda.xyz/api/v2/operators/liveness?operator_id=123123123", url)
 }


### PR DESCRIPTION
## Why are these changes needed?
- Make handlers naming consistent (not mixed with `FetchXX` and `FetchXXHandler`)
- Reduce handlers' naming redundancy (`FetchXX` is sufficient, the `Handler` suffix is unnecessary)
- Make latency computing a bit cleaner (`f * 1000` is ugly)
- Account the latency better (account the success request latency -- failed requests, like invalid args, will have a super low latency and skewed the view)
- API path naming fix: `operators/nodeinfo` -> `operators/node-info` which is more conventional 
- API path naming improvement: `operators/reachablity` -> `operators/liveness`
- Remove junk code (junk fields in `Metric`)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
