### PR TITLE
Reset cursors and deduplicate blobs in controller

### DIFF
--- a/api/docs/disperser_v2.html
+++ b/api/docs/disperser_v2.html
@@ -861,9 +861,7 @@ the blob is stored in a queue of some sort, and a response immediately returned 
                 <td><p>GATHERING_SIGNATURES means that the blob chunks are currently actively being transmitted to validators,
 and in doing so requesting that the validators sign to acknowledge receipt of the blob.
 Requests that timeout or receive errors are resubmitted to DA nodes for some period of time set by the disperser,
-after which the BlobStatus becomes COMPLETE.
-
-Note: this status is not currently implemented, and is a placeholder for future functionality.</p></td>
+after which the BlobStatus becomes COMPLETE.</p></td>
               </tr>
             
               <tr>

--- a/api/docs/disperser_v2.md
+++ b/api/docs/disperser_v2.md
@@ -307,9 +307,7 @@ Terminal states are states that will not be updated to a different state:
 This status is functionally equivalent to FAILED, but is used to indicate that the failure is due to an unanticipated bug. |
 | QUEUED | 1 | QUEUED means that the blob has been queued by the disperser for processing. The DisperseBlob API is asynchronous, meaning that after request validation, but before any processing, the blob is stored in a queue of some sort, and a response immediately returned to the client. |
 | ENCODED | 2 | ENCODED means that the blob has been Reed-Solomon encoded into chunks and is ready to be dispersed to DA Nodes. |
-| GATHERING_SIGNATURES | 3 | GATHERING_SIGNATURES means that the blob chunks are currently actively being transmitted to validators, and in doing so requesting that the validators sign to acknowledge receipt of the blob. Requests that timeout or receive errors are resubmitted to DA nodes for some period of time set by the disperser, after which the BlobStatus becomes COMPLETE.
-
-Note: this status is not currently implemented, and is a placeholder for future functionality. |
+| GATHERING_SIGNATURES | 3 | GATHERING_SIGNATURES means that the blob chunks are currently actively being transmitted to validators, and in doing so requesting that the validators sign to acknowledge receipt of the blob. Requests that timeout or receive errors are resubmitted to DA nodes for some period of time set by the disperser, after which the BlobStatus becomes COMPLETE. |
 | COMPLETE | 4 | COMPLETE means the blob has been dispersed to DA nodes, and the GATHERING_SIGNATURES period of time has completed. This status does not guarantee any signer percentage, so a client should check that the signature has met its required threshold, and resubmit a new blob dispersal request if not. |
 | FAILED | 5 | FAILED means that the blob has failed permanently. Note that this is a terminal state, and in order to retry the blob, the client must submit the blob again with different salt (blob key is required to be unique). |
 

--- a/api/docs/eigenda-protos.html
+++ b/api/docs/eigenda-protos.html
@@ -2568,9 +2568,7 @@ the blob is stored in a queue of some sort, and a response immediately returned 
                 <td><p>GATHERING_SIGNATURES means that the blob chunks are currently actively being transmitted to validators,
 and in doing so requesting that the validators sign to acknowledge receipt of the blob.
 Requests that timeout or receive errors are resubmitted to DA nodes for some period of time set by the disperser,
-after which the BlobStatus becomes COMPLETE.
-
-Note: this status is not currently implemented, and is a placeholder for future functionality.</p></td>
+after which the BlobStatus becomes COMPLETE.</p></td>
               </tr>
             
               <tr>

--- a/api/docs/eigenda-protos.md
+++ b/api/docs/eigenda-protos.md
@@ -1015,9 +1015,7 @@ Terminal states are states that will not be updated to a different state:
 This status is functionally equivalent to FAILED, but is used to indicate that the failure is due to an unanticipated bug. |
 | QUEUED | 1 | QUEUED means that the blob has been queued by the disperser for processing. The DisperseBlob API is asynchronous, meaning that after request validation, but before any processing, the blob is stored in a queue of some sort, and a response immediately returned to the client. |
 | ENCODED | 2 | ENCODED means that the blob has been Reed-Solomon encoded into chunks and is ready to be dispersed to DA Nodes. |
