### PR TITLE
Fix flaky encoded payload test

### DIFF
--- a/api/clients/v2/coretypes/encoded_payload_test.go
+++ b/api/clients/v2/coretypes/encoded_payload_test.go
@@ -34,7 +34,9 @@ func TestDecodeLongBytes(t *testing.T) {
 	encodedPayload, err := newEncodedPayload(NewPayload(originalData))
 	require.NoError(t, err)
 
-	encodedPayload.bytes = append(encodedPayload.bytes, make([]byte, 32)...)
+	// appending 33 bytes to the encoded payload guarantees that, after removing padding, the unpadded bytes will be
+	// at least 32 bytes longer than the expected length, which is the error case we're trying to trigger here
+	encodedPayload.bytes = append(encodedPayload.bytes, make([]byte, 33)...)
 	payload2, err := encodedPayload.decode()
 	require.Error(t, err)
 	require.Nil(t, payload2)


### PR DESCRIPTION
## Why are these changes needed?

- The old test logic only added 32 bytes to the encoded payload bytes, which means that in some cases, the resulting unpadded bytes are only 31 bytes longer than expected, which is within the tolerable range
- To guarantee that the unpadded bytes are not in the tolerable range, and thus trigger the error being tested, we must append 33 bytes to the encoded payload, which guarantees that the unpadded bytes will be at least 32 bytes larger than expected, and guaranteeing that the failure case is triggered

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
