### PR TITLE
feat: slashingRegistryCoordinator integration

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -15,4 +15,4 @@ optimizer_runs = 200
 # Whether or not to use the Yul intermediate representation compilation pipeline
 via_ir = false
 # Override the Solidity version (this overrides `auto_detect_solc`)
-solc_version = '0.8.12'
+solc_version = '0.8.27'

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,2 +1,2 @@
 @openzeppelin/=lib/eigenlayer-middleware/lib/openzeppelin-contracts
-@openzeppelin-upgradeable/=lib/eigenlayer-middleware/lib/openzeppelin-contracts-upgradeable
+@openzeppelin-upgrades/=lib/eigenlayer-middleware/lib/openzeppelin-contracts-upgradeable

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,1 +1,2 @@
-@openzeppelin/=node_modules/@openzeppelin/
+@openzeppelin/=lib/eigenlayer-middleware/lib/openzeppelin-contracts
+@openzeppelin-upgradeable/=lib/eigenlayer-middleware/lib/openzeppelin-contracts-upgradeable

--- a/contracts/script/DeployOpenEigenLayer.s.sol
+++ b/contracts/script/DeployOpenEigenLayer.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
@@ -8,8 +8,9 @@ import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 
 import "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IETHPOSDeposit.sol";
 
+import "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
 import "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
-import "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/core/Slasher.sol";
+import "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
 import "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
 import "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 import "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/core/RewardsCoordinator.sol";
