### PR TITLE
Add metrics to feed cache

### DIFF
--- a/disperser/dataapi/feed_cache_metrics.go
+++ b/disperser/dataapi/feed_cache_metrics.go
@@ -1,0 +1,96 @@
+// This file should have been placed under disperser/dataapi/v2.
+// The reason it's placed here in "dataapi" package is to avoid circular dependency
+// (the "v2" already has dependency on "dataapi").
+// Note the reason there is a "v2" package in the first place is to enable the separation of
+// swagger docs for v1 and v2 APIs.
+
+package dataapi
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const namespace = "eigenda_dataapi"
+
+type FeedCacheMetrics struct {
+	// Time range metrics
+	cacheTimeRangeSeconds      prometheus.Gauge
+	cacheSegmentStartTimestamp prometheus.Gauge
+	cacheSegmentEndTimestamp   prometheus.Gauge
+
+	// Cache hit metrics
+	cacheHitRatePercent prometheus.Gauge
+}
+
+func NewFeedCacheMetrics(name string, registry *prometheus.Registry) *FeedCacheMetrics {
+	cacheTimeRangeSeconds := promauto.With(registry).NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("%s_cache_time_range_seconds", name),
+			Help:      "Time range in seconds currently covered by the cache",
+		},
+	)
+
+	cacheSegmentStartTimestamp := promauto.With(registry).NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("%s_cache_segment_start_timestamp_seconds", name),
+			Help:      "Unix timestamp of the earliest item in the cache",
+		},
+	)
+
+	cacheSegmentEndTimestamp := promauto.With(registry).NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("%s_cache_segment_end_timestamp_seconds", name),
+			Help:      "Unix timestamp of the latest item in the cache",
+		},
+	)
+
+	cacheHitRatePercent := promauto.With(registry).NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      fmt.Sprintf("%s_cache_hit_rate_percent", name),
+			Help:      "Percentage of items served from cache vs total items requested",
+		},
+	)
+
+	return &FeedCacheMetrics{
+		cacheTimeRangeSeconds:      cacheTimeRangeSeconds,
+		cacheSegmentStartTimestamp: cacheSegmentStartTimestamp,
+		cacheSegmentEndTimestamp:   cacheSegmentEndTimestamp,
+		cacheHitRatePercent:        cacheHitRatePercent,
+	}
+}
+
+// UpdateHitRate updates the hit rate metric based on accumulated hits and misses.
+func (m *FeedCacheMetrics) UpdateHitRate(hits, misses int) {
+	total := hits + misses
+	if total > 0 {
+		hitRate := float64(hits) / float64(total) * 100.0
+		m.cacheHitRatePercent.Set(hitRate)
+	}
+}
+
+// RecordCacheUpdate updates metrics after a cache update operation.
+func (m *FeedCacheMetrics) RecordCacheUpdate(
+	cacheTimeStart time.Time,
+	cacheTimeEnd time.Time,
+) {
+	if cacheTimeStart.IsZero() || cacheTimeEnd.IsZero() || !cacheTimeEnd.After(cacheTimeStart) {
+		// Invalid time range, don't update metrics
+		return
+	}
+
+	// Update cache time range metric
+	cacheRangeSeconds := cacheTimeEnd.Sub(cacheTimeStart).Seconds()
+	m.cacheTimeRangeSeconds.Set(cacheRangeSeconds)
+
+	// Update cache segment timestamp gauges
+	m.cacheSegmentStartTimestamp.Set(float64(cacheTimeStart.Unix()))
+	m.cacheSegmentEndTimestamp.Set(float64(cacheTimeEnd.Unix()))
+}

--- a/disperser/dataapi/feed_cache_metrics.go
+++ b/disperser/dataapi/feed_cache_metrics.go
@@ -14,7 +14,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const namespace = "eigenda_dataapi"
+const namespace = "eigenda"
+const subsystem = "dataapi"
 
 type FeedCacheMetrics struct {
 	// Time range metrics
@@ -30,6 +31,7 @@ func NewFeedCacheMetrics(name string, registry *prometheus.Registry) *FeedCacheM
 	cacheTimeRangeSeconds := promauto.With(registry).NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
+			Subsystem: subsystem,
 			Name:      fmt.Sprintf("%s_cache_time_range_seconds", name),
 			Help:      "Time range in seconds currently covered by the cache",
 		},
