### PR TITLE
Make sure each relay `GetChunks` request is either by index or by range

### DIFF
--- a/api/clients/v2/relay_client.go
+++ b/api/clients/v2/relay_client.go
@@ -130,7 +130,6 @@ func (c *relayClient) signGetChunksRequest(ctx context.Context, request *relaygr
 	if err != nil {
 		return fmt.Errorf("failed to hash get chunks request: %v", err)
 	}
-
 	hashArray := [32]byte{}
 	copy(hashArray[:], hash)
 	signature, err := c.config.MessageSigner(ctx, hashArray)

--- a/api/hashing/relay_hashing.go
+++ b/api/hashing/relay_hashing.go
@@ -32,23 +32,23 @@ func HashGetChunksRequest(request *pb.GetChunksRequest) ([]byte, error) {
 		if chunkRequest.GetByIndex() != nil {
 			getByIndex := chunkRequest.GetByIndex()
 			hashChar(hasher, 'i')
-			err = hashByteArray(hasher, getByIndex.BlobKey)
+			err = hashByteArray(hasher, getByIndex.GetBlobKey())
 			if err != nil {
 				return nil, fmt.Errorf("failed to hash blob key: %w", err)
 			}
-			err = hashUint32Array(hasher, getByIndex.ChunkIndices)
+			err = hashUint32Array(hasher, getByIndex.GetChunkIndices())
 			if err != nil {
 				return nil, fmt.Errorf("failed to hash ChunkIndices: %w", err)
 			}
-		} else {
+		} else if chunkRequest.GetByRange() != nil {
 			getByRange := chunkRequest.GetByRange()
 			hashChar(hasher, 'r')
-			err = hashByteArray(hasher, getByRange.BlobKey)
+			err = hashByteArray(hasher, getByRange.GetBlobKey())
 			if err != nil {
 				return nil, fmt.Errorf("failed to hash blob key: %w", err)
 			}
-			hashUint32(hasher, getByRange.StartIndex)
-			hashUint32(hasher, getByRange.EndIndex)
+			hashUint32(hasher, getByRange.GetStartIndex())
+			hashUint32(hasher, getByRange.GetEndIndex())
 		}
 	}
 

--- a/relay/auth/request_signing.go
+++ b/relay/auth/request_signing.go
@@ -13,11 +13,7 @@ import (
 func SignGetChunksRequest(keys *core.KeyPair, request *pb.GetChunksRequest) ([]byte, error) {
 	hash, err := hashing.HashGetChunksRequest(request)
 	if err != nil {
-<<<<<<< HEAD
 		return nil, fmt.Errorf("failed to hash request: %w", err)
-=======
-		return nil, err
->>>>>>> add46e5a (make sure each getchunks request is either by index or by range)
 	}
 	signature := keys.SignMessage(([32]byte)(hash))
 	return signature.G1Point.Serialize(), nil

--- a/relay/auth/request_signing.go
+++ b/relay/auth/request_signing.go
@@ -13,7 +13,11 @@ import (
 func SignGetChunksRequest(keys *core.KeyPair, request *pb.GetChunksRequest) ([]byte, error) {
 	hash, err := hashing.HashGetChunksRequest(request)
 	if err != nil {
+<<<<<<< HEAD
 		return nil, fmt.Errorf("failed to hash request: %w", err)
+=======
+		return nil, err
+>>>>>>> add46e5a (make sure each getchunks request is either by index or by range)
 	}
 	signature := keys.SignMessage(([32]byte)(hash))
 	return signature.G1Point.Serialize(), nil

--- a/relay/server.go
+++ b/relay/server.go
@@ -215,9 +215,6 @@ func (s *Server) validateGetChunksRequest(request *pb.GetChunksRequest) error {
 	if request == nil {
 		return api.NewErrorInvalidArg("request is nil")
 	}
-	if len(request.OperatorId) == 0 {
-		return api.NewErrorInvalidArg("operator ID is empty")
-	}
 	if len(request.ChunkRequests) == 0 {
 		return api.NewErrorInvalidArg("no chunk requests provided")
 	}


### PR DESCRIPTION
## Why are these changes needed?
With protobuf's `oneof` field, it's possible neither `ByIndex` or `ByRange` is set. This PR adds a validation to ensure either field is set. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
