### PR TITLE
fix: ondemand scheme

### DIFF
--- a/common/aws/mock/dynamodb_client.go
+++ b/common/aws/mock/dynamodb_client.go
@@ -31,6 +31,11 @@ func (c *MockDynamoDBClient) PutItemWithCondition(ctx context.Context, tableName
 	return args.Error(0)
 }
 
+func (c *MockDynamoDBClient) PutItemWithConditionAndReturn(ctx context.Context, tableName string, item dynamodb.Item, condition string, expressionAttributeNames map[string]string, expressionAttributeValues map[string]types.AttributeValue) (dynamodb.Item, error) {
+	args := c.Called()
+	return args.Get(0).(dynamodb.Item), args.Error(1)
+}
+
 func (c *MockDynamoDBClient) PutItems(ctx context.Context, tableName string, items []dynamodb.Item) ([]dynamodb.Item, error) {
 	args := c.Called(ctx, tableName, items)
 	if args.Get(0) == nil {

--- a/core/meterer/meterer.go
+++ b/core/meterer/meterer.go
@@ -212,58 +212,35 @@ func (m *Meterer) ServeOnDemandRequest(ctx context.Context, header core.PaymentM
 		return fmt.Errorf("invalid quorum for On-Demand Request: %w", err)
 	}
 
-	// Compute paymentCharged at payment time
-	paymentCharged := PaymentCharged(symbolsCharged, m.ChainPaymentState.GetPricePerSymbol())
-
-	// Validate payments attached
-	err = m.ValidatePayment(ctx, header, onDemandPayment, paymentCharged)
-	if err != nil {
-		// No tolerance for incorrect payment amounts; no rollbacks
-		return fmt.Errorf("invalid on-demand payment: %w", err)
+	// Verify that the claimed cumulative payment doesn't exceed the on-chain deposit
+	fmt.Println("header.CumulativePayment", header.CumulativePayment, "onDemandPayment.CumulativePayment", onDemandPayment.CumulativePayment)
+	if header.CumulativePayment.Cmp(onDemandPayment.CumulativePayment) > 0 {
+		return fmt.Errorf("request claims a cumulative payment greater than the on-chain deposit")
 	}
 
-	err = m.OffchainStore.AddOnDemandPayment(ctx, header, paymentCharged)
+	// Compute paymentCharged at payment time
+	paymentCharged := PaymentCharged(symbolsCharged, m.ChainPaymentState.GetPricePerSymbol())
+	// Add the payment and get the old payment value
+	m.logger.Info("Adding on-demand payment", "header", header, "onDemandPayment", onDemandPayment, "paymentCharged", paymentCharged)
+	oldPayment, err := m.OffchainStore.AddOnDemandPayment(ctx, header, paymentCharged)
 	if err != nil {
 		return fmt.Errorf("failed to update cumulative payment: %w", err)
 	}
 
+	m.logger.Info("Incrementing global bin usage", "header", header, "onDemandPayment", onDemandPayment, "oldPayment", oldPayment)
 	// Update bin usage atomically and check against bin capacity
 	if err := m.IncrementGlobalBinUsage(ctx, uint64(symbolsCharged), receivedAt); err != nil {
-		//TODO: conditionally remove the payment based on the error type (maybe if the error is store-op related)
-		dbErr := m.OffchainStore.RemoveOnDemandPayment(ctx, header.AccountID, header.CumulativePayment)
+		// If global bin usage update fails, roll back the payment to its previous value
+		// The rollback will only happen if the current payment value still matches what we just wrote
+		// This ensures we don't accidentally roll back a newer payment that might have been processed
+		dbErr := m.OffchainStore.RollbackOnDemandPayment(ctx, header.AccountID, header.CumulativePayment, oldPayment)
 		if dbErr != nil {
 			return dbErr
 		}
 		return fmt.Errorf("failed global rate limiting: %w", err)
 	}
+	m.logger.Info("Successfully incremented global bin usage", "header", header, "onDemandPayment", onDemandPayment, "oldPayment", oldPayment)
 
-	return nil
-}
-
-// ValidatePayment checks if the provided payment header is valid against the local accounting
-// prevPmt is the largest  cumulative payment strictly less    than PaymentMetadata.cumulativePayment if exists
-// nextPmt is the smallest cumulative payment strictly greater than PaymentMetadata.cumulativePayment if exists
-// chargeOfNextPmt is the charge associated with nextPmt if exists
-// prevPmt + currentPaymentCharge <= PaymentMetadata.CumulativePayment
-// <= nextPmt - chargeOfNextPmt > nextPmt
-func (m *Meterer) ValidatePayment(ctx context.Context, header core.PaymentMetadata, onDemandPayment *core.OnDemandPayment, currentPaymentCharge *big.Int) error {
-	if header.CumulativePayment.Cmp(onDemandPayment.CumulativePayment) > 0 {
-		return fmt.Errorf("request claims a cumulative payment greater than the on-chain deposit")
-	}
-
-	prevPmt, nextPmt, chargeOfNextPmt, err := m.OffchainStore.GetRelevantOnDemandRecords(ctx, header.AccountID, header.CumulativePayment) // zero if DNE
-	if err != nil {
-		return fmt.Errorf("failed to get relevant on-demand records: %w", err)
-	}
-	// the current request must increment cumulative payment by a magnitude sufficient to cover the blob size
-	if new(big.Int).Add(prevPmt, currentPaymentCharge).Cmp(header.CumulativePayment) > 0 {
-		return fmt.Errorf("insufficient cumulative payment increment")
-	}
-	// the current request must not break the payment magnitude for the next payment if the two requests were delivered out-of-order
-	if nextPmt.Cmp(big.NewInt(0)) != 0 && new(big.Int).Add(header.CumulativePayment, chargeOfNextPmt).Cmp(nextPmt) > 0 {
-		return fmt.Errorf("breaking cumulative payment invariants")
-	}
-	// check passed: blob can be safely inserted into the set of payments
 	return nil
 }
 

--- a/core/meterer/meterer_test.go
+++ b/core/meterer/meterer_test.go
@@ -312,8 +312,8 @@ func TestMetererOnDemand(t *testing.T) {
 	// test insufficient cumulative payment
 	header = createPaymentHeader(now.UnixNano(), big.NewInt(1), accountID1)
 	_, err = mt.MeterRequest(ctx, *header, 1000, quorumNumbers, now)
-	assert.ErrorContains(t, err, "insufficient cumulative payment increment")
-	// Not record for invalid payment
+	assert.ErrorContains(t, err, "payment validation failed: payment charged is greater than cumulative payment")
+	// No record for invalid payment
 	result, err := dynamoClient.Query(ctx, ondemandTableName, "AccountID = :account", commondynamodb.ExpressionValues{
 		":account": &types.AttributeValueMemberS{
 			Value: accountID1.Hex(),
@@ -332,11 +332,11 @@ func TestMetererOnDemand(t *testing.T) {
 	assert.Equal(t, uint64(102), symbolsCharged)
 	header = createPaymentHeader(now.UnixNano(), priceCharged, accountID2)
 	_, err = mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
-	assert.ErrorContains(t, err, "exact payment already exists")
+	// Doesn't check for exact payment, checks for increment
+	assert.ErrorContains(t, err, "insufficient cumulative payment increment")
 
 	// test valid payments
-	numValidPayments := 9
-	for i := 1; i < numValidPayments; i++ {
+	for i := 1; i < 9; i++ {
 		header = createPaymentHeader(now.UnixNano(), new(big.Int).Mul(priceCharged, big.NewInt(int64(i+1))), accountID2)
 		symbolsCharged, err = mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
 		assert.NoError(t, err)
@@ -346,7 +346,7 @@ func TestMetererOnDemand(t *testing.T) {
 	// test cumulative payment on-chain constraint
 	header = createPaymentHeader(now.UnixNano(), big.NewInt(2023), accountID2)
 	_, err = mt.MeterRequest(ctx, *header, 1, quorumNumbers, now)
-	assert.ErrorContains(t, err, "invalid on-demand payment: request claims a cumulative payment greater than the on-chain deposit")
+	assert.ErrorContains(t, err, "invalid on-demand request: request claims a cumulative payment greater than the on-chain deposit")
 
 	// test insufficient increment in cumulative payment
 	previousCumulativePayment := priceCharged.Mul(priceCharged, big.NewInt(9))
@@ -355,21 +355,21 @@ func TestMetererOnDemand(t *testing.T) {
 	priceCharged = meterer.PaymentCharged(symbolsCharged, mt.ChainPaymentState.GetPricePerSymbol())
 	header = createPaymentHeader(now.UnixNano(), big.NewInt(0).Add(previousCumulativePayment, big.NewInt(0).Sub(priceCharged, big.NewInt(1))), accountID2)
 	_, err = mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
-	assert.ErrorContains(t, err, "invalid on-demand payment: insufficient cumulative payment increment")
+	assert.ErrorContains(t, err, "insufficient cumulative payment increment")
 	previousCumulativePayment = big.NewInt(0).Add(previousCumulativePayment, priceCharged)
 
 	// test cannot insert cumulative payment in out of order
 	symbolsCharged = mt.SymbolsCharged(uint64(50))
 	header = createPaymentHeader(now.UnixNano(), meterer.PaymentCharged(symbolsCharged, mt.ChainPaymentState.GetPricePerSymbol()), accountID2)
 	_, err = mt.MeterRequest(ctx, *header, 50, quorumNumbers, now)
-	assert.ErrorContains(t, err, "invalid on-demand payment: breaking cumulative payment invariants")
+	assert.ErrorContains(t, err, "insufficient cumulative payment increment")
 
 	result, err = dynamoClient.Query(ctx, ondemandTableName, "AccountID = :account", commondynamodb.ExpressionValues{
 		":account": &types.AttributeValueMemberS{
 			Value: accountID2.Hex(),
 		}})
 	assert.NoError(t, err)
-	assert.Equal(t, numValidPayments, len(result))
+	assert.Equal(t, 1, len(result))
 	// test failed global rate limit (previously payment recorded: 2, global limit: 1009)
 	header = createPaymentHeader(now.UnixNano(), big.NewInt(0).Add(previousCumulativePayment, meterer.PaymentCharged(1010, mt.ChainPaymentState.GetPricePerSymbol())), accountID1)
 	_, err = mt.MeterRequest(ctx, *header, 1010, quorumNumbers, now)
@@ -380,7 +380,7 @@ func TestMetererOnDemand(t *testing.T) {
 			Value: accountID2.Hex(),
 		}})
 	assert.NoError(t, err)
-	assert.Equal(t, numValidPayments, len(result))
+	assert.Equal(t, 1, len(result))
 }
 
 func TestPaymentCharged(t *testing.T) {

--- a/core/meterer/util.go
+++ b/core/meterer/util.go
@@ -57,24 +57,6 @@ func CreateGlobalReservationTable(clientConfig commonaws.ClientConfig, tableName
 				KeyType:       types.KeyTypeHash,
 			},
 		},
-		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
-			{
-				IndexName: aws.String("ReservationPeriodIndex"),
-				KeySchema: []types.KeySchemaElement{
-					{
-						AttributeName: aws.String("ReservationPeriod"),
-						KeyType:       types.KeyTypeHash,
-					},
-				},
-				Projection: &types.Projection{
-					ProjectionType: types.ProjectionTypeAll,
-				},
-				ProvisionedThroughput: &types.ProvisionedThroughput{
-					ReadCapacityUnits:  aws.Int64(10),
-					WriteCapacityUnits: aws.Int64(10),
-				},
-			},
-		},
 		TableName: aws.String(tableName),
 		ProvisionedThroughput: &types.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(10),
@@ -92,41 +74,11 @@ func CreateOnDemandTable(clientConfig commonaws.ClientConfig, tableName string) 
 				AttributeName: aws.String("AccountID"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
-			{
-				AttributeName: aws.String("CumulativePayments"),
-				AttributeType: types.ScalarAttributeTypeN,
-			},
-			{
-				AttributeName: aws.String("Charge"),
-				AttributeType: types.ScalarAttributeTypeN,
-			},
 		},
 		KeySchema: []types.KeySchemaElement{
 			{
 				AttributeName: aws.String("AccountID"),
 				KeyType:       types.KeyTypeHash,
-			},
-			{
-				AttributeName: aws.String("CumulativePayments"),
-				KeyType:       types.KeyTypeRange,
-			},
-		},
-		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
-			{
-				IndexName: aws.String("ChargeIndex"),
-				KeySchema: []types.KeySchemaElement{
-					{
-						AttributeName: aws.String("Charge"),
-						KeyType:       types.KeyTypeHash,
-					},
-				},
-				Projection: &types.Projection{
-					ProjectionType: types.ProjectionTypeAll,
-				},
-				ProvisionedThroughput: &types.ProvisionedThroughput{
-					ReadCapacityUnits:  aws.Int64(10),
-					WriteCapacityUnits: aws.Int64(10),
-				},
 			},
 		},
 		TableName: aws.String(tableName),
@@ -135,5 +87,11 @@ func CreateOnDemandTable(clientConfig commonaws.ClientConfig, tableName string) 
 			WriteCapacityUnits: aws.Int64(10),
 		},
 	})
-	return err
+	if err != nil {
+		if err.Error() == "ResourceInUseException: Table already exists" {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/disperser/apiserver/server_v2_test.go
+++ b/disperser/apiserver/server_v2_test.go
@@ -150,7 +150,7 @@ func TestV2DisperseBlob(t *testing.T) {
 		BlobHeader: blobHeaderProto2,
 	})
 	assert.Nil(t, reply)
-	assert.ErrorContains(t, err, "payment already exists")
+	assert.ErrorContains(t, err, "failed to update cumulative payment: insufficient cumulative payment increment")
 }
 
 func TestV2DisperseBlobRequestValidation(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?

addressing payment audit critical issue 2

- relax invariant to be always sufficient increment, doesn't allow out of order on-demand payments
- reduce the ondemand table scheme to be 1 record per account, record only tracks the largest cumulative payment
- conditional write to the table by checking existing record + new charge <= new cumulative payment

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
