### PR TITLE
fix: Use Protobuf Getters in Hasher

### DIFF
--- a/api/hashing/node_hashing.go
+++ b/api/hashing/node_hashing.go
@@ -15,46 +15,46 @@ import (
 func HashStoreChunksRequest(request *grpc.StoreChunksRequest) []byte {
 	hasher := sha3.NewLegacyKeccak256()
 
-	hashBatchHeader(hasher, request.Batch.Header)
-	for _, blobCertificate := range request.Batch.BlobCertificates {
+	hashBatchHeader(hasher, request.GetBatch().GetHeader())
+	for _, blobCertificate := range request.GetBatch().GetBlobCertificates() {
 		hashBlobCertificate(hasher, blobCertificate)
 	}
-	hashUint32(hasher, request.DisperserID)
+	hashUint32(hasher, request.GetDisperserID())
 
 	return hasher.Sum(nil)
 }
 
 func hashBlobCertificate(hasher hash.Hash, blobCertificate *common.BlobCertificate) {
-	hashBlobHeader(hasher, blobCertificate.BlobHeader)
-	hasher.Write(blobCertificate.Signature)
-	for _, relayKey := range blobCertificate.RelayKeys {
+	hashBlobHeader(hasher, blobCertificate.GetBlobHeader())
+	hasher.Write(blobCertificate.GetSignature())
+	for _, relayKey := range blobCertificate.GetRelayKeys() {
 		hashUint32(hasher, relayKey)
 	}
 }
 
 func hashBlobHeader(hasher hash.Hash, header *common.BlobHeader) {
-	hashUint32(hasher, header.Version)
-	for _, quorum := range header.QuorumNumbers {
+	hashUint32(hasher, header.GetVersion())
+	for _, quorum := range header.GetQuorumNumbers() {
 		hashUint32(hasher, quorum)
 	}
-	hashBlobCommitment(hasher, header.Commitment)
-	hashPaymentHeader(hasher, header.PaymentHeader)
+	hashBlobCommitment(hasher, header.GetCommitment())
+	hashPaymentHeader(hasher, header.GetPaymentHeader())
 }
 
 func hashBatchHeader(hasher hash.Hash, header *common.BatchHeader) {
-	hasher.Write(header.BatchRoot)
-	hashUint64(hasher, header.ReferenceBlockNumber)
+	hasher.Write(header.GetBatchRoot())
+	hashUint64(hasher, header.GetReferenceBlockNumber())
 }
 
 func hashBlobCommitment(hasher hash.Hash, commitment *commonv1.BlobCommitment) {
-	hasher.Write(commitment.Commitment)
-	hasher.Write(commitment.LengthCommitment)
-	hasher.Write(commitment.LengthProof)
-	hashUint32(hasher, commitment.Length)
+	hasher.Write(commitment.GetCommitment())
+	hasher.Write(commitment.GetLengthCommitment())
+	hasher.Write(commitment.GetLengthProof())
+	hashUint32(hasher, commitment.GetLength())
 }
 
 func hashPaymentHeader(hasher hash.Hash, header *common.PaymentHeader) {
-	hasher.Write([]byte(header.AccountId))
-	hashInt64(hasher, header.Timestamp)
-	hasher.Write(header.CumulativePayment)
+	hasher.Write([]byte(header.GetAccountId()))
+	hashInt64(hasher, header.GetTimestamp())
+	hasher.Write(header.GetCumulativePayment())
 }

--- a/node/auth/request_signing_test.go
+++ b/node/auth/request_signing_test.go
@@ -136,6 +136,12 @@ func TestHashing(t *testing.T) {
 	request.Batch.BlobCertificates[0].Signature = rand.Bytes(32)
 	hash = hashing.HashStoreChunksRequest(request)
 	require.NotEqual(t, originalRequestHash, hash)
+
+	// nil header
+	request = RandomStoreChunksRequest(rand)
+	request.Batch.Header = nil
+	hash = hashing.HashStoreChunksRequest(request)
+	require.NotEqual(t, originalRequestHash, hash)
 }
 
 func TestRequestSigning(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
Instead of directly accessing gRPC fields, use getters to guard against nil pointers 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
