### PR TITLE
Make sure no operator can reply to same batch multiple times

### DIFF
--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -133,6 +133,11 @@ func (a *StdSignatureAggregator) ReceiveSignatures(ctx context.Context, state *I
 	for numReply := 0; numReply < numOperators; numReply++ {
 		var err error
 		r := <-messageChan
+		if seen := signerMap[r.Operator]; seen {
+			a.Logger.Warn("duplicate signature received", "operatorID", r.Operator.Hex())
+			continue
+		}
+
 		operatorIDHex := r.Operator.Hex()
 		operatorAddr, ok := a.OperatorAddresses.Get(r.Operator)
 		if !ok && a.Transactor != nil {


### PR DESCRIPTION
## Why are these changes needed?
While this isn't currently possible given that only one request is made per operator, adding this validation as a protection measure 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