-| GATHERING_SIGNATURES | 3 | GATHERING_SIGNATURES means that the blob chunks are currently actively being transmitted to validators, and in doing so requesting that the validators sign to acknowledge receipt of the blob. Requests that timeout or receive errors are resubmitted to DA nodes for some period of time set by the disperser, after which the BlobStatus becomes COMPLETE.
-
-Note: this status is not currently implemented, and is a placeholder for future functionality. |
+| GATHERING_SIGNATURES | 3 | GATHERING_SIGNATURES means that the blob chunks are currently actively being transmitted to validators, and in doing so requesting that the validators sign to acknowledge receipt of the blob. Requests that timeout or receive errors are resubmitted to DA nodes for some period of time set by the disperser, after which the BlobStatus becomes COMPLETE. |
 | COMPLETE | 4 | COMPLETE means the blob has been dispersed to DA nodes, and the GATHERING_SIGNATURES period of time has completed. This status does not guarantee any signer percentage, so a client should check that the signature has met its required threshold, and resubmit a new blob dispersal request if not. |
 | FAILED | 5 | FAILED means that the blob has failed permanently. Note that this is a terminal state, and in order to retry the blob, the client must submit the blob again with different salt (blob key is required to be unique). |
 

--- a/api/grpc/disperser/v2/disperser_v2.pb.go
+++ b/api/grpc/disperser/v2/disperser_v2.pb.go
@@ -52,8 +52,6 @@ const (
 	// and in doing so requesting that the validators sign to acknowledge receipt of the blob.
 	// Requests that timeout or receive errors are resubmitted to DA nodes for some period of time set by the disperser,
 	// after which the BlobStatus becomes COMPLETE.
-	//
-	// Note: this status is not currently implemented, and is a placeholder for future functionality.
 	BlobStatus_GATHERING_SIGNATURES BlobStatus = 3
 	// COMPLETE means the blob has been dispersed to DA nodes, and the GATHERING_SIGNATURES period of time has completed.
 	// This status does not guarantee any signer percentage, so a client should check that the signature has met

--- a/api/proto/disperser/v2/disperser_v2.proto
+++ b/api/proto/disperser/v2/disperser_v2.proto
@@ -157,8 +157,6 @@ enum BlobStatus {
   // and in doing so requesting that the validators sign to acknowledge receipt of the blob.
   // Requests that timeout or receive errors are resubmitted to DA nodes for some period of time set by the disperser,
   // after which the BlobStatus becomes COMPLETE.
-  //
-  // Note: this status is not currently implemented, and is a placeholder for future functionality.
   GATHERING_SIGNATURES = 3;
 
   // COMPLETE means the blob has been dispersed to DA nodes, and the GATHERING_SIGNATURES period of time has completed.

--- a/common/aws/dynamodb/client_test.go
+++ b/common/aws/dynamodb/client_test.go
@@ -296,7 +296,7 @@ func TestBatchOperations(t *testing.T) {
 		}
 	}
 
-	fetchedItems, err := dynamoClient.GetItems(ctx, tableName, keys)
+	fetchedItems, err := dynamoClient.GetItems(ctx, tableName, keys, true)
 	assert.NoError(t, err)
 	assert.Len(t, fetchedItems, numItems)
 	blobKeys := make([]string, numItems)

--- a/common/aws/mock/dynamodb_client.go
+++ b/common/aws/mock/dynamodb_client.go
@@ -59,7 +59,7 @@ func (c *MockDynamoDBClient) GetItem(ctx context.Context, tableName string, key 
 	return args.Get(0).(dynamodb.Item), args.Error(1)
 }
 
-func (c *MockDynamoDBClient) GetItems(ctx context.Context, tableName string, keys []dynamodb.Key) ([]dynamodb.Item, error) {
+func (c *MockDynamoDBClient) GetItems(ctx context.Context, tableName string, keys []dynamodb.Key, consistentRead bool) ([]dynamodb.Item, error) {
 	args := c.Called()
 	return args.Get(0).([]dynamodb.Item), args.Error(1)
 }

--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -350,14 +350,22 @@ func (a *Attestation) ToProtobuf() (*disperserpb.Attestation, error) {
 		quorumResults[i] = a.QuorumResults[q]
 	}
 
-	apkG2Bytes := a.APKG2.Bytes()
-	sigmaBytes := a.Sigma.Bytes()
+	var apkG2Bytes []byte
+	var sigmaBytes []byte
+	if a.APKG2 != nil {
+		b := a.APKG2.Bytes()
+		apkG2Bytes = b[:]
+	}
+	if a.Sigma != nil {
+		b := a.Sigma.Bytes()
+		sigmaBytes = b[:]
+	}
 
 	return &disperserpb.Attestation{
 		NonSignerPubkeys:        nonSignerPubKeys,
-		ApkG2:                   apkG2Bytes[:],
+		ApkG2:                   apkG2Bytes,
 		QuorumApks:              quorumAPKs,
-		Sigma:                   sigmaBytes[:],
+		Sigma:                   sigmaBytes,
 		QuorumNumbers:           quorumNumbers,
 		QuorumSignedPercentages: quorumResults,
 	}, nil

--- a/core/v2/types_test.go
+++ b/core/v2/types_test.go
@@ -3,6 +3,7 @@ package v2_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/Layr-Labs/eigenda/core"
 	v2 "github.com/Layr-Labs/eigenda/core/v2"
@@ -119,4 +120,28 @@ func TestConvertBlobCertToFromProtobuf(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, blobCert, newBlobCert)
+}
+
+func TestAttestationToProtobuf(t *testing.T) {
+	zeroAttestation := &v2.Attestation{
+		BatchHeader: &v2.BatchHeader{
+			BatchRoot:            [32]byte{1, 1, 1},
+			ReferenceBlockNumber: 100,
+		},
+		AttestedAt:       uint64(time.Now().UnixNano()),
+		NonSignerPubKeys: nil,
+		APKG2:            nil,
+		QuorumAPKs:       nil,
+		Sigma:            nil,
+		QuorumNumbers:    nil,
+		QuorumResults:    nil,
+	}
+	attestationProto, err := zeroAttestation.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Empty(t, attestationProto.NonSignerPubkeys)
+	assert.Empty(t, attestationProto.ApkG2)
+	assert.Empty(t, attestationProto.QuorumApks)
+	assert.Empty(t, attestationProto.Sigma)
+	assert.Empty(t, attestationProto.QuorumNumbers)
+	assert.Empty(t, attestationProto.QuorumSignedPercentages)
 }

--- a/disperser/cmd/controller/main.go
+++ b/disperser/cmd/controller/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core/eth"
 	"github.com/Layr-Labs/eigenda/core/indexer"
 	"github.com/Layr-Labs/eigenda/core/thegraph"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/disperser/cmd/controller/flags"
 	"github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
 	"github.com/Layr-Labs/eigenda/disperser/controller"
@@ -104,6 +105,7 @@ func RunController(ctx *cli.Context) error {
 		return fmt.Errorf("failed to create encoder client: %v", err)
 	}
 	encodingPool := workerpool.New(config.NumConcurrentEncodingRequests)
+	encodingManagerBlobSet := controller.NewBlobSet()
 	encodingManager, err := controller.NewEncodingManager(
 		&config.EncodingManagerConfig,
 		blobMetadataStore,
@@ -112,6 +114,7 @@ func RunController(ctx *cli.Context) error {
 		chainReader,
 		logger,
 		metricsRegistry,
+		encodingManagerBlobSet,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create encoding manager: %v", err)
@@ -169,6 +172,11 @@ func RunController(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create node client manager: %v", err)
 	}
+	beforeDispatch := func(blobKey corev2.BlobKey) error {
+		encodingManagerBlobSet.RemoveBlob(blobKey)
+		return nil
+	}
+	dispatcherBlobSet := controller.NewBlobSet()
 	dispatcher, err := controller.NewDispatcher(
 		&config.DispatcherConfig,
 		blobMetadataStore,
@@ -178,6 +186,8 @@ func RunController(ctx *cli.Context) error {
 		nodeClientManager,
 		logger,
 		metricsRegistry,
+		beforeDispatch,
+		dispatcherBlobSet,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create dispatcher: %v", err)

--- a/disperser/common/blobstore/blob_metadata_store.go
+++ b/disperser/common/blobstore/blob_metadata_store.go
@@ -91,7 +91,7 @@ func (s *BlobMetadataStore) GetBulkBlobMetadata(ctx context.Context, blobKeys []
 			"MetadataHash": &types.AttributeValueMemberS{Value: blobKeys[i].MetadataHash},
 		}
 	}
-	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys)
+	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys, false)
 	if err != nil {
 		return nil, err
 	}

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -219,7 +219,7 @@ func (s *BlobMetadataStore) UpdateBlobStatus(ctx context.Context, blobKey corev2
 			return fmt.Errorf("%w: blob already in status %s", common.ErrAlreadyExists, status.String())
 		}
 
-		return fmt.Errorf("%w: invalid status transition to %s", ErrInvalidStateTransition, status.String())
+		return fmt.Errorf("%w: invalid status transition from %s to %s", ErrInvalidStateTransition, blob.BlobStatus.String(), status.String())
 	}
 
 	return err
@@ -594,23 +594,7 @@ func (s *BlobMetadataStore) GetBlobMetadataByStatusPaginated(
 
 	lastEvaludatedKey := res.LastEvaluatedKey
 	if lastEvaludatedKey == nil {
-		lastItem := res.Items[len(res.Items)-1]
-		u, ok := lastItem["UpdatedAt"].(*types.AttributeValueMemberN)
-		if !ok {
-			return nil, nil, fmt.Errorf("expected *types.AttributeValueMemberN for UpdatedAt, got %T", u)
-		}
-		updatedAt, err := strconv.ParseUint(u.Value, 10, 64)
-		if err != nil {
-			return nil, nil, err
-		}
-		bk, err := UnmarshalBlobKey(lastItem)
-		if err != nil {
-			return nil, nil, err
-		}
-		return metadata, &StatusIndexCursor{
-			BlobKey:   &bk,
-			UpdatedAt: updatedAt,
-		}, nil
+		return metadata, nil, nil
 	}
 
 	newCursor := StatusIndexCursor{}
@@ -710,7 +694,7 @@ func (s *BlobMetadataStore) GetBlobCertificates(ctx context.Context, blobKeys []
 		}
 	}
 
-	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys)
+	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -897,11 +881,8 @@ func (s *BlobMetadataStore) PutAttestation(ctx context.Context, attestation *cor
 		return err
 	}
 
