### PR TITLE
Disable auto IP discovery if not all ports are configured

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -349,12 +349,33 @@ func (n *Node) Start(ctx context.Context) error {
 
 	n.CurrentSocket = socket
 	// Start the Node IP updater only if the PUBLIC_IP_PROVIDER is greater than 0.
-	if n.Config.PubIPCheckInterval > 0 {
+	if n.Config.PubIPCheckInterval > 0 && n.allPortsConfigured() {
 		go n.checkRegisteredNodeIpOnChain(ctx)
 		go n.checkCurrentNodeIp(ctx)
 	}
 
 	return nil
+}
+
+// allPortsConfigured checks if all the ports are configured in the config.
+func (n *Node) allPortsConfigured() bool {
+	if err := core.ValidatePort(n.Config.DispersalPort); err != nil {
+		return false
+	}
+
+	if err := core.ValidatePort(n.Config.V2DispersalPort); err != nil {
+		return false
+	}
+
+	if err := core.ValidatePort(n.Config.RetrievalPort); err != nil {
+		return false
+	}
+
+	if err := core.ValidatePort(n.Config.V2RetrievalPort); err != nil {
+		return false
+	}
+
+	return true
 }
 
 // The expireLoop is a loop that is run once per configured second(s) while the node

--- a/node/node.go
+++ b/node/node.go
@@ -349,33 +349,12 @@ func (n *Node) Start(ctx context.Context) error {
 
 	n.CurrentSocket = socket
 	// Start the Node IP updater only if the PUBLIC_IP_PROVIDER is greater than 0.
-	if n.Config.PubIPCheckInterval > 0 && n.allPortsConfigured() {
+	if n.Config.PubIPCheckInterval > 0 && n.Config.EnableV1 && n.Config.EnableV2 {
 		go n.checkRegisteredNodeIpOnChain(ctx)
 		go n.checkCurrentNodeIp(ctx)
 	}
 
 	return nil
-}
-
-// allPortsConfigured checks if all the ports are configured in the config.
-func (n *Node) allPortsConfigured() bool {
-	if err := core.ValidatePort(n.Config.DispersalPort); err != nil {
-		return false
-	}
-
-	if err := core.ValidatePort(n.Config.V2DispersalPort); err != nil {
-		return false
-	}
-
-	if err := core.ValidatePort(n.Config.RetrievalPort); err != nil {
-		return false
-	}
-
-	if err := core.ValidatePort(n.Config.V2RetrievalPort); err != nil {
-		return false
-	}
-
-	return true
 }
 
 // The expireLoop is a loop that is run once per configured second(s) while the node


### PR DESCRIPTION
## Why are these changes needed?
If it auto registers the socket with missing ports, it can render the node unreachable. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
