### PR TITLE
Make feed cache update async

### DIFF
--- a/disperser/dataapi/v2/feed_cache_test.go
+++ b/disperser/dataapi/v2/feed_cache_test.go
@@ -97,12 +97,18 @@ func setupTestCache(maxItems int) (*v2.FeedCache[testItem], *testFetcher, time.T
 	return cache, fetcher, baseTime
 }
 
+func syncCacheGet(cache *v2.FeedCache[testItem], start, end time.Time, order v2.FetchOrder, limit int) ([]*testItem, error) {
+	items, err := cache.Get(start, end, order, limit)
+	cache.WaitForCacheUpdates()
+	return items, err
+}
+
 // Test invalid parameters
 func TestInvalidParameters(t *testing.T) {
 	cache, _, baseTime := setupTestCache(100)
 
 	// Test with end before start
-	_, err := cache.Get(baseTime.Add(5*time.Minute), baseTime, v2.Ascending, 0)
+	_, err := syncCacheGet(cache, baseTime.Add(5*time.Minute), baseTime, v2.Ascending, 0)
 	assert.Error(t, err)
 }
 
@@ -114,7 +120,7 @@ func TestFullCacheHit(t *testing.T) {
 		// Initial fetch with specified direction
 		start := baseTime
 		end := baseTime.Add(5 * time.Minute)
-		_, err := cache.Get(start, end, direction, 0)
+		_, err := syncCacheGet(cache, start, end, direction, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -122,7 +128,7 @@ func TestFullCacheHit(t *testing.T) {
 		subEnd := baseTime.Add(3 * time.Minute)
 
 		// Sub range query ascending: full cache hit
-		items, err := cache.Get(subStart, subEnd, v2.Ascending, 0)
+		items, err := syncCacheGet(cache, subStart, subEnd, v2.Ascending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		assert.Equal(t, 1, fetcher.getFetchCount())
@@ -131,13 +137,13 @@ func TestFullCacheHit(t *testing.T) {
 			assert.Equal(t, expectedTime, item.ts)
 		}
 		// With limit
-		items, err = cache.Get(subStart, subEnd, v2.Ascending, 1)
+		items, err = syncCacheGet(cache, subStart, subEnd, v2.Ascending, 1)
 		require.NoError(t, err)
 		require.Len(t, items, 1)
 		assert.Equal(t, subStart, items[0].ts)
 
 		// Sub range query descending: full cache hit
-		items, err = cache.Get(subStart, subEnd, v2.Descending, 0)
+		items, err = syncCacheGet(cache, subStart, subEnd, v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		assert.Equal(t, 1, fetcher.getFetchCount())
@@ -146,7 +152,7 @@ func TestFullCacheHit(t *testing.T) {
 			assert.Equal(t, expectedTime, item.ts)
 		}
 		// With limit
-		items, err = cache.Get(subStart, subEnd, v2.Descending, 1)
+		items, err = syncCacheGet(cache, subStart, subEnd, v2.Descending, 1)
 		require.NoError(t, err)
 		require.Len(t, items, 1)
 		assert.Equal(t, subEnd.Add(-time.Minute), items[0].ts)
@@ -203,25 +209,25 @@ func TestNoOverlap_NewerRange(t *testing.T) {
 			// Initial fetch
 			start := baseTime
 			end := baseTime.Add(5 * time.Minute)
-			_, err := cache.Get(start, end, tc.initialDirection, 0)
+			_, err := syncCacheGet(cache, start, end, tc.initialDirection, 0)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedFetchCounts[0], fetcher.getFetchCount())
 
 			// Query non-overlapping but newer range
 			newStart := baseTime.Add(10 * time.Minute)
 			newEnd := baseTime.Add(15 * time.Minute)
-			items, err := cache.Get(newStart, newEnd, tc.newerRangeDirection, 0)
+			items, err := syncCacheGet(cache, newStart, newEnd, tc.newerRangeDirection, 0)
 			require.NoError(t, err)
 			require.Len(t, items, 5)
 			assert.Equal(t, tc.expectedFetchCounts[1], fetcher.getFetchCount())
 
 			// The old cache was dropped
-			_, err = cache.Get(start, end, tc.initialDirection, 0)
+			_, err = syncCacheGet(cache, start, end, tc.initialDirection, 0)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedFetchCounts[2], fetcher.getFetchCount())
 
 			// Query the new range again - should hit the cache
-			_, err = cache.Get(newStart, newEnd, tc.newerRangeDirection, 0)
+			_, err = syncCacheGet(cache, newStart, newEnd, tc.newerRangeDirection, 0)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedFetchCounts[3], fetcher.getFetchCount())
 		})
@@ -235,7 +241,7 @@ func TestNoOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 	// Initial fetch
 	start := baseTime
 	end := baseTime.Add(5 * time.Minute)
-	_, err := cache.Get(start, end, v2.Ascending, 0)
+	_, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 	require.NoError(t, err)
 	assert.Equal(t, int(1), fetcher.getFetchCount())
 
@@ -243,23 +249,23 @@ func TestNoOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 	// With limit = 2, it'll just fetch 10:00, 11:00
 	newStart := baseTime.Add(10 * time.Minute)
 	newEnd := baseTime.Add(15 * time.Minute)
-	items, err := cache.Get(newStart, newEnd, v2.Ascending, 2)
+	items, err := syncCacheGet(cache, newStart, newEnd, v2.Ascending, 2)
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 	assert.Equal(t, 2, fetcher.getFetchCount())
 
 	// The old cache was dropped
-	_, err = cache.Get(start, end, v2.Ascending, 0)
+	_, err = syncCacheGet(cache, start, end, v2.Ascending, 0)
 	require.NoError(t, err)
 	assert.Equal(t, 3, fetcher.getFetchCount())
 
 	// Query [10:00, 11:00+1ns) should have full cache hit
-	_, err = cache.Get(newStart, newStart.Add(time.Minute).Add(time.Nanosecond), v2.Ascending, 0)
+	_, err = syncCacheGet(cache, newStart, newStart.Add(time.Minute).Add(time.Nanosecond), v2.Ascending, 0)
 	require.NoError(t, err)
 	assert.Equal(t, 3, fetcher.getFetchCount())
 
 	// Query the new range again - should fetch DB
-	_, err = cache.Get(newStart, newEnd, v2.Ascending, 0)
+	_, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 0)
 	require.NoError(t, err)
 	assert.Equal(t, 4, fetcher.getFetchCount())
 }
