### PR TITLE
fix: fix incorrect nil return value

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -507,7 +507,7 @@ func (n *Node) ProcessBatch(ctx context.Context, header *core.BatchHeader, blobs
 	result := <-storeChan
 	if result.err != nil {
 		log.Error("Store batch failed", "batchHeaderHash", batchHeaderHashHex, "err", result.err)
-		return nil, err
+		return nil, result.err
 	}
 	if result.keys != nil {
 		n.Metrics.RecordStoreChunksStage("stored", batchSize, result.latency)


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Since we have already checked err before and returned != nil, err must be nil here. In fact, it should return `result.err`.


## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
