### PR TITLE
Fix how relay/validators compute hashes.

### DIFF
--- a/api/clients/v2/dispersal_request_signer.go
+++ b/api/clients/v2/dispersal_request_signer.go
@@ -67,7 +67,10 @@ func NewDispersalRequestSigner(
 }
 
 func (s *requestSigner) SignStoreChunksRequest(ctx context.Context, request *grpc.StoreChunksRequest) ([]byte, error) {
-	hash := hashing.HashStoreChunksRequest(request)
+	hash, err := hashing.HashStoreChunksRequest(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash request: %w", err)
+	}
 
 	signature, err := aws2.SignKMS(ctx, s.keyManager, s.keyID, s.publicKey, hash)
 	if err != nil {

--- a/api/clients/v2/relay_client.go
+++ b/api/clients/v2/relay_client.go
@@ -126,7 +126,11 @@ func (c *relayClient) signGetChunksRequest(ctx context.Context, request *relaygr
 		return errors.New("no message signer provided in config, cannot sign get chunks request")
 	}
 
-	hash := hashing.HashGetChunksRequest(request)
+	hash, err := hashing.HashGetChunksRequest(request)
+	if err != nil {
+		return fmt.Errorf("failed to hash get chunks request: %v", err)
+	}
+
 	hashArray := [32]byte{}
 	copy(hashArray[:], hash)
 	signature, err := c.config.MessageSigner(ctx, hashArray)

--- a/api/docs/eigenda-protos.html
+++ b/api/docs/eigenda-protos.html
@@ -3650,9 +3650,9 @@ All integers are encoded as unsigned 4 byte big endian values.
 
 Perform a keccak256 hash on the following data in the following order:
 1. the length of the operator ID in bytes
-1. the operator id
-2. the number of chunk requests
-3. for each chunk request:
+2. the operator id
+3. the number of chunk requests
+4. for each chunk request:
    a. if the chunk request is a request by index:
       i.   a one byte ASCII representation of the character &#34;i&#34; (aka Ox69)
       ii.  the length blob key in bytes

--- a/api/docs/eigenda-protos.html
+++ b/api/docs/eigenda-protos.html
@@ -3649,15 +3649,19 @@ This algorithm is implemented in golang using relay.auth.HashGetChunksRequest().
 All integers are encoded as unsigned 4 byte big endian values.
 
 Perform a keccak256 hash on the following data in the following order:
+1. the length of the operator ID in bytes
 1. the operator id
-2. for each chunk request:
+2. the number of chunk requests
+3. for each chunk request:
    a. if the chunk request is a request by index:
       i.   a one byte ASCII representation of the character &#34;i&#34; (aka Ox69)
+      ii.  the length blob key in bytes
       ii.  the blob key
       iii. the start index
       iv.  the end index
    b. if the chunk request is a request by range:
       i.   a one byte ASCII representation of the character &#34;r&#34; (aka Ox72)
+      ii.  the length of the blob key in bytes
       ii.  the blob key
       iii. each requested chunk index, in order </p></td>
                 </tr>

--- a/api/docs/eigenda-protos.html
+++ b/api/docs/eigenda-protos.html
@@ -3656,14 +3656,14 @@ Perform a keccak256 hash on the following data in the following order:
    a. if the chunk request is a request by index:
       i.   a one byte ASCII representation of the character &#34;i&#34; (aka Ox69)
       ii.  the length blob key in bytes
-      ii.  the blob key
-      iii. the start index
-      iv.  the end index
+      iii. the blob key
+      iv.  the start index
+      v.   the end index
    b. if the chunk request is a request by range:
       i.   a one byte ASCII representation of the character &#34;r&#34; (aka Ox72)
       ii.  the length of the blob key in bytes
-      ii.  the blob key
-      iii. each requested chunk index, in order </p></td>
+      iii. the blob key
+      iv.  each requested chunk index, in order </p></td>
                 </tr>
               
             </tbody>

--- a/api/docs/eigenda-protos.md
+++ b/api/docs/eigenda-protos.md
@@ -1532,7 +1532,7 @@ The following describes the schema for computing the hash of this request This a
 
 All integers are encoded as unsigned 4 byte big endian values.
 
-Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 1. the operator id 2. the number of chunk requests 3. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes iii. the blob key iv. the start index v. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes iii. the blob key iv. each requested chunk index, in order |
+Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 2. the operator id 3. the number of chunk requests 4. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes iii. the blob key iv. the start index v. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes iii. the blob key iv. each requested chunk index, in order |
 
 
 

--- a/api/docs/eigenda-protos.md
+++ b/api/docs/eigenda-protos.md
@@ -1532,7 +1532,7 @@ The following describes the schema for computing the hash of this request This a
 
 All integers are encoded as unsigned 4 byte big endian values.
 
-Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 1. the operator id 2. the number of chunk requests 3. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes ii. the blob key iii. the start index iv. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes ii. the blob key iii. each requested chunk index, in order |
+Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 1. the operator id 2. the number of chunk requests 3. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes iii. the blob key iv. the start index v. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes iii. the blob key iv. each requested chunk index, in order |
 
 
 

--- a/api/docs/eigenda-protos.md
+++ b/api/docs/eigenda-protos.md
@@ -1532,7 +1532,7 @@ The following describes the schema for computing the hash of this request This a
 
 All integers are encoded as unsigned 4 byte big endian values.
 
-Perform a keccak256 hash on the following data in the following order: 1. the operator id 2. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the blob key iii. the start index iv. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the blob key iii. each requested chunk index, in order |
+Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 1. the operator id 2. the number of chunk requests 3. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes ii. the blob key iii. the start index iv. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes ii. the blob key iii. each requested chunk index, in order |
 
 
 

--- a/api/docs/relay.html
+++ b/api/docs/relay.html
@@ -441,9 +441,9 @@ All integers are encoded as unsigned 4 byte big endian values.
 
 Perform a keccak256 hash on the following data in the following order:
 1. the length of the operator ID in bytes
-1. the operator id
-2. the number of chunk requests
-3. for each chunk request:
+2. the operator id
+3. the number of chunk requests
+4. for each chunk request:
    a. if the chunk request is a request by index:
       i.   a one byte ASCII representation of the character &#34;i&#34; (aka Ox69)
       ii.  the length blob key in bytes

--- a/api/docs/relay.html
+++ b/api/docs/relay.html
@@ -447,14 +447,14 @@ Perform a keccak256 hash on the following data in the following order:
    a. if the chunk request is a request by index:
       i.   a one byte ASCII representation of the character &#34;i&#34; (aka Ox69)
       ii.  the length blob key in bytes
-      ii.  the blob key
-      iii. the start index
-      iv.  the end index
+      iii. the blob key
+      iv.  the start index
+      v.   the end index
    b. if the chunk request is a request by range:
       i.   a one byte ASCII representation of the character &#34;r&#34; (aka Ox72)
       ii.  the length of the blob key in bytes
-      ii.  the blob key
-      iii. each requested chunk index, in order </p></td>
+      iii. the blob key
+      iv.  each requested chunk index, in order </p></td>
                 </tr>
               
             </tbody>

--- a/api/docs/relay.html
+++ b/api/docs/relay.html
@@ -440,15 +440,19 @@ This algorithm is implemented in golang using relay.auth.HashGetChunksRequest().
 All integers are encoded as unsigned 4 byte big endian values.
 
 Perform a keccak256 hash on the following data in the following order:
+1. the length of the operator ID in bytes
 1. the operator id
-2. for each chunk request:
+2. the number of chunk requests
+3. for each chunk request:
    a. if the chunk request is a request by index:
       i.   a one byte ASCII representation of the character &#34;i&#34; (aka Ox69)
+      ii.  the length blob key in bytes
       ii.  the blob key
       iii. the start index
       iv.  the end index
    b. if the chunk request is a request by range:
       i.   a one byte ASCII representation of the character &#34;r&#34; (aka Ox72)
+      ii.  the length of the blob key in bytes
       ii.  the blob key
       iii. each requested chunk index, in order </p></td>
                 </tr>

--- a/api/docs/relay.md
+++ b/api/docs/relay.md
@@ -136,7 +136,7 @@ The following describes the schema for computing the hash of this request This a
 
 All integers are encoded as unsigned 4 byte big endian values.
 
-Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 1. the operator id 2. the number of chunk requests 3. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes iii. the blob key iv. the start index v. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes iii. the blob key iv. each requested chunk index, in order |
+Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 2. the operator id 3. the number of chunk requests 4. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes iii. the blob key iv. the start index v. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes iii. the blob key iv. each requested chunk index, in order |
 
 
 

--- a/api/docs/relay.md
+++ b/api/docs/relay.md
@@ -136,7 +136,7 @@ The following describes the schema for computing the hash of this request This a
 
 All integers are encoded as unsigned 4 byte big endian values.
 
-Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 1. the operator id 2. the number of chunk requests 3. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes ii. the blob key iii. the start index iv. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes ii. the blob key iii. each requested chunk index, in order |
+Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 1. the operator id 2. the number of chunk requests 3. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes iii. the blob key iv. the start index v. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes iii. the blob key iv. each requested chunk index, in order |
 
 
 

--- a/api/docs/relay.md
+++ b/api/docs/relay.md
@@ -136,7 +136,7 @@ The following describes the schema for computing the hash of this request This a
 
 All integers are encoded as unsigned 4 byte big endian values.
 
-Perform a keccak256 hash on the following data in the following order: 1. the operator id 2. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the blob key iii. the start index iv. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the blob key iii. each requested chunk index, in order |
+Perform a keccak256 hash on the following data in the following order: 1. the length of the operator ID in bytes 1. the operator id 2. the number of chunk requests 3. for each chunk request: a. if the chunk request is a request by index: i. a one byte ASCII representation of the character &#34;i&#34; (aka Ox69) ii. the length blob key in bytes ii. the blob key iii. the start index iv. the end index b. if the chunk request is a request by range: i. a one byte ASCII representation of the character &#34;r&#34; (aka Ox72) ii. the length of the blob key in bytes ii. the blob key iii. each requested chunk index, in order |
 
 
 

--- a/api/grpc/relay/relay.pb.go
+++ b/api/grpc/relay/relay.pb.go
@@ -146,14 +146,14 @@ type GetChunksRequest struct {
 	//     a. if the chunk request is a request by index:
 	//     i.   a one byte ASCII representation of the character "i" (aka Ox69)
 	//     ii.  the length blob key in bytes
-	//     ii.  the blob key
-	//     iii. the start index
-	//     iv.  the end index
+	//     iii. the blob key
+	//     iv.  the start index
+	//     v.   the end index
 	//     b. if the chunk request is a request by range:
 	//     i.   a one byte ASCII representation of the character "r" (aka Ox72)
 	//     ii.  the length of the blob key in bytes
-	//     ii.  the blob key
-	//     iii. each requested chunk index, in order
+	//     iii. the blob key
+	//     iv.  each requested chunk index, in order
 	OperatorSignature []byte `protobuf:"bytes,3,opt,name=operator_signature,json=operatorSignature,proto3" json:"operator_signature,omitempty"`
 }
 

--- a/api/grpc/relay/relay.pb.go
+++ b/api/grpc/relay/relay.pb.go
@@ -140,9 +140,9 @@ type GetChunksRequest struct {
 	//
 	// Perform a keccak256 hash on the following data in the following order:
 	//  1. the length of the operator ID in bytes
-	//  1. the operator id
-	//  2. the number of chunk requests
-	//  3. for each chunk request:
+	//  2. the operator id
+	//  3. the number of chunk requests
+	//  4. for each chunk request:
 	//     a. if the chunk request is a request by index:
 	//     i.   a one byte ASCII representation of the character "i" (aka Ox69)
 	//     ii.  the length blob key in bytes

--- a/api/grpc/relay/relay.pb.go
+++ b/api/grpc/relay/relay.pb.go
@@ -139,15 +139,19 @@ type GetChunksRequest struct {
 	// All integers are encoded as unsigned 4 byte big endian values.
 	//
 	// Perform a keccak256 hash on the following data in the following order:
+	//  1. the length of the operator ID in bytes
 	//  1. the operator id
-	//  2. for each chunk request:
+	//  2. the number of chunk requests
+	//  3. for each chunk request:
 	//     a. if the chunk request is a request by index:
 	//     i.   a one byte ASCII representation of the character "i" (aka Ox69)
+	//     ii.  the length blob key in bytes
 	//     ii.  the blob key
 	//     iii. the start index
 	//     iv.  the end index
 	//     b. if the chunk request is a request by range:
 	//     i.   a one byte ASCII representation of the character "r" (aka Ox72)
+	//     ii.  the length of the blob key in bytes
 	//     ii.  the blob key
 	//     iii. each requested chunk index, in order
 	OperatorSignature []byte `protobuf:"bytes,3,opt,name=operator_signature,json=operatorSignature,proto3" json:"operator_signature,omitempty"`

--- a/api/hashing/node_hashing.go
+++ b/api/hashing/node_hashing.go
@@ -1,6 +1,7 @@
 package hashing
 
 import (
+	"fmt"
 	"hash"
 
 	commonv1 "github.com/Layr-Labs/eigenda/api/grpc/common"
@@ -12,49 +13,109 @@ import (
 // This file contains code for hashing gRPC messages that are sent to the DA node.
 
 // HashStoreChunksRequest hashes the given StoreChunksRequest.
-func HashStoreChunksRequest(request *grpc.StoreChunksRequest) []byte {
+func HashStoreChunksRequest(request *grpc.StoreChunksRequest) ([]byte, error) {
 	hasher := sha3.NewLegacyKeccak256()
 
-	hashBatchHeader(hasher, request.Batch.Header)
+	err := hashBatchHeader(hasher, request.Batch.Header)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash batch header: %w", err)
+	}
+	err = hashLength(hasher, request.Batch.BlobCertificates)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash BlobCertificates length: %w", err)
+	}
 	for _, blobCertificate := range request.Batch.BlobCertificates {
-		hashBlobCertificate(hasher, blobCertificate)
+		err = hashBlobCertificate(hasher, blobCertificate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to hash blob certificate: %w", err)
+		}
 	}
 	hashUint32(hasher, request.DisperserID)
 
-	return hasher.Sum(nil)
+	return hasher.Sum(nil), nil
 }
 
-func hashBlobCertificate(hasher hash.Hash, blobCertificate *common.BlobCertificate) {
-	hashBlobHeader(hasher, blobCertificate.BlobHeader)
-	hasher.Write(blobCertificate.Signature)
-	for _, relayKey := range blobCertificate.RelayKeys {
-		hashUint32(hasher, relayKey)
+func hashBlobCertificate(hasher hash.Hash, blobCertificate *common.BlobCertificate) error {
+	err := hashBlobHeader(hasher, blobCertificate.BlobHeader)
+	if err != nil {
+		return fmt.Errorf("failed to hash blob header: %w", err)
 	}
+	err = hashByteArray(hasher, blobCertificate.Signature)
+	if err != nil {
+		return fmt.Errorf("failed to hash signature: %w", err)
+	}
+	err = hashUint32Array(hasher, blobCertificate.RelayKeys)
+	if err != nil {
+		return fmt.Errorf("failed to hash RelayKeys: %w", err)
+	}
+	return nil
 }
 
-func hashBlobHeader(hasher hash.Hash, header *common.BlobHeader) {
+func hashBlobHeader(hasher hash.Hash, header *common.BlobHeader) error {
 	hashUint32(hasher, header.Version)
-	for _, quorum := range header.QuorumNumbers {
-		hashUint32(hasher, quorum)
+	hashUint32(hasher, uint32(len(header.QuorumNumbers)))
+
+	err := hashUint32Array(hasher, header.QuorumNumbers)
+	if err != nil {
+		return fmt.Errorf("failed to hash QuorumNumbers: %w", err)
 	}
-	hashBlobCommitment(hasher, header.Commitment)
-	hashPaymentHeader(hasher, header.PaymentHeader)
+
+	err = hashBlobCommitment(hasher, header.Commitment)
+	if err != nil {
+		return fmt.Errorf("failed to hash commitment: %w", err)
+	}
+
+	err = hashPaymentHeader(hasher, header.PaymentHeader)
+	if err != nil {
+		return fmt.Errorf("failed to hash payment header: %w", err)
+	}
+
+	return nil
 }
 
-func hashBatchHeader(hasher hash.Hash, header *common.BatchHeader) {
-	hasher.Write(header.BatchRoot)
+func hashBatchHeader(hasher hash.Hash, header *common.BatchHeader) error {
+	err := hashByteArray(hasher, header.BatchRoot)
+	if err != nil {
+		return fmt.Errorf("failed to hash BatchRoot: %w", err)
+	}
 	hashUint64(hasher, header.ReferenceBlockNumber)
+
+	return nil
 }
 
-func hashBlobCommitment(hasher hash.Hash, commitment *commonv1.BlobCommitment) {
-	hasher.Write(commitment.Commitment)
-	hasher.Write(commitment.LengthCommitment)
-	hasher.Write(commitment.LengthProof)
+func hashBlobCommitment(hasher hash.Hash, commitment *commonv1.BlobCommitment) error {
+	err := hashByteArray(hasher, commitment.Commitment)
+	if err != nil {
+		return fmt.Errorf("failed to hash commitment: %w", err)
+	}
+
+	err = hashByteArray(hasher, commitment.LengthCommitment)
+	if err != nil {
+		return fmt.Errorf("failed to hash LengthCommitment: %w", err)
+	}
+
+	err = hashByteArray(hasher, commitment.LengthProof)
+	if err != nil {
+		return fmt.Errorf("failed to hash LengthProof: %w", err)
+	}
+
 	hashUint32(hasher, commitment.Length)
+
+	return nil
 }
 
-func hashPaymentHeader(hasher hash.Hash, header *common.PaymentHeader) {
-	hasher.Write([]byte(header.AccountId))
+func hashPaymentHeader(hasher hash.Hash, header *common.PaymentHeader) error {
+	err := hashByteArray(hasher, []byte(header.AccountId))
+	if err != nil {
+		return fmt.Errorf("failed to hash AccountId: %w", err)
+	}
+
 	hashInt64(hasher, header.Timestamp)
-	hasher.Write(header.CumulativePayment)
+
+	err = hashByteArray(hasher, header.CumulativePayment)
+	if err != nil {
+		return fmt.Errorf("failed to hash CumulativePayment: %w", err)
+	}
+
+	return nil
 }

--- a/api/hashing/relay_hashing.go
+++ b/api/hashing/relay_hashing.go
@@ -1,38 +1,49 @@
 package hashing
 
 import (
+	"fmt"
+
 	pb "github.com/Layr-Labs/eigenda/api/grpc/relay"
 	"golang.org/x/crypto/sha3"
 )
 
 // This file contains code for hashing gRPC messages that are sent to the relay.
 
-var (
-	iByte = []byte{0x69}
-	rByte = []byte{0x72}
-)
-
 // HashGetChunksRequest hashes the given GetChunksRequest.
-func HashGetChunksRequest(request *pb.GetChunksRequest) []byte {
+func HashGetChunksRequest(request *pb.GetChunksRequest) ([]byte, error) {
 	hasher := sha3.NewLegacyKeccak256()
 
-	hasher.Write(request.GetOperatorId())
+	err := hashByteArray(hasher, request.GetOperatorId())
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash operator ID: %w", err)
+	}
+	err = hashLength(hasher, request.GetChunkRequests())
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash GetChunkRequests length: %w", err)
+	}
 	for _, chunkRequest := range request.GetChunkRequests() {
 		if chunkRequest.GetByIndex() != nil {
 			getByIndex := chunkRequest.GetByIndex()
-			hasher.Write(iByte)
-			hasher.Write(getByIndex.BlobKey)
-			for _, index := range getByIndex.ChunkIndices {
-				hashUint32(hasher, index)
+			hashChar(hasher, 'i')
+			err = hashByteArray(hasher, getByIndex.BlobKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to hash blob key: %w", err)
+			}
+			err = hashUint32Array(hasher, getByIndex.ChunkIndices)
+			if err != nil {
+				return nil, fmt.Errorf("failed to hash ChunkIndices: %w", err)
 			}
 		} else {
 			getByRange := chunkRequest.GetByRange()
-			hasher.Write(rByte)
-			hasher.Write(getByRange.BlobKey)
+			hashChar(hasher, 'r')
+			err = hashByteArray(hasher, getByRange.BlobKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to hash blob key: %w", err)
+			}
 			hashUint32(hasher, getByRange.StartIndex)
 			hashUint32(hasher, getByRange.EndIndex)
 		}
 	}
 
-	return hasher.Sum(nil)
+	return hasher.Sum(nil), nil
 }

--- a/api/hashing/utils.go
+++ b/api/hashing/utils.go
@@ -2,8 +2,53 @@ package hashing
 
 import (
 	"encoding/binary"
+	"fmt"
 	"hash"
+	"math"
 )
+
+// hashLength hashes the length of the given thing.
+func hashLength[T any](hasher hash.Hash, thing []T) error {
+	if len(thing) > math.MaxUint32 {
+		return fmt.Errorf("array is too long: %d", len(thing))
+	}
+
+	hashUint32(hasher, uint32(len(thing)))
+
+	return nil
+}
+
+// hashByteArray hashes the given byte array.
+func hashByteArray(hasher hash.Hash, bytes []byte) error {
+	if len(bytes) > math.MaxUint32 {
+		return fmt.Errorf("byte array is too long: %d", len(bytes))
+	}
+
+	err := hashLength(hasher, bytes)
+	if err != nil {
+		return fmt.Errorf("failed to hash length: %w", err)
+	}
+	hasher.Write(bytes)
+
+	return nil
+}
+
+// hashUint32Array hashes the given uint32 array.
+func hashUint32Array(hasher hash.Hash, values []uint32) error {
+	if len(values) > math.MaxUint32 {
+		return fmt.Errorf("uint32 array is too long: %d", len(values))
+	}
+
+	err := hashLength(hasher, values)
+	if err != nil {
+		return fmt.Errorf("failed to hash length: %w", err)
+	}
+	for _, value := range values {
+		hashUint32(hasher, value)
+	}
+
+	return nil
+}
 
 // hashUint32 hashes the given uint32 value.
 func hashUint32(hasher hash.Hash, value uint32) {
@@ -24,4 +69,9 @@ func hashInt64(hasher hash.Hash, value int64) {
 	bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, uint64(value))
 	hasher.Write(bytes)
+}
+
+// hashChar hashes the given byte value.
+func hashChar(hasher hash.Hash, value byte) {
+	hasher.Write([]byte{value})
 }

--- a/api/proto/relay/relay.proto
+++ b/api/proto/relay/relay.proto
@@ -49,14 +49,14 @@ message GetChunksRequest {
   //    a. if the chunk request is a request by index:
   //       i.   a one byte ASCII representation of the character "i" (aka Ox69)
   //       ii.  the length blob key in bytes
-  //       ii.  the blob key
-  //       iii. the start index
-  //       iv.  the end index
+  //       iii. the blob key
+  //       iv.  the start index
+  //       v.   the end index
   //    b. if the chunk request is a request by range:
   //       i.   a one byte ASCII representation of the character "r" (aka Ox72)
   //       ii.  the length of the blob key in bytes
-  //       ii.  the blob key
-  //       iii. each requested chunk index, in order
+  //       iii. the blob key
+  //       iv.  each requested chunk index, in order
   bytes operator_signature = 3;
 }
 

--- a/api/proto/relay/relay.proto
+++ b/api/proto/relay/relay.proto
@@ -43,9 +43,9 @@ message GetChunksRequest {
   //
   // Perform a keccak256 hash on the following data in the following order:
   // 1. the length of the operator ID in bytes
-  // 1. the operator id
-  // 2. the number of chunk requests
-  // 3. for each chunk request:
+  // 2. the operator id
+  // 3. the number of chunk requests
+  // 4. for each chunk request:
   //    a. if the chunk request is a request by index:
   //       i.   a one byte ASCII representation of the character "i" (aka Ox69)
   //       ii.  the length blob key in bytes

--- a/api/proto/relay/relay.proto
+++ b/api/proto/relay/relay.proto
@@ -41,16 +41,20 @@ message GetChunksRequest {
   //
   // All integers are encoded as unsigned 4 byte big endian values.
   //
-  // Perform a keccak256 hash on the following data in the following order:
+  // Perform a keccak256 hash on the following data in the following order: // TODO
+  // 1. the length of the operator ID in bytes
   // 1. the operator id
-  // 2. for each chunk request:
+  // 2. the number of chunk requests
+  // 3. for each chunk request:
   //    a. if the chunk request is a request by index:
   //       i.   a one byte ASCII representation of the character "i" (aka Ox69)
+  //       ii.  the length blob key in bytes
   //       ii.  the blob key
   //       iii. the start index
   //       iv.  the end index
   //    b. if the chunk request is a request by range:
   //       i.   a one byte ASCII representation of the character "r" (aka Ox72)
+  //       ii.  the length of the blob key in bytes
   //       ii.  the blob key
   //       iii. each requested chunk index, in order
   bytes operator_signature = 3;

--- a/api/proto/relay/relay.proto
+++ b/api/proto/relay/relay.proto
@@ -41,7 +41,7 @@ message GetChunksRequest {
   //
   // All integers are encoded as unsigned 4 byte big endian values.
   //
-  // Perform a keccak256 hash on the following data in the following order: // TODO
+  // Perform a keccak256 hash on the following data in the following order:
   // 1. the length of the operator ID in bytes
   // 1. the operator id
   // 2. the number of chunk requests

--- a/node/auth/request_signing.go
+++ b/node/auth/request_signing.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/ecdsa"
 	"fmt"
+
 	grpc "github.com/Layr-Labs/eigenda/api/grpc/validator"
 	"github.com/Layr-Labs/eigenda/api/hashing"
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -12,7 +13,10 @@ import (
 // SignStoreChunksRequest signs the given StoreChunksRequest with the given private key. Does not
 // write the signature into the request.
 func SignStoreChunksRequest(key *ecdsa.PrivateKey, request *grpc.StoreChunksRequest) ([]byte, error) {
-	requestHash := hashing.HashStoreChunksRequest(request)
+	requestHash, err := hashing.HashStoreChunksRequest(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash request: %w", err)
+	}
 
 	signature, err := crypto.Sign(requestHash, key)
 	if err != nil {
@@ -25,7 +29,10 @@ func SignStoreChunksRequest(key *ecdsa.PrivateKey, request *grpc.StoreChunksRequ
 // VerifyStoreChunksRequest verifies the given signature of the given StoreChunksRequest with the given
 // public key.
 func VerifyStoreChunksRequest(key gethcommon.Address, request *grpc.StoreChunksRequest) error {
-	requestHash := hashing.HashStoreChunksRequest(request)
+	requestHash, err := hashing.HashStoreChunksRequest(request)
+	if err != nil {
+		return fmt.Errorf("failed to hash request: %w", err)
+	}
 
 	signingPublicKey, err := crypto.SigToPub(requestHash, request.Signature)
 	if err != nil {

--- a/node/auth/request_signing_test.go
+++ b/node/auth/request_signing_test.go
@@ -13,32 +13,37 @@ func TestHashing(t *testing.T) {
 	rand := random.NewTestRandom()
 
 	request := RandomStoreChunksRequest(rand)
-	originalRequestHash := hashing.HashStoreChunksRequest(request)
+	originalRequestHash, err := hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 
 	// modifying the signature should not change the hash
 	request.Signature = rand.Bytes(32)
-	hash := hashing.HashStoreChunksRequest(request)
+	hash, err := hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.Equal(t, originalRequestHash, hash)
 
 	// modify the disperser id
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.DisperserID = request.DisperserID + 1
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// remove a blob cert
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates = request.Batch.BlobCertificates[:len(request.Batch.BlobCertificates)-1]
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify a relay
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].RelayKeys[0] = request.Batch.BlobCertificates[0].RelayKeys[0] + 1
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, remove a relay
@@ -46,14 +51,16 @@ func TestHashing(t *testing.T) {
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].RelayKeys =
 		request.Batch.BlobCertificates[0].RelayKeys[:len(request.Batch.BlobCertificates[0].RelayKeys)-1]
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, add a relay
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].RelayKeys = append(request.Batch.BlobCertificates[0].RelayKeys, rand.Uint32())
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify a quorum number
@@ -61,7 +68,8 @@ func TestHashing(t *testing.T) {
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.QuorumNumbers[0] =
 		request.Batch.BlobCertificates[0].BlobHeader.QuorumNumbers[0] + 1
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, remove a quorum number
@@ -70,7 +78,8 @@ func TestHashing(t *testing.T) {
 	request.Batch.BlobCertificates[0].BlobHeader.QuorumNumbers =
 		request.Batch.BlobCertificates[0].BlobHeader.QuorumNumbers[:len(
 			request.Batch.BlobCertificates[0].BlobHeader.QuorumNumbers)-1]
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, add a quorum number
@@ -78,63 +87,72 @@ func TestHashing(t *testing.T) {
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.QuorumNumbers = append(
 		request.Batch.BlobCertificates[0].BlobHeader.QuorumNumbers, rand.Uint32())
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify the Commitment.Commitment
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.Commitment.Commitment = rand.Bytes(32)
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify the Commitment.LengthCommitment
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.Commitment.LengthCommitment = rand.Bytes(32)
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify the Commitment.LengthProof
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.Commitment.LengthProof = rand.Bytes(32)
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify the Commitment.Length
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.Commitment.Length = rand.Uint32()
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify the PaymentHeader.AccountId
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.PaymentHeader.AccountId = rand.String(32)
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify the PaymentHeader.Timestamp
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.PaymentHeader.Timestamp = rand.Time().UnixMicro()
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify the PaymentHeader.CumulativePayment
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].BlobHeader.PaymentHeader.CumulativePayment = rand.Bytes(32)
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 
 	// within a blob cert, modify the Signature
 	rand.Reset()
 	request = RandomStoreChunksRequest(rand)
 	request.Batch.BlobCertificates[0].Signature = rand.Bytes(32)
-	hash = hashing.HashStoreChunksRequest(request)
+	hash, err = hashing.HashStoreChunksRequest(request)
+	require.NoError(t, err)
 	require.NotEqual(t, originalRequestHash, hash)
 }
 

--- a/relay/auth/authenticator.go
+++ b/relay/auth/authenticator.go
@@ -131,7 +131,10 @@ func (a *requestAuthenticator) AuthenticateGetChunksRequest(
 		G1Point: g1Point,
 	}
 
-	hash := hashing.HashGetChunksRequest(request)
+	hash, err := hashing.HashGetChunksRequest(request)
+	if err != nil {
+		return fmt.Errorf("failed to hash request: %w", err)
+	}
 	isValid := signature.Verify(key, ([32]byte)(hash))
 
 	if !isValid {

--- a/relay/auth/authenticator_test.go
+++ b/relay/auth/authenticator_test.go
@@ -2,12 +2,13 @@ package auth
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	tu "github.com/Layr-Labs/eigenda/common/testutils"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 // TestMockSigning is a meta-test to verify that
@@ -67,7 +68,8 @@ func TestValidRequest(t *testing.T) {
 
 	request := randomGetChunksRequest()
 	request.OperatorId = operatorID[:]
-	signature := SignGetChunksRequest(ics.KeyPairs[operatorID], request)
+	signature, err := SignGetChunksRequest(ics.KeyPairs[operatorID], request)
+	require.NoError(t, err)
 	request.OperatorSignature = signature
 
 	now := time.Now()
@@ -136,7 +138,8 @@ func TestAuthenticationSavingDisabled(t *testing.T) {
 
 	request := randomGetChunksRequest()
 	request.OperatorId = operatorID[:]
-	signature := SignGetChunksRequest(ics.KeyPairs[operatorID], request)
+	signature, err := SignGetChunksRequest(ics.KeyPairs[operatorID], request)
+	require.NoError(t, err)
 	request.OperatorSignature = signature
 
 	now := time.Now()
@@ -217,7 +220,8 @@ func TestBadSignature(t *testing.T) {
 
 	request := randomGetChunksRequest()
 	request.OperatorId = operatorID[:]
-	request.OperatorSignature = SignGetChunksRequest(ics.KeyPairs[operatorID], request)
+	request.OperatorSignature, err = SignGetChunksRequest(ics.KeyPairs[operatorID], request)
+	require.NoError(t, err)
 
 	now := time.Now()
 

--- a/relay/auth/request_signing.go
+++ b/relay/auth/request_signing.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"fmt"
+
 	pb "github.com/Layr-Labs/eigenda/api/grpc/relay"
 	"github.com/Layr-Labs/eigenda/api/hashing"
 	"github.com/Layr-Labs/eigenda/core"
@@ -8,8 +10,11 @@ import (
 
 // SignGetChunksRequest signs the given GetChunksRequest with the given private key. Does not
 // write the signature into the request.
-func SignGetChunksRequest(keys *core.KeyPair, request *pb.GetChunksRequest) []byte {
-	hash := hashing.HashGetChunksRequest(request)
+func SignGetChunksRequest(keys *core.KeyPair, request *pb.GetChunksRequest) ([]byte, error) {
+	hash, err := hashing.HashGetChunksRequest(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash request: %w", err)
+	}
 	signature := keys.SignMessage(([32]byte)(hash))
-	return signature.G1Point.Serialize()
+	return signature.G1Point.Serialize(), nil
 }

--- a/relay/auth/request_signing_test.go
+++ b/relay/auth/request_signing_test.go
@@ -1,12 +1,13 @@
 package auth
 
 import (
+	"testing"
+
 	pb "github.com/Layr-Labs/eigenda/api/grpc/relay"
 	"github.com/Layr-Labs/eigenda/api/hashing"
 	tu "github.com/Layr-Labs/eigenda/common/testutils"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
-	"testing"
 )
 
 func randomGetChunksRequest() *pb.GetChunksRequest {
@@ -52,21 +53,26 @@ func TestHashGetChunksRequest(t *testing.T) {
 	requestB := randomGetChunksRequest()
 
 	// Hashing the same request twice should yield the same hash
-	hashA := hashing.HashGetChunksRequest(requestA)
-	hashAA := hashing.HashGetChunksRequest(requestA)
+	hashA, err := hashing.HashGetChunksRequest(requestA)
+	require.NoError(t, err)
+	hashAA, err := hashing.HashGetChunksRequest(requestA)
+	require.NoError(t, err)
 	require.Equal(t, hashA, hashAA)
 
 	// Hashing different requests should yield different hashes
-	hashB := hashing.HashGetChunksRequest(requestB)
+	hashB, err := hashing.HashGetChunksRequest(requestB)
+	require.NoError(t, err)
 	require.NotEqual(t, hashA, hashB)
 
 	// Adding a signature should not affect the hash
 	requestA.OperatorSignature = tu.RandomBytes(32)
-	hashAA = hashing.HashGetChunksRequest(requestA)
+	hashAA, err = hashing.HashGetChunksRequest(requestA)
+	require.NoError(t, err)
 	require.Equal(t, hashA, hashAA)
 
 	// Changing the requester ID should change the hash
 	requestA.OperatorId = tu.RandomBytes(32)
-	hashAA = hashing.HashGetChunksRequest(requestA)
+	hashAA, err = hashing.HashGetChunksRequest(requestA)
+	require.NoError(t, err)
 	require.NotEqual(t, hashA, hashAA)
 }

--- a/relay/server_test.go
+++ b/relay/server_test.go
@@ -3,9 +3,10 @@ package relay
 import (
 	"context"
 	"encoding/binary"
-	"github.com/docker/go-units"
 	"testing"
 	"time"
+
+	"github.com/docker/go-units"
 
 	"github.com/Layr-Labs/eigenda/common/testutils/random"
 	"github.com/Layr-Labs/eigenda/relay/auth"
@@ -93,7 +94,8 @@ func getChunks(
 	operatorIDBytes := make([]byte, 32)
 	binary.BigEndian.PutUint32(operatorIDBytes[24:], operatorID)
 	request.OperatorId = operatorIDBytes
-	signature := auth.SignGetChunksRequest(operatorKeys[operatorID], request)
+	signature, err := auth.SignGetChunksRequest(operatorKeys[operatorID], request)
+	require.NoError(t, err)
 	request.OperatorSignature = signature
 
 	var opts []grpc.DialOption


### PR DESCRIPTION
## Why are these changes needed?

Fix how relays & validators hash various messages for blazar release.