@@ -305,7 +311,7 @@ func TestNoOverlap_OlderRange(t *testing.T) {
 			// Initial fetch
 			start := baseTime.Add(5 * time.Minute)
 			end := baseTime.Add(10 * time.Minute)
-			items, err := cache.Get(start, end, tc.initialDirection, 0)
+			items, err := syncCacheGet(cache, start, end, tc.initialDirection, 0)
 			require.NoError(t, err)
 			require.Len(t, items, 5)
 			assert.Equal(t, tc.expectedFetchCounts[0], fetcher.getFetchCount())
@@ -313,17 +319,17 @@ func TestNoOverlap_OlderRange(t *testing.T) {
 			// Query older range
 			oldStart := baseTime
 			oldEnd := baseTime.Add(3 * time.Minute)
-			items, err = cache.Get(oldStart, oldEnd, tc.olderRangeDirection, 0)
+			items, err = syncCacheGet(cache, oldStart, oldEnd, tc.olderRangeDirection, 0)
 			require.NoError(t, err)
 			require.Len(t, items, 3)
 			assert.Equal(t, tc.expectedFetchCounts[1], fetcher.getFetchCount())
 
 			// Query the new range again - should hit the cache
 			for limit := 0; limit <= 5; limit++ {
-				_, err = cache.Get(start, end, v2.Ascending, limit)
+				_, err = syncCacheGet(cache, start, end, v2.Ascending, limit)
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedFetchCounts[2], fetcher.getFetchCount())
-				_, err = cache.Get(start, end, v2.Descending, limit)
+				_, err = syncCacheGet(cache, start, end, v2.Descending, limit)
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedFetchCounts[2], fetcher.getFetchCount())
 			}
