### PR TITLE
Check chunk length before deserialization

### DIFF
--- a/encoding/serialization.go
+++ b/encoding/serialization.go
@@ -35,6 +35,9 @@ func (c *Frame) SerializeGnark() ([]byte, error) {
 }
 
 func (c *Frame) DeserializeGnark(data []byte) (*Frame, error) {
+	if len(data) <= bn254.SizeOfG1AffineCompressed {
+		return nil, fmt.Errorf("chunk length must be at least %d: %d given", bn254.SizeOfG1AffineCompressed, len(data))
+	}
 	var f Frame
 	buf := data
 	err := f.Proof.Unmarshal(buf[:bn254.SizeOfG1AffineCompressed])

--- a/encoding/serialization_test.go
+++ b/encoding/serialization_test.go
@@ -45,6 +45,10 @@ func TestSerDeserGnark(t *testing.T) {
 	for i := 0; i < len(f.Coeffs); i++ {
 		assert.True(t, f.Coeffs[i].Equal(&c.Coeffs[i]))
 	}
+
+	// invalid length should return error
+	_, err = new(encoding.Frame).DeserializeGnark([]byte{1, 2, 3})
+	assert.ErrorContains(t, err, "chunk length must be at least")
 }
 
 func createFrames(b *testing.B, numFrames int) []encoding.Frame {


### PR DESCRIPTION
## Why are these changes needed?
Ensure `data` length is at least `bn254.SizeOfG1AffineCompressed`. Otherwise, it could panic during unmarshaling 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
