### PR TITLE
CI: upgrade test-contracts ubuntu to 24.04

### DIFF
--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   forge-tests:
     name: Foundry Project
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
         with:
@@ -56,7 +56,7 @@ jobs:
 
   binding-verify:
     name: Verify bindings are updated
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Why are these changes needed?
Unbreak ci

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
