### PR TITLE
Force consistent read from blob metadata store

### DIFF
--- a/common/aws/dynamodb/client.go
+++ b/common/aws/dynamodb/client.go
@@ -56,12 +56,12 @@ type Client interface {
 	UpdateItemWithCondition(ctx context.Context, tableName string, key Key, item Item, condition expression.ConditionBuilder) (Item, error)
 	IncrementBy(ctx context.Context, tableName string, key Key, attr string, value uint64) (Item, error)
 	GetItem(ctx context.Context, tableName string, key Key) (Item, error)
-	GetItems(ctx context.Context, tableName string, keys []Key) ([]Item, error)
+	GetItems(ctx context.Context, tableName string, keys []Key, consistentRead bool) ([]Item, error)
 	QueryIndex(ctx context.Context, tableName string, indexName string, keyCondition string, expAttributeValues ExpressionValues) ([]Item, error)
 	Query(ctx context.Context, tableName string, keyCondition string, expAttributeValues ExpressionValues) ([]Item, error)
 	QueryWithInput(ctx context.Context, input *dynamodb.QueryInput) ([]Item, error)
 	QueryIndexCount(ctx context.Context, tableName string, indexName string, keyCondition string, expAttributeValues ExpressionValues) (int32, error)
-	QueryIndexWithPagination(ctx context.Context, tableName string, indexName string, keyCondition string, expAttributeValues ExpressionValues, limit int32, exclusiveStartKey map[string]types.AttributeValue) (QueryResult, error)
+	QueryIndexWithPagination(ctx context.Context, tableName string, indexName string, keyCondition string, expAttributeValues ExpressionValues, limit int32, exclusiveStartKey map[string]types.AttributeValue, consistentRead bool) (QueryResult, error)
 	DeleteItem(ctx context.Context, tableName string, key Key) error
 	DeleteItems(ctx context.Context, tableName string, keys []Key) ([]Key, error)
 	TableExists(ctx context.Context, name string) error
@@ -276,8 +276,8 @@ func (c *client) GetItem(ctx context.Context, tableName string, key Key) (Item, 
 
 // GetItems returns the items for the given keys
 // Note: ordering of items is not guaranteed
-func (c *client) GetItems(ctx context.Context, tableName string, keys []Key) ([]Item, error) {
-	items, err := c.readItems(ctx, tableName, keys)
+func (c *client) GetItems(ctx context.Context, tableName string, keys []Key, consistentRead bool) ([]Item, error) {
+	items, err := c.readItems(ctx, tableName, keys, consistentRead)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +342,16 @@ func (c *client) QueryIndexCount(ctx context.Context, tableName string, indexNam
 // QueryIndexWithPagination returns all items in the index that match the given key
 // Results are limited to the given limit and the pagination token is returned
 // When limit is 0, all items are returned
-func (c *client) QueryIndexWithPagination(ctx context.Context, tableName string, indexName string, keyCondition string, expAttributeValues ExpressionValues, limit int32, exclusiveStartKey map[string]types.AttributeValue) (QueryResult, error) {
+func (c *client) QueryIndexWithPagination(
+	ctx context.Context,
+	tableName string,
+	indexName string,
+	keyCondition string,
+	expAttributeValues ExpressionValues,
+	limit int32,
+	exclusiveStartKey map[string]types.AttributeValue,
+	consistentRead bool,
+) (QueryResult, error) {
 	var queryInput *dynamodb.QueryInput
 
 	// Fetch all items if limit is 0
@@ -353,6 +362,7 @@ func (c *client) QueryIndexWithPagination(ctx context.Context, tableName string,
 			KeyConditionExpression:    aws.String(keyCondition),
 			ExpressionAttributeValues: expAttributeValues,
 			Limit:                     &limit,
+			ConsistentRead:            aws.Bool(consistentRead),
 		}
 	} else {
 		queryInput = &dynamodb.QueryInput{
@@ -360,6 +370,7 @@ func (c *client) QueryIndexWithPagination(ctx context.Context, tableName string,
 			IndexName:                 aws.String(indexName),
 			KeyConditionExpression:    aws.String(keyCondition),
 			ExpressionAttributeValues: expAttributeValues,
+			ConsistentRead:            aws.Bool(consistentRead),
 		}
 	}
 
@@ -444,7 +455,12 @@ func (c *client) writeItems(ctx context.Context, tableName string, requestItems 
 	return failedItems, nil
 }
 
-func (c *client) readItems(ctx context.Context, tableName string, keys []Key) ([]Item, error) {
+func (c *client) readItems(
+	ctx context.Context,
+	tableName string,
+	keys []Key,
+	consistentRead bool,
+) ([]Item, error) {
 	startIndex := 0
 	items := make([]Item, 0)
 	for startIndex < len(keys) {
@@ -454,7 +470,8 @@ func (c *client) readItems(ctx context.Context, tableName string, keys []Key) ([
 		output, err := c.dynamoClient.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
 			RequestItems: map[string]types.KeysAndAttributes{
 				tableName: {
-					Keys: keysBatch,
+					Keys:           keysBatch,
+					ConsistentRead: aws.Bool(consistentRead),
 				},
 			},
 		})

--- a/common/aws/dynamodb/client_test.go
+++ b/common/aws/dynamodb/client_test.go
@@ -296,7 +296,7 @@ func TestBatchOperations(t *testing.T) {
 		}
 	}
 
-	fetchedItems, err := dynamoClient.GetItems(ctx, tableName, keys)
+	fetchedItems, err := dynamoClient.GetItems(ctx, tableName, keys, true)
 	assert.NoError(t, err)
 	assert.Len(t, fetchedItems, numItems)
 	blobKeys := make([]string, numItems)
@@ -427,7 +427,7 @@ func TestQueryIndexPaginationSingleItem(t *testing.T) {
 	queryResult, err := dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 1, nil)
+		}}, 1, nil, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 1)
 	assert.Equal(t, "key0", queryResult.Items[0]["MetadataKey"].(*types.AttributeValueMemberS).Value)
@@ -442,7 +442,7 @@ func TestQueryIndexPaginationSingleItem(t *testing.T) {
 	queryResult, err = dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 1, lastEvaluatedKey)
+		}}, 1, lastEvaluatedKey, true)
 	assert.NoError(t, err)
 	assert.Nil(t, queryResult.Items)
 	assert.Nil(t, queryResult.LastEvaluatedKey)
@@ -473,7 +473,7 @@ func TestQueryIndexPaginationItemNoLimit(t *testing.T) {
 	queryResult, err := dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 0, nil)
+		}}, 0, nil, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 30)
 	assert.Equal(t, "key29", queryResult.Items[0]["MetadataKey"].(*types.AttributeValueMemberS).Value)
