### PR TITLE
Remove failed blobs from blobset in dispatcher

### DIFF
--- a/disperser/controller/dispatcher_test.go
+++ b/disperser/controller/dispatcher_test.go
@@ -204,6 +204,7 @@ func TestDispatcherInsufficientSignatures(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, v2.Complete, bm.BlobStatus)
 	}
+	components.BlobSet.AssertNumberOfCalls(t, "RemoveBlob", len(failedObjs.blobKeys)+len(successfulObjs.blobKeys))
 
 	// Get batch header
 	vis, err := components.BlobMetadataStore.GetBlobInclusionInfos(ctx, failedObjs.blobKeys[0])


### PR DESCRIPTION
## Why are these changes needed?
It should remove all blobs that have been processed from the blob set for deduplication. However, it was only removing blobs that transition to "complete" status. It should also remove those transition to "failed" status.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
