### PR TITLE
Enhance the metrics summary

### DIFF
--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   forge-tests:
     name: Foundry Project
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
         with:
@@ -56,7 +56,7 @@ jobs:
 
   binding-verify:
     name: Verify bindings are updated
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -358,7 +358,7 @@ const docTemplateV2 = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.Metric"
+                            "$ref": "#/definitions/v2.MetricSummary"
                         }
                     },
                     "400": {
@@ -1250,11 +1250,20 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "v2.Metric": {
+        "v2.MetricSummary": {
             "type": "object",
             "properties": {
-                "throughput": {
+                "average_bytes_per_second": {
                     "type": "number"
+                },
+                "end_timestamp_sec": {
+                    "type": "integer"
+                },
+                "start_timestamp_sec": {
+                    "type": "integer"
+                },
+                "total_bytes_posted": {
+                    "type": "integer"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -355,7 +355,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.Metric"
+                            "$ref": "#/definitions/v2.MetricSummary"
                         }
                     },
                     "400": {
@@ -1247,11 +1247,20 @@
                 }
             }
         },
-        "v2.Metric": {
+        "v2.MetricSummary": {
             "type": "object",
             "properties": {
-                "throughput": {
+                "average_bytes_per_second": {
                     "type": "number"
+                },
+                "end_timestamp_sec": {
+                    "type": "integer"
+                },
+                "start_timestamp_sec": {
+                    "type": "integer"
+                },
+                "total_bytes_posted": {
+                    "type": "integer"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -404,10 +404,16 @@ definitions:
       error:
         type: string
     type: object
-  v2.Metric:
+  v2.MetricSummary:
     properties:
-      throughput:
+      average_bytes_per_second:
         type: number
+      end_timestamp_sec:
+        type: integer
+      start_timestamp_sec:
+        type: integer
+      total_bytes_posted:
+        type: integer
     type: object
   v2.OperatorDispersalResponses:
     properties:
@@ -752,7 +758,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/v2.Metric'
+            $ref: '#/definitions/v2.MetricSummary'
         "400":
           description: 'error: Bad request'
           schema:

--- a/disperser/dataapi/metrics_handler.go
+++ b/disperser/dataapi/metrics_handler.go
@@ -24,6 +24,20 @@ func NewMetricsHandler(promClient PrometheusClient, version DataApiVersion) *Met
 	}
 }
 
+func (mh *MetricsHandler) GetCompleteBlobSize(ctx context.Context, startTime int64, endTime int64) (*PrometheusResult, error) {
+	var result *PrometheusResult
+	var err error
+	if mh.version == V1 {
+		result, err = mh.promClient.QueryDisperserBlobSizeBytesPerSecond(ctx, time.Unix(startTime, 0), time.Unix(endTime, 0))
+	} else {
+		result, err = mh.promClient.QueryDisperserBlobSizeBytesPerSecondV2(ctx, time.Unix(startTime, 0), time.Unix(endTime, 0))
+	}
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (mh *MetricsHandler) GetAvgThroughput(ctx context.Context, startTime int64, endTime int64) (float64, error) {
 	var result *PrometheusResult
 	var err error

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -119,7 +119,10 @@ type (
 	}
 
 	MetricSummary struct {
-		AvgThroughput float64 `json:"avg_throughput"`
+		TotalBytesPosted      uint64  `json:"total_bytes_posted"`
+		AverageBytesPerSecond float64 `json:"average_bytes_per_second"`
+		StartTimestampSec     int64   `json:"start_timestamp_sec"`
+		EndTimestampSec       int64   `json:"end_timestamp_sec"`
 	}
 
 	OperatorSigningInfo struct {

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -1998,7 +1998,7 @@ func TestFetchMetricsSummary(t *testing.T) {
 	w := executeRequest(t, r, http.MethodGet, "/v2/metrics/summary")
 	response := decodeResponseBody[serverv2.MetricSummary](t, w)
 
-	assert.Equal(t, 16555.555555555555, response.AvgThroughput)
+	assert.Equal(t, 16555.555555555555, response.AverageBytesPerSecond)
 }
 
 func TestFetchMetricsThroughputTimeseries(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
- Naming improvement: `avg_throughput` -> `average_bytes_per_second`
- Add `total_bytes_posted`
- Add the `start_timestamp_sec` and `end_timestamp_sec` to indicate what the time range this result is for
- Fix the return type of API: `Metric` -> `MetricSummary`

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
