### PR TITLE
Do not panic if the wrong number of chunks are returned.

### DIFF
--- a/api/clients/v2/retrieval_client.go
+++ b/api/clients/v2/retrieval_client.go
@@ -134,14 +134,6 @@ func (r *retrievalClient) GetBlob(
 			assignmentIndices[i] = uint(index)
 		}
 
-		if len(assignmentIndices) != len(reply.Chunks) {
-			r.logger.Warn("invalid number of chunks from operator",
-				"operator", reply.OperatorID.Hex(),
-				"expected", len(assignmentIndices),
-				"actual", len(reply.Chunks))
-			continue
-		}
-
 		err = r.verifier.VerifyFrames(reply.Chunks, assignmentIndices, blobCommitments, encodingParams)
 		if err != nil {
 			r.logger.Warn("failed to verify chunks from operator", "operator", reply.OperatorID.Hex(), "err", err)

--- a/api/clients/v2/retrieval_client.go
+++ b/api/clients/v2/retrieval_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/docker/go-units"
 
 	"github.com/Layr-Labs/eigenda/api/clients"
@@ -131,6 +132,14 @@ func (r *retrievalClient) GetBlob(
 		assignmentIndices := make([]uint, len(assignment.GetIndices()))
 		for i, index := range assignment.GetIndices() {
 			assignmentIndices[i] = uint(index)
+		}
+
+		if len(assignmentIndices) != len(reply.Chunks) {
+			r.logger.Warn("invalid number of chunks from operator",
+				"operator", reply.OperatorID.Hex(),
+				"expected", len(assignmentIndices),
+				"actual", len(reply.Chunks))
+			continue
 		}
 
 		err = r.verifier.VerifyFrames(reply.Chunks, assignmentIndices, blobCommitments, encodingParams)

--- a/encoding/kzg/verifier/verifier.go
+++ b/encoding/kzg/verifier/verifier.go
@@ -201,7 +201,15 @@ func VerifyLengthProof(lengthCommit *bn254.G2Affine, proof *bn254.G2Affine, g1Ch
 	return PairingsVerify(g1Challenge, lengthCommit, &kzg.GenG1, proof)
 }
 
-func (v *Verifier) VerifyFrames(frames []*encoding.Frame, indices []encoding.ChunkNumber, commitments encoding.BlobCommitments, params encoding.EncodingParams) error {
+func (v *Verifier) VerifyFrames(
+	frames []*encoding.Frame,
+	indices []encoding.ChunkNumber,
+	commitments encoding.BlobCommitments,
+	params encoding.EncodingParams) error {
+
+	if len(frames) != len(indices) {
+		return fmt.Errorf("invalid number of frames and indices: %d != %d", len(frames), len(indices))
+	}
 
 	verifier, err := v.GetKzgVerifier(params)
 	if err != nil {
@@ -222,7 +230,6 @@ func (v *Verifier) VerifyFrames(frames []*encoding.Frame, indices []encoding.Chu
 	}
 
 	return nil
-
 }
 
 func (v *ParametrizedVerifier) VerifyFrame(commit *bn254.G1Affine, f *encoding.Frame, index uint64, numChunks uint64) error {


### PR DESCRIPTION
## Why are these changes needed?

Handle the scenario where a validator returns an incorrect number of chunks.
