### PR TITLE
Calculate charge at the payment

### DIFF
--- a/core/meterer/meterer.go
+++ b/core/meterer/meterer.go
@@ -214,14 +214,20 @@ func (m *Meterer) ServeOnDemandRequest(ctx context.Context, header core.PaymentM
 		return fmt.Errorf("invalid quorum for On-Demand Request: %w", err)
 	}
 
+	// Compute charge at payment time
+	charge := new(big.Int).Mul(big.NewInt(int64(symbolsCharged)), big.NewInt(int64(m.ChainPaymentState.GetPricePerSymbol())))
+	if charge.Cmp(big.NewInt(0)) <= 0 {
+		return fmt.Errorf("invalid charge value: must be positive, got %s", charge.String())
+	}
+
 	// Validate payments attached
-	err = m.ValidatePayment(ctx, header, onDemandPayment, symbolsCharged)
+	err = m.ValidatePayment(ctx, header, onDemandPayment, charge)
 	if err != nil {
 		// No tolerance for incorrect payment amounts; no rollbacks
 		return fmt.Errorf("invalid on-demand payment: %w", err)
 	}
 
-	err = m.OffchainStore.AddOnDemandPayment(ctx, header, symbolsCharged)
+	err = m.OffchainStore.AddOnDemandPayment(ctx, header, charge)
 	if err != nil {
 		return fmt.Errorf("failed to update cumulative payment: %w", err)
 	}