-	err = s.dynamoDBClient.PutItemWithCondition(ctx, s.tableName, item, "attribute_not_exists(PK) AND attribute_not_exists(SK)", nil, nil)
-	if errors.Is(err, commondynamodb.ErrConditionFailed) {
-		return common.ErrAlreadyExists
-	}
-
+	// Allow overwrite of existing attestation
+	err = s.dynamoDBClient.PutItem(ctx, s.tableName, item)
 	return err
 }
 

--- a/disperser/controller/blob_set.go
+++ b/disperser/controller/blob_set.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"sync"
+
+	v2 "github.com/Layr-Labs/eigenda/core/v2"
+)
+
+// BlobSet is a set of blob keys. This can be used to track a set of blobs.
+type BlobSet interface {
+	AddBlob(blobKey v2.BlobKey)
+	RemoveBlob(blobKey v2.BlobKey)
+	Size() int
+	Contains(blobKey v2.BlobKey) bool
+}
+
+type blobSet struct {
+	mu    sync.RWMutex
+	blobs map[v2.BlobKey]struct{}
+}
+
+func NewBlobSet() BlobSet {
+	return &blobSet{
+		blobs: make(map[v2.BlobKey]struct{}),
+	}
+}
+
+func (q *blobSet) AddBlob(blobKey v2.BlobKey) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.blobs[blobKey] = struct{}{}
+}
+
+func (q *blobSet) RemoveBlob(blobKey v2.BlobKey) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	delete(q.blobs, blobKey)
+}
+
+func (q *blobSet) Size() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	return len(q.blobs)
+}
+
+func (q *blobSet) Contains(blobKey v2.BlobKey) bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	_, ok := q.blobs[blobKey]
+	return ok
+}

