### PR TITLE
rewards router

### DIFF
--- a/contracts/src/rewards/IServiceManagerRewardsRouter.sol
+++ b/contracts/src/rewards/IServiceManagerRewardsRouter.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {ServiceManagerBase, IRewardsCoordinator, IServiceManager} from "../../lib/eigenlayer-middleware/src/ServiceManagerBase.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title Interface for ServiceManagerRewardsRouter which is used to push rewards submissions through the ServiceManager
+**/
+interface IServiceManagerRewardsRouter {
+
+    /**
+     * @notice Returns whether the address is allowed to push rewards
+     * @param _address The address to check
+     * @return bool true if the address is allowed to push rewards, false otherwise
+     */
+    function isAllowedToPushRewards(address _address) external view returns (bool);
+
+     /**
+     * @notice Sets an addresses permission to push rewards
+     * @param _address The address to set as allowed
+     * @param _allowed Whether the address is allowed to push rewards
+     */
+    function setAllowedToPushRewards(address _address, bool _allowed) external;
+
+    /**
+     * @notice Creates a new rewards submission to the EigenLayer RewardsCoordinator contract, to be split amongst the
+     * set of stakers delegated to operators who are registered to this `avs`
+     * @param rewardsSubmissions The rewards submissions being created
+     * @dev Only callable by a permissioned rewardsInitiator address
+     * @dev The duration of the `rewardsSubmission` cannot exceed `MAX_REWARDS_DURATION`
+     * @dev The tokens are sent to the `RewardsCoordinator` contract
+     * @dev Strategies must be in ascending order of addresses to check for duplicates
+     * @dev This function will revert if the `rewardsSubmission` is malformed,
+     * e.g. if the `strategies` and `weights` arrays are of non-equal lengths
+     */
+    function createAVSRewardsSubmission(
+        IRewardsCoordinator.RewardsSubmission[] calldata rewardsSubmissions
+    ) external;
+
+    /**
+     * @notice Creates a new operator-directed rewards submission, to be split amongst the operators and
+     * set of stakers delegated to operators who are registered to this `avs`.
+     * @param operatorDirectedRewardsSubmissions The operator-directed rewards submissions being created.
+     * @dev Only callable by a permissioned rewardsInitiator address
+     * @dev The duration of the `rewardsSubmission` cannot exceed `MAX_REWARDS_DURATION`
+     * @dev The tokens are sent to the `RewardsCoordinator` contract
+     * @dev This contract needs a token approval of sum of all `operatorRewards` in the `operatorDirectedRewardsSubmissions`, before calling this function.
+     * @dev Strategies must be in ascending order of addresses to check for duplicates
+     * @dev Operators must be in ascending order of addresses to check for duplicates.
+     * @dev This function will revert if the `operatorDirectedRewardsSubmissions` is malformed.
+     * @dev This function may fail to execute with a large number of submissions due to gas limits. Use a
+     * smaller array of submissions if necessary.
+     */
+    function createOperatorDirectedAVSRewardsSubmission(
+        IRewardsCoordinator.OperatorDirectedRewardsSubmission[]
+            calldata operatorDirectedRewardsSubmissions
+    ) external;
+}

