### PR TITLE
Make operator stake API return operator address

### DIFF
--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -693,8 +693,8 @@ const docTemplateV2 = `{
                         }
                     ]
                 },
-                "reservation_period": {
-                    "description": "ReservationPeriod represents the range of time at which the dispersal is made",
+                "timestamp": {
+                    "description": "Timestamp represents the nanosecond of the dispersal request creation",
                     "type": "integer"
                 }
             }
@@ -879,10 +879,6 @@ const docTemplateV2 = `{
                     "items": {
                         "type": "integer"
                     }
-                },
-                "salt": {
-                    "description": "Salt is used to make blob intentionally unique when everything else is the same",
-                    "type": "integer"
                 }
             }
         },
@@ -1326,6 +1322,9 @@ const docTemplateV2 = `{
         "v2.OperatorStake": {
             "type": "object",
             "properties": {
+                "operator_address": {
+                    "type": "string"
+                },
                 "operator_id": {
                     "type": "string"
                 },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -690,8 +690,8 @@
                         }
                     ]
                 },
-                "reservation_period": {
-                    "description": "ReservationPeriod represents the range of time at which the dispersal is made",
+                "timestamp": {
+                    "description": "Timestamp represents the nanosecond of the dispersal request creation",
                     "type": "integer"
                 }
             }
@@ -1319,6 +1319,9 @@
         "v2.OperatorStake": {
             "type": "object",
             "properties": {
+                "operator_address": {
+                    "type": "string"
+                },
                 "operator_id": {
                     "type": "string"
                 },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -24,9 +24,9 @@ definitions:
         - $ref: '#/definitions/big.Int'
         description: CumulativePayment represents the total amount of payment (in
           wei) made by the user up to this point
-      reservation_period:
-        description: ReservationPeriod represents the range of time at which the dispersal
-          is made
+      timestamp:
+        description: Timestamp represents the nanosecond of the dispersal request
+          creation
         type: integer
     type: object
   core.Signature:
@@ -457,6 +457,8 @@ definitions:
     type: object
   v2.OperatorStake:
     properties:
+      operator_address:
+        type: string
       operator_id:
         type: string
       quorum_id:

--- a/disperser/dataapi/operator_handler.go
+++ b/disperser/dataapi/operator_handler.go
@@ -227,8 +227,7 @@ func (oh *OperatorHandler) GetOperatorsStakeAtBlock(ctx context.Context, operato
 		return nil, fmt.Errorf("failed to fetch indexed operator state: %w", err)
 	}
 
-	tqs, quorumsStake := operators.GetRankedOperators(state)
-	oh.metrics.UpdateOperatorsStake(tqs, quorumsStake)
+	_, quorumsStake := operators.GetRankedOperators(state)
 
 	stakeRanked := make(map[string][]*OperatorStake)
 	for q, operators := range quorumsStake {

--- a/disperser/dataapi/server.go
+++ b/disperser/dataapi/server.go
@@ -125,6 +125,7 @@ type (
 	OperatorStake struct {
 		QuorumId        string  `json:"quorum_id"`
 		OperatorId      string  `json:"operator_id"`
+		OperatorAddress string  `json:"operator_address"`
 		StakePercentage float64 `json:"stake_percentage"`
 		Rank            int     `json:"rank"`
 	}

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -139,6 +139,7 @@ type (
 	OperatorStake struct {
 		QuorumId        string  `json:"quorum_id"`
 		OperatorId      string  `json:"operator_id"`
+		OperatorAddress string  `json:"operator_address"`
 		StakePercentage float64 `json:"stake_percentage"`
 		Rank            int     `json:"rank"`
 	}


### PR DESCRIPTION
## Why are these changes needed?
Operator address is a main identifier for operators' use cases.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
