### PR TITLE
Feed cache: Use circular queue for zero-alloc of memory

### DIFF
--- a/disperser/dataapi/v2/circular_queue.go
+++ b/disperser/dataapi/v2/circular_queue.go
@@ -1,0 +1,319 @@
+package v2
+
+import (
+	"time"
+)
+
+// CircularQueue describes a segment of results fetched for a time range.
+//
+// It has the following properties:
+// - all data items that are in range [start, end) are in the segment
+// - no data items that are outside the range [start, end) are included in the segment
+//
+// The new segment of results can be appended or prepended to the queue if the time range
+// that they represent is connected to the cached segment. If over capacity, it'll always
+// evict the oldest items.
+//
+// The data items are in ascending order by timestamp.
+//
+// This implementation is NOT thread-safe. The caller must ensure proper synchronization
+// when used across multiple threads.
+type CircularQueue[T any] struct {
+	timeRange
+
+	items    []*T // circular queue
+	head     int  // Index of the oldest element
+	size     int  // Current number of elements
+	capacity int  // Maximum capacity (queue length)
+
+	getTimestamp func(*T) time.Time // Function to extract timestamp from items
+}
+
+// NewCircularQueue creates a new CircularQueue with the specified capacity.
+// It returns an error if the capacity is not positive.
+func NewCircularQueue[T any](capacity int, getTimestampFn func(*T) time.Time) *CircularQueue[T] {
+	return &CircularQueue[T]{
+		items:        make([]*T, capacity),
+		head:         0,
+		size:         0,
+		capacity:     capacity,
+		getTimestamp: getTimestampFn,
+	}
+}
+
+// QueryTimeRange returns cached data that's in time range [start, end).
+// If there are more than `limit` elements, it will cut off the results up to `limit`.
+//
+// Parameters:
+//   - start: The inclusive start time of the query range.
+//   - end: The exclusive end time of the query range.
+//   - order: The order in which to return results (Ascending or Descending).
+//     For ascending order, it'll get the oldest `limit` elements;
+//     for descending order, it'll get the newest `limit` elements.
+//   - limit: The maximum number of elements to return. If limit <= 0, all matching
+//     elements are returned.
+func (c *CircularQueue[T]) QueryTimeRange(start, end time.Time, order FetchOrder, limit int) []*T {
+	if c.size == 0 {
+		return []*T{}
+	}
+
+	// Find start and end indices of the overlap
+	startIdx := -1
+	endIdx := -1
+
+	for i := 0; i < c.size; i++ {
+		idx := (c.head + i) % c.capacity
+
+		timestamp := c.getTimestamp(c.items[idx])
+
+		// Found the first item at or after the start time
+		if startIdx == -1 && !timestamp.Before(start) {
+			startIdx = i
+		}
+
+		// Found the first item at or past the end time (exclusive)
+		if !timestamp.Before(end) {
+			endIdx = i
+			break
+		}
+	}
+
+	// If we never found the end, set it to the end of data
+	if endIdx == -1 {
+		endIdx = c.size
+	}
+
+	// No overlap found
+	if startIdx == -1 || startIdx >= endIdx {
+		return []*T{}
+	}
+
+	// Calculate how many items in the overlap
+	overlapCount := endIdx - startIdx
+
+	// Apply limit if needed
+	if limit > 0 && limit < overlapCount {
+		if order == Ascending {
+			// For ascending, take first 'limit' items
+			endIdx = startIdx + limit
+		} else {
+			// For descending, take last 'limit' items
+			startIdx = endIdx - limit
+		}
+	}
+
+	// Note: we need to make a copy of the overlap because the cache data can be mutated
+	// by other threads after this function returns (within this function, the caller
+	// makes sure a reader lock is held). The data is of type *T, so it won't deep copy
+	// the data, just the pointers.
+	result := make([]*T, endIdx-startIdx)
+	for i := 0; i < endIdx-startIdx; i++ {
+		idx := (c.head + startIdx + i) % c.capacity
+		result[i] = c.items[idx]
+	}
+
+	return result
+}
+
+// MergeTimeRange merges a new segment of results representing time range [start, end) to
+// the existing cache.
+//
+// Behavior:
+//   - If the queue is empty, initializes it with the provided data.
+//   - If the time ranges don't overlap but are connected, appends or prepends data as appropriate.
+//   - If the new time range is disconnected but newer, replaces the queue contents.
+//   - If the new time range overlaps, extends the range as needed.
+//   - If the new time range is entirely contained within the existing range, does nothing.
+//
+// This method handles these cases to ensure the time range invariant is maintained,
+// while prioritizing newer data when capacity constraints are encountered.
+func (c *CircularQueue[T]) MergeTimeRange(items []*T, start, end time.Time) {
+	if len(items) == 0 {
+		return
+	}
+
+	if c.size == 0 {
+		c.reset(items)
+		c.start, c.end = maxTimestamp(start, c.headTimestamp()), end
+		return
+	}
+
+	if !c.overlaps(timeRange{start: start, end: end}) {
+		// Two special cases: non-overlapping but internewItems are connected
+		if start.Equal(c.end) {
+			c.appendItems(items)
+			c.start, c.end = maxTimestamp(c.start, c.headTimestamp()), end
+		}
+		if end.Equal(c.start) {
+			c.prependItems(items)
+			// Note c.end unchanged
+			c.start = maxTimestamp(start, c.headTimestamp())
+		}
+
+		// If it's a disconnected newer segment, it should replace existing cache
+		if start.After(c.end) {
+			c.reset(items)
+			c.start, c.end = maxTimestamp(start, c.headTimestamp()), end
+		}
+
+		return
+	}
+
+	// It's a sub range contained in existing cache, do nothing
+	if !start.Before(c.start) && !end.After(c.end) {
+		return
+	}
+
+	// The data is newer than cache, extend the cache
+	if end.After(c.end) {
+		split := 0
+		for ; split < len(items); split++ {
+			if !c.getTimestamp(items[split]).Before(c.end) {
+				break
+			}
+		}
+		if split < len(items) {
+			c.appendItems(items[split:])
+			c.start, c.end = maxTimestamp(c.start, c.headTimestamp()), end
+		}
+		return
+	}
+
+	// Now we must have start.Before(segment.start) && segment.start.Before(end)
+	split := len(items) - 1
+	for ; split >= 0; split-- {
+		if c.getTimestamp(items[split]).Before(c.start) {
+			break
+		}
+	}
+	if split >= 0 {
+		c.prependItems(items[:split+1])
+		// Note c.end unchanged
+		c.start = maxTimestamp(start, c.headTimestamp())
+	}
+}
+
+// headTimestamp returns the timestamp of the head element in the queue.
+// Assumes the queue is not empty (c.size > 0) and c.items[c.head] is not nil (ensured by
+// the caller).
+func (c *CircularQueue[T]) headTimestamp() time.Time {
+	return c.getTimestamp(c.items[c.head])
+}
+
+// reset initializes the cache with the given data, limiting to capacity
+// This method resets the circular queue and adds at most capacity elements,
+// prioritizing the most recent (latest timestamp) elements if needed.
+// If newItems is empty, this method does nothing.
+func (c *CircularQueue[T]) reset(newItems []*T) {
+	if len(newItems) == 0 {
+		return
+	}
+
+	// Reset the circular queue
+	c.head = 0
+	c.size = 0
+
+	// Determine how many data points to use (up to capacity)
+	numToAdd := len(newItems)
+	startIdx := 0
+
+	if numToAdd > c.capacity {
+		// Only add the most recent points that fit in the capacity
+		startIdx = len(newItems) - c.capacity
+		numToAdd = c.capacity
+	}
+
+	// Add data points directly to the queue without function calls
+	for i := 0; i < numToAdd; i++ {
+		c.items[i] = newItems[startIdx+i]
+	}
+
+	// Update size
+	c.size = numToAdd
+}
+
+// prependItems adds multiple elements to the front of the queue
+// Elements must be in ascending time order (oldest to newest)
+// This never drops newer elements to make room for older ones
+func (c *CircularQueue[T]) prependItems(newItems []*T) {
+	if len(newItems) == 0 {
+		return
+	}
+
+	// If queue is empty, just initialize with the data
+	if c.size == 0 {
+		c.reset(newItems)
+		return
+	}
+
+	// Calculate how many elements we can actually add
+	// We never drop newer elements to make room for older ones
+	spaceAvailable := c.capacity - c.size
+	numToAdd := len(newItems)
+	if numToAdd > spaceAvailable {
+		numToAdd = spaceAvailable
+	}
+
+	if numToAdd <= 0 {
+		return // Queue is full, no room to add older elements
+	}
+
+	// Only add the newest numToAdd elements from newItems
+	// This means we take the last numToAdd elements from the array
+	startIdx := len(newItems) - numToAdd
+
+	// Add elements one by one to the front, starting with the newest
+	// to preserve ascending time order in the queue
+	for i := len(newItems) - 1; i >= startIdx; i-- {
+		// Move head back and increase size
+		c.head = (c.head - 1 + c.capacity) % c.capacity
+		c.items[c.head] = newItems[i]
+	}
+
+	c.size += numToAdd
+}
+
+// appendItems adds multiple elements to the back of the queue
+// Elements must be in ascending time order (oldest to newest)
+// Drops oldest elements if necessary to make room for newer ones
+func (c *CircularQueue[T]) appendItems(newItems []*T) {
+	if len(newItems) == 0 {
+		return
+	}
+
+	// If queue is empty, just initialize with the data
+	if c.size == 0 {
+		c.reset(newItems)
+		return
+	}
+
+	// If new data exceeds capacity, use only the newest portion
+	if len(newItems) >= c.capacity {
+		c.reset(newItems)
+		return
+	}
+
+	// Calculate if we need to drop oldest elements
+	totalSize := c.size + len(newItems)
+	overflow := totalSize - c.capacity
+
+	if overflow > 0 {
+		// We need to drop some oldest elements
+		c.head = (c.head + overflow) % c.capacity
+		c.size -= overflow
+	}
+
+	// Add new elements to the back
+	for _, val := range newItems {
+		idx := (c.head + c.size) % c.capacity
+		c.items[idx] = val
+		c.size++
+	}
+}
+
+func maxTimestamp(t1, t2 time.Time) time.Time {
+	if t1.Before(t2) {
+		return t2
+	}
+	return t1
+}

