### PR TITLE
Simplify payload disperser config and construction

### DIFF
--- a/api/clients/v2/config.go
+++ b/api/clients/v2/config.go
@@ -80,9 +80,6 @@ type ValidatorPayloadRetrieverConfig struct {
 type PayloadDisperserConfig struct {
 	PayloadClientConfig
 
-	// SignerPaymentKey is the private key used for signing payment authorization headers
-	SignerPaymentKey string
-
 	// DisperseBlobTimeout is the duration after which the PayloadDisperser will time out, when trying to disperse a
 	// blob
 	DisperseBlobTimeout time.Duration


### PR DESCRIPTION
## Why are these changes needed?

- The latest iteration of proxy v2 doesn't use the builder method anymore, so that's removed
- The payload disperser private key is removed from the config struct, since it is no longer needed

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