@@ -341,7 +347,7 @@ func TestWithLimit(t *testing.T) {
 	limit := 3
 
 	// Resulting in cache [0:00, 2:00+ns)
-	items, err := cache.Get(start, end, v2.Ascending, limit)
+	items, err := syncCacheGet(cache, start, end, v2.Ascending, limit)
 	require.NoError(t, err)
 	require.Len(t, items, limit)
 	for i, item := range items {
@@ -351,24 +357,24 @@ func TestWithLimit(t *testing.T) {
 	assert.Equal(t, 1, fetcher.getFetchCount())
 
 	// Full cache hit
-	_, err = cache.Get(start, start.Add(2*time.Minute).Add(time.Nanosecond), v2.Ascending, limit)
+	_, err = syncCacheGet(cache, start, start.Add(2*time.Minute).Add(time.Nanosecond), v2.Ascending, limit)
 	require.NoError(t, err)
 	assert.Equal(t, 1, fetcher.getFetchCount())
 
 	// [0:00, 3:00) with limit=3 should also have full cache, because there are already 3 items in
 	// the cache, so it won't do more fetches for [2:00+ns, 3:00).
-	_, err = cache.Get(start, start.Add(3*time.Minute), v2.Ascending, limit)
+	_, err = syncCacheGet(cache, start, start.Add(3*time.Minute), v2.Ascending, limit)
 	require.NoError(t, err)
 	assert.Equal(t, 1, fetcher.getFetchCount())
 	// However, with descending, it will have to fetch [2:00+ns, 3:00) first (instead of using cache),
 	// so this will cause an increase in fetch count.
-	_, err = cache.Get(start, start.Add(3*time.Minute), v2.Descending, limit)
+	_, err = syncCacheGet(cache, start, start.Add(3*time.Minute), v2.Descending, limit)
 	require.NoError(t, err)
 	assert.Equal(t, 2, fetcher.getFetchCount())
 
 	// Fetch with descending order and limit
 	// Resulting in cache [7:00, 10:00)
-	items, err = cache.Get(start, end, v2.Descending, limit)
+	items, err = syncCacheGet(cache, start, end, v2.Descending, limit)
 	require.NoError(t, err)
 	require.Len(t, items, limit)
 	for i, item := range items {
@@ -380,12 +386,12 @@ func TestWithLimit(t *testing.T) {
 	// Old cache dropped
 	// And this result won't be cached (remain as [7:00, 10:00)) as it's strictly older than
 	// what's in cache
-	_, err = cache.Get(start, start.Add(3*time.Minute), v2.Ascending, limit)
+	_, err = syncCacheGet(cache, start, start.Add(3*time.Minute), v2.Ascending, limit)
 	require.NoError(t, err)
 	assert.Equal(t, 4, fetcher.getFetchCount())
 
 	// Full hit new cache
-	_, err = cache.Get(start.Add(7*time.Minute), end, v2.Ascending, limit)
+	_, err = syncCacheGet(cache, start.Add(7*time.Minute), end, v2.Ascending, limit)
 	require.NoError(t, err)
 	assert.Equal(t, 4, fetcher.getFetchCount())
 }
@@ -436,7 +442,7 @@ func TestPartialOverlap_NewerRange(t *testing.T) {
 			// Initial fetch [0:00, 5:00)
 			start := baseTime
 			end := baseTime.Add(5 * time.Minute)
-			_, err := cache.Get(start, end, tc.initialDirection, 0)
+			_, err := syncCacheGet(cache, start, end, tc.initialDirection, 0)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedFetchCounts[0], fetcher.getFetchCount())
 
@@ -444,7 +450,7 @@ func TestPartialOverlap_NewerRange(t *testing.T) {
 			newStart := baseTime.Add(3 * time.Minute)
 			newEnd := baseTime.Add(8 * time.Minute)
 
-			items, err := cache.Get(newStart, newEnd, tc.overlapDirection, 0)
+			items, err := syncCacheGet(cache, newStart, newEnd, tc.overlapDirection, 0)
 			require.NoError(t, err)
 			require.Len(t, items, 5)
 			assert.Equal(t, tc.expectedFetchCounts[1], fetcher.getFetchCount())
@@ -461,7 +467,7 @@ func TestPartialOverlap_NewerRange(t *testing.T) {
 			// Query within the extended range - should be a cache hit
 			subStart := baseTime
 			subEnd := baseTime.Add(8 * time.Minute)
-			_, err = cache.Get(subStart, subEnd, tc.subRangeDirection, 0)
+			_, err = syncCacheGet(cache, subStart, subEnd, tc.subRangeDirection, 0)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedFetchCounts[2], fetcher.getFetchCount())
 		})
@@ -476,7 +482,7 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [0:00, 5:00)
 		start := baseTime
 		end := baseTime.Add(5 * time.Minute)
-		_, err := cache.Get(start, end, v2.Ascending, 0)
+		_, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -484,7 +490,7 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		// With limit=4, it'll cut off at 6:00 (the cache end set to +1ns)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(8 * time.Minute)
-		items, err := cache.Get(newStart, newEnd, v2.Ascending, 4)
+		items, err := syncCacheGet(cache, newStart, newEnd, v2.Ascending, 4)
 		require.NoError(t, err)
 		require.Len(t, items, 4)
 		for i, item := range items {
@@ -493,12 +499,12 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [0:00, 6:00) will have full cache hit
-		_, err = cache.Get(baseTime, baseTime.Add(6*time.Minute), v2.Ascending, 0)
+		_, err = syncCacheGet(cache, baseTime, baseTime.Add(6*time.Minute), v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [0:00, 8:00) will have to fetch DB
-		_, err = cache.Get(start, newEnd, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, start, newEnd, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 3, fetcher.getFetchCount())
 	})
@@ -509,7 +515,7 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [0:00, 5:00)
 		start := baseTime
 		end := baseTime.Add(5 * time.Minute)
-		_, err := cache.Get(start, end, v2.Ascending, 0)
+		_, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -518,7 +524,7 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		// and there is no DB fetch needed
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(8 * time.Minute)
-		items, err := cache.Get(newStart, newEnd, v2.Ascending, 2)
+		items, err := syncCacheGet(cache, newStart, newEnd, v2.Ascending, 2)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		for i, item := range items {
@@ -527,12 +533,12 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
 		// Querying [0:00, 5:00) will have full cache hit
-		_, err = cache.Get(start, end, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
 		// Querying [0:00, 6:00) will have to fetch DB
-		_, err = cache.Get(start, end.Add(time.Minute), v2.Ascending, 0)
+		_, err = syncCacheGet(cache, start, end.Add(time.Minute), v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 	})
@@ -543,7 +549,7 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [0:00, 5:00)
 		start := baseTime
 		end := baseTime.Add(5 * time.Minute)
-		_, err := cache.Get(start, end, v2.Ascending, 0)
+		_, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -551,7 +557,7 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		// high-end of items [6:00, 8:00) in the range
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(8 * time.Minute)
-		items, err := cache.Get(newStart, newEnd, v2.Descending, 2)
+		items, err := syncCacheGet(cache, newStart, newEnd, v2.Descending, 2)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		for i, item := range items {
@@ -560,12 +566,12 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [6:00, 8:00) will have full cache hit
-		_, err = cache.Get(baseTime.Add(6*time.Minute), baseTime.Add(8*time.Minute), v2.Ascending, 0)
+		_, err = syncCacheGet(cache, baseTime.Add(6*time.Minute), baseTime.Add(8*time.Minute), v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [0:00, 5:00) will have to fetch DB
-		_, err = cache.Get(start, end, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 3, fetcher.getFetchCount())
 	})
@@ -576,7 +582,7 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [0:00, 5:00)
 		start := baseTime
 		end := baseTime.Add(5 * time.Minute)
-		_, err := cache.Get(start, end, v2.Ascending, 0)
+		_, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -584,7 +590,7 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		// This will find 4 items [4:00, 8:00), which is connected to cache and can extend it
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(8 * time.Minute)
-		items, err := cache.Get(newStart, newEnd, v2.Descending, 4)
+		items, err := syncCacheGet(cache, newStart, newEnd, v2.Descending, 4)
 		require.NoError(t, err)
 		require.Len(t, items, 4)
 		for i, item := range items {
@@ -593,12 +599,12 @@ func TestPartialOverlap_NewerRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [2:00, 8:00) will have full cache hit
-		_, err = cache.Get(baseTime.Add(2*time.Minute), baseTime.Add(8*time.Minute), v2.Ascending, 0)
+		_, err = syncCacheGet(cache, baseTime.Add(2*time.Minute), baseTime.Add(8*time.Minute), v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [1:00, 8:00) will have to fetch DB (the cache range is [2:00, 8:00))
-		_, err = cache.Get(baseTime.Add(1*time.Minute), baseTime.Add(8*time.Minute), v2.Ascending, 0)
+		_, err = syncCacheGet(cache, baseTime.Add(1*time.Minute), baseTime.Add(8*time.Minute), v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 3, fetcher.getFetchCount())
 	})
@@ -612,7 +618,7 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		_, err := cache.Get(start, end, v2.Descending, 0)
+		_, err := syncCacheGet(cache, start, end, v2.Descending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -621,7 +627,7 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		// This results in cache [4:00, 10:00)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(8 * time.Minute)
-		items, err := cache.Get(newStart, newEnd, v2.Descending, 4)
+		items, err := syncCacheGet(cache, newStart, newEnd, v2.Descending, 4)
 		require.NoError(t, err)
 		require.Len(t, items, 4)
 		for i, item := range items {
@@ -630,12 +636,12 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [4:00, 10:00) will have full cache hit
-		_, err = cache.Get(baseTime.Add(4*time.Minute), end, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, baseTime.Add(4*time.Minute), end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [0:00, 8:00) will have to fetch DB
-		_, err = cache.Get(baseTime, newEnd, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, baseTime, newEnd, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 3, fetcher.getFetchCount())
 	})
@@ -646,7 +652,7 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		_, err := cache.Get(start, end, v2.Descending, 0)
+		_, err := syncCacheGet(cache, start, end, v2.Descending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -655,7 +661,7 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		// So the cache remains as [5:00, 10:00)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(8 * time.Minute)
-		items, err := cache.Get(newStart, newEnd, v2.Descending, 2)
+		items, err := syncCacheGet(cache, newStart, newEnd, v2.Descending, 2)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		for i, item := range items {
@@ -664,12 +670,12 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
 		// Querying [5:00, 10:00) will have full cache hit
-		_, err = cache.Get(start, end, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
 		// Querying [3:00, 8:00) will have to fetch DB
-		_, err = cache.Get(newStart, newEnd, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 	})
@@ -680,7 +686,7 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		_, err := cache.Get(start, end, v2.Descending, 0)
+		_, err := syncCacheGet(cache, start, end, v2.Descending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -689,7 +695,7 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		// so has no effect
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(8 * time.Minute)
-		items, err := cache.Get(newStart, newEnd, v2.Ascending, 2)
+		items, err := syncCacheGet(cache, newStart, newEnd, v2.Ascending, 2)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		for i, item := range items {
@@ -698,12 +704,12 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [5:00, 10:00) will have full cache hit
-		_, err = cache.Get(start, end, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [3:00, 8:00) will have to fetch DB
-		_, err = cache.Get(newStart, newEnd, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 3, fetcher.getFetchCount())
 	})
@@ -714,7 +720,7 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		_, err := cache.Get(start, end, v2.Descending, 0)
+		_, err := syncCacheGet(cache, start, end, v2.Descending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, fetcher.getFetchCount())
 
@@ -722,7 +728,7 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		// This could have created cache [3:00, 10:00), but with eviction it'll be [4:00, 10:00)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(8 * time.Minute)
-		items, err := cache.Get(newStart, newEnd, v2.Ascending, 3)
+		items, err := syncCacheGet(cache, newStart, newEnd, v2.Ascending, 3)
 		require.NoError(t, err)
 		require.Len(t, items, 3)
 		for i, item := range items {
@@ -731,12 +737,12 @@ func TestPartialOverlap_OlderRange(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [4:00, 10:00) will have full cache hit
-		_, err = cache.Get(baseTime.Add(4*time.Minute), end, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, baseTime.Add(4*time.Minute), end, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [3:00, 8:00) will have to fetch DB
-		_, err = cache.Get(newStart, newEnd, v2.Ascending, 0)
+		_, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 3, fetcher.getFetchCount())
 	})
@@ -750,7 +756,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		items, err := cache.Get(start, end, v2.Ascending, 0)
+		items, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 5)
 		assert.Equal(t, 1, fetcher.getFetchCount())
@@ -759,7 +765,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// With limit=2, it will not hit any data in cache [5:00, 10:00)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(12 * time.Minute)
-		items, err = cache.Get(newStart, newEnd, v2.Ascending, 2)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 2)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		for i, item := range items {
@@ -768,12 +774,12 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [5:00, 10:00) will hit full cache
-		items, err = cache.Get(start, end, v2.Descending, 0)
+		items, err = syncCacheGet(cache, start, end, v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 5)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
-		items, err = cache.Get(newStart, newEnd, v2.Ascending, 2)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 2)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		assert.Equal(t, 3, fetcher.getFetchCount())
@@ -785,7 +791,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		items, err := cache.Get(start, end, v2.Ascending, 0)
+		items, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 5)
 		assert.Equal(t, 1, fetcher.getFetchCount())
@@ -795,7 +801,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// The resulting cache is [3:00, 10:00)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(12 * time.Minute)
-		items, err = cache.Get(newStart, newEnd, v2.Ascending, 3)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 3)
 		require.NoError(t, err)
 		require.Len(t, items, 3)
 		for i, item := range items {
@@ -804,20 +810,20 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [3:00, 10:00) will hit full cache
-		items, err = cache.Get(newStart, end, v2.Descending, 0)
+		items, err = syncCacheGet(cache, newStart, end, v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 7)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Query a larger range [3:00, 12:00)
 		// With limit=8, this will cover from 3:00 to  10:00
-		items, err = cache.Get(newStart, newEnd, v2.Ascending, 8)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 8)
 		require.NoError(t, err)
 		require.Len(t, items, 8)
 		assert.Equal(t, 3, fetcher.getFetchCount())
 
 		// Querying [3:00, 10:00+1ns) will have full cache
-		items, err = cache.Get(newStart, baseTime.Add(10*time.Minute).Add(time.Nanosecond), v2.Descending, 0)
+		items, err = syncCacheGet(cache, newStart, baseTime.Add(10*time.Minute).Add(time.Nanosecond), v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 8)
 		assert.Equal(t, 3, fetcher.getFetchCount())
@@ -829,7 +835,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		items, err := cache.Get(start, end, v2.Ascending, 0)
+		items, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 5)
 		assert.Equal(t, 1, fetcher.getFetchCount())
@@ -842,7 +848,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// The resulting cache is [10:00, 12:00)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(12 * time.Minute)
-		items, err = cache.Get(newStart, newEnd, v2.Descending, 2)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Descending, 2)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		for i, item := range items {
@@ -851,19 +857,19 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [10:00, 12:00) will hit full cache
-		items, err = cache.Get(end, newEnd, v2.Descending, 0)
+		items, err = syncCacheGet(cache, end, newEnd, v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [3:00, 12:00) again with limit=2, should have full cache
-		items, err = cache.Get(newStart, newEnd, v2.Descending, 2)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Descending, 2)
 		require.NoError(t, err)
 		require.Len(t, items, 2)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [3:00, 12:00) again without limit will have to fetch DB
-		items, err = cache.Get(newStart, newEnd, v2.Ascending, 0)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Ascending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 9)
 		assert.Equal(t, 3, fetcher.getFetchCount())
@@ -875,7 +881,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		items, err := cache.Get(start, end, v2.Ascending, 0)
+		items, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 5)
 		assert.Equal(t, 1, fetcher.getFetchCount())
@@ -886,7 +892,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// The resulting cache is [5:00, 12:00)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(12 * time.Minute)
-		items, err = cache.Get(newStart, newEnd, v2.Descending, 3)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Descending, 3)
 		require.NoError(t, err)
 		require.Len(t, items, 3)
 		for i, item := range items {
@@ -895,14 +901,14 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [5:00, 12:00) will hit full cache
-		items, err = cache.Get(start, newEnd, v2.Descending, 0)
+		items, err = syncCacheGet(cache, start, newEnd, v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 7)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// With limit=8, it will retrieve backward up to 4:00
 		// Resulting cache [4:00, 12:00)
-		items, err = cache.Get(newStart, newEnd, v2.Descending, 8)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Descending, 8)
 		require.NoError(t, err)
 		require.Len(t, items, 8)
 		for i, item := range items {
@@ -911,7 +917,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 3, fetcher.getFetchCount())
 
 		// Querying [4:00, 12:00) will hit full cache