--- a/disperser/dataapi/v2/circular_queue_test.go
+++ b/disperser/dataapi/v2/circular_queue_test.go
@@ -1,0 +1,397 @@
+package v2_test
+
+import (
+	"testing"
+	"time"
+
+	v2 "github.com/Layr-Labs/eigenda/disperser/dataapi/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dataPoint represents a simple time-series data point for testing
+type dataPoint struct {
+	timestamp time.Time
+}
+
+// createDataPoints returns a slice of data points with sequential timestamps
+func createDataPoints(startTime time.Time, count int) []*dataPoint {
+	points := make([]*dataPoint, count)
+	current := startTime
+	for i := 0; i < count; i++ {
+		points[i] = &dataPoint{
+			timestamp: current,
+		}
+		current = current.Add(time.Minute)
+	}
+	return points
+}
+
+// Test MergeTimeRange method
+func TestMergeTimeRange(t *testing.T) {
+	getTimestamp := func(dp *dataPoint) time.Time { return dp.timestamp }
+	now := time.Now()
+
+	tests := []struct {
+		name               string
+		initialPoints      []*dataPoint
+		initialStart       time.Time
+		initialEnd         time.Time
+		mergePoints        []*dataPoint
+		mergeStart         time.Time
+		mergeEnd           time.Time
+		expectedSize       int
+		expectedTimestamps []time.Time
+		capacity           int
+	}{
+		{
+			name:               "empty queue initialization",
+			initialPoints:      []*dataPoint{},
+			mergePoints:        createDataPoints(now, 3),
+			mergeStart:         now,
+			mergeEnd:           now.Add(3 * time.Minute),
+			expectedSize:       3,
+			expectedTimestamps: []time.Time{now, now.Add(time.Minute), now.Add(2 * time.Minute)},
+			capacity:           5,
+		},
+		{
+			name:          "append connected range",
+			initialPoints: createDataPoints(now, 3),
+			initialStart:  now,
+			initialEnd:    now.Add(3 * time.Minute),
+			mergePoints:   createDataPoints(now.Add(3*time.Minute), 2),
+			mergeStart:    now.Add(3 * time.Minute),
+			mergeEnd:      now.Add(5 * time.Minute),
+			expectedSize:  5,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:          "prepend connected range",
+			initialPoints: createDataPoints(now.Add(3*time.Minute), 3),
+			initialStart:  now.Add(3 * time.Minute),
+			initialEnd:    now.Add(6 * time.Minute),
+			mergePoints:   createDataPoints(now, 3),
+			mergeStart:    now,
+			mergeEnd:      now.Add(3 * time.Minute),
+			expectedSize:  5, // Limited by capacity
+			expectedTimestamps: []time.Time{
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+				now.Add(5 * time.Minute),
+			}, // Only newest items from prepend
+			capacity: 5,
+		},
+		{
+			name:          "replace with newer disconnected range",
+			initialPoints: createDataPoints(now, 3),
+			initialStart:  now,
+			initialEnd:    now.Add(3 * time.Minute),
+			mergePoints:   createDataPoints(now.Add(5*time.Minute), 2),
+			mergeStart:    now.Add(5 * time.Minute),
+			mergeEnd:      now.Add(7 * time.Minute),
+			expectedSize:  2,
+			expectedTimestamps: []time.Time{
+				now.Add(5 * time.Minute),
+				now.Add(6 * time.Minute),
+			}, // New timestamps from newer range
+			capacity: 5,
+		},
+		{
+			name:          "ignore contained range",
+			initialPoints: createDataPoints(now, 5),
+			initialStart:  now,
+			initialEnd:    now.Add(5 * time.Minute),
+			mergePoints:   createDataPoints(now.Add(2*time.Minute), 2),
+			mergeStart:    now.Add(2 * time.Minute),
+			mergeEnd:      now.Add(4 * time.Minute),
+			expectedSize:  5, // Unchanged
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			}, // Unchanged
+			capacity: 5,
+		},
+		{
+			name:          "extend end range",
+			initialPoints: createDataPoints(now, 3),
+			initialStart:  now,
+			initialEnd:    now.Add(3 * time.Minute),
+			mergePoints:   createDataPoints(now.Add(2*time.Minute), 3),
+			mergeStart:    now.Add(2 * time.Minute),
+			mergeEnd:      now.Add(5 * time.Minute),
+			expectedSize:  5,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			}, // Original plus new items past the end
+			capacity: 5,
+		},
+		{
+			name:          "extend start range",
+			initialPoints: createDataPoints(now.Add(2*time.Minute), 3),
+			initialStart:  now.Add(2 * time.Minute),
+			initialEnd:    now.Add(5 * time.Minute),
+			mergePoints:   createDataPoints(now, 3),
+			mergeStart:    now,
+			mergeEnd:      now.Add(3 * time.Minute),
+			expectedSize:  5,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			}, // New items that extend start plus original
+			capacity: 5,
+		},
+		{
+			name:          "capacity constraint drops oldest",
+			initialPoints: createDataPoints(now, 3),
+			initialStart:  now,
+			initialEnd:    now.Add(3 * time.Minute),
+			mergePoints:   createDataPoints(now.Add(3*time.Minute), 5),
+			mergeStart:    now.Add(3 * time.Minute),
+			mergeEnd:      now.Add(8 * time.Minute),
+			expectedSize:  5,
+			expectedTimestamps: []time.Time{
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+				now.Add(5 * time.Minute),
+				now.Add(6 * time.Minute),
+				now.Add(7 * time.Minute),
+			}, // Only newest 5 items fit
+			capacity: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queue := v2.NewCircularQueue[dataPoint](tt.capacity, getTimestamp)
+
+			// Setup initial state if needed
+			if len(tt.initialPoints) > 0 {
+				queue.MergeTimeRange(tt.initialPoints, tt.initialStart, tt.initialEnd)
+			}
+
+			// Execute the target operation being tested
+			queue.MergeTimeRange(tt.mergePoints, tt.mergeStart, tt.mergeEnd)
+
+			// Verify results
+			// Note we fetch all items from the queue as the purpose here is to verify the desired
+			// cache state
+			results := queue.QueryTimeRange(time.Time{}, now.Add(24*time.Hour), v2.Ascending, 0)
+			require.Equal(t, len(tt.expectedTimestamps), len(results))
+			for i, expectedTime := range tt.expectedTimestamps {
+				assert.True(t, expectedTime.Equal(results[i].timestamp),
+					"Expected timestamp %v at index %d, got %v", expectedTime, i, results[i].timestamp)
+			}
+		})
+	}
+}
+
+// Test QueryTimeRange method
+func TestQueryTimeRange(t *testing.T) {
+	getTimestamp := func(dp *dataPoint) time.Time { return dp.timestamp }
+	now := time.Now()
+
+	tests := []struct {
+		name               string
+		points             []*dataPoint
+		queryStart         time.Time
+		queryEnd           time.Time
+		order              v2.FetchOrder
+		limit              int
+		expectedTimestamps []time.Time
+		capacity           int
+	}{
+		{
+			name:               "empty queue",
+			points:             []*dataPoint{},
+			queryStart:         now,
+			queryEnd:           now.Add(5 * time.Minute),
+			order:              v2.Ascending,
+			limit:              0,
+			expectedTimestamps: []time.Time{},
+			capacity:           5,
+		},
+		{
+			name:       "exact range match",
+			points:     createDataPoints(now, 5),
+			queryStart: now,
+			queryEnd:   now.Add(5 * time.Minute),
+			order:      v2.Ascending,
+			limit:      0,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:       "partial range match",
+			points:     createDataPoints(now, 5),
+			queryStart: now.Add(2 * time.Minute),
+			queryEnd:   now.Add(4 * time.Minute),
+			order:      v2.Ascending,
+			limit:      0,
+			expectedTimestamps: []time.Time{
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:               "no range overlap",
+			points:             createDataPoints(now, 5),
+			queryStart:         now.Add(6 * time.Minute),
+			queryEnd:           now.Add(8 * time.Minute),
+			order:              v2.Ascending,
+			limit:              0,
+			expectedTimestamps: []time.Time{},
+			capacity:           5,
+		},
+		{
+			name:       "limit ascending",
+			points:     createDataPoints(now, 5),
+			queryStart: now,
+			queryEnd:   now.Add(5 * time.Minute),
+			order:      v2.Ascending,
+			limit:      3,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:       "limit descending",
+			points:     createDataPoints(now, 5),
+			queryStart: now,
+			queryEnd:   now.Add(5 * time.Minute),
+			order:      v2.Descending,
+			limit:      3,
+			expectedTimestamps: []time.Time{
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:       "limit larger than range",
+			points:     createDataPoints(now, 3),
+			queryStart: now,
+			queryEnd:   now.Add(3 * time.Minute),
+			order:      v2.Ascending,
+			limit:      10,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:       "zero limit returns all",
+			points:     createDataPoints(now, 5),
+			queryStart: now,
+			queryEnd:   now.Add(5 * time.Minute),
+			order:      v2.Ascending,
+			limit:      0,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:       "negative limit returns all",
+			points:     createDataPoints(now, 5),
+			queryStart: now,
+			queryEnd:   now.Add(5 * time.Minute),
+			order:      v2.Ascending,
+			limit:      -1,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:       "start time equals data point time",
+			points:     createDataPoints(now, 5),
+			queryStart: now.Add(2 * time.Minute),
+			queryEnd:   now.Add(5 * time.Minute),
+			order:      v2.Ascending,
+			limit:      0,
+			expectedTimestamps: []time.Time{
+				now.Add(2 * time.Minute),
+				now.Add(3 * time.Minute),
+				now.Add(4 * time.Minute),
+			},
+			capacity: 5,
+		},
+		{
+			name:       "end time equals data point time (exclusive)",
+			points:     createDataPoints(now, 5),
+			queryStart: now,
+			queryEnd:   now.Add(3 * time.Minute),
+			order:      v2.Ascending,
+			limit:      0,
+			expectedTimestamps: []time.Time{
+				now,
+				now.Add(time.Minute),
+				now.Add(2 * time.Minute),
+			},
+			capacity: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queue := v2.NewCircularQueue[dataPoint](tt.capacity, getTimestamp)
+
+			// Setup initial data
+			if len(tt.points) > 0 {
+				// Add a ns to make it exclusive
+				queue.MergeTimeRange(tt.points, tt.points[0].timestamp,
+					tt.points[len(tt.points)-1].timestamp.Add(time.Nanosecond))
+			}
+
+			// Execute the query
+			results := queue.QueryTimeRange(tt.queryStart, tt.queryEnd, tt.order, tt.limit)
+
+			// Verify results
+			require.Equal(t, len(tt.expectedTimestamps), len(results))
+			for i, expectedTime := range tt.expectedTimestamps {
+				assert.True(t, expectedTime.Equal(results[i].timestamp),
+					"Expected timestamp %v at index %d, got %v", expectedTime, i, results[i].timestamp)
+			}
+		})
+	}
+}

--- a/disperser/dataapi/v2/feed_cache.go
+++ b/disperser/dataapi/v2/feed_cache.go
@@ -21,14 +21,13 @@ const (
 // cached segment, it'll extend the cache segment.
 // If there are more than maxItems in cache, it'll evict the oldest items.
 type FeedCache[T any] struct {
-	mu           sync.RWMutex
-	segment      *cacheEntry[T]
-	maxItems     int
-	fetchFromDB  func(ctx context.Context, start, end time.Time, order FetchOrder, limit int) ([]*T, error)
-	getTimestamp func(*T) time.Time
-
+	mu      sync.RWMutex
+	segment *CircularQueue[T]
 	// Async updates to the cache segment
 	updateWg *sync.WaitGroup
+
+	fetchFromDB  func(ctx context.Context, start, end time.Time, order FetchOrder, limit int) ([]*T, error)
+	getTimestamp func(*T) time.Time
 }
 
 func NewFeedCache[T any](
@@ -37,7 +36,7 @@ func NewFeedCache[T any](
 	timestampFn func(*T) time.Time,
 ) *FeedCache[T] {
 	return &FeedCache[T]{
-		maxItems:     maxItems,
+		segment:      NewCircularQueue[T](maxItems, timestampFn),
 		fetchFromDB:  fetchFn,
 		getTimestamp: timestampFn,
 		updateWg:     &sync.WaitGroup{},
@@ -49,18 +48,6 @@ func NewFeedCache[T any](
 type timeRange struct {
 	start time.Time
 	end   time.Time
-}
-
-// cacheEntry describes a segment of results fetched via fetchFromDB for a time range.
-//
-// It has the following properties:
-// - all data items that are in range [start, end) are in the segment
-// - no data items that are outside the range [start, end) are included in the segment
-//
-// The data items are in ascending order by timestamp.
-type cacheEntry[T any] struct {
-	timeRange
-	data []*T
 }
 
 // executionPlan describes the breakdown of a data fetch query [start, end) into sub ranges
@@ -138,7 +125,7 @@ func (c *FeedCache[T]) makePlan(start, end time.Time, queryOrder FetchOrder, lim
 	queryRange := timeRange{start: start, end: end}
 
 	// Handle no cache or no overlap cases together
-	if segment == nil || !queryRange.overlaps(segment.timeRange) {
+	if segment.size == 0 || !queryRange.overlaps(segment.timeRange) {
 		return executionPlan[T]{
 			// The data=nil, so it doesn't matter we fill the `before` or `after`
 			after: &queryRange,
@@ -146,7 +133,7 @@ func (c *FeedCache[T]) makePlan(start, end time.Time, queryOrder FetchOrder, lim
 	}
 
 	// Get cached data that's overlapping the query range
-	cachedOverlap := c.getCacheOverlap(segment.data, start, end, queryOrder, limit)
+	cachedOverlap := segment.QueryTimeRange(start, end, queryOrder, limit)
 
 	// The query range is fully contained in cache, it's a full cache hit
 	if !start.Before(segment.start) && !end.After(segment.end) {
@@ -307,6 +294,9 @@ func (c *FeedCache[T]) updateCache(result *executionResult[T]) {
 		return
 	}
 
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	before, after := result.before, result.after
 	beforeData, afterData := result.beforeData, result.afterData
 
@@ -322,7 +312,7 @@ func (c *FeedCache[T]) updateCache(result *executionResult[T]) {
 				start = c.getTimestamp(beforeData[0])
 			}
 		}
-		c.mergeCache(beforeData, start, end)
+		c.segment.MergeTimeRange(beforeData, start, end)
 	}
 
 	if len(afterData) > 0 {
@@ -337,143 +327,8 @@ func (c *FeedCache[T]) updateCache(result *executionResult[T]) {
 				start = c.getTimestamp(afterData[0])
 			}
 		}
-		c.mergeCache(afterData, start, end)
+		c.segment.MergeTimeRange(afterData, start, end)
 	}
-}
-
-func (c *FeedCache[T]) mergeCache(data []*T, start, end time.Time) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	segment := c.segment
-
-	// No cache yet
-	if segment == nil {
-		c.setCacheSegment(data, start, end)
-		return
-	}
-
-	// No overlap with the cache
-	if !segment.overlaps(timeRange{start: start, end: end}) {
-		// Two special cases: non-overlapping but intervals are connected
-		if start.Equal(segment.end) {
-			c.setCacheSegment(append(segment.data, data...), segment.start, end)
-		}
-		if end.Equal(segment.start) {
-			c.setCacheSegment(append(data, segment.data...), start, segment.end)
-		}
-
-		// If it's a disconnected newer segment, it should replace existing cache
-		if start.After(segment.end) {
-			c.setCacheSegment(data, start, end)
-		}
-
-		return
-	}
-
-	// It's a sub range contained in existing cache, do nothing
-	if !start.Before(segment.start) && !end.After(segment.end) {
-		return
-	}
-
-	// The data is newer than cache, extend the cache
-	if end.After(segment.end) {
-		split := 0
-		for ; split < len(data); split++ {
-			if !c.getTimestamp(data[split]).Before(c.segment.end) {
-				break
-			}
-		}
-		if split < len(data) {
-			newData := append(segment.data, data[split:]...)
-			c.setCacheSegment(newData, segment.start, end)
-		}
-		return
-	}
-
-	// Now we must have start.Before(segment.start) && segment.start.Before(end)
-	split := len(data) - 1
-	for ; split >= 0; split-- {
-		if c.getTimestamp(data[split]).Before(segment.start) {
-			break
-		}
-	}
-	if split >= 0 {
-		newData := append(data[:split+1], segment.data...)
-		c.setCacheSegment(newData, start, segment.end)
-	}
-}
-
-func (c *FeedCache[T]) setCacheSegment(data []*T, start, end time.Time) {
-	// Ensure we don't exceed maxItems, prioritizing recent data
-	if len(data) > c.maxItems {
-		data = data[len(data)-c.maxItems:] // Keep newest
-		start = c.getTimestamp(data[0])
-	}
-	c.segment = &cacheEntry[T]{
-		timeRange: timeRange{
-			start: start,
-			end:   end,
-		},
-		data: data,
-	}
-}
-
-func (c *FeedCache[T]) getCacheOverlap(data []*T, start, end time.Time, queryOrder FetchOrder, limit int) []*T {
-	if len(data) == 0 {
-		return []*T{}
-	}
-
-	// Find start and end indices of the overlap
-	startIdx := -1
-	endIdx := -1
-
-	for i, item := range data {
-		timestamp := c.getTimestamp(item)
-
-		// Found the first item at or after the start time
-		if startIdx == -1 && !timestamp.Before(start) {
-			startIdx = i
-		}
-
-		// Found the first item at or past the end time (exclusive)
-		if !timestamp.Before(end) {
-			endIdx = i
-			break
-		}
-	}
-
-	// If we never found the end, set it to the end of data
-	if endIdx == -1 {
-		endIdx = len(data)
-	}
-
-	// No overlap found
-	if startIdx == -1 || startIdx >= endIdx {
-		return []*T{}
-	}
-
-	// Calculate how many items in the overlap
-	overlapCount := endIdx - startIdx
-
-	// Apply limit if needed
-	if limit > 0 && limit < overlapCount {
-		if queryOrder == Ascending {
-			// For ascending, take first 'limit' items
-			endIdx = startIdx + limit
-		} else {
-			// For descending, take last 'limit' items
-			startIdx = endIdx - limit
-		}
-	}
-
-	// Note: we need to make a copy of the overlap because the cache data can be mutated
-	// by other threads after this function returns (within this function, the caller
-	// makes sure a reader lock is held)
-	result := make([]*T, endIdx-startIdx)
-	copy(result, data[startIdx:endIdx])
-
-	return result
 }
 
 func reverseOrder[T any](data []*T) []*T {


### PR DESCRIPTION
## Why are these changes needed?
**_TL;DR_**: **The cache performance can be improved by 11x with circular queue**

The existing feed cache uses a plain slice for cached data.
When it has to be updated with newly fetched data from DB, it may involve in significant amount of memory allocation and movement, e.g. in the existing code:
- `c.setCacheSegment(append(segment.data, data...), segment.start, end)` for appending and 
- `c.setCacheSegment(append(data, segment.data...), start, segment.end)` for prepending.

This PR introduces a circular queue for caching the data and completely eliminates the need to re-allocate the memory for the cache (it always operate on pre-allocated queue).

_**Perf Benchmark**_

Benchmarked the cache extension backward (i.e. `c.setCacheSegment(append(data, segment.data...), start, segment.end)` case) for different cache sizes.

When there is 200k items in cache, performance improvement is **11x**.

Note that 200k is a very practical number, for example, we cache for 2 days of batches, which will be **2*24*3600 = 172,800** batches in cache.

**Before**:
```
BenchmarkCacheExtendStart/CacheSize_10K-8        	   76166	     15203 ns/op	    6206 B/op	     133 allocs/op
BenchmarkCacheExtendStart/CacheSize_50K-8        	   73752	     15932 ns/op	    8422 B/op	     133 allocs/op
BenchmarkCacheExtendStart/CacheSize_200K-8       	   10000	    176257 ns/op	  274329 B/op	     133 allocs/op
```

**After**:
```
BenchmarkCacheExtendStart/CacheSize_10K-8        	   71349	     15441 ns/op	    6111 B/op	     133 allocs/op
BenchmarkCacheExtendStart/CacheSize_50K-8        	   77046	     15475 ns/op	    6111 B/op	     133 allocs/op
BenchmarkCacheExtendStart/CacheSize_200K-8       	   67117	     15726 ns/op	    6111 B/op	     133 allocs/op
```




<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
