### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/common/aws/s3/client.go
+++ b/common/aws/s3/client.go
@@ -182,7 +182,7 @@ func (s *client) DeleteObject(ctx context.Context, bucket string, key string) er
 		return err
 	}
 
-	return err
+	return nil
 }
 
 // ListObjects lists all items metadata in a bucket with the given prefix up to 1000 items.


### PR DESCRIPTION
## Why are these changes needed?

Keep the error handling logic consistent with `UploadObject` and `ListObjects`


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
