### PR TITLE
Check multiplication overflow in `ValidateEncodingParams`

### DIFF
--- a/encoding/params.go
+++ b/encoding/params.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"golang.org/x/exp/constraints"
 )
@@ -10,8 +11,6 @@ import (
 var (
 	ErrInvalidParams = errors.New("invalid encoding params")
 )
-
-const maxUint64 = ^uint64(0)
 
 type EncodingParams struct {
 	ChunkLength uint64 // ChunkSize is the length of the chunk in symbols
@@ -63,7 +62,14 @@ func GetNumSys(dataSize uint64, chunkLen uint64) uint64 {
 
 // ValidateEncodingParams takes in the encoding parameters and returns an error if they are invalid.
 func ValidateEncodingParams(params EncodingParams, SRSOrder uint64) error {
-	if params.ChunkLength != 0 && params.NumChunks > maxUint64/params.ChunkLength {
+	if params.NumChunks == 0 {
+		return errors.New("number of chunks must be greater than 0")
+	}
+	if params.ChunkLength == 0 {
+		return errors.New("chunk length must be greater than 0")
+	}
+
+	if params.NumChunks > math.MaxUint64/params.ChunkLength {
 		return fmt.Errorf("multiplication overflow: ChunkLength: %d, NumChunks: %d", params.ChunkLength, params.NumChunks)
 	}
 

--- a/encoding/params.go
+++ b/encoding/params.go
@@ -11,6 +11,8 @@ var (
 	ErrInvalidParams = errors.New("invalid encoding params")
 )
 
+const maxUint64 = ^uint64(0)
+
 type EncodingParams struct {
 	ChunkLength uint64 // ChunkSize is the length of the chunk in symbols
 	NumChunks   uint64
@@ -61,6 +63,9 @@ func GetNumSys(dataSize uint64, chunkLen uint64) uint64 {
 
 // ValidateEncodingParams takes in the encoding parameters and returns an error if they are invalid.
 func ValidateEncodingParams(params EncodingParams, SRSOrder uint64) error {
+	if params.ChunkLength != 0 && params.NumChunks > maxUint64/params.ChunkLength {
+		return fmt.Errorf("multiplication overflow: ChunkLength: %d, NumChunks: %d", params.ChunkLength, params.NumChunks)
+	}
 
 	// Check that the parameters are valid with respect to the SRS. The precomputed terms of the amortized KZG
 	// prover use up to order params.ChunkLen*params.NumChunks-1 for the SRS, so we must have


### PR DESCRIPTION
## Why are these changes needed?
Ensure that `params.ChunkLength*params.NumChunks` doesn't result in overflow
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
