### PR TITLE
Improve perf of blob retrieval within bucket

### DIFF
--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -291,30 +291,33 @@ func (s *BlobMetadataStore) GetBlobMetadataByStatus(ctx context.Context, status 
 	return metadata, nil
 }
 
-// queryBucketBlobMetadata returns blobs (as metadata) within range [startKey, endKey] from a single bucket.
+// queryBucketBlobMetadata appends blobs (as metadata) within range (startKey, endKey) from a single bucket to the provided result slice.
 // Results are ordered by <RequestedAt, Bobkey> in ascending order.
 //
 // The function handles DynamoDB's 1MB response size limitation by performing multiple queries if necessary.
+// It filters out blobs at the exact startKey and endKey as they are exclusive bounds.
 func (s *BlobMetadataStore) queryBucketBlobMetadata(
 	ctx context.Context,
 	bucket uint64,
+	ascending bool,
+	after BlobFeedCursor,
+	before BlobFeedCursor,
 	startKey string,
 	endKey string,
-	ascending bool,
+	limit int,
+	result []*v2.BlobMetadata,
+	lastProcessedCursor **BlobFeedCursor,
 ) ([]*v2.BlobMetadata, error) {
-	metadata := make([]*v2.BlobMetadata, 0)
 	var lastEvaledKey map[string]types.AttributeValue
-
 	for {
 		start := startKey
 		if lastEvaledKey != nil {
 			requestedAtBlobkey, err := UnmarshalRequestedAtBlobKey(lastEvaledKey)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse the RequestedAtBlobkey from the LastEvaluatedKey: %w", err)
+				return result, fmt.Errorf("failed to parse the RequestedAtBlobkey from the LastEvaluatedKey: %w", err)
 			}
 			start = requestedAtBlobkey
 		}
-
 		res, err := s.dynamoDBClient.QueryIndexWithPagination(
 			ctx,
 			s.tableName,
@@ -330,16 +333,40 @@ func (s *BlobMetadataStore) queryBucketBlobMetadata(
 			ascending,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("query failed for bucket %d: %w", bucket, err)
+			return result, fmt.Errorf("query failed for bucket %d: %w", bucket, err)
 		}
 
 		// Collect results
 		for _, item := range res.Items {
 			bm, err := UnmarshalBlobMetadata(item)
 			if err != nil {
-				return nil, fmt.Errorf("failed to unmarshal blob metadata: %w", err)
+				return result, fmt.Errorf("failed to unmarshal blob metadata: %w", err)
 			}
-			metadata = append(metadata, bm)
+
+			// Get blob key for filtering
+			blobKey, err := bm.BlobHeader.BlobKey()
+			if err != nil {
+				return result, fmt.Errorf("failed to get blob key: %w", err)
+			}
+
+			// Skip blobs at the endpoints (exclusive bounds)
+			if after.Equal(bm.RequestedAt, &blobKey) || before.Equal(bm.RequestedAt, &blobKey) {
+				continue
+			}
+
+			// Add to result
+			result = append(result, bm)
+
+			// Update last processed cursor
+			*lastProcessedCursor = &BlobFeedCursor{
+				RequestedAt: bm.RequestedAt,
+				BlobKey:     &blobKey,
+			}
+
+			// Check limit
+			if limit > 0 && len(result) >= limit {
+				return result, nil
+			}
 		}
 
 		// Exhausted all items already
@@ -350,7 +377,7 @@ func (s *BlobMetadataStore) queryBucketBlobMetadata(
 		lastEvaledKey = res.LastEvaluatedKey
 	}
 
-	return metadata, nil
+	return result, nil
 }
 
 // GetBlobMetadataByRequestedAtForward returns blobs (as BlobMetadata) in cursor range
@@ -368,6 +395,7 @@ func (s *BlobMetadataStore) GetBlobMetadataByRequestedAtForward(
 	if !after.LessThan(&before) {
 		return nil, nil, errors.New("after cursor must be less than before cursor")
 	}
+
 	startBucket, endBucket := GetRequestedAtBucketIDRange(after.RequestedAt, before.RequestedAt)
 	startKey := after.ToCursorKey()
 	endKey := before.ToCursorKey()
@@ -378,30 +406,21 @@ func (s *BlobMetadataStore) GetBlobMetadataByRequestedAtForward(
 		if limit > 0 && len(result) >= limit {
 			break
 		}
-		bucketMetadata, err := s.queryBucketBlobMetadata(ctx, bucket, startKey, endKey, true)
+
+		// Pass the result slice to be modified in-place along with cursors for filtering
+		var err error
+		result, err = s.queryBucketBlobMetadata(
+			ctx, bucket, true, after, before, startKey, endKey, limit, result, &lastProcessedCursor,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
-		// Process bucket results
-		for _, bm := range bucketMetadata {
-			blobKey, err := bm.BlobHeader.BlobKey()
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get blob key: %w", err)
-			}
-			// Skip blobs at the endpoints
-			if after.Equal(bm.RequestedAt, &blobKey) || before.Equal(bm.RequestedAt, &blobKey) {
-				continue
-			}
-			result = append(result, bm)
-			lastProcessedCursor = &BlobFeedCursor{
-				RequestedAt: bm.RequestedAt,
-				BlobKey:     &blobKey,
-			}
-			if limit > 0 && len(result) >= limit {
-				break
-			}
+
+		if limit > 0 && len(result) >= limit {
+			break
 		}
 	}
+
 	return result, lastProcessedCursor, nil
 }
 
@@ -420,6 +439,7 @@ func (s *BlobMetadataStore) GetBlobMetadataByRequestedAtBackward(
 	if !after.LessThan(&before) {
 		return nil, nil, errors.New("after cursor must be less than before cursor")
 	}
+
 	startBucket, endBucket := GetRequestedAtBucketIDRange(after.RequestedAt, before.RequestedAt)
 	startKey := after.ToCursorKey()
 	endKey := before.ToCursorKey()
@@ -431,28 +451,18 @@ func (s *BlobMetadataStore) GetBlobMetadataByRequestedAtBackward(
 		if limit > 0 && len(result) >= limit {
 			break
 		}
-		bucketMetadata, err := s.queryBucketBlobMetadata(ctx, bucket, startKey, endKey, false)
+
+		// Pass the result slice to be modified in-place along with cursors for filtering
+		var err error
+		result, err = s.queryBucketBlobMetadata(
+			ctx, bucket, false, after, before, startKey, endKey, limit, result, &lastProcessedCursor,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
-		// Process bucket results
-		for _, bm := range bucketMetadata {
-			blobKey, err := bm.BlobHeader.BlobKey()
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get blob key: %w", err)
-			}
-			// Skip blobs at the endpoints
-			if before.Equal(bm.RequestedAt, &blobKey) || after.Equal(bm.RequestedAt, &blobKey) {
-				continue
-			}
-			result = append(result, bm)
-			lastProcessedCursor = &BlobFeedCursor{
-				RequestedAt: bm.RequestedAt,
-				BlobKey:     &blobKey,
-			}
-			if limit > 0 && len(result) >= limit {
-				break
-			}
+
+		if limit > 0 && len(result) >= limit {
+			break
 		}
 	}
 	return result, lastProcessedCursor, nil

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -403,10 +403,6 @@ func (s *BlobMetadataStore) GetBlobMetadataByRequestedAtForward(
 	var lastProcessedCursor *BlobFeedCursor
 
 	for bucket := startBucket; bucket <= endBucket; bucket++ {
-		if limit > 0 && len(result) >= limit {
-			break
-		}
-
 		// Pass the result slice to be modified in-place along with cursors for filtering
 		var err error
 		result, err = s.queryBucketBlobMetadata(
@@ -448,10 +444,6 @@ func (s *BlobMetadataStore) GetBlobMetadataByRequestedAtBackward(
 
 	// Traverse buckets in reverse order
 	for bucket := endBucket; bucket >= startBucket; bucket-- {
-		if limit > 0 && len(result) >= limit {
-			break
-		}
-
 		// Pass the result slice to be modified in-place along with cursors for filtering
 		var err error
 		result, err = s.queryBucketBlobMetadata(

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -606,7 +606,7 @@ func TestBlobMetadataStoreGetBlobMetadataByRequestedAtForward(t *testing.T) {
 		for i := 0; i < numBlobs; i++ {
 			metadata, lastProcessedCursor, err := blobMetadataStore.GetBlobMetadataByRequestedAtForward(ctx, startCursor, endCursor, 1)
 			require.NoError(t, err)
-			assert.Equal(t, 1, len(metadata))
+			require.Equal(t, 1, len(metadata))
 			checkBlobKeyEqual(t, keys[i], metadata[0].BlobHeader)
 			require.NotNil(t, lastProcessedCursor)
 			assert.Equal(t, keys[i], *lastProcessedCursor.BlobKey)


### PR DESCRIPTION
## Why are these changes needed?
This is perf optimization for blob feed retrieval:
- Apply `limit` to within bucket retrieval
  - e.g. if the client wants just 1 blob, it won't need to exhaust the entire bucket (which can have up to 360,000 blobs, assuming 100 blobs/ and 1h per bucket)
- Avoid allocating additional slice

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