-		items, err = cache.Get(baseTime.Add(4*time.Minute), newEnd, v2.Descending, 0)
+		items, err = syncCacheGet(cache, baseTime.Add(4*time.Minute), newEnd, v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 8)
 		assert.Equal(t, 3, fetcher.getFetchCount())
@@ -923,7 +929,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// Initial fetch [5:00, 10:00)
 		start := baseTime.Add(5 * time.Minute)
 		end := baseTime.Add(10 * time.Minute)
-		items, err := cache.Get(start, end, v2.Ascending, 0)
+		items, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 5)
 		assert.Equal(t, 1, fetcher.getFetchCount())
@@ -932,7 +938,7 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		// This could have created cache [5:00, 12:00), but with eviction it'll be [6:00, 12:00)
 		newStart := baseTime.Add(3 * time.Minute)
 		newEnd := baseTime.Add(12 * time.Minute)
-		items, err = cache.Get(newStart, newEnd, v2.Descending, 3)
+		items, err = syncCacheGet(cache, newStart, newEnd, v2.Descending, 3)
 		require.NoError(t, err)
 		require.Len(t, items, 3)
 		for i, item := range items {
@@ -941,13 +947,13 @@ func TestPartialOverlap_NewerAndOlderRange_WithQueryLimit(t *testing.T) {
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [6:00, 12:00) will have full cache hit
-		items, err = cache.Get(start.Add(time.Minute), newEnd, v2.Descending, 0)
+		items, err = syncCacheGet(cache, start.Add(time.Minute), newEnd, v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 6)
 		assert.Equal(t, 2, fetcher.getFetchCount())
 
 		// Querying [5:00, 12:00) will fetch DB to cover 5:00
-		items, err = cache.Get(start, newEnd, v2.Descending, 0)
+		items, err = syncCacheGet(cache, start, newEnd, v2.Descending, 0)
 		require.NoError(t, err)
 		require.Len(t, items, 7)
 		assert.Equal(t, 3, fetcher.getFetchCount())
@@ -962,7 +968,7 @@ func TestPartialOverlap_NewerAndOlderRange(t *testing.T) {
 	// Initial fetch [5:00, 10:00)
 	start := baseTime.Add(5 * time.Minute)
 	end := baseTime.Add(10 * time.Minute)
-	items, err := cache.Get(start, end, v2.Ascending, 0)
+	items, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 	require.NoError(t, err)
 	require.Len(t, items, 5)
 	assert.Equal(t, 1, fetcher.getFetchCount())
@@ -970,7 +976,7 @@ func TestPartialOverlap_NewerAndOlderRange(t *testing.T) {
 	// Query a larger range [3:00, 12:00)
 	extendedStart := baseTime.Add(3 * time.Minute)
 	extendedEnd := baseTime.Add(12 * time.Minute)
-	items, err = cache.Get(extendedStart, extendedEnd, v2.Ascending, 0)
+	items, err = syncCacheGet(cache, extendedStart, extendedEnd, v2.Ascending, 0)
 	require.NoError(t, err)
 	require.Len(t, items, 9)
 
@@ -984,7 +990,7 @@ func TestPartialOverlap_NewerAndOlderRange(t *testing.T) {
 	}
 
 	// Query within the extended range - should be a cache hit
-	_, err = cache.Get(extendedStart, extendedEnd, v2.Ascending, 0)
+	_, err = syncCacheGet(cache, extendedStart, extendedEnd, v2.Ascending, 0)
 	require.NoError(t, err)
 	assert.Equal(t, 3, fetcher.getFetchCount())
 }
@@ -996,7 +1002,7 @@ func TestEviction(t *testing.T) {
 	// Fetch 5 minutes worth of data
 	start := baseTime
 	end := baseTime.Add(5 * time.Minute)
-	items, err := cache.Get(start, end, v2.Ascending, 0)
+	items, err := syncCacheGet(cache, start, end, v2.Ascending, 0)
 	require.NoError(t, err)
 	require.Len(t, items, 5)
 	assert.Equal(t, 1, fetcher.getFetchCount())
@@ -1005,7 +1011,7 @@ func TestEviction(t *testing.T) {
 	// Only the most recent 3 items should be in cache due to maxItems
 	start2 := baseTime
 	end2 := baseTime.Add(5 * time.Minute)
-	items2, err := cache.Get(start2, end2, v2.Ascending, 0)
+	items2, err := syncCacheGet(cache, start2, end2, v2.Ascending, 0)
 	require.NoError(t, err)
 	require.Len(t, items2, 5)
 	assert.Equal(t, 2, fetcher.getFetchCount()) // Need to fetch older items not in cache
@@ -1013,7 +1019,7 @@ func TestEviction(t *testing.T) {
 	// Query just the most recent 3 items - should be a cache hit
 	recentStart := baseTime.Add(2 * time.Minute)
 	recentEnd := baseTime.Add(5 * time.Minute)
-	items3, err := cache.Get(recentStart, recentEnd, v2.Ascending, 0)
+	items3, err := syncCacheGet(cache, recentStart, recentEnd, v2.Ascending, 0)
 	require.NoError(t, err)
 	require.Len(t, items3, 3)
 	assert.Equal(t, 2, fetcher.getFetchCount()) // No new fetch needed
@@ -1038,8 +1044,17 @@ func TestConcurrentAccess(t *testing.T) {
 				direction = v2.Descending
 			}
 			items, err := cache.Get(start, end, direction, 0)
-			assert.NoError(t, err)
-			assert.NotNil(t, items)
+			require.NoError(t, err)
+			require.Equal(t, 5, len(items))
+			if direction == v2.Ascending {
+				for i, item := range items {
+					assert.Equal(t, start.Add(time.Duration(i)*time.Minute), item.ts)
+				}
+			} else {
+				for i, item := range items {
+					assert.Equal(t, end.Add(time.Duration(-i-1)*time.Minute), item.ts)
+				}
+			}
 		}(i)
 	}
 


### PR DESCRIPTION
## Why are these changes needed?
- Reduce latency: Get() can return results faster
- Improve concurrency: multiple Get() threads will not be running in serial to update the cache

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
