### PR TITLE
Make blob feed API into two-way APIs

### DIFF
--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -92,8 +92,8 @@ type (
 		BlobMetadata *disperserv2.BlobMetadata `json:"blob_metadata"`
 	}
 	BlobFeedResponse struct {
-		Blobs           []BlobInfo `json:"blobs"`
-		PaginationToken string     `json:"pagination_token"`
+		Blobs  []BlobInfo `json:"blobs"`
+		Cursor string     `json:"cursor"`
 	}
 
 	BatchResponse struct {
@@ -263,7 +263,8 @@ func (s *ServerV2) Start() error {
 	{
 		blobs := v2.Group("/blobs")
 		{
-			blobs.GET("/feed", s.FetchBlobFeed)
+			blobs.GET("/feed/forward", s.FetchBlobFeedForward)
+			blobs.GET("/feed/backward", s.FetchBlobFeedBackward)
 			blobs.GET("/:blob_key", s.FetchBlob)
 			blobs.GET("/:blob_key/certificate", s.FetchBlobCertificate)
 			blobs.GET("/:blob_key/attestation-info", s.FetchBlobAttestationInfo)


### PR DESCRIPTION
## Why are these changes needed?
To make it easy and reliable to traverse the feed backward and forward in time

This PR changes the APIs to support this.

Note: the existing API is forward iteration, so `FetchBlobFeedForward` works here already; but `FetchBlobFeedBackward` will need a change in DB layer (in a followup later)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
