### PR TITLE
add trailing option to read g2 file

### DIFF
--- a/encoding/kzg/cli.go
+++ b/encoding/kzg/cli.go
@@ -37,7 +37,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:     G2TrailingPathFlagName,
-			Usage:    "Path to trailing G2 SRS file. Its intended purpose is to allow local generation the blob length proof. If you already downloaded the entire G2 SRS file which contains 268435456 G2 points with total size 16GiB. With this G2TrailingPathFlag, user can use a smaller file that contains only the trailing end of the whole G2 SRS file. Ignoring this flag, the program assumes the entire G2 SRS file is provided. With this flag, the size of the provided file must be at least SRSLoadingNumberFlagName * 64 Bytes.",
+			Usage:    "Path to trailing G2 SRS file. Its intended purpose is to allow local generation the blob length proof. If you already downloaded the entire G2 SRS file which contains 268435456 G2 points with total size 16GiB, this flag is not needed. With this G2TrailingPathFlag, user can use a smaller file that contains only the trailing end of the whole G2 SRS file. Ignoring this flag, the program assumes the entire G2 SRS file is provided. With this flag, the size of the provided file must be at least SRSLoadingNumberFlagName * 64 Bytes.",
 			Required: false,
 			EnvVar:   common.PrefixEnvVar(envPrefix, "G2_TRAILING_PATH"),
 		},

