### PR TITLE
chore(disperser/dataapi): clean type conversion

### DIFF
--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -484,7 +484,7 @@ func (s *ServerV2) getOperatorsOfInterest(
 	operatorList := dataapi.NewOperatorList()
 
 	// The first part: active operators at startBlock
-	operatorsByQuorum, err := s.chainReader.GetOperatorStakesForQuorums(ctx, quorumIDs, uint32(startBlock))
+	operatorsByQuorum, err := s.chainReader.GetOperatorStakesForQuorums(ctx, quorumIDs, startBlock)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why are these changes needed?

`startBlock, endBlock uint32` is already uint32, is unnecessary for type conversion


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
