### PR TITLE
Integrate feed cache with batch feed and operators signinginfo

### DIFF
--- a/disperser/dataapi/v2/batches.go
+++ b/disperser/dataapi/v2/batches.go
@@ -73,7 +73,7 @@ func (s *ServerV2) FetchBatchFeed(c *gin.Context) {
 	}
 
 	startTime := endTime.Add(-time.Duration(interval) * time.Second)
-	attestations, err := s.blobMetadataStore.GetAttestationByAttestedAtForward(c.Request.Context(), uint64(startTime.UnixNano())+1, uint64(endTime.UnixNano()), limit)
+	attestations, err := s.batchFeedCache.Get(c.Request.Context(), startTime.Add(time.Nanosecond), endTime, Ascending, limit)
 	if err != nil {
 		s.metrics.IncrementFailedRequestNum("FetchBatchFeed")
 		errorResponse(c, fmt.Errorf("failed to fetch feed from blob metadata store: %w", err))

--- a/disperser/dataapi/v2/feed_cache_test.go
+++ b/disperser/dataapi/v2/feed_cache_test.go
@@ -1,6 +1,7 @@
 package v2_test
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -35,7 +36,7 @@ func roundUpToNextMinute(t time.Time) time.Time {
 }
 
 // Implement fetch method matching the interface expected by FeedCache
-func (tf *testFetcher) fetch(start, end time.Time, order v2.FetchOrder, limit int) ([]*testItem, error) {
+func (tf *testFetcher) fetch(ctx context.Context, start, end time.Time, order v2.FetchOrder, limit int) ([]*testItem, error) {
 	tf.fetchCount.Add(1)
 	var items []*testItem
 
@@ -98,7 +99,7 @@ func setupTestCache(maxItems int) (*v2.FeedCache[testItem], *testFetcher, time.T
 }
 
 func syncCacheGet(cache *v2.FeedCache[testItem], start, end time.Time, order v2.FetchOrder, limit int) ([]*testItem, error) {
-	items, err := cache.Get(start, end, order, limit)
+	items, err := cache.Get(context.Background(), start, end, order, limit)
 	cache.WaitForCacheUpdates()
 	return items, err
 }
@@ -1043,7 +1044,7 @@ func TestConcurrentAccess(t *testing.T) {
 			if offset%2 == 0 {
 				direction = v2.Descending
 			}
-			items, err := cache.Get(start, end, direction, 0)
+			items, err := cache.Get(context.Background(), start, end, direction, 0)
 			require.NoError(t, err)
 			require.Equal(t, 5, len(items))
 			if direction == v2.Ascending {

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -114,8 +114,8 @@ func (s *ServerV2) FetchOperatorSigningInfo(c *gin.Context) {
 		startTime = oldestTime
 	}
 
-	attestations, err := s.blobMetadataStore.GetAttestationByAttestedAtForward(
-		c.Request.Context(), uint64(startTime.UnixNano())+1, uint64(endTime.UnixNano()), -1,
+	attestations, err := s.batchFeedCache.Get(
+		c.Request.Context(), startTime.Add(time.Nanosecond), endTime, Ascending, -1,
 	)
 	if err != nil {
 		s.metrics.IncrementFailedRequestNum("FetchOperatorSigningInfo")

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -221,11 +221,11 @@ func NewServerV2(
 	fetchBatchFn := func(ctx context.Context, start, end time.Time, order FetchOrder, limit int) ([]*corev2.Attestation, error) {
 		if order == Ascending {
 			return blobMetadataStore.GetAttestationByAttestedAtForward(
-				ctx, uint64(start.UnixNano())+1, uint64(end.UnixNano()), limit,
+				ctx, uint64(start.UnixNano())-1, uint64(end.UnixNano()), limit,
 			)
 		}
 		return blobMetadataStore.GetAttestationByAttestedAtBackward(
-			ctx, uint64(end.UnixNano()), uint64(start.UnixNano())+1, limit,
+			ctx, uint64(end.UnixNano()), uint64(start.UnixNano())-1, limit,
 		)
 	}
 	batchFeedCache := NewFeedCache[corev2.Attestation](

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -40,6 +40,10 @@ const (
 	// The quorum IDs that are allowed to query for signing info are [0, maxQuorumIDAllowed]
 	maxQuorumIDAllowed = 2
 
+	// Suppose 1 batch/s, we cache 2 days worth of batch attestations.
+	// Suppose 1KB for each attestation, this will be 173MB memory.
+	maxNumBatchesToCache = 3600 * 24 * 2
+
 	cacheControlParam       = "Cache-Control"
 	maxFeedBlobAge          = 300 // this is completely static
 	maxOperatorsStakeAge    = 300 // not expect the stake change to happen frequently
@@ -194,6 +198,8 @@ type ServerV2 struct {
 
 	operatorHandler *dataapi.OperatorHandler
 	metricsHandler  *dataapi.MetricsHandler
+
+	batchFeedCache *FeedCache[corev2.Attestation]
 }
 
 func NewServerV2(
@@ -208,6 +214,26 @@ func NewServerV2(
 	metrics *dataapi.Metrics,
 ) *ServerV2 {
 	l := logger.With("component", "DataAPIServerV2")
+
+	getBatchTimestampFn := func(item *corev2.Attestation) time.Time {
+		return time.Unix(0, int64(item.AttestedAt))
+	}
+	fetchBatchFn := func(ctx context.Context, start, end time.Time, order FetchOrder, limit int) ([]*corev2.Attestation, error) {
+		if order == Ascending {
+			return blobMetadataStore.GetAttestationByAttestedAtForward(
+				ctx, uint64(start.UnixNano())+1, uint64(end.UnixNano()), limit,
+			)
+		}
+		return blobMetadataStore.GetAttestationByAttestedAtBackward(
+			ctx, uint64(end.UnixNano()), uint64(start.UnixNano())+1, limit,
+		)
+	}
+	batchFeedCache := NewFeedCache[corev2.Attestation](
+		maxNumBatchesToCache,
+		fetchBatchFn,
+		getBatchTimestampFn,
+	)
+
 	return &ServerV2{
 		logger:            l,
 		serverMode:        config.ServerMode,
@@ -222,6 +248,7 @@ func NewServerV2(
 		metrics:           metrics,
 		operatorHandler:   dataapi.NewOperatorHandler(l, metrics, chainReader, chainState, indexedChainState, subgraphClient),
 		metricsHandler:    dataapi.NewMetricsHandler(promClient, dataapi.V2),
+		batchFeedCache:    batchFeedCache,
 	}
 }
 

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -1083,6 +1083,10 @@ func TestFetchBatchFeed(t *testing.T) {
 	}
 	defer deleteItems(t, dynamoKeys)
 
+	// Create a local server so the internal state (e.g. cache) will be re-created.
+	// This is needed because /v2/operators/signing-info API shares the cache state with
+	// /v2/batches/feed API.
+	testDataApiServerV2 := serverv2.NewServerV2(config, blobMetadataStore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger))
 	r.GET("/v2/batches/feed", testDataApiServerV2.FetchBatchFeed)
 
 	t.Run("invalid params", func(t *testing.T) {
@@ -1440,6 +1444,10 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		+------------------+-------------------+------------------+--------------+
 	*/
 
+	// Create a local server so the internal state (e.g. cache) will be re-created.
+	// This is needed because /v2/operators/signing-info API shares the cache state with
+	// /v2/batches/feed API.
+	testDataApiServerV2 := serverv2.NewServerV2(config, blobMetadataStore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger))
 	r.GET("/v2/operators/signing-info", testDataApiServerV2.FetchOperatorSigningInfo)
 
 	t.Run("invalid params", func(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
There are two APIs operating on batch feed: the batch feed API and operators signing-info API.

By using FeedCache, they can share the batch data (attestations) fetched from DB.

**TESTED:**

In operators signing-info API, it's common to compute signing rates over the past 24h (which is the SLA defined based on).

The first query will take about 6s (understandably):
```
time curl http://localhost:9000/api/v2/operators/signing-info?interval=86400
{"start_block":3442752,"end_block":3445906,"start_time_unix_sec":1741123021,"end_time_unix_sec":1741209421,"operator_signing_info":[{"operator_id":"f512db9a07eefc22336c0de9f0dd8cb71400d0718e9ed00cb4af2643dc64325e","operator_address":"0x08300f3797DcEE9cc813EbAaE25127B4E3B550e3","quorum_id":0,"total_unsigned_batches":182,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":98.76425856,"stake_percentage":6.999840085928379},{"operator_id":"f512db9a07eefc22336c0de9f0dd8cb71400d0718e9ed00cb4af2643dc64325e","operator_address":"0x08300f3797DcEE9cc813EbAaE25127B4E3B550e3","quorum_id":1,"total_unsigned_batches":183,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":98.75755313,"stake_percentage":6.06971062654588},{"operator_id":"45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497","operator_address":"0xcb14cFAaC122E52024232583e7354589AedE74Ff","quorum_id":1,"total_unsigned_batches":187,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":98.73039582,"stake_percentage":8.194109345836937},{"operator_id":"39638352822b2eecf33f2ea0e6893a576edbcc202b4925c3ab2875677945bf58","operator_address":"0xaD9770d6b5514724c7b766f087bEa8A784038cBE","quorum_id":1,"total_unsigned_batches":192,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":98.69644918,"stake_percentage":3.7935691415911745},{"operator_id":"f164538a282cef97b2beeee1d2b77571583c1e581df08d6fdebaf5dc84a62abb","operator_address":"0x021c256B9c707a8d1Def06bA1bA2bbF3A9187Cbd","quorum_id":0,"total_unsigned_batches":196,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":98.66920152,"stake_percentage":8.626272115014835},{"operator_id":"f164538a282cef97b2beeee1d2b77571583c1e581df08d6fdebaf5dc84a62abb","operator_address":"0x021c256B9c707a8d1Def06bA1bA2bbF3A9187Cbd","quorum_id":1,"total_unsigned_batches":197,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":98.66250255,"stake_percentage":7.587138283182349},{"operator_id":"28abefa1a7943a52b1697988e0c433aebd75552c65ea213b50d71ce768e6822d","operator_address":"0xb9507513e0ea9eE549Cdc0B8c68D43C647Ae92d0","quorum_id":0,"total_unsigned_batches":3077,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":79.10782184,"stake_percentage":8.626272115014835},{"operator_id":"28abefa1a7943a52b1697988e0c433aebd75552c65ea213b50d71ce768e6822d","operator_address":"0xb9507513e0ea9eE549Cdc0B8c68D43C647Ae92d0","quorum_id":1,"total_unsigned_batches":3078,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":79.10245095,"stake_percentage":7.587138283182349},{"operator_id":"ea77395332488b77d4040e93c31bd5802e735ad4daa4f4514ee677390ce88205","operator_address":"0xDC4e08B0EFDD159d84d78c6C517a83bdB52f2092","quorum_id":0,"total_unsigned_batches":3186,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":78.36773493,"stake_percentage":8.626313503311762},{"operator_id":"ea77395332488b77d4040e93c31bd5802e735ad4daa4f4514ee677390ce88205","operator_address":"0xDC4e08B0EFDD159d84d78c6C517a83bdB52f2092","quorum_id":1,"total_unsigned_batches":3187,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":78.36241428,"stake_percentage":7.587138283182349},{"operator_id":"13865da12cdefdbac46cb2f35f8a39f0ac4cdc79dde6d4499cbd234bc5a5a7a2","operator_address":"0x5349ecb0485d3153A384B5B13DD476aAC2821466","quorum_id":0,"total_unsigned_batches":3492,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":76.29005975,"stake_percentage":8.626293089881635},{"operator_id":"13865da12cdefdbac46cb2f35f8a39f0ac4cdc79dde6d4499cbd234bc5a5a7a2","operator_address":"0x5349ecb0485d3153A384B5B13DD476aAC2821466","quorum_id":1,"total_unsigned_batches":3493,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":76.28488017,"stake_percentage":7.587138283182349},{"operator_id":"67f07ad6750215dd050672d0a45570f7e8e52b7165afa8c0e1d5cebc630d481d","operator_address":"0xE521cA581612E27078E447b542eaC25cb87a8693","quorum_id":0,"total_unsigned_batches":3543,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":75.94378055,"stake_percentage":8.626332308027445},{"operator_id":"67f07ad6750215dd050672d0a45570f7e8e52b7165afa8c0e1d5cebc630d481d","operator_address":"0xE521cA581612E27078E447b542eaC25cb87a8693","quorum_id":1,"total_unsigned_batches":3544,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":75.93862448,"stake_percentage":7.588655710838986},{"operator_id":"b0abb18a35f0981dc0ef99d194afdb679c9a238777f48c69e261cad9378f75d7","operator_address":"0x253738F483541943895A6c4C85C19721c38c7CE6","quorum_id":0,"total_unsigned_batches":3556,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":75.85551331,"stake_percentage":8.626272115014835},{"operator_id":"b0abb18a35f0981dc0ef99d194afdb679c9a238777f48c69e261cad9378f75d7","operator_address":"0x253738F483541943895A6c4C85C19721c38c7CE6","quorum_id":1,"total_unsigned_batches":3557,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":75.85036323,"stake_percentage":7.587138283182349},{"operator_id":"dd575a6e956bac91e2774ef5882bbcb8a5a1605513918b3eaf51a252ddaba4ce","operator_address":"0x8e9C55CCc803F10a154E07A75e08975A8ecA4f7b","quorum_id":0,"total_unsigned_batches":3882,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":73.64204237,"stake_percentage":8.626272115014835},{"operator_id":"dd575a6e956bac91e2774ef5882bbcb8a5a1605513918b3eaf51a252ddaba4ce","operator_address":"0x8e9C55CCc803F10a154E07A75e08975A8ecA4f7b","quorum_id":1,"total_unsigned_batches":3883,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":73.63704257,"stake_percentage":7.587138283182349},{"operator_id":"26497dbfcd68dabf5537651cccec12349d6c35220d9c08285024c446ea2f967f","operator_address":"0x702d8ceE5566b92e41c8EB36686BE3a5Aac81D70","quorum_id":0,"total_unsigned_batches":3922,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":73.37045084,"stake_percentage":8.626272115014835},{"operator_id":"26497dbfcd68dabf5537651cccec12349d6c35220d9c08285024c446ea2f967f","operator_address":"0x702d8ceE5566b92e41c8EB36686BE3a5Aac81D70","quorum_id":1,"total_unsigned_batches":3923,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":73.36546948,"stake_percentage":7.587138283182349},{"operator_id":"acc7ccfc647f9db0df0d97b1447b69b8091d73dc9ff6efcb47b3f4eb60bc6f63","operator_address":"0xcea7fCC7a97486c8ea980c5dec0FF52064a517e5","quorum_id":0,"total_unsigned_batches":3989,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":72.91553504,"stake_percentage":8.626272115014835},{"operator_id":"acc7ccfc647f9db0df0d97b1447b69b8091d73dc9ff6efcb47b3f4eb60bc6f63","operator_address":"0xcea7fCC7a97486c8ea980c5dec0FF52064a517e5","quorum_id":1,"total_unsigned_batches":3990,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":72.91058456,"stake_percentage":7.587138283182349},{"operator_id":"c04fdd95090334f47247672d5955cd402f9e54115528a57fa349a16677f7cffc","operator_address":"0x519991808d28e397487b0DE83e57546BB0F2E2b4","quorum_id":0,"total_unsigned_batches":4106,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":72.12112982,"stake_percentage":8.626272115014835},{"operator_id":"c04fdd95090334f47247672d5955cd402f9e54115528a57fa349a16677f7cffc","operator_address":"0x519991808d28e397487b0DE83e57546BB0F2E2b4","quorum_id":1,"total_unsigned_batches":4107,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":72.11623328,"stake_percentage":7.587138283182349},{"operator_id":"e442c84a76ae6593c22cebc9d9a2ade6b28f11228ec1e9eaa435984454a1efc9","operator_address":"0x7613eAEc492F218430032E9545d27841AB9cF813","quorum_id":0,"total_unsigned_batches":10803,"total_responsible_batches":14728,"total_batches":14728,"signing_percentage":26.64991852,"stake_percentage":6.737316207746938},{"operator_id":"e442c84a76ae6593c22cebc9d9a2ade6b28f11228ec1e9eaa435984454a1efc9","operator_address":"0x7613eAEc492F218430032E9545d27841AB9cF813","quorum_id":1,"total_unsigned_batches":10804,"total_responsible_batches":14729,"total_batches":14729,"signing_percentage":26.64810917,"stake_percentage":6.06971062654588}]}
real	0m5.750s
user	0m0.011s
sys	0m0.014s
```

If without cache, each following queries will take about the same 6s time.

With feed cache, it takes only 0.3s, massively faster and cheaper:
```
time curl http://localhost:9000/api/v2/operators/signing-info?interval=86400
{"start_block":3442755,"end_block":3445911,"start_time_unix_sec":1741123086,"end_time_unix_sec":1741209486,"operator_signing_info":[{"operator_id":"f512db9a07eefc22336c0de9f0dd8cb71400d0718e9ed00cb4af2643dc64325e","operator_address":"0x08300f3797DcEE9cc813EbAaE25127B4E3B550e3","quorum_id":0,"total_unsigned_batches":181,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":98.77088143,"stake_percentage":6.999840085928379},{"operator_id":"f512db9a07eefc22336c0de9f0dd8cb71400d0718e9ed00cb4af2643dc64325e","operator_address":"0x08300f3797DcEE9cc813EbAaE25127B4E3B550e3","quorum_id":1,"total_unsigned_batches":182,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":98.76417465,"stake_percentage":6.06971062654588},{"operator_id":"45fc52054b0b4b95f9188959eac542abf08537b62575fb0c89a8e42a77a93497","operator_address":"0xcb14cFAaC122E52024232583e7354589AedE74Ff","quorum_id":1,"total_unsigned_batches":187,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":98.7302234,"stake_percentage":8.194109345836937},{"operator_id":"39638352822b2eecf33f2ea0e6893a576edbcc202b4925c3ab2875677945bf58","operator_address":"0xaD9770d6b5514724c7b766f087bEa8A784038cBE","quorum_id":1,"total_unsigned_batches":191,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":98.7030624,"stake_percentage":3.7935691415911745},{"operator_id":"f164538a282cef97b2beeee1d2b77571583c1e581df08d6fdebaf5dc84a62abb","operator_address":"0x021c256B9c707a8d1Def06bA1bA2bbF3A9187Cbd","quorum_id":0,"total_unsigned_batches":195,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":98.67581149,"stake_percentage":8.626272115014835},{"operator_id":"f164538a282cef97b2beeee1d2b77571583c1e581df08d6fdebaf5dc84a62abb","operator_address":"0x021c256B9c707a8d1Def06bA1bA2bbF3A9187Cbd","quorum_id":1,"total_unsigned_batches":196,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":98.66911116,"stake_percentage":7.587138283182349},{"operator_id":"28abefa1a7943a52b1697988e0c433aebd75552c65ea213b50d71ce768e6822d","operator_address":"0xb9507513e0ea9eE549Cdc0B8c68D43C647Ae92d0","quorum_id":0,"total_unsigned_batches":3076,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":79.11177509,"stake_percentage":8.626272115014835},{"operator_id":"28abefa1a7943a52b1697988e0c433aebd75552c65ea213b50d71ce768e6822d","operator_address":"0xb9507513e0ea9eE549Cdc0B8c68D43C647Ae92d0","quorum_id":1,"total_unsigned_batches":3077,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":79.1064032,"stake_percentage":7.587138283182349},{"operator_id":"ea77395332488b77d4040e93c31bd5802e735ad4daa4f4514ee677390ce88205","operator_address":"0xDC4e08B0EFDD159d84d78c6C517a83bdB52f2092","quorum_id":0,"total_unsigned_batches":3186,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":78.36479696,"stake_percentage":8.626313503311762},{"operator_id":"ea77395332488b77d4040e93c31bd5802e735ad4daa4f4514ee677390ce88205","operator_address":"0xDC4e08B0EFDD159d84d78c6C517a83bdB52f2092","quorum_id":1,"total_unsigned_batches":3187,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":78.35947579,"stake_percentage":7.587138283182349},{"operator_id":"13865da12cdefdbac46cb2f35f8a39f0ac4cdc79dde6d4499cbd234bc5a5a7a2","operator_address":"0x5349ecb0485d3153A384B5B13DD476aAC2821466","quorum_id":0,"total_unsigned_batches":3494,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":76.27325818,"stake_percentage":8.626293089881635},{"operator_id":"13865da12cdefdbac46cb2f35f8a39f0ac4cdc79dde6d4499cbd234bc5a5a7a2","operator_address":"0x5349ecb0485d3153A384B5B13DD476aAC2821466","quorum_id":1,"total_unsigned_batches":3495,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":76.26807904,"stake_percentage":7.587138283182349},{"operator_id":"67f07ad6750215dd050672d0a45570f7e8e52b7165afa8c0e1d5cebc630d481d","operator_address":"0xE521cA581612E27078E447b542eaC25cb87a8693","quorum_id":0,"total_unsigned_batches":3541,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":75.9540948,"stake_percentage":8.626332308027445},{"operator_id":"67f07ad6750215dd050672d0a45570f7e8e52b7165afa8c0e1d5cebc630d481d","operator_address":"0xE521cA581612E27078E447b542eaC25cb87a8693","quorum_id":1,"total_unsigned_batches":3542,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":75.94893733,"stake_percentage":7.588655710838986},{"operator_id":"b0abb18a35f0981dc0ef99d194afdb679c9a238777f48c69e261cad9378f75d7","operator_address":"0x253738F483541943895A6c4C85C19721c38c7CE6","quorum_id":0,"total_unsigned_batches":3558,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":75.83865272,"stake_percentage":8.626272115014835},{"operator_id":"b0abb18a35f0981dc0ef99d194afdb679c9a238777f48c69e261cad9378f75d7","operator_address":"0x253738F483541943895A6c4C85C19721c38c7CE6","quorum_id":1,"total_unsigned_batches":3559,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":75.83350309,"stake_percentage":7.587138283182349},{"operator_id":"dd575a6e956bac91e2774ef5882bbcb8a5a1605513918b3eaf51a252ddaba4ce","operator_address":"0x8e9C55CCc803F10a154E07A75e08975A8ecA4f7b","quorum_id":0,"total_unsigned_batches":3883,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":73.63167187,"stake_percentage":8.626272115014835},{"operator_id":"dd575a6e956bac91e2774ef5882bbcb8a5a1605513918b3eaf51a252ddaba4ce","operator_address":"0x8e9C55CCc803F10a154E07A75e08975A8ecA4f7b","quorum_id":1,"total_unsigned_batches":3884,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":73.6266721,"stake_percentage":7.587138283182349},{"operator_id":"26497dbfcd68dabf5537651cccec12349d6c35220d9c08285024c446ea2f967f","operator_address":"0x702d8ceE5566b92e41c8EB36686BE3a5Aac81D70","quorum_id":0,"total_unsigned_batches":3923,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":73.36004346,"stake_percentage":8.626272115014835},{"operator_id":"26497dbfcd68dabf5537651cccec12349d6c35220d9c08285024c446ea2f967f","operator_address":"0x702d8ceE5566b92e41c8EB36686BE3a5Aac81D70","quorum_id":1,"total_unsigned_batches":3924,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":73.35506213,"stake_percentage":7.587138283182349},{"operator_id":"acc7ccfc647f9db0df0d97b1447b69b8091d73dc9ff6efcb47b3f4eb60bc6f63","operator_address":"0xcea7fCC7a97486c8ea980c5dec0FF52064a517e5","quorum_id":0,"total_unsigned_batches":3988,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":72.91864729,"stake_percentage":8.626272115014835},{"operator_id":"acc7ccfc647f9db0df0d97b1447b69b8091d73dc9ff6efcb47b3f4eb60bc6f63","operator_address":"0xcea7fCC7a97486c8ea980c5dec0FF52064a517e5","quorum_id":1,"total_unsigned_batches":3989,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":72.91369593,"stake_percentage":7.587138283182349},{"operator_id":"c04fdd95090334f47247672d5955cd402f9e54115528a57fa349a16677f7cffc","operator_address":"0x519991808d28e397487b0DE83e57546BB0F2E2b4","quorum_id":0,"total_unsigned_batches":4106,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":72.11734347,"stake_percentage":8.626272115014835},{"operator_id":"c04fdd95090334f47247672d5955cd402f9e54115528a57fa349a16677f7cffc","operator_address":"0x519991808d28e397487b0DE83e57546BB0F2E2b4","quorum_id":1,"total_unsigned_batches":4107,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":72.11244653,"stake_percentage":7.587138283182349},{"operator_id":"e442c84a76ae6593c22cebc9d9a2ade6b28f11228ec1e9eaa435984454a1efc9","operator_address":"0x7613eAEc492F218430032E9545d27841AB9cF813","quorum_id":0,"total_unsigned_batches":10813,"total_responsible_batches":14726,"total_batches":14726,"signing_percentage":26.57204944,"stake_percentage":6.737316207746938},{"operator_id":"e442c84a76ae6593c22cebc9d9a2ade6b28f11228ec1e9eaa435984454a1efc9","operator_address":"0x7613eAEc492F218430032E9545d27841AB9cF813","quorum_id":1,"total_unsigned_batches":10814,"total_responsible_batches":14727,"total_batches":14727,"signing_percentage":26.57024513,"stake_percentage":6.06971062654588}]}
real	0m0.331s
user	0m0.009s
sys	0m0.015s
```






<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