@@ -54,8 +55,9 @@ contract DeployOpenEigenLayer is Script, Test {
     // EigenLayer Contracts
     ProxyAdmin public eigenLayerProxyAdmin;
     PauserRegistry public eigenLayerPauserReg;
-    Slasher public slasher;
-    Slasher public slasherImplementation;
+    PermissionController public permissionController;
+    AllocationManager public allocationManager;
+    AllocationManager public allocationManagerImplementation;
     DelegationManager public delegation;
     DelegationManager public delegationImplementation;
     StrategyManager public strategyManager;
@@ -89,7 +91,7 @@ contract DeployOpenEigenLayer is Script, Test {
 
         // deploy proxy admin for the ability to upgrade proxy contracts
         eigenLayerProxyAdmin = new ProxyAdmin();
-
+        permissionController = new PermissionController();
         //deploy pauser registry
         {
             address[] memory pausers = new address[](3);
@@ -104,6 +106,9 @@ contract DeployOpenEigenLayer is Script, Test {
          * not yet deployed, we give these proxies an empty contract as the initial implementation, to act as if they have no code.
          */
         emptyContract = new EmptyContract();
+        allocationManager = AllocationManager(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
+        );
         delegation = DelegationManager(
             address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
         );
@@ -111,9 +116,6 @@ contract DeployOpenEigenLayer is Script, Test {
             address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
         );
         strategyManager = StrategyManager(
-            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
-        );
-        slasher = Slasher(
             address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
         );
         eigenPodManager = EigenPodManager(
@@ -133,25 +135,36 @@ contract DeployOpenEigenLayer is Script, Test {
         eigenPodBeacon = new UpgradeableBeacon(address(eigenPodImplementation));
 
         // Second, deploy the *implementation* contracts, using the *proxy contracts* as inputs
-        delegationImplementation = new DelegationManager(strategyManager, slasher, eigenPodManager);
-        avsDirectoryImplementation = new AVSDirectory(delegation);
+        delegationImplementation = new DelegationManager(
+            strategyManager,
+            eigenPodManager,
+            allocationManager,
+            eigenLayerPauserReg,
+            permissionController,
+            14 days /* minWithdrawalDelay */
+        );
+        avsDirectoryImplementation = new AVSDirectory(
+            delegation,
+            eigenLayerPauserReg
+        );
         rewardsCoordinatorImplementation = new RewardsCoordinator(
             delegation,
             strategyManager,
+            allocationManager,
+            eigenLayerPauserReg,
+            permissionController,
             CALCULATION_INTERVAL_SECONDS,
             MAX_REWARDS_DURATION,
             MAX_RETROACTIVE_LENGTH,
             MAX_FUTURE_LENGTH,
             GENESIS_REWARDS_TIMESTAMP
         );
-        strategyManagerImplementation = new StrategyManager(delegation, eigenPodManager, slasher);
-        slasherImplementation = new Slasher(strategyManager, delegation);
+        strategyManagerImplementation = new StrategyManager(delegation, eigenLayerPauserReg);
         eigenPodManagerImplementation = new EigenPodManager(
             ethPOSDeposit,
             eigenPodBeacon,
-            strategyManager,
-            slasher,
-            delegation
+            delegation,
+            eigenLayerPauserReg
         );
 
         // Third, upgrade the proxy contracts to use the correct implementation contracts and initialize them.
@@ -193,11 +206,6 @@ contract DeployOpenEigenLayer is Script, Test {
             )
         );
         eigenLayerProxyAdmin.upgradeAndCall(
-            TransparentUpgradeableProxy(payable(address(slasher))),
-            address(slasherImplementation),
-            abi.encodeWithSelector(Slasher.initialize.selector, executorMultisig, eigenLayerPauserReg, 0)
-        );
-        eigenLayerProxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(eigenPodManager))),
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
@@ -209,7 +217,7 @@ contract DeployOpenEigenLayer is Script, Test {
         );
 
         // deploy StrategyBaseTVLLimits contract implementation
-        baseStrategyImplementation = new StrategyBaseTVLLimits(strategyManager);
+        baseStrategyImplementation = new StrategyBaseTVLLimits(strategyManager, eigenLayerPauserReg);
         // create upgradeable proxies that each point to the implementation and initialize them
         for (uint256 i = 0; i < strategyConfigs.length; ++i) {
             deployedStrategyArray.push(

--- a/contracts/script/EigenLayerUtils.s.sol
+++ b/contracts/script/EigenLayerUtils.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/script/EjectionManagerDeployer.s.sol
+++ b/contracts/script/EjectionManagerDeployer.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import {EmptyContract} from "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 import {EjectionManager} from "../lib/eigenlayer-middleware/src/EjectionManager.sol";
-import {IEjectionManager} from "../lib/eigenlayer-middleware/src/interfaces/IEjectionManager.sol";
+import {IEjectionManager, IEjectionManagerTypes} from "../lib/eigenlayer-middleware/src/interfaces/IEjectionManager.sol";
 import {RegistryCoordinator} from "../lib/eigenlayer-middleware/src/RegistryCoordinator.sol";
 import {IRegistryCoordinator} from "../lib/eigenlayer-middleware/src/interfaces/IRegistryCoordinator.sol";
 import {StakeRegistry} from "../lib/eigenlayer-middleware/src/StakeRegistry.sol";
@@ -101,9 +101,9 @@ contract Deployer_EjectionManager is Script, Test {
         EjectionManager _ejectionManagerImplementation,
         string memory config_data
     ) internal {
-        require(address(_ejectionManager.registryCoordinator()) == address(registryCoordinator), "ejectionManager.registryCoordinator() != registryCoordinator");
+        require(address(_ejectionManager.slashingRegistryCoordinator()) == address(registryCoordinator), "ejectionManager.registryCoordinator() != registryCoordinator");
         require(address(_ejectionManager.stakeRegistry()) == address(stakeRegistry), "ejectionManager.stakeRegistry() != stakeRegistry");
-        require(address(_ejectionManagerImplementation.registryCoordinator()) == address(registryCoordinator), "ejectionManagerImplementation.registryCoordinator() != registryCoordinator");
+        require(address(_ejectionManagerImplementation.slashingRegistryCoordinator()) == address(registryCoordinator), "ejectionManagerImplementation.registryCoordinator() != registryCoordinator");
         require(address(_ejectionManagerImplementation.stakeRegistry()) == address(stakeRegistry), "ejectionManagerImplementation.stakeRegistry() != stakeRegistry");
 
         require(eigenDAProxyAdmin.getProxyImplementation(
@@ -114,10 +114,10 @@ contract Deployer_EjectionManager is Script, Test {
         require(_ejectionManager.owner() == ejectorOwner, "ejectionManager.owner() != ejectorOwner");
         require(_ejectionManager.isEjector(ejector) == true, "ejector != ejector");
 
-        IEjectionManager.QuorumEjectionParams[] memory quorumEjectionParams = _parseQuorumEjectionParams(config_data);
+        IEjectionManagerTypes.QuorumEjectionParams[] memory quorumEjectionParams = _parseQuorumEjectionParams(config_data);
         for (uint8 i = 0; i < quorumEjectionParams.length; ++i) {
             (uint32 rateLimitWindow, uint16 ejectableStakePercent) = _ejectionManager.quorumEjectionParams(i);
-            IEjectionManager.QuorumEjectionParams memory params = IEjectionManager.QuorumEjectionParams(
+            IEjectionManagerTypes.QuorumEjectionParams memory params = IEjectionManagerTypes.QuorumEjectionParams(
                 rateLimitWindow,
                 ejectableStakePercent
             );
@@ -128,8 +128,8 @@ contract Deployer_EjectionManager is Script, Test {
         }
     }
 
-    function _parseQuorumEjectionParams(string memory config_data) internal returns (IEjectionManager.QuorumEjectionParams[] memory quorumEjectionParams) {
+    function _parseQuorumEjectionParams(string memory config_data) internal returns (IEjectionManagerTypes.QuorumEjectionParams[] memory quorumEjectionParams) {
         bytes memory quorumEjectionParamsRaw = stdJson.parseRaw(config_data, ".quorumEjectionParams");
-        quorumEjectionParams = abi.decode(quorumEjectionParamsRaw, (IEjectionManager.QuorumEjectionParams[]));
+        quorumEjectionParams = abi.decode(quorumEjectionParamsRaw, (IEjectionManagerTypes.QuorumEjectionParams[]));
     }
 }

--- a/contracts/script/SetUpEigenDA.s.sol
+++ b/contracts/script/SetUpEigenDA.s.sol
@@ -156,11 +156,10 @@ contract SetupEigenDA is EigenDADeployer, EigenLayerUtils {
 
         {
             IStrategy[] memory strategies = new IStrategy[](numStrategies);
-            bool[] memory transferLocks = new bool[](numStrategies);
             for (uint8 i = 0; i < numStrategies; i++) {
                 strategies[i] = deployedStrategyArray[i];
             }
-            strategyManager.addStrategiesToDepositWhitelist(strategies, transferLocks);
+            strategyManager.addStrategiesToDepositWhitelist(strategies);
         }
 
         vm.stopBroadcast();
@@ -168,11 +167,14 @@ contract SetupEigenDA is EigenDADeployer, EigenLayerUtils {
         // Register operators with EigenLayer
         for (uint256 i = 0; i < operatorPrivateKeys.length; i++) {
             vm.broadcast(operatorPrivateKeys[i]);
-            address earningsReceiver = address(uint160(uint256(keccak256(abi.encodePacked(operatorPrivateKeys[i])))));
-            address delegationApprover = address(0); //address(uint160(uint256(keccak256(abi.encodePacked(earningsReceiver)))));
-            uint32 stakerOptOutWindowBlocks = 100;
+            address delegationApprover = address(0);
+            uint32 allocationDelay = 10;
             string memory metadataURI = string.concat("https://urmom.com/operator/", vm.toString(i));
-            delegation.registerAsOperator(IDelegationManager.OperatorDetails(earningsReceiver, delegationApprover, stakerOptOutWindowBlocks), metadataURI);
+            delegation.registerAsOperator(
+                delegationApprover,
+                allocationDelay,
+                metadataURI
+            );
         }
 
 

--- a/contracts/script/deploy/certverifier/CertVerifierDeployer.s.sol
+++ b/contracts/script/deploy/certverifier/CertVerifierDeployer.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import {EigenDACertVerifier} from "src/core/EigenDACertVerifier.sol";
 import {RegistryCoordinator} from "lib/eigenlayer-middleware/src/RegistryCoordinator.sol";

--- a/contracts/script/deploy/goerliv2/GoerliV2_Deploy.s.sol
+++ b/contracts/script/deploy/goerliv2/GoerliV2_Deploy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 /*
 import {PauserRegistry} from "../lib/eigenlayer-middleware/src/contracts/permissions/PauserRegistry.sol";
 import {EmptyContract} from "../lib/eigenlayer-middleware/src/test/mocks/EmptyContract.sol";

--- a/contracts/src/core/EigenDADisperserRegistry.sol
+++ b/contracts/src/core/EigenDADisperserRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 import {EigenDADisperserRegistryStorage} from "./EigenDADisperserRegistryStorage.sol";
 import {IEigenDADisperserRegistry} from "../interfaces/IEigenDADisperserRegistry.sol";
 import "../interfaces/IEigenDAStructs.sol";

--- a/contracts/src/core/EigenDADisperserRegistry.sol
+++ b/contracts/src/core/EigenDADisperserRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {EigenDADisperserRegistryStorage} from "./EigenDADisperserRegistryStorage.sol";
 import {IEigenDADisperserRegistry} from "../interfaces/IEigenDADisperserRegistry.sol";
 import "../interfaces/IEigenDAStructs.sol";

--- a/contracts/src/core/EigenDARelayRegistry.sol
+++ b/contracts/src/core/EigenDARelayRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 import {EigenDARelayRegistryStorage} from "./EigenDARelayRegistryStorage.sol";
 import {IEigenDARelayRegistry} from "../interfaces/IEigenDARelayRegistry.sol";
 import "../interfaces/IEigenDAStructs.sol";

--- a/contracts/src/core/EigenDARelayRegistry.sol
+++ b/contracts/src/core/EigenDARelayRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import {OwnableUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {EigenDARelayRegistryStorage} from "./EigenDARelayRegistryStorage.sol";
 import {IEigenDARelayRegistry} from "../interfaces/IEigenDARelayRegistry.sol";
 import "../interfaces/IEigenDAStructs.sol";

--- a/contracts/src/core/EigenDAServiceManagerStorage.sol
+++ b/contracts/src/core/EigenDAServiceManagerStorage.sol
@@ -44,18 +44,6 @@ abstract contract EigenDAServiceManagerStorage is IEigenDAServiceManager {
     IPaymentVault public immutable paymentVault;
     IEigenDADisperserRegistry public immutable eigenDADisperserRegistry;
     
-    constructor(
-        IEigenDAThresholdRegistry _eigenDAThresholdRegistry,
-        IEigenDARelayRegistry _eigenDARelayRegistry,
-        IPaymentVault _paymentVault,
-        IEigenDADisperserRegistry _eigenDADisperserRegistry
-    ) {
-        eigenDAThresholdRegistry = _eigenDAThresholdRegistry;
-        eigenDARelayRegistry = _eigenDARelayRegistry;
-        paymentVault = _paymentVault;
-        eigenDADisperserRegistry = _eigenDADisperserRegistry;
-    }
-
     /// @notice The current batchId
     uint32 public batchId;
 

--- a/contracts/src/interfaces/IEigenDAServiceManager.sol
+++ b/contracts/src/interfaces/IEigenDAServiceManager.sol
@@ -5,9 +5,36 @@ import {IServiceManager} from "../../lib/eigenlayer-middleware/src/interfaces/IS
 import {BLSSignatureChecker} from "../../lib/eigenlayer-middleware/src/BLSSignatureChecker.sol";
 import {BN254} from "../../lib/eigenlayer-middleware/src/libraries/BN254.sol";
 import {IEigenDAThresholdRegistry} from "./IEigenDAThresholdRegistry.sol";
+import {IRewardsCoordinator} from "../../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
+import {IPauserRegistry} from "../../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
+import {IPermissionController} from "../../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IPermissionController.sol";
+import {IAllocationManager} from "../../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IAVSDirectory} from "../../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IRegistryCoordinator} from "../../lib/eigenlayer-middleware/src/interfaces/IRegistryCoordinator.sol";
+import {IStakeRegistry} from "../../lib/eigenlayer-middleware/src/interfaces/IStakeRegistry.sol";
+import {IEigenDARelayRegistry} from "./IEigenDARelayRegistry.sol";
+import {IPaymentVault} from "./IPaymentVault.sol";
+import {IEigenDADisperserRegistry} from "./IEigenDADisperserRegistry.sol";
 import "./IEigenDAStructs.sol";
 
 interface IEigenDAServiceManager is IServiceManager, IEigenDAThresholdRegistry {
+    
+    // STRUCTS
+
+    struct EigenDASMConstructorParams {
+        IRewardsCoordinator rewardsCoordinator;
+        IPermissionController permissionController;
+        IAllocationManager allocationManager;
+        IAVSDirectory avsDirectory;
+        IPauserRegistry pauserRegistry;
+        IRegistryCoordinator registryCoordinator;
+        IStakeRegistry stakeRegistry;
+        IEigenDAThresholdRegistry eigenDAThresholdRegistry;
+        IEigenDARelayRegistry eigenDARelayRegistry;
+        IPaymentVault paymentVault;
+        IEigenDADisperserRegistry eigenDADisperserRegistry;
+    }
+
     // EVENTS
     
     /**

--- a/contracts/src/payments/PaymentVault.sol
+++ b/contracts/src/payments/PaymentVault.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {PaymentVaultStorage} from "./PaymentVaultStorage.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/payments/PaymentVault.sol
+++ b/contracts/src/payments/PaymentVault.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 import {PaymentVaultStorage} from "./PaymentVaultStorage.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/test/MockEigenDADeployer.sol
+++ b/contracts/test/MockEigenDADeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -103,16 +103,20 @@ contract MockEigenDADeployer is BLSMockAVSDeployer {
             )
         );
 
-        eigenDAServiceManagerImplementation = new EigenDAServiceManager(
-            avsDirectory,
-            rewardsCoordinator,
-            registryCoordinator,
-            stakeRegistry,
-            eigenDAThresholdRegistry,
-            eigenDARelayRegistry,
-            paymentVault,
-            eigenDADisperserRegistry
-        );
+        IEigenDAServiceManager.EigenDASMConstructorParams memory params = IEigenDAServiceManager.EigenDASMConstructorParams({
+            rewardsCoordinator: rewardsCoordinator,
+            permissionController: permissionControllerMock,
+            allocationManager: allocationManager,
+            avsDirectory: avsDirectory,
+            pauserRegistry: pauserRegistry,
+            registryCoordinator: registryCoordinator,
+            stakeRegistry: stakeRegistry,
+            eigenDAThresholdRegistry: eigenDAThresholdRegistry,
+            eigenDARelayRegistry: eigenDARelayRegistry,
+            paymentVault: paymentVault,
+            eigenDADisperserRegistry: eigenDADisperserRegistry
+        });
+        eigenDAServiceManagerImplementation = new EigenDAServiceManager(params);
 
         address[] memory confirmers = new address[](1);
         confirmers[0] = confirmer;
@@ -123,7 +127,6 @@ contract MockEigenDADeployer is BLSMockAVSDeployer {
             address(eigenDAServiceManagerImplementation),
             abi.encodeWithSelector(
                 EigenDAServiceManager.initialize.selector,
-                pauserRegistry,
                 0,
                 registryCoordinatorOwner,
                 confirmers,

--- a/contracts/test/MockEigenDADeployer.sol
+++ b/contracts/test/MockEigenDADeployer.sol
@@ -127,7 +127,6 @@ contract MockEigenDADeployer is BLSMockAVSDeployer {
             address(eigenDAServiceManagerImplementation),
             abi.encodeWithSelector(
                 EigenDAServiceManager.initialize.selector,
-                0,
                 registryCoordinatorOwner,
                 confirmers,
                 registryCoordinatorOwner

--- a/contracts/test/unit/EigenDABlobUtilsV1Unit.t.sol
+++ b/contracts/test/unit/EigenDABlobUtilsV1Unit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../MockEigenDADeployer.sol";
 

--- a/contracts/test/unit/EigenDACertVerifierV2Unit.t.sol
+++ b/contracts/test/unit/EigenDACertVerifierV2Unit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../MockEigenDADeployer.sol";
 

--- a/contracts/test/unit/EigenDADisperserRegistryUnit.t.sol
+++ b/contracts/test/unit/EigenDADisperserRegistryUnit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../MockEigenDADeployer.sol";
 

--- a/contracts/test/unit/EigenDARelayRegistryUnit.t.sol
+++ b/contracts/test/unit/EigenDARelayRegistryUnit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../MockEigenDADeployer.sol";
 

--- a/contracts/test/unit/EigenDAServiceManagerUnit.t.sol
+++ b/contracts/test/unit/EigenDAServiceManagerUnit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../MockEigenDADeployer.sol";
 

--- a/contracts/test/unit/EigenDAThresholdRegistryUnit.t.sol
+++ b/contracts/test/unit/EigenDAThresholdRegistryUnit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../MockEigenDADeployer.sol";
 

--- a/contracts/test/unit/PaymentVaultUnit.t.sol
+++ b/contracts/test/unit/PaymentVaultUnit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../MockEigenDADeployer.sol";
 


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

While importing EigenDA contract I'm require later version of middleware contracts with OperatorSets and slashing in core contracts. For now, will keep this PR open as a draft which uses the `SlashingRegistryCoordinator` and `RegistryCoordinator` which inherits from it.

Changes
- Bumping solidity version to 0.8.27
- Updating eigenlayer-middleware to `v1.1.1` (although there is absolute import path that is causing an error, will need to update the commit this is pointing to)
- EigenDASM
    - Refactored constructor due to stack-to-deep
    - Updated `Pausable` import
- Tests and scripts passing and building

## Checks

- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