--- a/encoding/kzg/cli.go
+++ b/encoding/kzg/cli.go
@@ -10,6 +10,7 @@ import (
 const (
 	G1PathFlagName            = "kzg.g1-path"
 	G2PathFlagName            = "kzg.g2-path"
+	G2TrailingPathFlagName    = "kzg.g2-trailing-path"
 	CachePathFlagName         = "kzg.cache-path"
 	SRSOrderFlagName          = "kzg.srs-order"
 	NumWorkerFlagName         = "kzg.num-workers"
@@ -33,6 +34,12 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			Usage:    "Path to G2 SRS. Either this flag or G2_POWER_OF_2_PATH needs to be specified. For operator node, if both are specified, the node uses G2_POWER_OF_2_PATH first, if failed then tries to G2_PATH",
 			Required: false,
 			EnvVar:   common.PrefixEnvVar(envPrefix, "G2_PATH"),
+		},
+		cli.StringFlag{
+			Name:     G2TrailingPathFlagName,
+			Usage:    "Path to trailing G2 SRS file. User can specify a file that contains the trailing end of the G2 SRS points. Using this flag has the advantage to download less G2 SRS file in order to compute the length proof. If you already downloaded the entire G2 SRS file, feel free to ignore this option.",
+			Required: false,
+			EnvVar:   common.PrefixEnvVar(envPrefix, "G2_TRAILING_PATH"),
 		},
 		cli.StringFlag{
 			Name:     CachePathFlagName,
@@ -90,6 +97,7 @@ func ReadCLIConfig(ctx *cli.Context) KzgConfig {
 	cfg := KzgConfig{}
 	cfg.G1Path = ctx.GlobalString(G1PathFlagName)
 	cfg.G2Path = ctx.GlobalString(G2PathFlagName)
+	cfg.G2TrailingPath = ctx.GlobalString(G2TrailingPathFlagName)
 	cfg.CacheDir = ctx.GlobalString(CachePathFlagName)
 	cfg.SRSOrder = ctx.GlobalUint64(SRSOrderFlagName)
 	cfg.SRSNumberToLoad = ctx.GlobalUint64(SRSLoadingNumberFlagName)

--- a/encoding/kzg/cli.go
+++ b/encoding/kzg/cli.go
@@ -37,7 +37,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:     G2TrailingPathFlagName,
-			Usage:    "Path to trailing G2 SRS file. User can specify a file that contains the trailing end of the G2 SRS points. Using this flag has the advantage to download less G2 SRS file in order to compute the length proof. If you already downloaded the entire G2 SRS file, feel free to ignore this option.",
+			Usage:    "Path to trailing G2 SRS file. Its intended purpose is to allow local generation the blob length proof. If you already downloaded the entire G2 SRS file which contains 268435456 G2 points with total size 16GiB. With this G2TrailingPathFlag, user can use a smaller file that contains only the trailing end of the whole G2 SRS file. Ignoring this flag, the program assumes the entire G2 SRS file is provided. With this flag, the size of the provided file must be at least SRSLoadingNumberFlagName * 64 Bytes.",
 			Required: false,
 			EnvVar:   common.PrefixEnvVar(envPrefix, "G2_TRAILING_PATH"),
 		},

--- a/encoding/kzg/kzgrs.go
+++ b/encoding/kzg/kzgrs.go
@@ -3,6 +3,7 @@ package kzg
 type KzgConfig struct {
 	G1Path          string
 	G2Path          string
+	G2TrailingPath  string
 	G1PowerOf2Path  string
 	G2PowerOf2Path  string
 	CacheDir        string

--- a/encoding/kzg/prover/prover.go
+++ b/encoding/kzg/prover/prover.go
@@ -74,12 +74,12 @@ func NewProver(kzgConfig *kzg.KzgConfig, encoderConfig *encoding.Config) (*Prove
 			}
 			fileSizeByte := fileStat.Size()
 			if fileSizeByte%64 != 0 {
-				return nil, errors.New("corrupted g2 points from G2TrailingPath.")
+				return nil, fmt.Errorf("corrupted g2 point from the G2TrailingPath. The size of the file on the provided path has size that is not multiple of 64, which is %v. It indicates there is an incomplete g2 point.", fileSizeByte)
 			}
 			// get the size
 			numG2point := uint64(fileSizeByte / kzg.G2PointBytes)
 			if numG2point < kzgConfig.SRSNumberToLoad {
-				return nil, errors.New("Insufficent number of g2 points from G2TrailingPath")
+				return nil, fmt.Errorf("insufficent number of g2 points from G2TrailingPath. Requested %v, Acutal %v", kzgConfig.SRSNumberToLoad, numG2point)
 			}
 
 			// use g2 trailing file

--- a/encoding/kzg/prover/prover.go
+++ b/encoding/kzg/prover/prover.go
@@ -68,8 +68,8 @@ func NewProver(kzgConfig *kzg.KzgConfig, encoderConfig *encoding.Config) (*Prove
 
 		hasG2TrailingFile := len(kzgConfig.G2TrailingPath) != 0
 		if hasG2TrailingFile {
-			fileStat, err := os.Stat(kzgConfig.G2TrailingPath)
-			if err != nil {
+			fileStat, errStat := os.Stat(kzgConfig.G2TrailingPath)
+			if errStat != nil {
 				return nil, err
 			}
 			fileSizeByte := fileStat.Size()

--- a/encoding/kzg/prover/prover.go
+++ b/encoding/kzg/prover/prover.go
@@ -79,7 +79,7 @@ func NewProver(kzgConfig *kzg.KzgConfig, encoderConfig *encoding.Config) (*Prove
 			// get the size
 			numG2point := uint64(fileSizeByte / kzg.G2PointBytes)
 			if numG2point < kzgConfig.SRSNumberToLoad {
-				return nil, fmt.Errorf("insufficent number of g2 points from G2TrailingPath. Requested %v, Acutal %v", kzgConfig.SRSNumberToLoad, numG2point)
+				return nil, fmt.Errorf("insufficent number of g2 points from G2TrailingPath. Requested %v, Actual %v", kzgConfig.SRSNumberToLoad, numG2point)
 			}
 
 			// use g2 trailing file

--- a/encoding/kzg/prover/prover.go
+++ b/encoding/kzg/prover/prover.go
@@ -66,12 +66,25 @@ func NewProver(kzgConfig *kzg.KzgConfig, encoderConfig *encoding.Config) (*Prove
 			return nil, err
 		}
 
-		g2Trailing, err = kzg.ReadG2PointSection(
-			kzgConfig.G2Path,
-			kzgConfig.SRSOrder-kzgConfig.SRSNumberToLoad,
-			kzgConfig.SRSOrder, // last exclusive
-			kzgConfig.NumWorker,
-		)
+		hasG2TrailingFile := len(kzgConfig.G2TrailingPath) != 0
+		if hasG2TrailingFile {
+			// use g2 trailing file
+			g2Trailing, err = kzg.ReadG2PointSection(
+				kzgConfig.G2TrailingPath,
+				0,
+				kzgConfig.SRSNumberToLoad, // last exclusive
+				kzgConfig.NumWorker,
+			)
+		} else {
+			// require entire g2 srs be available on disk
+			g2Trailing, err = kzg.ReadG2PointSection(
+				kzgConfig.G2Path,
+				kzgConfig.SRSOrder-kzgConfig.SRSNumberToLoad,
+				kzgConfig.SRSOrder, // last exclusive
+				kzgConfig.NumWorker,
+			)
+		}
+
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR adds a new flag to the encoding prover cli interface. The flag allows user to specify a file containing only a trailing portion of g2 points.

This PR is driven by the requirement of generating blob length proof on the proxy. It avoids downloading the 2^28 G2 points (having 16GiB) bytes

The encoder service hosted by eigenlabs can safely ignore the new flag, and continue to run with the current configuration.