--- a/disperser/controller/blob_set_test.go
+++ b/disperser/controller/blob_set_test.go
@@ -1,0 +1,42 @@
+package controller_test
+
+import (
+	"testing"
+
+	v2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/Layr-Labs/eigenda/disperser/controller"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlobSetOperations(t *testing.T) {
+	q := controller.NewBlobSet()
+	require.Equal(t, 0, q.Size())
+
+	key0 := v2.BlobKey([32]byte{0})
+	q.AddBlob(key0)
+	require.Equal(t, 1, q.Size())
+	require.True(t, q.Contains(key0))
+
+	key1 := v2.BlobKey([32]byte{1})
+	q.AddBlob(key1)
+	require.Equal(t, 2, q.Size())
+	require.True(t, q.Contains(key1))
+
+	q.RemoveBlob(key0)
+	require.Equal(t, 1, q.Size())
+	require.False(t, q.Contains(key0))
+	require.True(t, q.Contains(key1))
+
+	q.RemoveBlob(key1)
+	require.Equal(t, 0, q.Size())
+	require.False(t, q.Contains(key0))
+	require.False(t, q.Contains(key1))
+
+	q.RemoveBlob(key1)
+	require.Equal(t, 0, q.Size())
+	require.False(t, q.Contains(key0))
+
+	q.AddBlob(key0)
+	require.Equal(t, 1, q.Size())
+	require.True(t, q.Contains(key0))
+}

