### PR TITLE
Add getter for relay registry address

### DIFF
--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -182,6 +182,26 @@ func (cv *CertVerifier) GetQuorumNumbersRequired(ctx context.Context) ([]uint8, 
 	return quorumNumbersRequired, nil
 }
 
+// GetRelayRegistryAddress returns the address of the EigenDARelayRegistry contract
+func (cv *CertVerifier) GetRelayRegistryAddress(ctx context.Context) (*gethcommon.Address, error) {
+	blockNumber, err := cv.ethClient.BlockNumber(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch block number from eth client: %w", err)
+	}
+
+	certVerifierCaller, err := cv.getVerifierCallerFromBlockNumber(ctx, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("get verifier caller form block number: %w", err)
+	}
+
+	relayRegistryAddress, err := certVerifierCaller.EigenDARelayRegistry(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, fmt.Errorf("get relay registry address: %w", err)
+	}
+
+	return &relayRegistryAddress, nil
+}
+
 // getVerifierCallerFromBlockNumber returns a ContractEigenDACertVerifierCaller that corresponds to the input reference
 // block number.
 //

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -191,7 +191,7 @@ func (cv *CertVerifier) GetRelayRegistryAddress(ctx context.Context) (*gethcommo
 
 	certVerifierCaller, err := cv.getVerifierCallerFromBlockNumber(ctx, blockNumber)
 	if err != nil {
-		return nil, fmt.Errorf("get verifier caller form block number: %w", err)
+		return nil, fmt.Errorf("get verifier caller from block number: %w", err)
 	}
 
 	relayRegistryAddress, err := certVerifierCaller.EigenDARelayRegistry(&bind.CallOpts{Context: ctx})


### PR DESCRIPTION
## Why are these changes needed?

- The proxy needs access to the relay registry address
- The proxy already has a cert verifier
- Since the cert verifier contract has the address for the relay registry, it is nice and easy to just add a method to be able to access it

