### PR TITLE
Add environment variable to hold eth RPC urls.

### DIFF
--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -130,8 +130,13 @@ func NewTestClient(
 		return nil, fmt.Errorf("failed to populate accountant: %w", err)
 	}
 
+	ethRPCUrls, err := loadEthRPCURLs(config.EthRPCURLs, config.EthRPCUrlsVar)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Ethereum RPC URLs: %w", err)
+	}
+
 	ethClientConfig := geth.EthClientConfig{
-		RPCURLs:          config.EthRPCURLs,
+		RPCURLs:          ethRPCUrls,
 		PrivateKeyString: privateKey,
 		NumConfirmations: 0,
 		NumRetries:       3,
@@ -307,6 +312,24 @@ func loadPrivateKey(keyPath string, keyVar string) (string, error) {
 		return "", fmt.Errorf("key not found in environment variable %s", keyVar)
 	}
 	return formatPrivateKey(privateKey), nil
+}
+
+// loadEthRPCURLs loads the Ethereum RPC URLs from the file/env var specified in the config.
+func loadEthRPCURLs(urls []string, urlsVar string) ([]string, error) {
+	if len(urls) > 0 {
+		return urls, nil
+	}
+
+	if urlsVar == "" {
+		return nil, fmt.Errorf("either EthRPCURLs or EthRPCUrlsVar must be set")
+	}
+
+	ethRPCURLs := os.Getenv(urlsVar)
+	if ethRPCURLs == "" {
+		return nil, fmt.Errorf("URLs not found in environment variable %s", urlsVar)
+	}
+
+	return strings.Split(ethRPCURLs, ","), nil
 }
 
 // formatPrivateKey formats the private key by removing leading/trailing whitespace and "0x" prefix.

--- a/test/v2/client/test_client_config.go
+++ b/test/v2/client/test_client_config.go
@@ -23,7 +23,13 @@ type TestClientConfig struct {
 	// The disperser's port
 	DisperserPort int
 	// The URL(s) to point the eth client to
+	//
+	// Either this or EthRPCURLsVar must be set. If both are set, EthRPCURLs is used.
 	EthRPCURLs []string
+	// The environment variable that contains the URL(s) to point the eth client to. Use a comma-separated list.
+	//
+	// Either this or EthRPCURLs must be set. If both are set, EthRPCURLsVar is used.
+	EthRPCUrlsVar string
 	// The contract address for the EigenDA BLS operator state retriever
 	BLSOperatorStateRetrieverAddr string
 	// The contract address for the EigenDA service manager

--- a/test/v2/client/test_client_config.go
+++ b/test/v2/client/test_client_config.go
@@ -28,7 +28,7 @@ type TestClientConfig struct {
 	EthRPCURLs []string
 	// The environment variable that contains the URL(s) to point the eth client to. Use a comma-separated list.
 	//
-	// Either this or EthRPCURLs must be set. If both are set, EthRPCURLsVar is used.
+	// Either this or EthRPCURLs must be set. If both are set, EthRPCURLs is used.
 	EthRPCUrlsVar string
 	// The contract address for the EigenDA BLS operator state retriever
 	BLSOperatorStateRetrieverAddr string


### PR DESCRIPTION
## Why are these changes needed?

Make it so that the eth RPC URLs can be loaded from an environment variable.
