### PR TITLE
fix: log the file path upon error in nodeplugin

### DIFF
--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -105,7 +105,7 @@ func pluginOps(ctx *cli.Context) {
 
 	sk, privateKey, err := plugin.GetECDSAPrivateKey(config.EcdsaKeyFile, config.EcdsaKeyPassword)
 	if err != nil {
-		log.Printf("Error: failed to read or decrypt the ECDSA private key: %v", err)
+		log.Printf("Error: failed to read or decrypt the ECDSA from file (%s) for private key: %v", config.EcdsaKeyFile, err)
 		return
 	}
 	log.Printf("Info: ECDSA key read and decrypted from %s", config.EcdsaKeyFile)


### PR DESCRIPTION
## Why are these changes needed?
To make it more clear what file has failed to read/decrypt.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