@@ -486,7 +486,7 @@ func TestQueryIndexPaginationItemNoLimit(t *testing.T) {
 	queryResult, err = dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 2, lastEvaluatedKey)
+		}}, 2, lastEvaluatedKey, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 2)
 	assert.Equal(t, "key29", queryResult.Items[0]["MetadataKey"].(*types.AttributeValueMemberS).Value)
@@ -502,7 +502,7 @@ func TestQueryIndexPaginationNoStoredItems(t *testing.T) {
 	queryResult, err := dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 1, nil)
+		}}, 1, nil, true)
 	assert.NoError(t, err)
 	assert.Nil(t, queryResult.Items)
 	assert.Nil(t, queryResult.LastEvaluatedKey)
@@ -542,7 +542,7 @@ func TestQueryIndexPagination(t *testing.T) {
 	queryResult, err := dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 10, nil)
+		}}, 10, nil, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 10)
 	assert.Equal(t, "key29", queryResult.Items[0]["MetadataKey"].(*types.AttributeValueMemberS).Value)
@@ -554,7 +554,7 @@ func TestQueryIndexPagination(t *testing.T) {
 	queryResult, err = dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 10, queryResult.LastEvaluatedKey)
+		}}, 10, queryResult.LastEvaluatedKey, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 10)
 	assert.Equal(t, "key10", queryResult.LastEvaluatedKey["MetadataKey"].(*types.AttributeValueMemberS).Value)
@@ -563,7 +563,7 @@ func TestQueryIndexPagination(t *testing.T) {
 	queryResult, err = dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 10, queryResult.LastEvaluatedKey)
+		}}, 10, queryResult.LastEvaluatedKey, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 10)
 	assert.Equal(t, "key0", queryResult.LastEvaluatedKey["MetadataKey"].(*types.AttributeValueMemberS).Value)
@@ -572,7 +572,7 @@ func TestQueryIndexPagination(t *testing.T) {
 	queryResult, err = dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 10, queryResult.LastEvaluatedKey)
+		}}, 10, queryResult.LastEvaluatedKey, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 0)
 	assert.Nil(t, queryResult.LastEvaluatedKey)
@@ -603,7 +603,7 @@ func TestQueryIndexWithPaginationForBatch(t *testing.T) {
 	queryResult, err := dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 10, nil)
+		}}, 10, nil, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 10)
 
@@ -611,7 +611,7 @@ func TestQueryIndexWithPaginationForBatch(t *testing.T) {
 	queryResult, err = dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 10, queryResult.LastEvaluatedKey)
+		}}, 10, queryResult.LastEvaluatedKey, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 10)
 
@@ -619,18 +619,18 @@ func TestQueryIndexWithPaginationForBatch(t *testing.T) {
 	queryResult, err = dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 10, queryResult.LastEvaluatedKey)
