### PR TITLE
Onchain payment state refresh robustness fix

### DIFF
--- a/core/meterer/onchain_state.go
+++ b/core/meterer/onchain_state.go
@@ -2,6 +2,7 @@ package meterer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/eth"
+	"github.com/Layr-Labs/eigensdk-go/logging"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
@@ -30,7 +32,8 @@ type OnchainPayment interface {
 var _ OnchainPayment = (*OnchainPaymentState)(nil)
 
 type OnchainPaymentState struct {
-	tx *eth.Reader
+	tx     *eth.Reader
+	logger logging.Logger
 
 	ReservedPayments map[gethcommon.Address]*core.ReservedPayment
 	OnDemandPayments map[gethcommon.Address]*core.OnDemandPayment
@@ -50,9 +53,10 @@ type PaymentVaultParams struct {
 	OnDemandQuorumNumbers    []uint8
 }
 
-func NewOnchainPaymentState(ctx context.Context, tx *eth.Reader) (*OnchainPaymentState, error) {
+func NewOnchainPaymentState(ctx context.Context, tx *eth.Reader, logger logging.Logger) (*OnchainPaymentState, error) {
 	state := OnchainPaymentState{
 		tx:                 tx,
+		logger:             logger.With("component", "OnchainPaymentState"),
 		ReservedPayments:   make(map[gethcommon.Address]*core.ReservedPayment),
 		OnDemandPayments:   make(map[gethcommon.Address]*core.OnDemandPayment),
 		PaymentVaultParams: atomic.Pointer[PaymentVaultParams]{},
@@ -122,7 +126,29 @@ func (pcs *OnchainPaymentState) RefreshOnchainPaymentState(ctx context.Context) 
 	// These parameters should be rarely updated, but we refresh them anyway
 	pcs.PaymentVaultParams.Store(paymentVaultParams)
 
+	var refreshErr error
+	if reservedPaymentsErr := pcs.refreshReservedPayments(ctx); reservedPaymentsErr != nil {
+		pcs.logger.Error("failed to refresh reserved payments", "error", reservedPaymentsErr)
+		refreshErr = errors.Join(refreshErr, reservedPaymentsErr)
+	}
+
+	if ondemandPaymentsErr := pcs.refreshOnDemandPayments(ctx); ondemandPaymentsErr != nil {
+		pcs.logger.Error("failed to refresh on-demand payments", "error", ondemandPaymentsErr)
+		refreshErr = errors.Join(refreshErr, ondemandPaymentsErr)
+	}
+
+	return refreshErr
+}
+
+func (pcs *OnchainPaymentState) refreshReservedPayments(ctx context.Context) error {
 	pcs.ReservationsLock.Lock()
+	defer pcs.ReservationsLock.Unlock()
+
+	if len(pcs.ReservedPayments) == 0 {
+		pcs.logger.Info("No reserved payments to refresh")
+		return nil
+	}
+
 	accountIDs := make([]gethcommon.Address, 0, len(pcs.ReservedPayments))
 	for accountID := range pcs.ReservedPayments {
 		accountIDs = append(accountIDs, accountID)
@@ -133,10 +159,19 @@ func (pcs *OnchainPaymentState) RefreshOnchainPaymentState(ctx context.Context) 
 		return err
 	}
 	pcs.ReservedPayments = reservedPayments
-	pcs.ReservationsLock.Unlock()
+	return nil
+}
 
+func (pcs *OnchainPaymentState) refreshOnDemandPayments(ctx context.Context) error {
 	pcs.OnDemandLocks.Lock()
-	accountIDs = make([]gethcommon.Address, 0, len(pcs.OnDemandPayments))
+	defer pcs.OnDemandLocks.Unlock()
+
+	if len(pcs.OnDemandPayments) == 0 {
+		pcs.logger.Info("No on-demand payments to refresh")
+		return nil
+	}
+
+	accountIDs := make([]gethcommon.Address, 0, len(pcs.OnDemandPayments))
 	for accountID := range pcs.OnDemandPayments {
 		accountIDs = append(accountIDs, accountID)
 	}
@@ -146,8 +181,6 @@ func (pcs *OnchainPaymentState) RefreshOnchainPaymentState(ctx context.Context) 
 		return err
 	}
 	pcs.OnDemandPayments = onDemandPayments
-	pcs.OnDemandLocks.Unlock()
-
 	return nil
 }
 

--- a/disperser/cmd/apiserver/main.go
+++ b/disperser/cmd/apiserver/main.go
@@ -103,7 +103,7 @@ func RunDisperserServer(ctx *cli.Context) error {
 			UpdateInterval:   config.OnchainStateRefreshInterval,
 		}
 
-		paymentChainState, err := mt.NewOnchainPaymentState(context.Background(), transactor)
+		paymentChainState, err := mt.NewOnchainPaymentState(context.Background(), transactor, logger)
 		if err != nil {
 			return fmt.Errorf("failed to create onchain payment state: %w", err)
 		}


### PR DESCRIPTION
## Why are these changes needed?
It should still attempt at refreshing on demand even if reservation refresh fails
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