--- a/contracts/src/rewards/ServiceManagerRewardsRouter.sol
+++ b/contracts/src/rewards/ServiceManagerRewardsRouter.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {ServiceManagerBase, IRewardsCoordinator, IServiceManager} from "../../lib/eigenlayer-middleware/src/ServiceManagerBase.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IServiceManagerRewardsRouter} from "./IServiceManagerRewardsRouter.sol";
+
+/**
+ * @title Entrypoint for pushing rewards submissions through the ServiceManager
+ * @dev This contract should be set as the `rewardsInitiator` on the ServiceManager contract
+**/
+contract ServiceManagerRewardsRouter is OwnableUpgradeable, IServiceManagerRewardsRouter {
+    using SafeERC20 for IERC20;
+
+    /// @notice The ServiceManager contract with rewards interface
+    IServiceManager public immutable serviceManager;
+
+    /// @notice Mapping of addresses that are allowed to push rewards
+    mapping(address => bool) public isAllowedToPushRewards;
+
+    modifier onlyAllowedToPushRewards() {
+        require(isAllowedToPushRewards[msg.sender], "ServiceManagerRewardsRouter: Address not permissioned to push rewards");
+        _;
+    }
+ 
+    constructor(
+        IServiceManager _serviceManager
+    ) {
+        serviceManager = _serviceManager;
+    }
+
+    function initialize(address _initialOwner) public initializer {
+        _transferOwnership(_initialOwner);
+    }
+
+     /**
+     * @notice Sets an addresses permission to push rewards
+     * @param _address The address to set as allowed
+     * @param _allowed Whether the address is allowed to push rewards
+     */
+    function setAllowedToPushRewards(address _address, bool _allowed) external onlyOwner {
+        isAllowedToPushRewards[_address] = _allowed;
+    }
+
+    /**
+     * @notice Creates a new rewards submission to the EigenLayer RewardsCoordinator contract, to be split amongst the
+     * set of stakers delegated to operators who are registered to this `avs`
+     * @param rewardsSubmissions The rewards submissions being created
+     * @dev Only callable by a permissioned rewardsInitiator address
+     * @dev The duration of the `rewardsSubmission` cannot exceed `MAX_REWARDS_DURATION`
+     * @dev The tokens are sent to the `RewardsCoordinator` contract
+     * @dev Strategies must be in ascending order of addresses to check for duplicates
+     * @dev This function will revert if the `rewardsSubmission` is malformed,
+     * e.g. if the `strategies` and `weights` arrays are of non-equal lengths
+     */
+    function createAVSRewardsSubmission(
+        IRewardsCoordinator.RewardsSubmission[] calldata rewardsSubmissions
+    ) public virtual onlyAllowedToPushRewards {
+
+        for (uint256 i = 0; i < rewardsSubmissions.length; ++i) {
+            // transfer token to ServiceManagerRewardsRouter and approve ServiceManager to transfer again in createAVSRewardsSubmission() call
+            rewardsSubmissions[i].token.safeTransferFrom(
+                msg.sender,
+                address(this),
+                rewardsSubmissions[i].amount
+            );
+            rewardsSubmissions[i].token.safeIncreaseAllowance(
+                address(serviceManager),
+                rewardsSubmissions[i].amount
+            );
+        }
+
+        serviceManager.createAVSRewardsSubmission(rewardsSubmissions);
+    }
+
+    /**
+     * @notice Creates a new operator-directed rewards submission, to be split amongst the operators and
+     * set of stakers delegated to operators who are registered to this `avs`.
+     * @param operatorDirectedRewardsSubmissions The operator-directed rewards submissions being created.
+     * @dev Only callable by a permissioned rewardsInitiator address
+     * @dev The duration of the `rewardsSubmission` cannot exceed `MAX_REWARDS_DURATION`
+     * @dev The tokens are sent to the `RewardsCoordinator` contract
+     * @dev This contract needs a token approval of sum of all `operatorRewards` in the `operatorDirectedRewardsSubmissions`, before calling this function.
+     * @dev Strategies must be in ascending order of addresses to check for duplicates
+     * @dev Operators must be in ascending order of addresses to check for duplicates.
+     * @dev This function will revert if the `operatorDirectedRewardsSubmissions` is malformed.
+     * @dev This function may fail to execute with a large number of submissions due to gas limits. Use a
+     * smaller array of submissions if necessary.
+     */
+    function createOperatorDirectedAVSRewardsSubmission(
+        IRewardsCoordinator.OperatorDirectedRewardsSubmission[]
+            calldata operatorDirectedRewardsSubmissions
+    ) public virtual onlyAllowedToPushRewards {
+
+        for (
+            uint256 i = 0;
+            i < operatorDirectedRewardsSubmissions.length;
+            ++i
+        ) {
+            // Calculate total amount of token to transfer
+            uint256 totalAmount = 0;
+            for (
+                uint256 j = 0;
+                j <
+                operatorDirectedRewardsSubmissions[i].operatorRewards.length;
+                ++j
+            ) {
+                totalAmount += operatorDirectedRewardsSubmissions[i]
+                    .operatorRewards[j]
+                    .amount;
+            }
+
+            // Transfer token to ServiceManagerRewardsRouter and approve ServiceManager to transfer again
+            // in createOperatorDirectedAVSRewardsSubmission() call
+            operatorDirectedRewardsSubmissions[i].token.safeTransferFrom(
+                msg.sender,
+                address(this),
+                totalAmount
+            );
+            operatorDirectedRewardsSubmissions[i].token.safeIncreaseAllowance(
+                address(serviceManager),
+                totalAmount
+            );
+        }
+
+        serviceManager.createOperatorDirectedAVSRewardsSubmission(operatorDirectedRewardsSubmissions);
+    }
+}

