### PR TITLE
Add API for per-operator batch feed

### DIFF
--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -39,7 +39,70 @@ const docTemplateV2 = `{
                     },
                     {
                         "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than 'before' [default: before-1h]",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.BatchFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/batches/feed/{operator_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Batches"
+                ],
+                "summary": "Fetch batch feed dispersed to an operator in specified direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
                         "name": "after",
                         "in": "query"
                     },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -36,7 +36,70 @@
                     },
                     {
                         "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than 'before' [default: before-1h]",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.BatchFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/batches/feed/{operator_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Batches"
+                ],
+                "summary": "Fetch batch feed dispersed to an operator in specified direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
                         "name": "after",
                         "in": "query"
                     },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -562,7 +562,7 @@ paths:
         name: before
         type: string
       - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
-          2006-01-02T15:04:05Z); must be smaller than ''before'' [default: before-1h]'
+          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
         in: query
         name: after
         type: string
@@ -591,6 +591,51 @@ paths:
           schema:
             $ref: '#/definitions/v2.ErrorResponse'
       summary: Fetch batch feed in specified direction
+      tags:
+      - Batches
+  /batches/feed/{operator_id}:
+    get:
+      parameters:
+      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
+          or ''backward'' (newest to oldest, DESC order) [default: forward]'
+        in: query
+        name: direction
+        type: string
+      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
+          example: 2006-01-02T15:04:05Z) [default: now]'
+        in: query
+        name: before
+        type: string
+      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
+          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
+        in: query
+        name: after
+        type: string
+      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
+          it''s treated as 1000 [default: 20; max: 1000]'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.BatchFeedResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+      summary: Fetch batch feed dispersed to an operator in specified direction
       tags:
       - Batches
   /blobs/{blob_key}:

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -118,6 +118,17 @@ type (
 		Batches []*BatchInfo `json:"batches"`
 	}
 
+	OperatorBatch struct {
+		BatchHeaderHash string              `json:"batch_header_hash"`
+		BatchHeader     *corev2.BatchHeader `json:"batch_header"`
+		DispersedAt     uint64
+	}
+	OperatorBatchFeedResponse struct {
+		OperatorIdentity OperatorIdentity `json:"operator_identity"`
+		OperatorSocket   string           `json:"operator_socket"`
+		Batches          []*OperatorBatch `json:"batches"`
+	}
+
 	MetricSummary struct {
 		AvgThroughput float64 `json:"avg_throughput"`
 	}
@@ -299,6 +310,7 @@ func (s *ServerV2) Start() error {
 		batches := v2.Group("/batches")
 		{
 			batches.GET("/feed", s.FetchBatchFeed)
+			batches.GET("/feed/:operator_id", s.FetchOperatorBatchFeed)
 			batches.GET("/:batch_header_hash", s.FetchBatch)
 		}
 		operators := v2.Group("/operators")

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -361,6 +361,239 @@ func TestFetchBlob(t *testing.T) {
 	assert.Equal(t, blobHeader.PaymentMetadata.CumulativePayment, response.BlobHeader.PaymentMetadata.CumulativePayment)
 }
 
+func TestFetchOperatorBatchFeed(t *testing.T) {
+	r := setUpRouter()
+	ctx := context.Background()
+
+	numRequests := 60
+	opID := core.OperatorID{16, 32}
+	now := uint64(time.Now().UnixNano())
+	firstRequestTs := now - uint64(int64(numRequests)*time.Minute.Nanoseconds())
+	nanoSecsPerRequest := uint64(time.Minute.Nanoseconds()) // 1 batch/min
+
+	dispersedAt := make([]uint64, numRequests)
+	batchHeaders := make([]*corev2.BatchHeader, numRequests)
+	dynamoKeys := make([]commondynamodb.Key, numRequests)
+	for i := 0; i < numRequests; i++ {
+		dispersedAt[i] = firstRequestTs + uint64(i)*nanoSecsPerRequest
+		batchHeaders[i] = &corev2.BatchHeader{
+			BatchRoot:            [32]byte{1, 2, 3},
+			ReferenceBlockNumber: uint64(i + 100),
+		}
+		dispersalRequest := &corev2.DispersalRequest{
+			OperatorID:      opID,
+			OperatorAddress: gethcommon.HexToAddress("0x1234567"),
+			Socket:          "socket",
+			DispersedAt:     dispersedAt[i],
+			BatchHeader:     *batchHeaders[i],
+		}
+
+		err := blobMetadataStore.PutDispersalRequest(ctx, dispersalRequest)
+		require.NoError(t, err)
+
+		bhh, err := dispersalRequest.BatchHeader.Hash()
+		require.NoError(t, err)
+		dynamoKeys[i] = commondynamodb.Key{
+			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
+			"SK": &types.AttributeValueMemberS{Value: "DispersalRequest#" + opID.Hex()},
+		}
+	}
+	defer deleteItems(t, dynamoKeys)
+
+	r.GET("/v2/batches/feed/:operator_id", testDataApiServerV2.FetchOperatorBatchFeed)
+	baseUrl := fmt.Sprintf("/v2/batches/feed/%s", opID.Hex())
+
+	t.Run("invalid params", func(t *testing.T) {
+		now := time.Now()
+
+		tests := []struct {
+			name        string
+			queryParams map[string]string
+			wantError   string // expected error message
+		}{
+			// Invalid direction
+			{
+				name:        "invalid direction",
+				queryParams: map[string]string{"direction": "abc"},
+				wantError:   "`direction` must be either \"forward\" or \"backward\", found: \"abc\"",
+			},
+
+			// Invalid time formats
+			{
+				name:        "invalid before format",
+				queryParams: map[string]string{"before": "2006-01-02T15:04:05"}, // missing Z
+				wantError:   "failed to parse `before` param",
+			},
+			{
+				name:        "invalid before value",
+				queryParams: map[string]string{"before": "abc"},
+				wantError:   "failed to parse `before` param",
+			},
+			{
+				name:        "invalid after format",
+				queryParams: map[string]string{"after": "2006-01-02T15:04:05"}, // missing Z
+				wantError:   "failed to parse `after` param",
+			},
+			{
+				name:        "invalid after value",
+				queryParams: map[string]string{"after": "abc"},
+				wantError:   "failed to parse `after` param",
+			},
+			{
+				name:        "after in future",
+				queryParams: map[string]string{"after": "3025-01-02T15:04:05Z"},
+				wantError:   "`after` must be before current time",
+			},
+
+			// Invalid time ranges
+			{
+				name: "after >= before",
+				queryParams: map[string]string{
+					"after":  now.Add(-time.Minute).UTC().Format("2006-01-02T15:04:05.999999999Z"),
+					"before": now.Add(-time.Hour).UTC().Format("2006-01-02T15:04:05.999999999Z"),
+				},
+				wantError: "must be earlier than `before` timestamp",
+			},
+			{
+				name: "before too old",
+				queryParams: map[string]string{
+					"before": "2020-01-02T15:04:05Z",
+				},
+				wantError: "`before` time cannot be more than 14 days in the past",
+			},
+
+			// Invalid limit
+			{
+				name:        "invalid limit format",
+				queryParams: map[string]string{"limit": "abc"},
+				wantError:   "failed to parse `limit` param",
+			},
+		}
+
+		for _, tt := range tests {
+			params := url.Values{}
+			for k, v := range tt.queryParams {
+				params.Add(k, v)
+			}
+
+			url := fmt.Sprintf("%s?%s", baseUrl, params.Encode())
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			r.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+
+			var errResp serverv2.ErrorResponse
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+			assert.Contains(t, errResp.Error, tt.wantError)
+		}
+	})
+
+	t.Run("nonexistent operatorid", func(t *testing.T) {
+		otherID := core.OperatorID{4, 16}
+		url := fmt.Sprintf("/v2/batches/feed/%s", otherID.Hex())
+		w := executeRequest(t, r, http.MethodGet, url)
+		response := decodeResponseBody[serverv2.OperatorBatchFeedResponse](t, w)
+		require.Equal(t, 0, len(response.Batches))
+	})
+
+	t.Run("default params", func(t *testing.T) {
+		// Default query returns:
+		// - Most recent 1 hour of dispersals include all of dispersals[1] through dispersals[59]
+		// - Limited to 20 results (the default "limit")
+		// - Result will first 20 dispersals
+		w := executeRequest(t, r, http.MethodGet, baseUrl)
+		response := decodeResponseBody[serverv2.OperatorBatchFeedResponse](t, w)
+		require.Equal(t, 20, len(response.Batches))
+		for i := 0; i < 20; i++ {
+			assert.Equal(t, dispersedAt[1+i], response.Batches[i].DispersedAt)
+			assert.Equal(t, batchHeaders[1+i].ReferenceBlockNumber, response.Batches[i].BatchHeader.ReferenceBlockNumber)
+			assert.Equal(t, batchHeaders[1+i].BatchRoot, response.Batches[i].BatchHeader.BatchRoot)
+		}
+	})
+
+	t.Run("forward iteration with various query ranges and limits", func(t *testing.T) {
+		// Test 1: Unlimited results in 1-hour window
+		// With 1h ending time at now, this retrieves dispersals[1] through batch[59] (59 batches)
+		w := executeRequest(t, r, http.MethodGet, baseUrl+"?limit=0")
+		response := decodeResponseBody[serverv2.OperatorBatchFeedResponse](t, w)
+		require.Equal(t, 59, len(response.Batches))
+		for i := 0; i < 59; i++ {
+			assert.Equal(t, dispersedAt[1+i], response.Batches[i].DispersedAt)
+			assert.Equal(t, batchHeaders[1+i].ReferenceBlockNumber, response.Batches[i].BatchHeader.ReferenceBlockNumber)
+			assert.Equal(t, batchHeaders[1+i].BatchRoot, response.Batches[i].BatchHeader.BatchRoot)
+		}
+
+		// Test 2: 2-hour window captures all test batches
+		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		reqUrl := fmt.Sprintf("%s?limit=-1&after=%s", baseUrl, afterTime)
+		w = executeRequest(t, r, http.MethodGet, reqUrl)
+		response = decodeResponseBody[serverv2.OperatorBatchFeedResponse](t, w)
+		require.Equal(t, 60, len(response.Batches))
+		for i := 0; i < 60; i++ {
+			assert.Equal(t, dispersedAt[i], response.Batches[i].DispersedAt)
+			assert.Equal(t, batchHeaders[i].ReferenceBlockNumber, response.Batches[i].BatchHeader.ReferenceBlockNumber)
+			assert.Equal(t, batchHeaders[i].BatchRoot, response.Batches[i].BatchHeader.BatchRoot)
+		}
+
+		// Teste 3: custom end time
+		after := time.Unix(0, int64(dispersedAt[20])).UTC()
+		afterTime = after.Format("2006-01-02T15:04:05.999999999Z")
+		before := time.Unix(0, int64(dispersedAt[50])).UTC()
+		beforeTime := before.Format("2006-01-02T15:04:05.999999999Z")
+		reqUrl = fmt.Sprintf("%s?before=%s&after=%s&limit=-1", baseUrl, beforeTime, afterTime)
+		w = executeRequest(t, r, http.MethodGet, reqUrl)
+		response = decodeResponseBody[serverv2.OperatorBatchFeedResponse](t, w)
+		require.Equal(t, 29, len(response.Batches))
+		for i := 0; i < 29; i++ {
+			assert.Equal(t, dispersedAt[21+i], response.Batches[i].DispersedAt)
+			assert.Equal(t, batchHeaders[21+i].ReferenceBlockNumber, response.Batches[i].BatchHeader.ReferenceBlockNumber)
+			assert.Equal(t, batchHeaders[21+i].BatchRoot, response.Batches[i].BatchHeader.BatchRoot)
+		}
+	})
+
+	t.Run("backward iteration with various query ranges and limits", func(t *testing.T) {
+		// Test 1: Unlimited results in 1-hour window
+		// With 1h ending time at now, this retrieves dispersals[59] through batch[1] (59 batches)
+		w := executeRequest(t, r, http.MethodGet, baseUrl+"?limit=0&direction=backward")
+		response := decodeResponseBody[serverv2.OperatorBatchFeedResponse](t, w)
+		require.Equal(t, 59, len(response.Batches))
+		for i := 0; i < 59; i++ {
+			assert.Equal(t, dispersedAt[59-i], response.Batches[i].DispersedAt)
+			assert.Equal(t, batchHeaders[59-i].ReferenceBlockNumber, response.Batches[i].BatchHeader.ReferenceBlockNumber)
+			assert.Equal(t, batchHeaders[59-i].BatchRoot, response.Batches[i].BatchHeader.BatchRoot)
+		}
+
+		// Test 2: 2-hour window captures all test batches
+		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		reqUrl := fmt.Sprintf("%s?limit=-1&after=%s&direction=backward", baseUrl, afterTime)
+		w = executeRequest(t, r, http.MethodGet, reqUrl)
+		response = decodeResponseBody[serverv2.OperatorBatchFeedResponse](t, w)
+		require.Equal(t, 60, len(response.Batches))
+		for i := 0; i < 60; i++ {
+			assert.Equal(t, dispersedAt[59-i], response.Batches[i].DispersedAt)
+			assert.Equal(t, batchHeaders[59-i].ReferenceBlockNumber, response.Batches[i].BatchHeader.ReferenceBlockNumber)
+			assert.Equal(t, batchHeaders[59-i].BatchRoot, response.Batches[i].BatchHeader.BatchRoot)
+		}
+
+		// Teste 3: custom end time
+		after := time.Unix(0, int64(dispersedAt[20])).UTC()
+		afterTime = after.Format("2006-01-02T15:04:05.999999999Z")
+		before := time.Unix(0, int64(dispersedAt[50])).UTC()
+		beforeTime := before.Format("2006-01-02T15:04:05.999999999Z")
+		reqUrl = fmt.Sprintf("%s?before=%s&after=%s&limit=-1&direction=backward", baseUrl, beforeTime, afterTime)
+		w = executeRequest(t, r, http.MethodGet, reqUrl)
+		response = decodeResponseBody[serverv2.OperatorBatchFeedResponse](t, w)
+		require.Equal(t, 29, len(response.Batches))
+		for i := 0; i < 29; i++ {
+			assert.Equal(t, dispersedAt[49-i], response.Batches[i].DispersedAt)
+			assert.Equal(t, batchHeaders[49-i].ReferenceBlockNumber, response.Batches[i].BatchHeader.ReferenceBlockNumber)
+			assert.Equal(t, batchHeaders[49-i].BatchRoot, response.Batches[i].BatchHeader.BatchRoot)
+		}
+	})
+
+}
+
 func TestFetchBlobCertificate(t *testing.T) {
 	r := setUpRouter()
 


### PR DESCRIPTION
## Why are these changes needed?
Retrieve batches that have been assigned to an operator in a time window.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
