### PR TITLE
Update inabox's README.md

### DIFF
--- a/inabox/README.md
+++ b/inabox/README.md
@@ -32,6 +32,12 @@ Notice: The scripts for setting up a local geth chain are currently broken. The 
    ```
    $ npm install --global yarn
    ```
+- Install contracts
+  ```
+  cd contracts
+  yarn install
+  cd ..
+  ```
 - The Graph is installed
    ```
    $ npm install -g @graphprotocol/graph-cli@latest


### PR DESCRIPTION
Update README.md to include that contracts must be installed with yarn

## Why are these changes needed?

Running `make run-e2e` currently fails with:
```
  2025-02-28T21:51:24.744416Z ERROR foundry_compilers_artifacts_solc::sources: error="/Users/dralves/work/eigen/eigenda/contracts/node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol": No such file or directory (os error 2)

  --- std err ---
  Warning: This is a nightly build of Foundry. It is recommended to use the latest stable version. Visit https://book.getfoundry.sh/announcements for more information.
  To mute this warning set `FOUNDRY_DISABLE_NIGHTLY_WARNING` in your environment.

  Error: failed to resolve file: "/Users/dralves/work/eigen/eigenda/contracts/node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol": No such file or directory (os error 2); check configured remappings
  	--> /Users/dralves/work/eigen/eigenda/contracts/script/SetUpEigenDA.s.sol
  	@openzeppelin/contracts/token/ERC20/IERC20.sol
```
