### PR TITLE
Second round of misc improvements to dataapi

### DIFF
--- a/disperser/dataapi/config.go
+++ b/disperser/dataapi/config.go
@@ -8,3 +8,10 @@ type Config struct {
 	ChurnerHostname    string
 	BatcherHealthEndpt string
 }
+
+type DataApiVersion uint
+
+const (
+	V1 DataApiVersion = 1
+	V2 DataApiVersion = 2
+)

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -1306,17 +1306,32 @@ const docTemplateV2 = `{
         "v2.OperatorsSigningInfoResponse": {
             "type": "object",
             "properties": {
+                "end_block": {
+                    "type": "integer"
+                },
+                "end_time_unix_sec": {
+                    "type": "integer"
+                },
                 "operator_signing_info": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/v2.OperatorSigningInfo"
                     }
+                },
+                "start_block": {
+                    "type": "integer"
+                },
+                "start_time_unix_sec": {
+                    "type": "integer"
                 }
             }
         },
         "v2.OperatorsStakeResponse": {
             "type": "object",
             "properties": {
+                "current_block": {
+                    "type": "integer"
+                },
                 "stake_ranked_operators": {
                     "type": "object",
                     "additionalProperties": {

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -1303,17 +1303,32 @@
         "v2.OperatorsSigningInfoResponse": {
             "type": "object",
             "properties": {
+                "end_block": {
+                    "type": "integer"
+                },
+                "end_time_unix_sec": {
+                    "type": "integer"
+                },
                 "operator_signing_info": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/v2.OperatorSigningInfo"
                     }
+                },
+                "start_block": {
+                    "type": "integer"
+                },
+                "start_time_unix_sec": {
+                    "type": "integer"
                 }
             }
         },
         "v2.OperatorsStakeResponse": {
             "type": "object",
             "properties": {
+                "current_block": {
+                    "type": "integer"
+                },
                 "stake_ranked_operators": {
                     "type": "object",
                     "additionalProperties": {

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -448,13 +448,23 @@ definitions:
     type: object
   v2.OperatorsSigningInfoResponse:
     properties:
+      end_block:
+        type: integer
+      end_time_unix_sec:
+        type: integer
       operator_signing_info:
         items:
           $ref: '#/definitions/v2.OperatorSigningInfo'
         type: array
+      start_block:
+        type: integer
+      start_time_unix_sec:
+        type: integer
     type: object
   v2.OperatorsStakeResponse:
     properties:
+      current_block:
+        type: integer
       stake_ranked_operators:
         additionalProperties:
           items:

--- a/disperser/dataapi/prometheus_client.go
+++ b/disperser/dataapi/prometheus_client.go
@@ -18,6 +18,8 @@ type (
 	PrometheusClient interface {
 		QueryDisperserBlobSizeBytesPerSecond(ctx context.Context, start time.Time, end time.Time) (*PrometheusResult, error)
 		QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, windowSizeInSec uint16) (*PrometheusResult, error)
+		QueryDisperserBlobSizeBytesPerSecondV2(ctx context.Context, start time.Time, end time.Time) (*PrometheusResult, error)
+		QueryDisperserAvgThroughputBlobSizeBytesV2(ctx context.Context, start time.Time, end time.Time, windowSizeInSec uint16) (*PrometheusResult, error)
 	}
 
 	PrometheusResultValues struct {
@@ -46,8 +48,18 @@ func (pc *prometheusClient) QueryDisperserBlobSizeBytesPerSecond(ctx context.Con
 	return pc.queryRange(ctx, query, start, end)
 }
 
+func (pc *prometheusClient) QueryDisperserBlobSizeBytesPerSecondV2(ctx context.Context, start time.Time, end time.Time) (*PrometheusResult, error) {
+	query := fmt.Sprintf("eigenda_dispatcher_completed_blobs_total{state=\"complete\",data=\"size\",cluster=\"%s\"}", pc.cluster)
+	return pc.queryRange(ctx, query, start, end)
+}
+
 func (pc *prometheusClient) QueryDisperserAvgThroughputBlobSizeBytes(ctx context.Context, start time.Time, end time.Time, throughputRateSecs uint16) (*PrometheusResult, error) {
 	query := fmt.Sprintf("avg_over_time( sum by (job) (rate(eigenda_batcher_blobs_total{state=\"confirmed\",data=\"size\",cluster=\"%s\"}[%ds])) [9m:])", pc.cluster, throughputRateSecs)
+	return pc.queryRange(ctx, query, start, end)
+}
+
+func (pc *prometheusClient) QueryDisperserAvgThroughputBlobSizeBytesV2(ctx context.Context, start time.Time, end time.Time, throughputRateSecs uint16) (*PrometheusResult, error) {
+	query := fmt.Sprintf("avg_over_time( sum by (job) (rate(eigenda_dispatcher_completed_blobs_total{state=\"complete\",data=\"size\",cluster=\"%s\"}[%ds])) [9m:])", pc.cluster, throughputRateSecs)
 	return pc.queryRange(ctx, query, start, end)
 }
 

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -130,6 +130,7 @@ type (
 	}
 
 	OperatorsStakeResponse struct {
+		CurrentBlock         uint32                      `json:"current_block"`
 		StakeRankedOperators map[string][]*OperatorStake `json:"stake_ranked_operators"`
 	}
 
@@ -267,7 +268,7 @@ func NewServer(
 		eigenDAGRPCServiceChecker: eigenDAGRPCServiceChecker,
 		eigenDAHttpServiceChecker: eigenDAHttpServiceChecker,
 		operatorHandler:           NewOperatorHandler(logger, metrics, transactor, chainState, indexedChainState, subgraphClient),
-		metricsHandler:            NewMetricsHandler(promClient),
+		metricsHandler:            NewMetricsHandler(promClient, V1),
 	}
 }
 

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -896,7 +896,7 @@ func (s *ServerV2) FetchOperatorsStake(c *gin.Context) {
 	operatorId := c.DefaultQuery("operator_id", "")
 	s.logger.Info("getting operators stake distribution", "operatorId", operatorId)
 
-	currentBlock, err := s.chainReader.GetCurrentBlockNumber(c.Request.Context())
+	currentBlock, err := s.indexedChainState.GetCurrentBlockNumber()
 	if err != nil {
 		s.metrics.IncrementFailedRequestNum("FetchOperatorsStake")
 		errorResponse(c, fmt.Errorf("failed to get current block number: %w", err))
@@ -908,7 +908,7 @@ func (s *ServerV2) FetchOperatorsStake(c *gin.Context) {
 		errorResponse(c, fmt.Errorf("failed to get operator stake: %w", err))
 		return
 	}
-	operatorsStakeResponse.CurrentBlock = currentBlock
+	operatorsStakeResponse.CurrentBlock = uint32(currentBlock)
 
 	s.metrics.IncrementSuccessfulRequestNum("FetchOperatorsStake")
 	s.metrics.ObserveLatency("FetchOperatorsStake", time.Since(handlerStart))

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -1516,23 +1516,17 @@ func TestFetchOperatorsStake(t *testing.T) {
 
 	// The quorums and the operators in the quorum are defined in "mockChainState"
 	// There are 3 quorums (0, 1) and a "total" entry for TotalQuorumStake
-	assert.Equal(t, 3, len(response.StakeRankedOperators))
+	require.Equal(t, 2, len(response.StakeRankedOperators))
 	// Quorum 0
 	ops, ok := response.StakeRankedOperators["0"]
-	assert.True(t, ok)
-	assert.Equal(t, 2, len(ops))
+	require.True(t, ok)
+	require.Equal(t, 2, len(ops))
 	assert.Equal(t, opId0.Hex(), ops[0].OperatorId)
 	assert.Equal(t, opId1.Hex(), ops[1].OperatorId)
 	// Quorum 1
 	ops, ok = response.StakeRankedOperators["1"]
-	assert.True(t, ok)
-	assert.Equal(t, 2, len(ops))
-	assert.Equal(t, opId1.Hex(), ops[0].OperatorId)
-	assert.Equal(t, opId0.Hex(), ops[1].OperatorId)
-	// "total"
-	ops, ok = response.StakeRankedOperators["total"]
-	assert.True(t, ok)
-	assert.Equal(t, 2, len(ops))
+	require.True(t, ok)
+	require.Equal(t, 2, len(ops))
 	assert.Equal(t, opId1.Hex(), ops[0].OperatorId)
 	assert.Equal(t, opId0.Hex(), ops[1].OperatorId)
 }


### PR DESCRIPTION
## Why are these changes needed?
- Make the metric handlers querying the right v2 metric
- Return block and time range for the operators signing info response
- Return block number for the operators stake (stake is always tied to specific block)
- Keep 8 decimals for the signing rate (we need 1/(3600 * 24 * 14) resolution assuming 1 attestation/sec)
- Fix the `StakePercentage`: it was a ratio, not percentage before
- Drop the "total" quorum in operator stake, because in V2, stake percentage across quorums are not additive any more

**Tested**:

**Metrics response**:
```
curl http://localhost:9000/api/v2/metrics/summary
{"avg_throughput":3246651.648888889}
```

**Operator stake response**:
```
{
  "current_block": 3307192,
  "stake_ranked_operators": {
    "0": [],
    "1": [
      {
        "quorum_id": "1",
        "operator_id": "45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
        "stake_percentage": 30.16759776536313,
        "rank": 2
      }
    ],
    "2": [
      {
        "quorum_id": "2",
        "operator_id": "45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
        "stake_percentage": 33.333333333333336,
        "rank": 2
      }
    ]
  }
}
```


**Signing info response**:
```
{
  "start_block": 3306876,
  "end_block": 3307153,
  "start_time_unix_sec": 1738968247,
  "end_time_unix_sec": 1738971847,
  "operator_signing_info": [
    {
      "operator_id": "45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497",
      "operator_address": "0xcb14cFAaC122E52024232583e7354589AedE74Ff",
      "quorum_id": 1,
      "total_unsigned_batches": 0,
      "total_responsible_batches": 3445,
      "total_batches": 3445,
      "signing_percentage": 100,
      "stake_percentage": 30.16759776536313
    },
    {
      "operator_id": "f512db9a07eefc22336c0de9f0dd8cb71400d0718e9ed00cb4af2643dc64325e",
      "operator_address": "0x08300f3797DcEE9cc813EbAaE25127B4E3B550e3",
      "quorum_id": 0,
      "total_unsigned_batches": 1,
      "total_responsible_batches": 3445,
      "total_batches": 3445,
      "signing_percentage": 99.97097242,
      "stake_percentage": 20.008438185415173
    },
    {
      "operator_id": "f512db9a07eefc22336c0de9f0dd8cb71400d0718e9ed00cb4af2643dc64325e",
      "operator_address": "0x08300f3797DcEE9cc813EbAaE25127B4E3B550e3",
      "quorum_id": 1,
      "total_unsigned_batches": 1,
      "total_responsible_batches": 3445,
      "total_batches": 3445,
      "signing_percentage": 99.97097242,
      "stake_percentage": 22.3463687150838
    },
    {
      "operator_id": "a96bfb4a7ca981ad365220f336dc5a3de0816ebd5130b79bbc85aca94bc9b6ab",
      "operator_address": "0x5145447d2d9bb236C66f9De25A62590d5ed06620",
      "quorum_id": 0,
      "total_unsigned_batches": 203,
      "total_responsible_batches": 3445,
      "total_batches": 3445,
      "signing_percentage": 94.10740203,
      "stake_percentage": 79.99156181458483
    },
    {
      "operator_id": "a96bfb4a7ca981ad365220f336dc5a3de0816ebd5130b79bbc85aca94bc9b6ab",
      "operator_address": "0x5145447d2d9bb236C66f9De25A62590d5ed06620",
      "quorum_id": 1,
      "total_unsigned_batches": 203,
      "total_responsible_batches": 3445,
      "total_batches": 3445,
      "signing_percentage": 94.10740203,
      "stake_percentage": 33.5195530726257
    }
  ]
}
```



<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