+		}}, 10, queryResult.LastEvaluatedKey, true)
 	assert.NoError(t, err)
-	assert.Len(t, queryResult.Items, 10)
+	assert.Len(t, queryResult.Items, 10, true)
 
 	// Empty result Since all items are processed
 	queryResult, err = dynamoClient.QueryIndexWithPagination(ctx, tableName, indexName, "BlobStatus = :status", commondynamodb.ExpressionValues{
 		":status": &types.AttributeValueMemberN{
 			Value: "0",
-		}}, 10, queryResult.LastEvaluatedKey)
+		}}, 10, queryResult.LastEvaluatedKey, true)
 	assert.NoError(t, err)
 	assert.Len(t, queryResult.Items, 0)
-	assert.Nil(t, queryResult.LastEvaluatedKey)
+	assert.Nil(t, queryResult.LastEvaluatedKey, true)
 }
 
 func TestQueryWithInput(t *testing.T) {

--- a/common/aws/mock/dynamodb_client.go
+++ b/common/aws/mock/dynamodb_client.go
@@ -59,7 +59,7 @@ func (c *MockDynamoDBClient) GetItem(ctx context.Context, tableName string, key 
 	return args.Get(0).(dynamodb.Item), args.Error(1)
 }
 
-func (c *MockDynamoDBClient) GetItems(ctx context.Context, tableName string, keys []dynamodb.Key) ([]dynamodb.Item, error) {
+func (c *MockDynamoDBClient) GetItems(ctx context.Context, tableName string, keys []dynamodb.Key, consistentRead bool) ([]dynamodb.Item, error) {
 	args := c.Called()
 	return args.Get(0).([]dynamodb.Item), args.Error(1)
 }
@@ -84,7 +84,7 @@ func (c *MockDynamoDBClient) QueryIndexCount(ctx context.Context, tableName stri
 	return args.Get(0).(int32), args.Error(1)
 }
 
-func (c *MockDynamoDBClient) QueryIndexWithPagination(ctx context.Context, tableName string, indexName string, keyCondition string, expAttributeValues dynamodb.ExpressionValues, limit int32, exclusiveStartKey map[string]types.AttributeValue) (dynamodb.QueryResult, error) {
+func (c *MockDynamoDBClient) QueryIndexWithPagination(ctx context.Context, tableName string, indexName string, keyCondition string, expAttributeValues dynamodb.ExpressionValues, limit int32, exclusiveStartKey map[string]types.AttributeValue, consistentRead bool) (dynamodb.QueryResult, error) {
 	args := c.Called()
 	return args.Get(0).(dynamodb.QueryResult), args.Error(1)
 }

--- a/disperser/common/blobstore/blob_metadata_store.go
+++ b/disperser/common/blobstore/blob_metadata_store.go
@@ -91,7 +91,7 @@ func (s *BlobMetadataStore) GetBulkBlobMetadata(ctx context.Context, blobKeys []
 			"MetadataHash": &types.AttributeValueMemberS{Value: blobKeys[i].MetadataHash},
 		}
 	}
-	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys)
+	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys, false)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (s *BlobMetadataStore) GetBlobMetadataByStatusWithPagination(ctx context.Co
 		":expiry": &types.AttributeValueMemberN{
 			Value: strconv.FormatInt(time.Now().Unix(), 10),
 		},
-	}, limit, attributeMap)
+	}, limit, attributeMap, false)
 
 	if err != nil {
 		return nil, nil, err
@@ -268,6 +268,7 @@ func (s *BlobMetadataStore) GetAllBlobMetadataByBatchWithPagination(
 		},
 		limit,
 		attributeMap,
+		false,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -325,6 +325,7 @@ func (s *BlobMetadataStore) queryBucketBlobMetadata(
 			},
 			0, // no limit within a bucket
 			lastEvaledKey,
+			false,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("query failed for bucket %d: %w", bucket, err)
@@ -443,6 +444,7 @@ func (s *BlobMetadataStore) queryBucketAttestation(ctx context.Context, bucket, 
 			},
 			0, // no limit within a bucket
 			lastEvaledKey,
+			false,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("query failed for bucket %d: %w", bucket, err)
@@ -570,7 +572,7 @@ func (s *BlobMetadataStore) GetBlobMetadataByStatusPaginated(
 		":status": &types.AttributeValueMemberN{
 			Value: strconv.Itoa(int(status)),
 		},
-	}, limit, cursor)
+	}, limit, cursor, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -710,7 +712,7 @@ func (s *BlobMetadataStore) GetBlobCertificates(ctx context.Context, blobKeys []
 		}
 	}
 
-	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys)
+	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys, true)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Why are these changes needed?
Force consistent read from v2 blob metadata store
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
