### PR TITLE
ci(docker-publish): fix workflow by updating cache action v2->v4

### DIFF
--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -52,7 +52,7 @@ jobs:
         driver-opts: image=moby/buildkit:master
 
     - name: Cache docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
Workflow was failing with:
> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down 

See https://github.com/Layr-Labs/eigenda/actions/runs/13663605780/job/38200085990



## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
