### PR TITLE
refactor: Structify Opeartor Socket

### DIFF
--- a/api/clients/node_client.go
+++ b/api/clients/node_client.go
@@ -85,8 +85,9 @@ func (c client) GetChunks(
 	quorumID core.QuorumID,
 	chunksChan chan RetrievedChunks,
 ) {
+
 	conn, err := grpc.NewClient(
-		core.OperatorSocket(opInfo.Socket).GetV1RetrievalSocket(),
+		opInfo.Socket.GetV1RetrievalSocket(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/api/clients/v2/retrieval_client.go
+++ b/api/clients/v2/retrieval_client.go
@@ -175,8 +175,9 @@ func (r *retrievalClient) getChunksFromOperator(
 	fudgeFactor := units.MiB      // to allow for some overhead from things like protobuf encoding
 	maxMessageSize := maxBlobSize*encodingRate + fudgeFactor
 
+
 	conn, err := grpc.NewClient(
-		core.OperatorSocket(opInfo.Socket).GetV2RetrievalSocket(),
+		opInfo.Socket.GetV2RetrievalSocket(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSize)),
 	)

--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -509,10 +509,16 @@ func (t *Reader) GetOperatorStakesWithSocketForQuorums(ctx context.Context, quor
 		state[quorumID] = make(map[core.OperatorIndex]core.OperatorStakeWithSocket, len(result.Operators[i]))
 		for j, op := range result.Operators[i] {
 			operatorIndex := core.OperatorIndex(j)
+			operatorSocket, err := core.ParseOperatorSocket(result.Sockets[i][j])
+			if err != nil {
+				t.logger.Errorf("failed to parse operator socket from: %v, err: %v", result.Sockets[i][j], err)
+				return nil, fmt.Errorf("failed to parse operator socket from: %v, err: %v", result.Sockets[i][j], err)
+
+			}
 			state[quorumID][operatorIndex] = core.OperatorStakeWithSocket{
 				Stake:      op.Stake,
 				OperatorID: op.OperatorId,
-				Socket:     core.OperatorSocket(result.Sockets[i][j]),
+				Socket:     operatorSocket,
 			}
 		}
 	}

--- a/core/eth/state.go
+++ b/core/eth/state.go
@@ -118,7 +118,7 @@ func getOperatorStateWithSocket(operatorsByQuorum core.OperatorStakesWithSocket,
 		totals[quorumID] = &core.OperatorInfo{
 			Stake:  totalStake,
 			Index:  core.OperatorIndex(len(quorum)),
-			Socket: core.OperatorSocket(""),
+			Socket: core.OperatorSocket{},
 		}
 	}
 

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -142,10 +142,10 @@ func (d *ChainDataMock) GetTotalOperatorStateWithQuorums(ctx context.Context, bl
 		retrievalPort := fmt.Sprintf("3%03v", 2*i+1)
 		v2DispersalPort := fmt.Sprintf("3%03v", 2*i+2)
 		v2RetrievalPort := fmt.Sprintf("3%03v", 2*i+3)
-		socket := core.MakeOperatorSocket(host, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
+		socket := core.NewOperatorSocket(host, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
 
 		indexed := &core.IndexedOperatorInfo{
-			Socket:   string(socket),
+			Socket:   socket.Encode(),
 			PubkeyG1: d.KeyPairs[id].GetPubKeyG1(),
 			PubkeyG2: d.KeyPairs[id].GetPubKeyG2(),
 		}

--- a/core/serialization.go
+++ b/core/serialization.go
@@ -528,33 +528,33 @@ func decode(data []byte, obj any) error {
 }
 
 func (s OperatorSocket) GetV1DispersalSocket() string {
-	ip, v1DispersalPort, _, _, _, err := ParseOperatorSocket(string(s))
-	if err != nil {
+	if s.host == "" || s.v1DispersalPort == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s", ip, v1DispersalPort)
+	return fmt.Sprintf("%s:%s", s.host, s.v1DispersalPort)
 }
 
 func (s OperatorSocket) GetV2DispersalSocket() string {
-	ip, _, _, v2DispersalPort, _, err := ParseOperatorSocket(string(s))
-	if err != nil || v2DispersalPort == "" {
+	if s.host == "" || s.v2DispersalPort == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s", ip, v2DispersalPort)
+	return fmt.Sprintf("%s:%s", s.host, s.v2DispersalPort)
 }
 
 func (s OperatorSocket) GetV1RetrievalSocket() string {
-	ip, _, v1retrievalPort, _, _, err := ParseOperatorSocket(string(s))
-	if err != nil {
+	if s.host == "" || s.v1RetrievalPort == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s", ip, v1retrievalPort)
+	return fmt.Sprintf("%s:%s", s.host, s.v1RetrievalPort)
 }
 
 func (s OperatorSocket) GetV2RetrievalSocket() string {
-	ip, _, _, _, v2RetrievalPort, err := ParseOperatorSocket(string(s))
-	if err != nil || v2RetrievalPort == "" {
+	if s.host == "" || s.v2RetrievalPort == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s", ip, v2RetrievalPort)
+	return fmt.Sprintf("%s:%s", s.host, s.v2RetrievalPort)
+}
+
+func (s OperatorSocket) GetHost() string {
+	return s.host
 }

--- a/core/serialization_test.go
+++ b/core/serialization_test.go
@@ -195,125 +195,184 @@ func TestHashPubKeyG1(t *testing.T) {
 }
 
 func TestParseOperatorSocket(t *testing.T) {
-	operatorSocket := "localhost:1234;5678;9999;10001"
-	host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort, err := core.ParseOperatorSocket(operatorSocket)
+	opSocketStr := "localhost:1234;5678;9999;10001"
+	operatorSocket, err := core.ParseOperatorSocket(opSocketStr)
 	assert.NoError(t, err)
-	assert.Equal(t, "localhost", host)
-	assert.Equal(t, "1234", v1DispersalPort)
-	assert.Equal(t, "5678", v1RetrievalPort)
-	assert.Equal(t, "9999", v2DispersalPort)
-	assert.Equal(t, "10001", v2RetrievalPort)
 
-	host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, _, err = core.ParseOperatorSocket("localhost:1234;5678")
+	assert.Equal(t, "localhost", operatorSocket.GetHost())
+	assert.Equal(t, "localhost:1234", operatorSocket.GetV1DispersalSocket())
+	assert.Equal(t, "localhost:5678", operatorSocket.GetV1RetrievalSocket())
+	assert.Equal(t, "localhost:9999", operatorSocket.GetV2DispersalSocket())
+	assert.Equal(t, "localhost:10001", operatorSocket.GetV2RetrievalSocket())
+
+	opSocketStr = "localhost:1234;5678"
+	operatorSocket, err = core.ParseOperatorSocket(opSocketStr)
 	assert.NoError(t, err)
-	assert.Equal(t, "localhost", host)
-	assert.Equal(t, "1234", v1DispersalPort)
-	assert.Equal(t, "5678", v1RetrievalPort)
-	assert.Equal(t, "", v2DispersalPort)
+	assert.Equal(t, "localhost", operatorSocket.GetHost())
+	assert.Equal(t, "localhost:1234", operatorSocket.GetV1DispersalSocket())
+	assert.Equal(t, "localhost:5678", operatorSocket.GetV1RetrievalSocket())
+	assert.Equal(t, "", operatorSocket.GetV2DispersalSocket())
 
-	_, _, _, _, _, err = core.ParseOperatorSocket("localhost;1234;5678")
+	opSocketStr = "localhost;1234;5678"
+	_, err = core.ParseOperatorSocket(opSocketStr)
 	assert.NotNil(t, err)
 	assert.ErrorContains(t, err, "invalid host address format")
 
-	_, _, _, _, _, err = core.ParseOperatorSocket("localhost:12345678")
+	opSocketStr = "localhost:12345678"
+	_, err = core.ParseOperatorSocket(opSocketStr)
 	assert.NotNil(t, err)
 	assert.ErrorContains(t, err, "invalid v1 dispersal port format")
 
-	_, _, _, _, _, err = core.ParseOperatorSocket("localhost1234;5678")
+	opSocketStr = "localhost1234;5678"
+	_, err = core.ParseOperatorSocket(opSocketStr)
 	assert.NotNil(t, err)
 	assert.ErrorContains(t, err, "invalid host address format")
 }
 
 func TestGetV1DispersalSocket(t *testing.T) {
-	operatorSocket := core.OperatorSocket("localhost:1234;5678;9999;1025")
+	operatorSocket, err := core.ParseOperatorSocket("localhost:1234;5678;9999;1025")
 	socket := operatorSocket.GetV1DispersalSocket()
+	assert.NoError(t, err)
 	assert.Equal(t, "localhost:1234", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234;5678")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;5678")
 	socket = operatorSocket.GetV1DispersalSocket()
+	assert.NoError(t, err)
 	assert.Equal(t, "localhost:1234", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234;5678;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;5678;")
 	socket = operatorSocket.GetV1DispersalSocket()
+	assert.NotNil(t, err)
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV1DispersalSocket()
 	assert.Equal(t, "", socket)
 }
 
 func TestGetV1RetrievalSocket(t *testing.T) {
 	// Valid v1/v2 socket
-	operatorSocket := core.OperatorSocket("localhost:1234;5678;9999;10001")
+	operatorSocket, err := core.ParseOperatorSocket("localhost:1234;5678;9999;10001")
+	assert.NoError(t, err)
 	socket := operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "localhost:5678", socket)
 
 	// Valid v1 socket
-	operatorSocket = core.OperatorSocket("localhost:1234;5678")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;5678")
 	socket = operatorSocket.GetV1RetrievalSocket()
+	assert.NoError(t, err)
 	assert.Equal(t, "localhost:5678", socket)
 
 	// Invalid socket testcases
-	operatorSocket = core.OperatorSocket("localhost:1234;5678;9999;10001;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;5678;9999;10001;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234;5678;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;5678;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:;1234;5678;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:;1234;5678;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234;:;5678;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;:;5678;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:;;;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:;;;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV1RetrievalSocket()
 	assert.Equal(t, "", socket)
 }
 
 func TestGetV2RetrievalSocket(t *testing.T) {
 	// Valid v1/v2 socket
-	operatorSocket := core.OperatorSocket("localhost:1234;5678;9999;10001")
+	operatorSocket, err := core.ParseOperatorSocket("localhost:1234;5678;9999;10001")
+	assert.NoError(t, err)
 	socket := operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "localhost:10001", socket)
 
-	// Invalid v2 socket
-	operatorSocket = core.OperatorSocket("localhost:1234;5678")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;5678")
+	assert.NoError(t, err)
 	socket = operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "", socket)
 
 	// Invalid socket testcases
-	operatorSocket = core.OperatorSocket("localhost:1234;5678;9999;10001;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;5678;9999;10001;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234;5678;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;5678;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:;1234;5678;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:;1234;5678;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234;:;5678;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234;:;5678;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:;;;")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:;;;")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "", socket)
 
-	operatorSocket = core.OperatorSocket("localhost:1234")
+	operatorSocket, err = core.ParseOperatorSocket("localhost:1234")
+	assert.NotNil(t, err)
 	socket = operatorSocket.GetV2RetrievalSocket()
 	assert.Equal(t, "", socket)
+}
+
+func TestParseOperatorSocketOnInvalidSocketStrings(t *testing.T) {
+	//Invalid Socket String Cases
+	invalidSocketStr_OnlyHost := "localhost"
+	_, err := core.ParseOperatorSocket(invalidSocketStr_OnlyHost)
+	assert.ErrorContains(t, err, "invalid host address format")
+
+	invalidSocketStr_MissingPorts := "localhost:"
+	_, err = core.ParseOperatorSocket(invalidSocketStr_MissingPorts)
+	assert.ErrorContains(t, err, "invalid v1 dispersal port format")
+
+	invalidSocketStr_MissingHost := ":1234;4567"
+	_, err = core.ParseOperatorSocket(invalidSocketStr_MissingHost)
+	assert.ErrorContains(t, err, "unable to lookup host")
+
+	invalidSocketStr_MissingV1RetrievalPort := "localhost:1234"
+	_, err = core.ParseOperatorSocket(invalidSocketStr_MissingV1RetrievalPort)
+	assert.ErrorContains(t, err, " it must specify v1 dispersal/retrieval ports")
+
+	invalidSocketStr_MissingV1DisperserPort := "localhost:;5467"
+	_, err = core.ParseOperatorSocket(invalidSocketStr_MissingV1DisperserPort)
+	assert.ErrorContains(t, err, "invalid v1 dispersal port format")
+
+	invalidSocketStr_MissingV2RetrievalPort := "localhost:1234;5678;9101"
+	_, err = core.ParseOperatorSocket(invalidSocketStr_MissingV2RetrievalPort)
+	assert.ErrorContains(t, err, "invalid opSocketStr address format")
+
+	invalidSocketStr_MissingV2DispersalPort := "localhost:1234;5678;;9101"
+	_, err = core.ParseOperatorSocket(invalidSocketStr_MissingV2DispersalPort)
+	assert.ErrorContains(t, err, "invalid v2 dispersal port format")
+
+	invalidSocketStr_MissingV1Ports := "localhost:;;1234;5678"
+	_, err = core.ParseOperatorSocket(invalidSocketStr_MissingV1Ports)
+	assert.ErrorContains(t, err, "it must specify valid v1 dispersal port")
 }
 
 func TestSignatureBytes(t *testing.T) {

--- a/core/state.go
+++ b/core/state.go
@@ -13,78 +13,84 @@ import (
 
 // Operators
 
-// OperatorSocket is formatted as "host:dispersalPort;retrievalPort;v2DispersalPort"
-type OperatorSocket string
+// OperatorSocket is formatted as follows:
+// v1-only 	  "host:dispersalPort;retrievalPort"
+// v1-and-v2  "host:dispersalPort;retrievalPort;v2DispersalPort;v2RetrievalPort"
+// v2-only    "host:dispersalPort;retrievalPort;v2DispersalPort;v2RetrievalPort" (currently v2 only mandates running v1)
 
-func (s OperatorSocket) String() string {
-	return string(s)
+type OperatorSocket struct {
+	host            string
+	v1DispersalPort string
+	v1RetrievalPort string
+	v2DispersalPort string
+	v2RetrievalPort string
 }
 
-func MakeOperatorSocket(nodeIP, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort string) OperatorSocket {
-	//TODO:  Add config checks for invalid v1/v2 configs -- for v1, both v2 ports must be empty and for v2, both ports must be valid, reject any other combinations.
-	if v2DispersalPort == "" && v2RetrievalPort == "" {
-		return OperatorSocket(fmt.Sprintf("%s:%s;%s", nodeIP, dispersalPort, retrievalPort))
+// NewOperatorSocket returns new OperatorSocket struct
+func NewOperatorSocket(host, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort string) OperatorSocket {
+	return OperatorSocket{
+		host:            host,
+		v1DispersalPort: dispersalPort,
+		v1RetrievalPort: retrievalPort,
+		v2DispersalPort: v2DispersalPort,
+		v2RetrievalPort: v2RetrievalPort,
 	}
-	return OperatorSocket(fmt.Sprintf("%s:%s;%s;%s;%s", nodeIP, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort))
 }
+
+func (s OperatorSocket) Encode() string {
+	if s.v2DispersalPort == "" && s.v2RetrievalPort == "" {
+		return fmt.Sprintf("%s:%s;%s", s.host, s.v1DispersalPort, s.v1RetrievalPort)
+	}
+	return fmt.Sprintf("%s:%s;%s;%s;%s", s.host, s.v1DispersalPort, s.v1RetrievalPort, s.v2DispersalPort, s.v2RetrievalPort)
+}
+
 
 type StakeAmount = *big.Int
 
-func ParseOperatorSocket(socket string) (host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort string, err error) {
+func ParseOperatorSocket(opSocketStr string) (opSocket OperatorSocket, err error) {
 
-	s := strings.Split(socket, ";")
+	operatorSocket := OperatorSocket{}
+	s := strings.Split(opSocketStr, ";")
 
-	host, v1DispersalPort, err = net.SplitHostPort(s[0])
+	host, v1DispersalPort, err := net.SplitHostPort(s[0])
 	if err != nil {
-		err = fmt.Errorf("invalid host address format in %s: it must specify valid IP or host name (ex. 0.0.0.0:32004;32005;32006;32007)", socket)
-
+		err = fmt.Errorf("invalid host address format in %s: it must specify valid IP or host name (ex. 0.0.0.0:32004;32005;32006;32007)", opSocketStr)
 		return
 	}
 	if _, err = net.LookupHost(host); err != nil {
-		//Invalid host
-		host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort, err =
-			"", "", "", "", "",
-			fmt.Errorf("invalid host address format in %s: it must specify valid IP or host name (ex. 0.0.0.0:32004;32005;32006;32007)", socket)
+		err = fmt.Errorf("invalid host address format in %s: unable to lookup host)", opSocketStr)
 		return
 	}
 	if err = ValidatePort(v1DispersalPort); err != nil {
-		host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort, err =
-			"", "", "", "", "",
-			fmt.Errorf("invalid v1 dispersal port format in %s: it must specify valid v1 dispersal port (ex. 0.0.0.0:32004;32005;32006;32007)", socket)
+		err = fmt.Errorf("invalid v1 dispersal port format in %s: it must specify valid v1 dispersal port (ex. 0.0.0.0:32004;32005;32006;32007)", opSocketStr)
 		return
 	}
 
 	switch len(s) {
 	case 4:
-		v2DispersalPort = s[2]
-		if err = ValidatePort(v2DispersalPort); err != nil {
-			host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort, err =
-				"", "", "", "", "",
-				fmt.Errorf("invalid v2 dispersal port format in %s: it must specify valid v2 dispersal port (ex. 0.0.0.0:32004;32005;32006;32007)", socket)
+		if err = ValidatePort(s[2]); err != nil {
+			err = fmt.Errorf("invalid v2 dispersal port format in %s: it must specify valid v2 dispersal port (ex. 0.0.0.0:32004;32005;32006;32007)", opSocketStr)
 			return
 		}
 
-		v2RetrievalPort = s[3]
-		if err = ValidatePort(v2RetrievalPort); err != nil {
-			host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort, err =
-				"", "", "", "", "",
-				fmt.Errorf("invalid v2 retrieval port format in %s: it must specify valid v2 retrieval port (ex. 0.0.0.0:32004;32005;32006;32007)", socket)
+		if err = ValidatePort(s[3]); err != nil {
+			err = fmt.Errorf("invalid v2 retrieval port format in %s: it must specify valid v2 retrieval port (ex. 0.0.0.0:32004;32005;32006;32007)", opSocketStr)
 			return
 		}
+		operatorSocket.v2DispersalPort = s[2]
+		operatorSocket.v2RetrievalPort = s[3]
 		fallthrough
 	case 2:
-		// V1 Parsing
-		v1RetrievalPort = s[1]
-		if err = ValidatePort(v1RetrievalPort); err != nil {
-			host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort, err =
-				"", "", "", "", "",
-				fmt.Errorf("invalid v1 retrieval port format in %s: it must specify valid v1 retrieval port (ex. 0.0.0.0:32004;32005;32006;32007)", socket)
+		operatorSocket.host = host
+		operatorSocket.v1DispersalPort = v1DispersalPort
+		if err = ValidatePort(s[1]); err != nil {
+			err = fmt.Errorf("invalid v1 retrieval port format in %s: it must specify valid v1 retrieval port (ex. 0.0.0.0:32004;32005;32006;32007)", opSocketStr)
+			return
 		}
-		return
+		operatorSocket.v1RetrievalPort = s[1]
+		return operatorSocket, nil
 	default:
-		host, v1DispersalPort, v1RetrievalPort, v2DispersalPort, v2RetrievalPort, err =
-			"", "", "", "", "",
-			fmt.Errorf("invalid socket address format %s: it must specify v1 dispersal/retrieval ports, or v2 dispersal/retrieval ports (ex. 0.0.0.0:32004;32005;32006;32007)", socket)
+		err = fmt.Errorf("invalid opSocketStr address format %s: it must specify v1 dispersal/retrieval ports, or v2 dispersal/retrieval ports (ex. 0.0.0.0:32004;32005;32006;32007)", opSocketStr)
 		return
 	}
 }
@@ -97,7 +103,7 @@ type OperatorInfo struct {
 	// Index is the index of the operator within the quorum
 	Index OperatorIndex
 	// Socket is the socket address of the operator
-	// Populated only when using GetOperatorStateWithSocket; otherwise it is an empty string
+	// Populated only when using GetOperatorStateWithSocket; otherwise it is an default zero operator socket struct
 	Socket OperatorSocket
 }
 

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -16,24 +16,24 @@ func TestOperatorStateHash(t *testing.T) {
 				[32]byte{0}: &core.OperatorInfo{
 					Stake:  big.NewInt(12),
 					Index:  uint(2),
-					Socket: "192.168.1.100:8080",
+					Socket: core.NewOperatorSocket("192.168.1.100", "8080", "", "", ""),
 				},
 				[32]byte{1}: &core.OperatorInfo{
 					Stake:  big.NewInt(23),
 					Index:  uint(3),
-					Socket: "127.0.0.1:3000",
+					Socket: core.NewOperatorSocket("127.0.0.1", "3000", "", "", ""),
 				},
 			},
 			1: {
 				[32]byte{1}: &core.OperatorInfo{
 					Stake:  big.NewInt(23),
 					Index:  uint(3),
-					Socket: "127.0.0.1:3000",
+					Socket: core.NewOperatorSocket("127.0.0.1", "3000", "", "", ""),
 				},
 				[32]byte{2}: &core.OperatorInfo{
 					Stake:  big.NewInt(34),
 					Index:  uint(4),
-					Socket: "192.168.1.100:8080",
+					Socket: core.NewOperatorSocket("192.168.1.100", "8080", "", "", ""),
 				},
 			},
 		},
@@ -41,12 +41,12 @@ func TestOperatorStateHash(t *testing.T) {
 			0: {
 				Stake:  big.NewInt(35),
 				Index:  uint(2),
-				Socket: "",
+				Socket: core.OperatorSocket{},
 			},
 			1: {
 				Stake:  big.NewInt(57),
 				Index:  uint(2),
-				Socket: "",
+				Socket: core.OperatorSocket{},
 			},
 		},
 		BlockNumber: uint(123),
@@ -56,8 +56,8 @@ func TestOperatorStateHash(t *testing.T) {
 	assert.NoError(t, err)
 	q0 := hash1[0]
 	q1 := hash1[1]
-	assert.Equal(t, "6098562ea2e61a8f68743f9162b0adc0", hex.EncodeToString(q0[:]))
-	assert.Equal(t, "8ceea2ec543eb311e51ccfdc9e00ea4f", hex.EncodeToString(q1[:]))
+	assert.Equal(t, "7f227566a0f077dd9bba7613a40de260", hex.EncodeToString(q0[:]))
+	assert.Equal(t, "aa1da3df03ce4c71fae05d5e6c957748", hex.EncodeToString(q1[:]))
 
 	s2 := core.OperatorState{
 		Operators: map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo{
@@ -99,6 +99,6 @@ func TestOperatorStateHash(t *testing.T) {
 	assert.NoError(t, err)
 	q0 = hash2[0]
 	q1 = hash2[1]
-	assert.Equal(t, "dc1bbb0b2b5d20238adfd4bd33661423", hex.EncodeToString(q0[:]))
-	assert.Equal(t, "8ceea2ec543eb311e51ccfdc9e00ea4f", hex.EncodeToString(q1[:]))
+	assert.Equal(t, "a382adf83f330be719af7e2cdaad0ebe", hex.EncodeToString(q0[:]))
+	assert.Equal(t, "aa1da3df03ce4c71fae05d5e6c957748", hex.EncodeToString(q1[:]))
 }

--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -120,13 +120,18 @@ func (c *dispatcher) sendAllChunks(ctx context.Context, state *core.IndexedOpera
 
 func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.EncodedBlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) (*core.Signature, error) {
 	// TODO Add secure Grpc
+	operatorSocket, err := core.ParseOperatorSocket(op.Socket)
+	if err != nil {
+		c.logger.Error("Disperser failed to parse socket", "socket", op.Socket, "err", err)
+		return nil, err
+	}
 
 	conn, err := grpc.NewClient(
-		core.OperatorSocket(op.Socket).GetV1DispersalSocket(),
+		operatorSocket.GetV1DispersalSocket(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
-		c.logger.Warn("Disperser cannot connect to operator dispersal socket", "dispersal_socket", core.OperatorSocket(op.Socket).GetV1DispersalSocket(), "err", err)
+		c.logger.Error("Disperser cannot connect to operator dispersal socket", "dispersal_socket", operatorSocket.GetV1DispersalSocket(), "err", err)
 		return nil, err
 	}
 	defer conn.Close()

--- a/disperser/cmd/dataapi/docs/docs.go
+++ b/disperser/cmd/dataapi/docs/docs.go
@@ -12,7 +12,7 @@ const docTemplate = `{
         "contact": {},
         "version": "{{.Version}}"
     },
-    "host": "{{.Host}}",
+    "host": "{{.host}}",
     "basePath": "{{.BasePath}}",
     "paths": {}
 }`

--- a/disperser/common/semver/semver.go
+++ b/disperser/common/semver/semver.go
@@ -28,7 +28,10 @@ func ScanOperators(operators map[core.OperatorID]*core.IndexedOperatorInfo, oper
 	operatorChan := make(chan core.OperatorID, len(operators))
 	worker := func() {
 		for operatorId := range operatorChan {
-			operatorSocket := core.OperatorSocket(operators[operatorId].Socket)
+			operatorSocket, err := core.ParseOperatorSocket(operators[operatorId].Socket)
+			if err != nil {
+				logger.Errorf("Failed to parse operator socket: %v", err)
+			}
 			var socket string
 			if useRetrievalSocket {
 				socket = operatorSocket.GetV1RetrievalSocket()

--- a/disperser/dataapi/docs/v1/V1_docs.go
+++ b/disperser/dataapi/docs/v1/V1_docs.go
@@ -12,7 +12,7 @@ const docTemplateV1 = `{
         "contact": {},
         "version": "{{.Version}}"
     },
-    "host": "{{.Host}}",
+    "host": "{{.host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
         "/feed/batches/{batch_header_hash}/blobs": {

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -12,7 +12,7 @@ const docTemplateV2 = `{
         "contact": {},
         "version": "{{.Version}}"
     },
-    "host": "{{.Host}}",
+    "host": "{{.host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
         "/accounts/{account_id}/blobs": {

--- a/disperser/dataapi/operator_handler.go
+++ b/disperser/dataapi/operator_handler.go
@@ -95,7 +95,11 @@ func (oh *OperatorHandler) ProbeV2OperatorPorts(ctx context.Context, operatorId 
 		return &OperatorPortCheckResponse{}, err
 	}
 
-	operatorSocket := core.OperatorSocket(operatorInfo.Socket)
+	operatorSocket, err := core.ParseOperatorSocket(operatorInfo.Socket)
+	if err != nil {
+		oh.logger.Error("failed to parse operator socket", "operatorId", operatorId, "error", err)
+		return &OperatorPortCheckResponse{}, err
+	}
 
 	retrievalOnline, retrievalStatus := false, "v2 retrieval port closed or unreachable"
 	retrievalSocket := operatorSocket.GetV2RetrievalSocket()
@@ -144,7 +148,12 @@ func (oh *OperatorHandler) ProbeV1OperatorPorts(ctx context.Context, operatorId 
 		return &OperatorPortCheckResponse{}, err
 	}
 
-	operatorSocket := core.OperatorSocket(operatorInfo.Socket)
+	operatorSocket, err := core.ParseOperatorSocket(operatorInfo.Socket)
+	if err != nil {
+		oh.logger.Error("failed to parse operator socket", "operatorId", operatorId, "error", err)
+		return &OperatorPortCheckResponse{}, err
+	}
+	
 	retrievalSocket := operatorSocket.GetV1RetrievalSocket()
 	retrievalPortOpen := checkIsOperatorPortOpen(retrievalSocket, 3, oh.logger)
 	retrievalOnline, retrievalStatus := false, "v1 retrieval port closed or unreachable"

--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -198,7 +198,11 @@ func checkIsOnlineAndProcessOperator(operatorStatus OperatorOnlineStatus, operat
 	var isOnline bool
 	var socket string
 	if operatorStatus.IndexedOperatorInfo != nil {
-		socket = core.OperatorSocket(operatorStatus.IndexedOperatorInfo.Socket).GetV1RetrievalSocket()
+		operatorSocket, err := core.ParseOperatorSocket(operatorStatus.IndexedOperatorInfo.Socket)
+		if err != nil {
+			logger.Error("Failed to parse operator socket", "err", err)
+		}
+		socket = operatorSocket.GetV1RetrievalSocket()
 		isOnline = checkIsOperatorPortOpen(socket, 10, logger)
 	}
 

--- a/inabox/deploy/deploy.go
+++ b/inabox/deploy/deploy.go
@@ -362,7 +362,7 @@ func (env *Config) StopAnvil() {
 func (env *Config) RunNodePluginBinary(operation string, operator OperatorVars) {
 	changeDirectory(filepath.Join(env.rootPath, "inabox"))
 
-	socket := string(core.MakeOperatorSocket(operator.NODE_HOSTNAME, operator.NODE_DISPERSAL_PORT, operator.NODE_RETRIEVAL_PORT, operator.NODE_V2_DISPERSAL_PORT, operator.NODE_V2_RETRIEVAL_PORT))
+	socket := core.NewOperatorSocket(operator.NODE_HOSTNAME, operator.NODE_DISPERSAL_PORT, operator.NODE_RETRIEVAL_PORT, operator.NODE_V2_DISPERSAL_PORT, operator.NODE_V2_RETRIEVAL_PORT)
 
 	envVars := []string{
 		"NODE_OPERATION=" + operation,
@@ -370,7 +370,7 @@ func (env *Config) RunNodePluginBinary(operation string, operator OperatorVars) 
 		"NODE_BLS_KEY_FILE=" + operator.NODE_BLS_KEY_FILE,
 		"NODE_ECDSA_KEY_PASSWORD=" + operator.NODE_ECDSA_KEY_PASSWORD,
 		"NODE_BLS_KEY_PASSWORD=" + operator.NODE_BLS_KEY_PASSWORD,
-		"NODE_SOCKET=" + socket,
+		"NODE_SOCKET=" + socket.Encode(),
 		"NODE_QUORUM_ID_LIST=" + operator.NODE_QUORUM_ID_LIST,
 		"NODE_CHAIN_RPC=" + operator.NODE_CHAIN_RPC,
 		"NODE_BLS_OPERATOR_STATE_RETRIVER=" + operator.NODE_BLS_OPERATOR_STATE_RETRIVER,

--- a/node/node.go
+++ b/node/node.go
@@ -302,7 +302,7 @@ func (n *Node) Start(ctx context.Context) error {
 	}
 
 	// Build the socket based on the hostname/IP provided in the CLI
-	socket := string(core.MakeOperatorSocket(n.Config.Hostname, n.Config.DispersalPort, n.Config.RetrievalPort, n.Config.V2DispersalPort, n.Config.V2RetrievalPort))
+	socket := core.NewOperatorSocket(n.Config.Hostname, n.Config.DispersalPort, n.Config.RetrievalPort, n.Config.V2DispersalPort, n.Config.V2RetrievalPort)
 	var operator *Operator
 	if n.Config.RegisterNodeAtStart {
 		n.Logger.Info("Registering node on chain with the following parameters:", "operatorId",
@@ -314,7 +314,7 @@ func (n *Node) Start(ctx context.Context) error {
 		}
 		operator = &Operator{
 			Address:             crypto.PubkeyToAddress(privateKey.PublicKey).Hex(),
-			Socket:              socket,
+			Socket:              socket.Encode(),
 			Timeout:             10 * time.Second,
 			PrivKey:             privateKey,
 			Signer:              n.BLSSigner,
@@ -333,7 +333,7 @@ func (n *Node) Start(ctx context.Context) error {
 		if err != nil {
 			n.Logger.Warnf("failed to get operator socket: %w", err)
 		}
-		if registeredSocket != socket {
+		if registeredSocket != socket.Encode() {
 			n.Logger.Warnf("registered socket %s does not match expected socket %s", registeredSocket, socket)
 		}
 
@@ -355,7 +355,7 @@ func (n *Node) Start(ctx context.Context) error {
 		}
 	}
 
-	n.CurrentSocket = socket
+	n.CurrentSocket = socket.Encode()
 	// Start the Node IP updater only if the PUBLIC_IP_PROVIDER is greater than 0.
 	if n.Config.PubIPCheckInterval > 0 && n.Config.EnableV1 && n.Config.EnableV2 {
 		go n.checkRegisteredNodeIpOnChain(ctx)

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"net"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
@@ -135,9 +136,33 @@ func pluginOps(ctx *cli.Context) {
 		return
 	}
 
-	_, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort, err := core.ParseOperatorSocket(config.Socket)
+	opSocket, err := core.ParseOperatorSocket(config.Socket)
 	if err != nil {
 		log.Printf("Error: failed to parse operator socket: %v", err)
+		return
+	}
+
+	_, dispersalPort, err := net.SplitHostPort(opSocket.GetV1DispersalSocket())
+	if err != nil {
+		log.Printf("Error: failed to get dispersal port from the socket: %s, err: %s", opSocket.Encode(), err)
+		return
+	}
+
+	_, retrievalPort, err := net.SplitHostPort(opSocket.GetV1RetrievalSocket())
+	if err != nil {
+		log.Printf("Error: failed to get retrieval port from the socket: %s, err: %s", opSocket.Encode(), err)
+		return
+	}
+
+	_, v2DispersalPort, err := net.SplitHostPort(opSocket.GetV2DispersalSocket())
+	if err != nil {
+		log.Printf("Error: failed to get v2 dispersal port from the socket: %s, err: %s", opSocket.Encode(), err)
+		return
+	}
+
+	_, v2RetrievalPort, err := net.SplitHostPort(opSocket.GetV2RetrievalSocket())
+	if err != nil {
+		log.Printf("Error: failed to get v2 retrieval port from the socket: %s, err: %s", opSocket.Encode(), err)
 		return
 	}
 

--- a/node/utils.go
+++ b/node/utils.go
@@ -126,8 +126,8 @@ func SocketAddress(ctx context.Context, provider pubip.Provider, dispersalPort, 
 	if err != nil {
 		return "", fmt.Errorf("failed to get public ip address from IP provider: %w", err)
 	}
-	socket := core.MakeOperatorSocket(ip, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
-	return socket.String(), nil
+	socket := core.NewOperatorSocket(ip, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
+	return socket.Encode(), nil
 }
 
 func GetBundleEncodingFormat(blob *pb.Blob) core.BundleEncodingFormat {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -387,8 +387,8 @@ func mustMakeOperators(t *testing.T, cst *coremock.ChainDataMock, logger logging
 		tx.On("GetBlockStaleMeasure").Return(nil)
 		tx.On("GetStoreDurationBlocks").Return(nil)
 		tx.On("OperatorIDToAddress").Return(gethcommon.Address{1}, nil)
-		socket := core.MakeOperatorSocket(config.Hostname, config.DispersalPort, config.RetrievalPort, config.V2DispersalPort, config.V2RetrievalPort)
-		tx.On("GetOperatorSocket", mock.Anything, mock.Anything).Return(socket.String(), nil)
+		socket := core.NewOperatorSocket(config.Hostname, config.DispersalPort, config.RetrievalPort, config.V2DispersalPort, config.V2RetrievalPort)
+		tx.On("GetOperatorSocket", mock.Anything, mock.Anything).Return(socket.Encode(), nil)
 
 		noopMetrics := metrics.NewNoopMetrics()
 		reg := prometheus.NewRegistry()


### PR DESCRIPTION
Changes:
	Defines a concrete type OperatorSocket
	Internal state is unexported to prevent unintented changes from the importing package.
	Defines Get functions to access methods

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