--- a/disperser/controller/encoding_manager_metrics.go
+++ b/disperser/controller/encoding_manager_metrics.go
@@ -24,6 +24,7 @@ type encodingManagerMetrics struct {
 	batchRetryCount         *prometheus.GaugeVec
 	failedSubmissionCount   *prometheus.CounterVec
 	completedBlobs          *prometheus.CounterVec
+	blobSetSize             *prometheus.GaugeVec
 }
 
 // NewEncodingManagerMetrics sets up metrics for the encoding manager.
@@ -133,6 +134,15 @@ func newEncodingManagerMetrics(registry *prometheus.Registry) *encodingManagerMe
 		[]string{"state", "data"},
 	)
 
+	blobSetSize := promauto.With(registry).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: encodingManagerNamespace,
+			Name:      "blob_queue_size",
+			Help:      "The number of blobs in the encoding queue.",
+		},
+		[]string{},
+	)
+
 	return &encodingManagerMetrics{
 		batchSubmissionLatency:  batchSubmissionLatency,
 		blobHandleLatency:       blobHandleLatency,
@@ -145,6 +155,7 @@ func newEncodingManagerMetrics(registry *prometheus.Registry) *encodingManagerMe
 		batchRetryCount:         batchRetryCount,
 		failedSubmissionCount:   failSubmissionCount,
 		completedBlobs:          completedBlobs,
+		blobSetSize:             blobSetSize,
 	}
 }
 
@@ -202,4 +213,8 @@ func (m *encodingManagerMetrics) reportCompletedBlob(size int, status dispv2.Blo
 
 	m.completedBlobs.WithLabelValues("total", "number").Inc()
 	m.completedBlobs.WithLabelValues("total", "size").Add(float64(size))
+}
+
+func (m *encodingManagerMetrics) reportBlobSetSize(size int) {
+	m.blobSetSize.WithLabelValues().Set(float64(size))
 }

--- a/disperser/controller/mock_blob_set.go
+++ b/disperser/controller/mock_blob_set.go
@@ -1,0 +1,28 @@
+package controller
+
+import (
+	v2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockBlobSet struct {
+	mock.Mock
+}
+
+func (q *MockBlobSet) AddBlob(blobKey v2.BlobKey) {
+	_ = q.Called(blobKey)
+}
+
+func (q *MockBlobSet) RemoveBlob(blobKey v2.BlobKey) {
+	_ = q.Called(blobKey)
+}
+
+func (q *MockBlobSet) Size() int {
+	args := q.Called()
+	return args.Int(0)
+}
+
+func (q *MockBlobSet) Contains(blobKey v2.BlobKey) bool {
+	args := q.Called(blobKey)
+	return args.Bool(0)
+}

--- a/disperser/encoder/metrics.go
+++ b/disperser/encoder/metrics.go
@@ -26,7 +26,7 @@ type Metrics struct {
 	NumEncodeBlobRequests *prometheus.CounterVec
 	BlobSizeTotal         *prometheus.CounterVec
 	Latency               *prometheus.SummaryVec
-	BlobQueue             *prometheus.GaugeVec
+	BlobSet               *prometheus.GaugeVec
 	QueueCapacity         prometheus.Gauge
 	QueueUtilization      prometheus.Gauge
 }
@@ -64,7 +64,7 @@ func NewMetrics(reg *prometheus.Registry, httpPort string, logger logging.Logger
 			},
 			[]string{"time"}, // time is either encoding or total
 		),
-		BlobQueue: promauto.With(reg).NewGaugeVec(
+		BlobSet: promauto.With(reg).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: "eigenda_encoder",
 				Name:      "blob_queue",
@@ -124,7 +124,7 @@ func (m *Metrics) ObserveLatency(stage string, duration time.Duration) {
 func (m *Metrics) ObserveQueue(queueStats map[string]int) {
 	total := 0
 	for bucket, num := range queueStats {
-		m.BlobQueue.With(prometheus.Labels{"size_bucket": bucket}).Set(float64(num))
+		m.BlobSet.With(prometheus.Labels{"size_bucket": bucket}).Set(float64(num))
 		total += num
 	}
 	m.QueueUtilization.Set(float64(total))


### PR DESCRIPTION
## Why are these changes needed?
- `GetBlobMetadataByStatusPaginated`: Cursor is reset to nil when all records have been enumerated. This will ensure that any blobs that have not been enumerated will be eventually picked up (in controller's encoding manager and dispatcher)
- `EncodingManager` and `Dispatcher` keep track of blobs in flight and deduplicate them
- `Dispatcher` transitions blobs to `GatheringSignatures` status and creates an empty attestation object before sending payloads to DA network. These blobs are finalized to `Complete` or `Failed` status after the dispersal is complete (has received all signatures or timed out)
- Enable consistent read on blob cert retrieval 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
