### PR TITLE
Only override private BLS key in test mode if TestPrivateBlsFlag is defined

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -173,7 +173,13 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	}
 
 	var blsSignerConfig blssignerTypes.SignerConfig
-	if !testMode {
+	if testMode && ctx.GlobalString(flags.TestPrivateBlsFlag.Name) != "" {
+		privateBls := ctx.GlobalString(flags.TestPrivateBlsFlag.Name)
+		blsSignerConfig = blssignerTypes.SignerConfig{
+			SignerType: blssignerTypes.PrivateKey,
+			PrivateKey: privateBls,
+		}
+	} else {
 		blsSignerCertFilePath := ctx.GlobalString(flags.BLSSignerCertFileFlag.Name)
 		enableTLS := len(blsSignerCertFilePath) > 0
 		signerType := blssignerTypes.Local
@@ -211,12 +217,6 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 			EnableTLS:        enableTLS,
 			TLSCertFilePath:  ctx.GlobalString(flags.BLSSignerCertFileFlag.Name),
 			CerberusAPIKey:   blsSignerAPIKey,
-		}
-	} else if testMode && ctx.GlobalString(flags.TestPrivateBlsFlag.Name) != "" {
-		privateBls := ctx.GlobalString(flags.TestPrivateBlsFlag.Name)
-		blsSignerConfig = blssignerTypes.SignerConfig{
-			SignerType: blssignerTypes.PrivateKey,
-			PrivateKey: privateBls,
 		}
 	}
 

--- a/node/config.go
+++ b/node/config.go
@@ -212,7 +212,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 			TLSCertFilePath:  ctx.GlobalString(flags.BLSSignerCertFileFlag.Name),
 			CerberusAPIKey:   blsSignerAPIKey,
 		}
-	} else {
+	} else if testMode && ctx.GlobalString(flags.TestPrivateBlsFlag.Name) != "" {
 		privateBls := ctx.GlobalString(flags.TestPrivateBlsFlag.Name)
 		blsSignerConfig = blssignerTypes.SignerConfig{
 			SignerType: blssignerTypes.PrivateKey,

--- a/node/node.go
+++ b/node/node.go
@@ -158,6 +158,7 @@ func NewNode(
 	var blockStaleMeasure, storeDurationBlocks uint32
 	if config.EnableTestMode && config.OverrideBlockStaleMeasure > 0 {
 		blockStaleMeasure = uint32(config.OverrideBlockStaleMeasure)
+		logger.Info("Test Mode Override!", "blockStaleMeasure", blockStaleMeasure)
 	} else {
 		staleMeasure, err := tx.GetBlockStaleMeasure(context.Background())
 		if err != nil {
@@ -167,6 +168,7 @@ func NewNode(
 	}
 	if config.EnableTestMode && config.OverrideStoreDurationBlocks > 0 {
 		storeDurationBlocks = uint32(config.OverrideStoreDurationBlocks)
+		logger.Info("Test Mode Override!", "storeDurationBlocks", storeDurationBlocks)
 	} else {
 		storeDuration, err := tx.GetStoreDurationBlocks(context.Background())
 		if err != nil {


### PR DESCRIPTION
Only override private BLS key in test mode if TestPrivateBlsFlag is defined

Previously enabling test mode required TestPrivateBlsFlag to be set or would halt node with
```
pp-eigenda-native-node  | 2025/02/07 20:45:40 application failed: failed to create BLS signer: Element.SetString failed -> can't parse number into a big.Int
```

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