--- a/contracts/test/MockEigenDADeployer.sol
+++ b/contracts/test/MockEigenDADeployer.sol
@@ -105,7 +105,7 @@ contract MockEigenDADeployer is BLSMockAVSDeployer {
 
         eigenDAServiceManagerImplementation = new EigenDAServiceManager(
             avsDirectory,
-            rewardsCoordinator,
+            rewardsCoordinatorMock,
             registryCoordinator,
             stakeRegistry,
             eigenDAThresholdRegistry,

--- a/contracts/test/unit/ServiceManagerRewardsRouterUnit.t.sol
+++ b/contracts/test/unit/ServiceManagerRewardsRouterUnit.t.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.12;
+
+import "../MockEigenDADeployer.sol";
+import {ServiceManagerRewardsRouter} from "../../src/rewards/ServiceManagerRewardsRouter.sol";
+import {IServiceManagerRewardsRouter} from "../../src/rewards/IServiceManagerRewardsRouter.sol";
+
+contract ServiceManagerRewardsRouterUnit is MockEigenDADeployer {
+
+    IServiceManagerRewardsRouter serviceManagerRewardsRouter;
+    IServiceManagerRewardsRouter serviceManagerRewardsRouterImplementation;
+    
+    function setUp() virtual public {
+        _deployDA();
+
+        serviceManagerRewardsRouterImplementation = new ServiceManagerRewardsRouter(eigenDAServiceManager);
+        serviceManagerRewardsRouter = IServiceManagerRewardsRouter(
+            address(
+                new TransparentUpgradeableProxy(address(serviceManagerRewardsRouterImplementation), address(proxyAdmin), "")
+            )
+        );
+        cheats.prank(proxyAdminOwner);
+        proxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(serviceManagerRewardsRouter))),
+            address(serviceManagerRewardsRouterImplementation),
+            abi.encodeWithSelector(
+                ServiceManagerRewardsRouter.initialize.selector,
+                registryCoordinatorOwner
+            )
+        );
+
+        vm.prank(registryCoordinatorOwner);
+        eigenDAServiceManager.setRewardsInitiator(address(serviceManagerRewardsRouter));
+    }
+
+    function test_setAllowedToPushRewards() public {
+        vm.prank(registryCoordinatorOwner);
+        serviceManagerRewardsRouter.setAllowedToPushRewards(rewardsInitiator, true);
+        assertEq(serviceManagerRewardsRouter.isAllowedToPushRewards(rewardsInitiator), true);
+
+        vm.prank(registryCoordinatorOwner);
+        serviceManagerRewardsRouter.setAllowedToPushRewards(rewardsInitiator, false);
+        assertEq(serviceManagerRewardsRouter.isAllowedToPushRewards(rewardsInitiator), false);
+    }
+
+    function test_setAllowedToPushRewards_reverts_NotOwner() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        serviceManagerRewardsRouter.setAllowedToPushRewards(rewardsInitiator, true);
+    }
+
+    function test_createAVSRewardsSubmission() public {
+        vm.prank(registryCoordinatorOwner);
+        serviceManagerRewardsRouter.setAllowedToPushRewards(rewardsInitiator, true);
+
+        IRewardsCoordinator.RewardsSubmission[] memory rewardsSubmissions = new IRewardsCoordinator.RewardsSubmission[](0);
+            
+        vm.prank(rewardsInitiator);
+        serviceManagerRewardsRouter.createAVSRewardsSubmission(rewardsSubmissions);
+    }
+
+    function test_createAVSRewardsSubmission_reverts_NotAllowed() public {
+        vm.prank(registryCoordinatorOwner);
+        serviceManagerRewardsRouter.setAllowedToPushRewards(rewardsInitiator, false);
+
+        IRewardsCoordinator.RewardsSubmission[] memory rewardsSubmissions = new IRewardsCoordinator.RewardsSubmission[](0);
+
+        vm.expectRevert("ServiceManagerRewardsRouter: Address not permissioned to push rewards");
+        serviceManagerRewardsRouter.createAVSRewardsSubmission(rewardsSubmissions);
+    }
+
+    function test_createOperatorDirectedAVSRewardsSubmission() public {
+        vm.prank(registryCoordinatorOwner);
+        serviceManagerRewardsRouter.setAllowedToPushRewards(rewardsInitiator, true);
+
+        IRewardsCoordinator.OperatorDirectedRewardsSubmission[] memory operatorDirectedRewardsSubmissions = new IRewardsCoordinator.OperatorDirectedRewardsSubmission[](0);
+
+        vm.prank(rewardsInitiator);
+        serviceManagerRewardsRouter.createOperatorDirectedAVSRewardsSubmission(operatorDirectedRewardsSubmissions);
+    }
+
+    function test_createOperatorDirectedAVSRewardsSubmission_reverts_NotAllowed() public {
+        vm.prank(registryCoordinatorOwner);
+        serviceManagerRewardsRouter.setAllowedToPushRewards(rewardsInitiator, false);
+
+        IRewardsCoordinator.OperatorDirectedRewardsSubmission[] memory operatorDirectedRewardsSubmissions = new IRewardsCoordinator.OperatorDirectedRewardsSubmission[](0);
+
+        vm.expectRevert("ServiceManagerRewardsRouter: Address not permissioned to push rewards");
+        serviceManagerRewardsRouter.createOperatorDirectedAVSRewardsSubmission(operatorDirectedRewardsSubmissions);
+    }
+}


### PR DESCRIPTION
Adds a ServiceManagerRewardsRouter contract that allows governance to permission multiple rewards initiators to push operator rewards