@@ -242,37 +248,28 @@ func (m *Meterer) ServeOnDemandRequest(ctx context.Context, header core.PaymentM
 // ValidatePayment checks if the provided payment header is valid against the local accounting
 // prevPmt is the largest  cumulative payment strictly less    than PaymentMetadata.cumulativePayment if exists
 // nextPmt is the smallest cumulative payment strictly greater than PaymentMetadata.cumulativePayment if exists
-// nextPmtnumSymbols is the numSymbols of corresponding to nextPmt if exists
-// prevPmt + PaymentMetadata.numSymbols * m.FixedFeePerByte
-// <= PaymentMetadata.CumulativePayment
-// <= nextPmt - nextPmtnumSymbols * m.FixedFeePerByte > nextPmt
-func (m *Meterer) ValidatePayment(ctx context.Context, header core.PaymentMetadata, onDemandPayment *core.OnDemandPayment, symbolsCharged uint32) error {
+// chargeOfNextPmt is the charge associated with nextPmt if exists
+// prevPmt + charge <= PaymentMetadata.CumulativePayment
+// <= nextPmt - chargeOfNextPmt > nextPmt
+func (m *Meterer) ValidatePayment(ctx context.Context, header core.PaymentMetadata, onDemandPayment *core.OnDemandPayment, charge *big.Int) error {
 	if header.CumulativePayment.Cmp(onDemandPayment.CumulativePayment) > 0 {
 		return fmt.Errorf("request claims a cumulative payment greater than the on-chain deposit")
 	}
 
-	prevPmt, nextPmt, nextPmtnumSymbols, err := m.OffchainStore.GetRelevantOnDemandRecords(ctx, header.AccountID, header.CumulativePayment) // zero if DNE
+	prevPmt, nextPmt, chargeOfNextPmt, err := m.OffchainStore.GetRelevantOnDemandRecords(ctx, header.AccountID, header.CumulativePayment) // zero if DNE
 	if err != nil {
 		return fmt.Errorf("failed to get relevant on-demand records: %w", err)
 	}
 	// the current request must increment cumulative payment by a magnitude sufficient to cover the blob size
-	if new(big.Int).Add(prevPmt, m.PaymentCharged(uint(symbolsCharged))).Cmp(header.CumulativePayment) > 0 {
+	if new(big.Int).Add(prevPmt, charge).Cmp(header.CumulativePayment) > 0 {
 		return fmt.Errorf("insufficient cumulative payment increment")
 	}
 	// the current request must not break the payment magnitude for the next payment if the two requests were delivered out-of-order
-	if nextPmt.Cmp(big.NewInt(0)) != 0 && new(big.Int).Add(header.CumulativePayment, m.PaymentCharged(uint(nextPmtnumSymbols))).Cmp(nextPmt) > 0 {
+	if nextPmt.Cmp(big.NewInt(0)) != 0 && new(big.Int).Add(header.CumulativePayment, chargeOfNextPmt).Cmp(nextPmt) > 0 {
 		return fmt.Errorf("breaking cumulative payment invariants")
 	}
 	// check passed: blob can be safely inserted into the set of payments
 	return nil
-}
-
-// PaymentCharged returns the chargeable price for a given data length
-func (m *Meterer) PaymentCharged(numSymbols uint) *big.Int {
-	// symbolsCharged == m.SymbolsCharged(numSymbols) if numSymbols is already a multiple of MinNumSymbols
-	symbolsCharged := big.NewInt(int64(m.SymbolsCharged(numSymbols)))
-	pricePerSymbol := big.NewInt(int64(m.ChainPaymentState.GetPricePerSymbol()))
-	return symbolsCharged.Mul(symbolsCharged, pricePerSymbol)
 }
 
 // SymbolsCharged returns the number of symbols charged for a given data length

--- a/core/meterer/meterer_test.go
+++ b/core/meterer/meterer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
 	testifymock "github.com/stretchr/testify/mock"
 )

--- a/core/meterer/offchain_store.go
+++ b/core/meterer/offchain_store.go
@@ -121,7 +121,7 @@ func (s *OffchainStore) UpdateGlobalBin(ctx context.Context, reservationPeriod u
 	return binUsageValue, nil
 }
 
-func (s *OffchainStore) AddOnDemandPayment(ctx context.Context, paymentMetadata core.PaymentMetadata, symbolsCharged uint32) error {
+func (s *OffchainStore) AddOnDemandPayment(ctx context.Context, paymentMetadata core.PaymentMetadata, charge *big.Int) error {
 	result, err := s.dynamoClient.GetItem(ctx, s.onDemandTableName,
 		commondynamodb.Item{
 			"AccountID":          &types.AttributeValueMemberS{Value: paymentMetadata.AccountID},
@@ -138,7 +138,7 @@ func (s *OffchainStore) AddOnDemandPayment(ctx context.Context, paymentMetadata 
 		commondynamodb.Item{
 			"AccountID":          &types.AttributeValueMemberS{Value: paymentMetadata.AccountID},
 			"CumulativePayments": &types.AttributeValueMemberN{Value: paymentMetadata.CumulativePayment.String()},
-			"DataLength":         &types.AttributeValueMemberN{Value: strconv.FormatUint(uint64(symbolsCharged), 10)},
+			"Charge":             &types.AttributeValueMemberN{Value: charge.String()},
 		},
 	)
 
@@ -164,9 +164,9 @@ func (s *OffchainStore) RemoveOnDemandPayment(ctx context.Context, accountID str
 	return nil
 }
 
-// GetRelevantOnDemandRecords gets previous cumulative payment, next cumulative payment, blob size of next payment
+// GetRelevantOnDemandRecords gets previous cumulative payment, next cumulative payment, and charge
 // The queries are done sequentially instead of one-go for efficient querying and would not cause race condition errors for honest requests
-func (s *OffchainStore) GetRelevantOnDemandRecords(ctx context.Context, accountID string, cumulativePayment *big.Int) (*big.Int, *big.Int, uint32, error) {
+func (s *OffchainStore) GetRelevantOnDemandRecords(ctx context.Context, accountID string, cumulativePayment *big.Int) (*big.Int, *big.Int, *big.Int, error) {
 	// Fetch the largest entry smaller than the given cumulativePayment
 	queryInput := &dynamodb.QueryInput{
 		TableName:              aws.String(s.onDemandTableName),
@@ -180,21 +180,21 @@ func (s *OffchainStore) GetRelevantOnDemandRecords(ctx context.Context, accountI
 	}
 	smallerResult, err := s.dynamoClient.QueryWithInput(ctx, queryInput)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to query smaller payments for account: %w", err)
+		return nil, nil, big.NewInt(0), fmt.Errorf("failed to query smaller payments for account: %w", err)
 	}
 	prevPayment := big.NewInt(0)
 	if len(smallerResult) > 0 {
 		cumulativePaymentsAttr, ok := smallerResult[0]["CumulativePayments"]
 		if !ok {
-			return nil, nil, 0, fmt.Errorf("CumulativePayments field not found in result")
+			return nil, nil, big.NewInt(0), fmt.Errorf("CumulativePayments field not found in result")
 		}
 		cumulativePaymentsNum, ok := cumulativePaymentsAttr.(*types.AttributeValueMemberN)
 		if !ok {
-			return nil, nil, 0, fmt.Errorf("CumulativePayments has invalid type")
+			return nil, nil, big.NewInt(0), fmt.Errorf("CumulativePayments has invalid type")
 		}
 		setPrevPayment, success := prevPayment.SetString(cumulativePaymentsNum.Value, 10)
 		if !success {
-			return nil, nil, 0, fmt.Errorf("failed to parse previous payment: %w", err)
+			return nil, nil, big.NewInt(0), fmt.Errorf("failed to parse previous payment: %w", err)
 		}
 		prevPayment = setPrevPayment
 	}
@@ -212,41 +212,39 @@ func (s *OffchainStore) GetRelevantOnDemandRecords(ctx context.Context, accountI
 	}
 	largerResult, err := s.dynamoClient.QueryWithInput(ctx, queryInput)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to query the next payment for account: %w", err)
+		return nil, nil, big.NewInt(0), fmt.Errorf("failed to query the next payment for account: %w", err)
 	}
 	nextPayment := big.NewInt(0)
-	nextDataLength := uint32(0)
+	charge := big.NewInt(0)
 	if len(largerResult) > 0 {
 		cumulativePaymentsAttr, ok := largerResult[0]["CumulativePayments"]
 		if !ok {
-			return nil, nil, 0, fmt.Errorf("CumulativePayments field not found in result")
+			return nil, nil, big.NewInt(0), fmt.Errorf("CumulativePayments field not found in result")
 		}
 		cumulativePaymentsNum, ok := cumulativePaymentsAttr.(*types.AttributeValueMemberN)
 		if !ok {
-			return nil, nil, 0, fmt.Errorf("CumulativePayments has invalid type")
+			return nil, nil, big.NewInt(0), fmt.Errorf("CumulativePayments has invalid type")
 		}
 		setNextPayment, success := nextPayment.SetString(cumulativePaymentsNum.Value, 10)
 		if !success {
-			return nil, nil, 0, fmt.Errorf("failed to parse previous payment: %w", err)
+			return nil, nil, big.NewInt(0), fmt.Errorf("failed to parse previous payment: %w", err)
 		}
 		nextPayment = setNextPayment
 
-		dataLengthAttr, ok := largerResult[0]["DataLength"]
+		chargeAttr, ok := largerResult[0]["Charge"]
 		if !ok {
-			return nil, nil, 0, fmt.Errorf("DataLength field not found in result")
+			return nil, nil, big.NewInt(0), fmt.Errorf("Charge field not found in result")
 		}
-		dataLengthNum, ok := dataLengthAttr.(*types.AttributeValueMemberN)
+		chargeNum, ok := chargeAttr.(*types.AttributeValueMemberN)
 		if !ok {
-			return nil, nil, 0, fmt.Errorf("DataLength has invalid type")
+			return nil, nil, big.NewInt(0), fmt.Errorf("Charge has invalid type")
 		}
-		dataLength, err := strconv.ParseUint(dataLengthNum.Value, 10, 32)
-		if err != nil {
-			return nil, nil, 0, fmt.Errorf("failed to parse data length: %w", err)
+		if _, success := charge.SetString(chargeNum.Value, 10); !success {
+			return nil, nil, big.NewInt(0), fmt.Errorf("failed to parse charge value: %w", err)
 		}
-		nextDataLength = uint32(dataLength)
 	}
 
-	return prevPayment, nextPayment, nextDataLength, nil
+	return prevPayment, nextPayment, charge, nil
 }
 
 func (s *OffchainStore) GetPeriodRecords(ctx context.Context, accountID string, reservationPeriod uint32) ([MinNumBins]*pb.PeriodRecord, error) {

--- a/core/meterer/offchain_store_test.go
+++ b/core/meterer/offchain_store_test.go
@@ -1,6 +1,7 @@
 package meterer_test
 
 import (
+	"big"
 	"context"
 	"fmt"
 	"strconv"
@@ -178,11 +179,13 @@ func TestOnDemandUsageBasicOperations(t *testing.T) {
 
 	ctx := context.Background()
 
+	charge := big.NewInt(2000)
+
 	err = dynamoClient.PutItem(ctx, tableName,
 		commondynamodb.Item{
 			"AccountID":          &types.AttributeValueMemberS{Value: "account1"},
 			"CumulativePayments": &types.AttributeValueMemberN{Value: "1"},
-			"DataLength":         &types.AttributeValueMemberN{Value: "1000"},
+			"Charge":             &types.AttributeValueMemberN{Value: charge.String()},
 		},
 	)
 	assert.NoError(t, err)
@@ -191,10 +194,11 @@ func TestOnDemandUsageBasicOperations(t *testing.T) {
 	repetitions := 5
 	items := make([]commondynamodb.Item, numItems)
 	for i := 0; i < numItems; i += 1 {
+		chargeValue := big.NewInt(int64(i * 1000))
 		items[i] = commondynamodb.Item{
 			"AccountID":          &types.AttributeValueMemberS{Value: fmt.Sprintf("account%d", i%repetitions)},
 			"CumulativePayments": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", i)},
-			"DataLength":         &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", i*1000)},
+			"Charge":             &types.AttributeValueMemberN{Value: chargeValue.String()},
 		}
 	}
 	unprocessed, err := dynamoClient.PutItems(ctx, tableName, items)
@@ -208,7 +212,7 @@ func TestOnDemandUsageBasicOperations(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "1", item["CumulativePayments"].(*types.AttributeValueMemberN).Value)
-	assert.Equal(t, "1000", item["DataLength"].(*types.AttributeValueMemberN).Value)
+	assert.Equal(t, charge.String(), item["Charge"].(*types.AttributeValueMemberN).Value)
 
 	queryResult, err := dynamoClient.Query(ctx, tableName, "AccountID = :account", commondynamodb.ExpressionValues{
 		":account": &types.AttributeValueMemberS{
@@ -218,7 +222,8 @@ func TestOnDemandUsageBasicOperations(t *testing.T) {
 	assert.Len(t, queryResult, numItems/repetitions)
 	for _, item := range queryResult {
 		cumulativePayments, _ := strconv.Atoi(item["CumulativePayments"].(*types.AttributeValueMemberN).Value)
-		assert.Equal(t, fmt.Sprintf("%d", cumulativePayments*1000), item["DataLength"].(*types.AttributeValueMemberN).Value)
+		expectedCharge := fmt.Sprintf("%d", cumulativePayments*1000)
+		assert.Equal(t, expectedCharge, item["Charge"].(*types.AttributeValueMemberN).Value)
 	}
 	queryResult, err = dynamoClient.Query(ctx, tableName, "AccountID = :account_id", commondynamodb.ExpressionValues{
 		":account_id": &types.AttributeValueMemberS{
@@ -227,6 +232,7 @@ func TestOnDemandUsageBasicOperations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, queryResult, 0)
 
+	newCharge := big.NewInt(5000)
 	updatedItem, err := dynamoClient.UpdateItem(ctx, tableName, commondynamodb.Key{
 		"AccountID":          &types.AttributeValueMemberS{Value: "account1"},
 		"CumulativePayments": &types.AttributeValueMemberN{Value: "1"},
@@ -234,15 +240,15 @@ func TestOnDemandUsageBasicOperations(t *testing.T) {
 	}, commondynamodb.Item{
 		"AccountID":          &types.AttributeValueMemberS{Value: "account1"},
 		"CumulativePayments": &types.AttributeValueMemberN{Value: "3"},
-		"DataLength":         &types.AttributeValueMemberN{Value: "3000"},
+		"Charge":             &types.AttributeValueMemberN{Value: newCharge.String()},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "3000", updatedItem["DataLength"].(*types.AttributeValueMemberN).Value)
+	assert.Equal(t, newCharge.String(), updatedItem["Charge"].(*types.AttributeValueMemberN).Value)
 
 	item, err = dynamoClient.GetItem(ctx, tableName, commondynamodb.Key{
 		"AccountID":          &types.AttributeValueMemberS{Value: "account1"},
 		"CumulativePayments": &types.AttributeValueMemberN{Value: "1"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "3000", item["DataLength"].(*types.AttributeValueMemberN).Value)
+	assert.Equal(t, newCharge.String(), item["Charge"].(*types.AttributeValueMemberN).Value)
 }

--- a/core/meterer/util.go
+++ b/core/meterer/util.go
@@ -96,6 +96,10 @@ func CreateOnDemandTable(clientConfig commonaws.ClientConfig, tableName string) 
 				AttributeName: aws.String("CumulativePayments"),
 				AttributeType: types.ScalarAttributeTypeN,
 			},
+			{
+				AttributeName: aws.String("Charge"),
+				AttributeType: types.ScalarAttributeTypeN,
+			},
 		},
 		KeySchema: []types.KeySchemaElement{
 			{


### PR DESCRIPTION
## Why are these changes needed?

- Calculate the charge at the time of payment and replace dataLength with the computed charge, storing it in DynamoDB.
- Resolves the issue where updates to pricePerSymbol would otherwise impact existing payments.
- Linear: EGDA-990

## Checks

- [✔] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [✔] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [✔] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