@@ -38,6 +40,7 @@ func NewFeedCacheMetrics(name string, registry *prometheus.Registry) *FeedCacheM
 	cacheSegmentStartTimestamp := promauto.With(registry).NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
+			Subsystem: subsystem,
 			Name:      fmt.Sprintf("%s_cache_segment_start_timestamp_seconds", name),
 			Help:      "Unix timestamp of the earliest item in the cache",
 		},
@@ -46,6 +49,7 @@ func NewFeedCacheMetrics(name string, registry *prometheus.Registry) *FeedCacheM
 	cacheSegmentEndTimestamp := promauto.With(registry).NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
+			Subsystem: subsystem,
 			Name:      fmt.Sprintf("%s_cache_segment_end_timestamp_seconds", name),
 			Help:      "Unix timestamp of the latest item in the cache",
 		},
@@ -54,6 +58,7 @@ func NewFeedCacheMetrics(name string, registry *prometheus.Registry) *FeedCacheM
 	cacheHitRatePercent := promauto.With(registry).NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
+			Subsystem: subsystem,
 			Name:      fmt.Sprintf("%s_cache_hit_rate_percent", name),
 			Help:      "Percentage of items served from cache vs total items requested",
 		},

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/disperser"
-
 	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
 	"github.com/Layr-Labs/eigenda/disperser/common/semver"
 	commonv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"

--- a/disperser/dataapi/metrics.go
+++ b/disperser/dataapi/metrics.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/disperser"
+
 	"github.com/Layr-Labs/eigenda/disperser/common/blobstore"
 	"github.com/Layr-Labs/eigenda/disperser/common/semver"
 	commonv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
@@ -30,6 +31,9 @@ type Metrics struct {
 	NumRequests    *prometheus.CounterVec
 	Latency        *prometheus.SummaryVec
 	OperatorsStake *prometheus.GaugeVec
+
+	// Cache metrics in v2
+	BatchFeedCacheMetrics *FeedCacheMetrics
 
 	Semvers                *prometheus.GaugeVec
 	SemversStakePctQuorum0 *prometheus.GaugeVec
@@ -110,9 +114,10 @@ func NewMetrics(serverVersion uint, blobMetadataStore interface{}, httpPort stri
 			// The "topn" can be: 1, 2, 3, 5, 8, 10
 			[]string{"quorum", "topn"},
 		),
-		registry: reg,
-		httpPort: httpPort,
-		logger:   logger.With("component", "DataAPIMetrics"),
+		BatchFeedCacheMetrics: NewFeedCacheMetrics("batch_feed", reg),
+		registry:              reg,
+		httpPort:              httpPort,
+		logger:                logger.With("component", "DataAPIMetrics"),
 	}
 	return metrics
 }

--- a/disperser/dataapi/v2/feed_cache_test.go
+++ b/disperser/dataapi/v2/feed_cache_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Layr-Labs/eigenda/common/testutils"
+	"github.com/Layr-Labs/eigenda/disperser/dataapi"
 	v2 "github.com/Layr-Labs/eigenda/disperser/dataapi/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,6 +95,7 @@ func setupTestCache(maxItems int) (*v2.FeedCache[testItem], *testFetcher, time.T
 		maxItems,
 		fetcher.fetch,
 		timestampFn,
+		dataapi.NewMetrics(uint(2), nil, "9001", testutils.GetLogger()).BatchFeedCacheMetrics,
 	)
 
 	return cache, fetcher, baseTime

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -232,6 +232,7 @@ func NewServerV2(
 		maxNumBatchesToCache,
 		fetchBatchFn,
 		getBatchTimestampFn,
+		metrics.BatchFeedCacheMetrics,
 	)
 
 	return &ServerV2{


### PR DESCRIPTION
## Why are these changes needed?
Provide visibility to the feed cache.

**TESTED**

**cache hit rate**
![Screenshot 2025-03-14 at 9 03 04 PM](https://github.com/user-attachments/assets/3ac34bb0-fe70-4e40-a08f-66a65f0c6680)


**cached time range**
![Screenshot 2025-03-14 at 9 03 21 PM](https://github.com/user-attachments/assets/e04ea21a-0d56-4743-abd2-b21b6d4be0b6)

**cache start/end time**
![Screenshot 2025-03-14 at 9 04 06 PM](https://github.com/user-attachments/assets/4d490bb4-75bb-487e-9d06-d9f0a80a7179)





<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
