### PR TITLE
test: ensure chunk count is at least half of target

### DIFF
--- a/core/assignment_test.go
+++ b/core/assignment_test.go
@@ -175,10 +175,10 @@ func FuzzOperatorAssignments(f *testing.F) {
 			ok, err := asn.ValidateChunkLength(state.OperatorState, blobLength, quorumInfo)
 
 			// Make sure that the number of chunks is less than the target
-			// TODO: Make sure that the number of chunks is no less than half the target (this currently fails in some rare cases
-			// but it isn't a critical problem)
+			// and not less than half the target
 			if ok && err == nil {
 				assert.GreaterOrEqual(t, targetNumChunks, info.TotalChunks)
+				assert.GreaterOrEqual(t, info.TotalChunks, targetNumChunks/2)
 			}
 		}
 


### PR DESCRIPTION
### Why are these changes needed?
The FuzzOperatorAssignments test had a TODO comment indicating that we need to verify the actual number of chunks is not less than half of the target value. This check is important to ensure the CalculateChunkLength algorithm produces reasonable chunk distributions. Without this validation, we might miss cases where the chunk count becomes too low relative to the target, which could lead to inefficient data distribution among operators.
### Checks
[x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
[x] I've checked the new test coverage and the coverage percentage didn't drop.
Testing Strategy
[x] Unit tests
[ ] Integration tests
[ ] This PR is not tested :(