### PR TITLE
chore: fix minor text issues for clarity and accuracy

### DIFF
--- a/tools/srs-utils/README.md
+++ b/tools/srs-utils/README.md
@@ -27,7 +27,7 @@ It produces two files, g1.point and g2.point. g1.point contains 8589934592 Bytes
 
 This procedure takes roughly 10 minutes.
 
-Note: The challenge files contains 2^29 G1 points and 2^28 G2 points with secret tau. We use only the first 2^28 G1 points for EigenDA.
+Note: The challenge files contain 2^29 G1 points and 2^28 G2 points with secret tau. We use only the first 2^28 G1 points for EigenDA.
 
 ### How to verify the parsed G1, G2 points
 
@@ -35,7 +35,7 @@ Note: The challenge files contains 2^29 G1 points and 2^28 G2 points with secret
 
 The verification is based on method listed here (https://github.com/ethereum/kzg-ceremony-specs/blob/master/docs/sequencer/sequencer.md#pairing-checks)
 
-This procedures takes roughly 27 Hours on a 8 thread machines.
+This procedure takes roughly 27 Hours on 8-thread machine.
 
 The program periodically prints out the time spent and its progress of validating 2^28 G1 and G2 points. If no error message is shown and program terminates with "Done. Everything is correct". Then SRS is deemed as correct. 
 


### PR DESCRIPTION
## Why are these changes needed?

I’ve made a few fixes to improve clarity and accuracy in the text:

- Changed “This procedures” to “This procedure” to correctly refer to the singular process.
- Corrected “a 8 thread machines” to “8-thread machine” for proper grammar and consistency.
- Updated “The challenge files contains” to “The challenge files contain” to ensure subject-verb agreement.

These adjustments should make the text clearer and more precise.

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- x ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [x] This PR is not tested :(
