### PR TITLE
docs(mdbook): add basic documentation for rollup stacks

### DIFF
--- a/docs/spec/src/SUMMARY.md
+++ b/docs/spec/src/SUMMARY.md
@@ -26,5 +26,5 @@
   - [Contracts](./integration/contracts.md)
   - [Optimism](./integration/optimism.md)
   - [Arbitrum](./integration/arbitrum.md)
-  - [zkSync](./integration/zkSync.md)
+  - [ZKsync](./integration/ZKsync.md)
 - [V1](./v1.md)

--- a/docs/spec/src/integration/arbitrum.md
+++ b/docs/spec/src/integration/arbitrum.md
@@ -1,0 +1,9 @@
+# Arbitrum Nitro
+
+Our up-to-date Nitro docs are available at [docs.eigenda.xyz](https://docs.eigenda.xyz/integrations-guides/rollup-guides/orbit/overview).
+
+We maintain fork diffs for the different nitro repos that we fork:
+- [nitro](https://layr-labs.github.io/nitro/)
+- [nitro-contracts](https://layr-labs.github.io/nitro-contracts/)
+- [nitro-testnode](https://layr-labs.github.io/nitro-testnode/)
+- [nitro-go-ethereum](https://layr-labs.github.io/nitro-go-ethereum/)

--- a/docs/spec/src/integration/optimism.md
+++ b/docs/spec/src/integration/optimism.md
@@ -1,0 +1,5 @@
+# Optimism
+
+Links:
+- [Our OP Fork](https://github.com/Layr-Labs/optimism)
+- [Fork Diff](https://layr-labs.github.io/optimism/)

--- a/docs/spec/src/integration/zkSync.md
+++ b/docs/spec/src/integration/zkSync.md
@@ -1,0 +1,5 @@
+# ZKsync
+
+ZKSync-era currently supports and maintains a [validium mode](https://docs.zksync.io/zk-stack/running/validium), which means we don't need to fork ZKSync, unlike the other stacks.
+
+The zksync eigenda client is implemented [here](https://github.com/matter-labs/zksync-era/tree/8ce774d20865a2b5223d26e10e227f0ea7cb3693/core/node/da_clients/src/eigen). It makes use of our [eigenda-client-rs](https://github.com/Layr-Labs/eigenda-client-rs) repo.


### PR DESCRIPTION
## Why are these changes needed?

Closes EGDA-1090

This just adds very very basic documentation for rollup stacks, just to say that the pages aren't empty.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
