### PR TITLE
Refactor the data APIs

### DIFF
--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -78,69 +78,6 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/batches/feed/{operator_id}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Batches"
-                ],
-                "summary": "Fetch batch feed dispersed to an operator in specified direction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
-                        "name": "direction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
-                        "name": "before",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
-                        "name": "after",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.BatchFeedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
@@ -677,7 +614,77 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/operators/{batch_header_hash}": {
+        "/operators/{operator_id}/dispersals": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Fetch batches dispersed to an operator in a time window by specific direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorDispersalFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/operators/{operator_id}/dispersals/{batch_header_hash}/response": {
             "get": {
                 "produces": [
                     "application/json"
@@ -689,23 +696,24 @@ const docTemplateV2 = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Batch header hash in hex string",
-                        "name": "batch_header_hash",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID in hex string [default: all operators if unspecified]",
-                        "name": "operator_id",
-                        "in": "query"
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalResponses"
+                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
                         }
                     },
                     "400": {
@@ -1321,14 +1329,42 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "v2.OperatorDispersalResponses": {
+        "v2.OperatorDispersal": {
             "type": "object",
             "properties": {
-                "operator_dispersal_responses": {
+                "batch_header": {
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader"
+                },
+                "batch_header_hash": {
+                    "type": "string"
+                },
+                "dispersedAt": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.OperatorDispersalFeedResponse": {
+            "type": "object",
+            "properties": {
+                "dispersals": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.DispersalResponse"
+                        "$ref": "#/definitions/v2.OperatorDispersal"
                     }
+                },
+                "operator_identity": {
+                    "$ref": "#/definitions/v2.OperatorIdentity"
+                },
+                "operator_socket": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.OperatorDispersalResponse": {
+            "type": "object",
+            "properties": {
+                "operator_dispersal_response": {
+                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -684,7 +684,7 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/operators/{operator_id}/dispersals/{batch_header_hash}": {
+        "/operators/{operator_id}/dispersals/{batch_header_hash}/response": {
             "get": {
                 "produces": [
                     "application/json"

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -78,6 +78,69 @@ const docTemplateV2 = `{
                 }
             }
         },
+        "/batches/feed/{operator_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Batches"
+                ],
+                "summary": "Fetch batch feed dispersed to an operator in specified direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.BatchFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
@@ -614,77 +677,7 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/operators/{operator_id}/dispersals": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Operators"
-                ],
-                "summary": "Fetch batches dispersed to an operator in a time window by specific direction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "The operator ID to fetch batch feed for",
-                        "name": "operator_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
-                        "name": "direction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
-                        "name": "before",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
-                        "name": "after",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalFeedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/operators/{operator_id}/dispersals/{batch_header_hash}/response": {
+        "/operators/{batch_header_hash}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -696,24 +689,23 @@ const docTemplateV2 = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The operator ID to fetch batch feed for",
-                        "name": "operator_id",
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Batch header hash in hex string",
-                        "name": "batch_header_hash",
-                        "in": "path",
-                        "required": true
+                        "description": "Operator ID in hex string [default: all operators if unspecified]",
+                        "name": "operator_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
+                            "$ref": "#/definitions/v2.OperatorDispersalResponses"
                         }
                     },
                     "400": {
@@ -1329,42 +1321,14 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "v2.OperatorDispersal": {
+        "v2.OperatorDispersalResponses": {
             "type": "object",
             "properties": {
-                "batch_header": {
-                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader"
-                },
-                "batch_header_hash": {
-                    "type": "string"
-                },
-                "dispersedAt": {
-                    "type": "integer"
-                }
-            }
-        },
-        "v2.OperatorDispersalFeedResponse": {
-            "type": "object",
-            "properties": {
-                "dispersals": {
+                "operator_dispersal_responses": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.OperatorDispersal"
+                        "$ref": "#/definitions/v2.DispersalResponse"
                     }
-                },
-                "operator_identity": {
-                    "$ref": "#/definitions/v2.OperatorIdentity"
-                },
-                "operator_socket": {
-                    "type": "string"
-                }
-            }
-        },
-        "v2.OperatorDispersalResponse": {
-            "type": "object",
-            "properties": {
-                "operator_dispersal_response": {
-                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -78,69 +78,6 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/batches/feed/{operator_id}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Batches"
-                ],
-                "summary": "Fetch batch feed dispersed to an operator in specified direction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
-                        "name": "direction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
-                        "name": "before",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
-                        "name": "after",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.BatchFeedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
@@ -677,7 +614,77 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/operators/{batch_header_hash}": {
+        "/operators/{operator_id}/dispersals": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Fetch batches dispersed to an operator in a time window by specific direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorDispersalFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/operators/{operator_id}/dispersals/{batch_header_hash}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -689,23 +696,24 @@ const docTemplateV2 = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Batch header hash in hex string",
-                        "name": "batch_header_hash",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID in hex string [default: all operators if unspecified]",
-                        "name": "operator_id",
-                        "in": "query"
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalResponses"
+                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
                         }
                     },
                     "400": {
@@ -1321,14 +1329,42 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "v2.OperatorDispersalResponses": {
+        "v2.OperatorDispersal": {
             "type": "object",
             "properties": {
-                "operator_dispersal_responses": {
+                "batch_header": {
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader"
+                },
+                "batch_header_hash": {
+                    "type": "string"
+                },
+                "dispersedAt": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.OperatorDispersalFeedResponse": {
+            "type": "object",
+            "properties": {
+                "dispersals": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.DispersalResponse"
+                        "$ref": "#/definitions/v2.OperatorDispersal"
                     }
+                },
+                "operator_identity": {
+                    "$ref": "#/definitions/v2.OperatorIdentity"
+                },
+                "operator_socket": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.OperatorDispersalResponse": {
+            "type": "object",
+            "properties": {
+                "operator_dispersal_response": {
+                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -78,76 +78,6 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/batches/feed/{operator_id}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Batches"
-                ],
-                "summary": "Fetch batch feed dispersed to an operator in specified direction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "The operator ID to fetch batch feed for",
-                        "name": "operator_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
-                        "name": "direction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
-                        "name": "before",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
-                        "name": "after",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.BatchFeedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
@@ -684,7 +614,77 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "/operators/{batch_header_hash}": {
+        "/operators/{operator_id}/dispersals": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Fetch batches dispersed to an operator in a time window by specific direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than ` + "`" + `before` + "`" + ` [default: ` + "`" + `before` + "`" + `-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorDispersalFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/operators/{operator_id}/dispersals/{batch_header_hash}/response": {
             "get": {
                 "produces": [
                     "application/json"
@@ -696,23 +696,24 @@ const docTemplateV2 = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Batch header hash in hex string",
-                        "name": "batch_header_hash",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID in hex string [default: all operators if unspecified]",
-                        "name": "operator_id",
-                        "in": "query"
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalResponses"
+                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
                         }
                     },
                     "400": {
@@ -1328,14 +1329,42 @@ const docTemplateV2 = `{
                 }
             }
         },
-        "v2.OperatorDispersalResponses": {
+        "v2.OperatorDispersal": {
             "type": "object",
             "properties": {
-                "operator_dispersal_responses": {
+                "batch_header": {
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader"
+                },
+                "batch_header_hash": {
+                    "type": "string"
+                },
+                "dispersedAt": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.OperatorDispersalFeedResponse": {
+            "type": "object",
+            "properties": {
+                "dispersals": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.DispersalResponse"
+                        "$ref": "#/definitions/v2.OperatorDispersal"
                     }
+                },
+                "operator_identity": {
+                    "$ref": "#/definitions/v2.OperatorIdentity"
+                },
+                "operator_socket": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.OperatorDispersalResponse": {
+            "type": "object",
+            "properties": {
+                "operator_dispersal_response": {
+                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -75,69 +75,6 @@
                 }
             }
         },
-        "/batches/feed/{operator_id}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Batches"
-                ],
-                "summary": "Fetch batch feed dispersed to an operator in specified direction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
-                        "name": "direction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
-                        "name": "before",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
-                        "name": "after",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.BatchFeedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
@@ -674,7 +611,77 @@
                 }
             }
         },
-        "/operators/{batch_header_hash}": {
+        "/operators/{operator_id}/dispersals": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Fetch batches dispersed to an operator in a time window by specific direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorDispersalFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/operators/{operator_id}/dispersals/{batch_header_hash}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -686,23 +693,24 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Batch header hash in hex string",
-                        "name": "batch_header_hash",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID in hex string [default: all operators if unspecified]",
-                        "name": "operator_id",
-                        "in": "query"
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalResponses"
+                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
                         }
                     },
                     "400": {
@@ -1318,14 +1326,42 @@
                 }
             }
         },
-        "v2.OperatorDispersalResponses": {
+        "v2.OperatorDispersal": {
             "type": "object",
             "properties": {
-                "operator_dispersal_responses": {
+                "batch_header": {
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader"
+                },
+                "batch_header_hash": {
+                    "type": "string"
+                },
+                "dispersedAt": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.OperatorDispersalFeedResponse": {
+            "type": "object",
+            "properties": {
+                "dispersals": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.DispersalResponse"
+                        "$ref": "#/definitions/v2.OperatorDispersal"
                     }
+                },
+                "operator_identity": {
+                    "$ref": "#/definitions/v2.OperatorIdentity"
+                },
+                "operator_socket": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.OperatorDispersalResponse": {
+            "type": "object",
+            "properties": {
+                "operator_dispersal_response": {
+                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -681,7 +681,7 @@
                 }
             }
         },
-        "/operators/{operator_id}/dispersals/{batch_header_hash}": {
+        "/operators/{operator_id}/dispersals/{batch_header_hash}/response": {
             "get": {
                 "produces": [
                     "application/json"

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -75,76 +75,6 @@
                 }
             }
         },
-        "/batches/feed/{operator_id}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Batches"
-                ],
-                "summary": "Fetch batch feed dispersed to an operator in specified direction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "The operator ID to fetch batch feed for",
-                        "name": "operator_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
-                        "name": "direction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
-                        "name": "before",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
-                        "name": "after",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.BatchFeedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
@@ -681,7 +611,77 @@
                 }
             }
         },
-        "/operators/{batch_header_hash}": {
+        "/operators/{operator_id}/dispersals": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Fetch batches dispersed to an operator in a time window by specific direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorDispersalFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/operators/{operator_id}/dispersals/{batch_header_hash}/response": {
             "get": {
                 "produces": [
                     "application/json"
@@ -693,23 +693,24 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Batch header hash in hex string",
-                        "name": "batch_header_hash",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID in hex string [default: all operators if unspecified]",
-                        "name": "operator_id",
-                        "in": "query"
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalResponses"
+                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
                         }
                     },
                     "400": {
@@ -1325,14 +1326,42 @@
                 }
             }
         },
-        "v2.OperatorDispersalResponses": {
+        "v2.OperatorDispersal": {
             "type": "object",
             "properties": {
-                "operator_dispersal_responses": {
+                "batch_header": {
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader"
+                },
+                "batch_header_hash": {
+                    "type": "string"
+                },
+                "dispersedAt": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.OperatorDispersalFeedResponse": {
+            "type": "object",
+            "properties": {
+                "dispersals": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.DispersalResponse"
+                        "$ref": "#/definitions/v2.OperatorDispersal"
                     }
+                },
+                "operator_identity": {
+                    "$ref": "#/definitions/v2.OperatorIdentity"
+                },
+                "operator_socket": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.OperatorDispersalResponse": {
+            "type": "object",
+            "properties": {
+                "operator_dispersal_response": {
+                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -75,69 +75,6 @@
                 }
             }
         },
-        "/batches/feed/{operator_id}": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Batches"
-                ],
-                "summary": "Fetch batch feed dispersed to an operator in specified direction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
-                        "name": "direction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
-                        "name": "before",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
-                        "name": "after",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.BatchFeedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
@@ -674,7 +611,77 @@
                 }
             }
         },
-        "/operators/{batch_header_hash}": {
+        "/operators/{operator_id}/dispersals": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Operators"
+                ],
+                "summary": "Fetch batches dispersed to an operator in a time window by specific direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.OperatorDispersalFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/operators/{operator_id}/dispersals/{batch_header_hash}/response": {
             "get": {
                 "produces": [
                     "application/json"
@@ -686,23 +693,24 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Batch header hash in hex string",
-                        "name": "batch_header_hash",
+                        "description": "The operator ID to fetch batch feed for",
+                        "name": "operator_id",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Operator ID in hex string [default: all operators if unspecified]",
-                        "name": "operator_id",
-                        "in": "query"
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalResponses"
+                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
                         }
                     },
                     "400": {
@@ -1318,14 +1326,42 @@
                 }
             }
         },
-        "v2.OperatorDispersalResponses": {
+        "v2.OperatorDispersal": {
             "type": "object",
             "properties": {
-                "operator_dispersal_responses": {
+                "batch_header": {
+                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader"
+                },
+                "batch_header_hash": {
+                    "type": "string"
+                },
+                "dispersedAt": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v2.OperatorDispersalFeedResponse": {
+            "type": "object",
+            "properties": {
+                "dispersals": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.DispersalResponse"
+                        "$ref": "#/definitions/v2.OperatorDispersal"
                     }
+                },
+                "operator_identity": {
+                    "$ref": "#/definitions/v2.OperatorIdentity"
+                },
+                "operator_socket": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2.OperatorDispersalResponse": {
+            "type": "object",
+            "properties": {
+                "operator_dispersal_response": {
+                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -75,6 +75,69 @@
                 }
             }
         },
+        "/batches/feed/{operator_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Batches"
+                ],
+                "summary": "Fetch batch feed dispersed to an operator in specified direction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
+                        "name": "before",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
+                        "name": "after",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.BatchFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "error: Not found",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/batches/{batch_header_hash}": {
             "get": {
                 "produces": [
@@ -611,77 +674,7 @@
                 }
             }
         },
-        "/operators/{operator_id}/dispersals": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Operators"
-                ],
-                "summary": "Fetch batches dispersed to an operator in a time window by specific direction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "The operator ID to fetch batch feed for",
-                        "name": "operator_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]",
-                        "name": "direction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]",
-                        "name": "before",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]",
-                        "name": "after",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of batches to return; if limit \u003c= 0 or \u003e1000, it's treated as 1000 [default: 20; max: 1000]",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalFeedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "error: Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "error: Not found",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "error: Server error",
-                        "schema": {
-                            "$ref": "#/definitions/v2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/operators/{operator_id}/dispersals/{batch_header_hash}/response": {
+        "/operators/{batch_header_hash}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -693,24 +686,23 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "The operator ID to fetch batch feed for",
-                        "name": "operator_id",
+                        "description": "Batch header hash in hex string",
+                        "name": "batch_header_hash",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "description": "Batch header hash in hex string",
-                        "name": "batch_header_hash",
-                        "in": "path",
-                        "required": true
+                        "description": "Operator ID in hex string [default: all operators if unspecified]",
+                        "name": "operator_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v2.OperatorDispersalResponse"
+                            "$ref": "#/definitions/v2.OperatorDispersalResponses"
                         }
                     },
                     "400": {
@@ -1326,42 +1318,14 @@
                 }
             }
         },
-        "v2.OperatorDispersal": {
+        "v2.OperatorDispersalResponses": {
             "type": "object",
             "properties": {
-                "batch_header": {
-                    "$ref": "#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader"
-                },
-                "batch_header_hash": {
-                    "type": "string"
-                },
-                "dispersedAt": {
-                    "type": "integer"
-                }
-            }
-        },
-        "v2.OperatorDispersalFeedResponse": {
-            "type": "object",
-            "properties": {
-                "dispersals": {
+                "operator_dispersal_responses": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/v2.OperatorDispersal"
+                        "$ref": "#/definitions/v2.DispersalResponse"
                     }
-                },
-                "operator_identity": {
-                    "$ref": "#/definitions/v2.OperatorIdentity"
-                },
-                "operator_socket": {
-                    "type": "string"
-                }
-            }
-        },
-        "v2.OperatorDispersalResponse": {
-            "type": "object",
-            "properties": {
-                "operator_dispersal_response": {
-                    "$ref": "#/definitions/v2.DispersalResponse"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -409,12 +409,30 @@ definitions:
       throughput:
         type: number
     type: object
-  v2.OperatorDispersalResponses:
+  v2.OperatorDispersal:
     properties:
-      operator_dispersal_responses:
+      batch_header:
+        $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader'
+      batch_header_hash:
+        type: string
+      dispersedAt:
+        type: integer
+    type: object
+  v2.OperatorDispersalFeedResponse:
+    properties:
+      dispersals:
         items:
-          $ref: '#/definitions/v2.DispersalResponse'
+          $ref: '#/definitions/v2.OperatorDispersal'
         type: array
+      operator_identity:
+        $ref: '#/definitions/v2.OperatorIdentity'
+      operator_socket:
+        type: string
+    type: object
+  v2.OperatorDispersalResponse:
+    properties:
+      operator_dispersal_response:
+        $ref: '#/definitions/v2.DispersalResponse'
     type: object
   v2.OperatorIdentity:
     properties:
@@ -591,51 +609,6 @@ paths:
           schema:
             $ref: '#/definitions/v2.ErrorResponse'
       summary: Fetch batch feed in specified direction
-      tags:
-      - Batches
-  /batches/feed/{operator_id}:
-    get:
-      parameters:
-      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
-          or ''backward'' (newest to oldest, DESC order) [default: forward]'
-        in: query
-        name: direction
-        type: string
-      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
-          example: 2006-01-02T15:04:05Z) [default: now]'
-        in: query
-        name: before
-        type: string
-      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
-          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
-        in: query
-        name: after
-        type: string
-      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
-          it''s treated as 1000 [default: 20; max: 1000]'
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/v2.BatchFeedResponse'
-        "400":
-          description: 'error: Bad request'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "404":
-          description: 'error: Not found'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "500":
-          description: 'error: Server error'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-      summary: Fetch batch feed dispersed to an operator in specified direction
       tags:
       - Batches
   /blobs/{blob_key}:
@@ -848,17 +821,69 @@ paths:
       summary: Fetch throughput time series
       tags:
       - Metrics
-  /operators/{batch_header_hash}:
+  /operators/{operator_id}/dispersals:
     get:
       parameters:
+      - description: The operator ID to fetch batch feed for
+        in: path
+        name: operator_id
+        required: true
+        type: string
+      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
+          or ''backward'' (newest to oldest, DESC order) [default: forward]'
+        in: query
+        name: direction
+        type: string
+      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
+          example: 2006-01-02T15:04:05Z) [default: now]'
+        in: query
+        name: before
+        type: string
+      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
+          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
+        in: query
+        name: after
+        type: string
+      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
+          it''s treated as 1000 [default: 20; max: 1000]'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.OperatorDispersalFeedResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+      summary: Fetch batches dispersed to an operator in a time window by specific
+        direction
+      tags:
+      - Operators
+  /operators/{operator_id}/dispersals/{batch_header_hash}/response:
+    get:
+      parameters:
+      - description: The operator ID to fetch batch feed for
+        in: path
+        name: operator_id
+        required: true
+        type: string
       - description: Batch header hash in hex string
         in: path
         name: batch_header_hash
         required: true
-        type: string
-      - description: 'Operator ID in hex string [default: all operators if unspecified]'
-        in: query
-        name: operator_id
         type: string
       produces:
       - application/json
@@ -866,7 +891,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/v2.OperatorDispersalResponses'
+            $ref: '#/definitions/v2.OperatorDispersalResponse'
         "400":
           description: 'error: Bad request'
           schema:

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -409,30 +409,12 @@ definitions:
       throughput:
         type: number
     type: object
-  v2.OperatorDispersal:
+  v2.OperatorDispersalResponses:
     properties:
-      batch_header:
-        $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader'
-      batch_header_hash:
-        type: string
-      dispersedAt:
-        type: integer
-    type: object
-  v2.OperatorDispersalFeedResponse:
-    properties:
-      dispersals:
+      operator_dispersal_responses:
         items:
-          $ref: '#/definitions/v2.OperatorDispersal'
+          $ref: '#/definitions/v2.DispersalResponse'
         type: array
-      operator_identity:
-        $ref: '#/definitions/v2.OperatorIdentity'
-      operator_socket:
-        type: string
-    type: object
-  v2.OperatorDispersalResponse:
-    properties:
-      operator_dispersal_response:
-        $ref: '#/definitions/v2.DispersalResponse'
     type: object
   v2.OperatorIdentity:
     properties:
@@ -609,6 +591,51 @@ paths:
           schema:
             $ref: '#/definitions/v2.ErrorResponse'
       summary: Fetch batch feed in specified direction
+      tags:
+      - Batches
+  /batches/feed/{operator_id}:
+    get:
+      parameters:
+      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
+          or ''backward'' (newest to oldest, DESC order) [default: forward]'
+        in: query
+        name: direction
+        type: string
+      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
+          example: 2006-01-02T15:04:05Z) [default: now]'
+        in: query
+        name: before
+        type: string
+      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
+          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
+        in: query
+        name: after
+        type: string
+      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
+          it''s treated as 1000 [default: 20; max: 1000]'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.BatchFeedResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+      summary: Fetch batch feed dispersed to an operator in specified direction
       tags:
       - Batches
   /blobs/{blob_key}:
@@ -821,77 +848,25 @@ paths:
       summary: Fetch throughput time series
       tags:
       - Metrics
-  /operators/{operator_id}/dispersals:
+  /operators/{batch_header_hash}:
     get:
       parameters:
-      - description: The operator ID to fetch batch feed for
-        in: path
-        name: operator_id
-        required: true
-        type: string
-      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
-          or ''backward'' (newest to oldest, DESC order) [default: forward]'
-        in: query
-        name: direction
-        type: string
-      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
-          example: 2006-01-02T15:04:05Z) [default: now]'
-        in: query
-        name: before
-        type: string
-      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
-          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
-        in: query
-        name: after
-        type: string
-      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
-          it''s treated as 1000 [default: 20; max: 1000]'
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/v2.OperatorDispersalFeedResponse'
-        "400":
-          description: 'error: Bad request'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "404":
-          description: 'error: Not found'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "500":
-          description: 'error: Server error'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-      summary: Fetch batches dispersed to an operator in a time window by specific
-        direction
-      tags:
-      - Operators
-  /operators/{operator_id}/dispersals/{batch_header_hash}/response:
-    get:
-      parameters:
-      - description: The operator ID to fetch batch feed for
-        in: path
-        name: operator_id
-        required: true
-        type: string
       - description: Batch header hash in hex string
         in: path
         name: batch_header_hash
         required: true
         type: string
+      - description: 'Operator ID in hex string [default: all operators if unspecified]'
+        in: query
+        name: operator_id
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/v2.OperatorDispersalResponse'
+            $ref: '#/definitions/v2.OperatorDispersalResponses'
         "400":
           description: 'error: Bad request'
           schema:

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -409,12 +409,30 @@ definitions:
       throughput:
         type: number
     type: object
-  v2.OperatorDispersalResponses:
+  v2.OperatorDispersal:
     properties:
-      operator_dispersal_responses:
+      batch_header:
+        $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader'
+      batch_header_hash:
+        type: string
+      dispersedAt:
+        type: integer
+    type: object
+  v2.OperatorDispersalFeedResponse:
+    properties:
+      dispersals:
         items:
-          $ref: '#/definitions/v2.DispersalResponse'
+          $ref: '#/definitions/v2.OperatorDispersal'
         type: array
+      operator_identity:
+        $ref: '#/definitions/v2.OperatorIdentity'
+      operator_socket:
+        type: string
+    type: object
+  v2.OperatorDispersalResponse:
+    properties:
+      operator_dispersal_response:
+        $ref: '#/definitions/v2.DispersalResponse'
     type: object
   v2.OperatorIdentity:
     properties:
@@ -591,56 +609,6 @@ paths:
           schema:
             $ref: '#/definitions/v2.ErrorResponse'
       summary: Fetch batch feed in specified direction
-      tags:
-      - Batches
-  /batches/feed/{operator_id}:
-    get:
-      parameters:
-      - description: The operator ID to fetch batch feed for
-        in: path
-        name: operator_id
-        required: true
-        type: string
-      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
-          or ''backward'' (newest to oldest, DESC order) [default: forward]'
-        in: query
-        name: direction
-        type: string
-      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
-          example: 2006-01-02T15:04:05Z) [default: now]'
-        in: query
-        name: before
-        type: string
-      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
-          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
-        in: query
-        name: after
-        type: string
-      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
-          it''s treated as 1000 [default: 20; max: 1000]'
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/v2.BatchFeedResponse'
-        "400":
-          description: 'error: Bad request'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "404":
-          description: 'error: Not found'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "500":
-          description: 'error: Server error'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-      summary: Fetch batch feed dispersed to an operator in specified direction
       tags:
       - Batches
   /blobs/{blob_key}:
@@ -853,17 +821,69 @@ paths:
       summary: Fetch throughput time series
       tags:
       - Metrics
-  /operators/{batch_header_hash}:
+  /operators/{operator_id}/dispersals:
     get:
       parameters:
+      - description: The operator ID to fetch batch feed for
+        in: path
+        name: operator_id
+        required: true
+        type: string
+      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
+          or ''backward'' (newest to oldest, DESC order) [default: forward]'
+        in: query
+        name: direction
+        type: string
+      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
+          example: 2006-01-02T15:04:05Z) [default: now]'
+        in: query
+        name: before
+        type: string
+      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
+          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
+        in: query
+        name: after
+        type: string
+      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
+          it''s treated as 1000 [default: 20; max: 1000]'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.OperatorDispersalFeedResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+      summary: Fetch batches dispersed to an operator in a time window by specific
+        direction
+      tags:
+      - Operators
+  /operators/{operator_id}/dispersals/{batch_header_hash}/response:
+    get:
+      parameters:
+      - description: The operator ID to fetch batch feed for
+        in: path
+        name: operator_id
+        required: true
+        type: string
       - description: Batch header hash in hex string
         in: path
         name: batch_header_hash
         required: true
-        type: string
-      - description: 'Operator ID in hex string [default: all operators if unspecified]'
-        in: query
-        name: operator_id
         type: string
       produces:
       - application/json
@@ -871,7 +891,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/v2.OperatorDispersalResponses'
+            $ref: '#/definitions/v2.OperatorDispersalResponse'
         "400":
           description: 'error: Bad request'
           schema:

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -409,12 +409,30 @@ definitions:
       throughput:
         type: number
     type: object
-  v2.OperatorDispersalResponses:
+  v2.OperatorDispersal:
     properties:
-      operator_dispersal_responses:
+      batch_header:
+        $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader'
+      batch_header_hash:
+        type: string
+      dispersedAt:
+        type: integer
+    type: object
+  v2.OperatorDispersalFeedResponse:
+    properties:
+      dispersals:
         items:
-          $ref: '#/definitions/v2.DispersalResponse'
+          $ref: '#/definitions/v2.OperatorDispersal'
         type: array
+      operator_identity:
+        $ref: '#/definitions/v2.OperatorIdentity'
+      operator_socket:
+        type: string
+    type: object
+  v2.OperatorDispersalResponse:
+    properties:
+      operator_dispersal_response:
+        $ref: '#/definitions/v2.DispersalResponse'
     type: object
   v2.OperatorIdentity:
     properties:
@@ -591,51 +609,6 @@ paths:
           schema:
             $ref: '#/definitions/v2.ErrorResponse'
       summary: Fetch batch feed in specified direction
-      tags:
-      - Batches
-  /batches/feed/{operator_id}:
-    get:
-      parameters:
-      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
-          or ''backward'' (newest to oldest, DESC order) [default: forward]'
-        in: query
-        name: direction
-        type: string
-      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
-          example: 2006-01-02T15:04:05Z) [default: now]'
-        in: query
-        name: before
-        type: string
-      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
-          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
-        in: query
-        name: after
-        type: string
-      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
-          it''s treated as 1000 [default: 20; max: 1000]'
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/v2.BatchFeedResponse'
-        "400":
-          description: 'error: Bad request'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "404":
-          description: 'error: Not found'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-        "500":
-          description: 'error: Server error'
-          schema:
-            $ref: '#/definitions/v2.ErrorResponse'
-      summary: Fetch batch feed dispersed to an operator in specified direction
       tags:
       - Batches
   /blobs/{blob_key}:
@@ -848,17 +821,69 @@ paths:
       summary: Fetch throughput time series
       tags:
       - Metrics
-  /operators/{batch_header_hash}:
+  /operators/{operator_id}/dispersals:
     get:
       parameters:
+      - description: The operator ID to fetch batch feed for
+        in: path
+        name: operator_id
+        required: true
+        type: string
+      - description: 'Direction to fetch: ''forward'' (oldest to newest, ASC order)
+          or ''backward'' (newest to oldest, DESC order) [default: forward]'
+        in: query
+        name: direction
+        type: string
+      - description: 'Fetch batches before this time, exclusive (ISO 8601 format,
+          example: 2006-01-02T15:04:05Z) [default: now]'
+        in: query
+        name: before
+        type: string
+      - description: 'Fetch batches after this time, exclusive (ISO 8601 format, example:
+          2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]'
+        in: query
+        name: after
+        type: string
+      - description: 'Maximum number of batches to return; if limit <= 0 or >1000,
+          it''s treated as 1000 [default: 20; max: 1000]'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.OperatorDispersalFeedResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "404":
+          description: 'error: Not found'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+      summary: Fetch batches dispersed to an operator in a time window by specific
+        direction
+      tags:
+      - Operators
+  /operators/{operator_id}/dispersals/{batch_header_hash}:
+    get:
+      parameters:
+      - description: The operator ID to fetch batch feed for
+        in: path
+        name: operator_id
+        required: true
+        type: string
       - description: Batch header hash in hex string
         in: path
         name: batch_header_hash
         required: true
-        type: string
-      - description: 'Operator ID in hex string [default: all operators if unspecified]'
-        in: query
-        name: operator_id
         type: string
       produces:
       - application/json
@@ -866,7 +891,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/v2.OperatorDispersalResponses'
+            $ref: '#/definitions/v2.OperatorDispersalResponse'
         "400":
           description: 'error: Bad request'
           schema:

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -872,7 +872,7 @@ paths:
         direction
       tags:
       - Operators
-  /operators/{operator_id}/dispersals/{batch_header_hash}:
+  /operators/{operator_id}/dispersals/{batch_header_hash}/response:
     get:
       parameters:
       - description: The operator ID to fetch batch feed for

--- a/disperser/dataapi/v2/batches.go
+++ b/disperser/dataapi/v2/batches.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Layr-Labs/eigenda/core"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi"
 	"github.com/gin-gonic/gin"
@@ -95,97 +94,6 @@ func ParseFeedParams(c *gin.Context, metrics *dataapi.Metrics, handlerName strin
 	params.limit = limit
 
 	return params, nil
-}
-
-// FetchOperatorBatchFeed godoc
-//
-//	@Summary	Fetch batch feed dispersed to an operator in specified direction
-//	@Tags		Batches
-//	@Produce	json
-//	@Param		direction	query		string	false	"Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]"
-//	@Param		before		query		string	false	"Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]"
-//	@Param		after		query		string	false	"Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]"
-//	@Param		limit		query		int		false	"Maximum number of batches to return; if limit <= 0 or >1000, it's treated as 1000 [default: 20; max: 1000]"
-//	@Success	200			{object}	BatchFeedResponse
-//	@Failure	400			{object}	ErrorResponse	"error: Bad request"
-//	@Failure	404			{object}	ErrorResponse	"error: Not found"
-//	@Failure	500			{object}	ErrorResponse	"error: Server error"
-//	@Router		/batches/feed/{operator_id} [get]
-func (s *ServerV2) FetchOperatorBatchFeed(c *gin.Context) {
-	handlerStart := time.Now()
-	var err error
-
-	params, err := ParseFeedParams(c, s.metrics, "FetchOperatorBatchFeed")
-	if err != nil {
-		invalidParamsErrorResponse(c, err)
-		return
-	}
-
-	operatorId, err := core.OperatorIDFromHex(c.Param("operator_id"))
-	if err != nil {
-		s.metrics.IncrementInvalidArgRequestNum("FetchOperatorBatchFeed")
-		errorResponse(c, errors.New("invalid operator id"))
-		return
-	}
-
-	var dispersals []*corev2.DispersalRequest
-
-	if params.direction == "forward" {
-		dispersals, err = s.blobMetadataStore.GetDispersalRequestByDispersedAt(
-			c.Request.Context(),
-			operatorId,
-			uint64(params.afterTime.UnixNano()),
-			uint64(params.beforeTime.UnixNano()),
-			params.limit,
-			true, // ascending=true
-		)
-	} else {
-		dispersals, err = s.blobMetadataStore.GetDispersalRequestByDispersedAt(
-			c.Request.Context(),
-			operatorId,
-			uint64(params.afterTime.UnixNano()),
-			uint64(params.beforeTime.UnixNano()),
-			params.limit,
-			false, // ascending=false
-		)
-	}
-
-	if err != nil {
-		s.metrics.IncrementFailedRequestNum("FetchOperatorBatchFeed")
-		errorResponse(c, fmt.Errorf("failed to fetch dispersals from blob metadata store: %w", err))
-		return
-	}
-
-	batches := make([]*OperatorBatch, len(dispersals))
-	for i, d := range dispersals {
-		batchHeaderHash, err := d.BatchHeader.Hash()
-		if err != nil {
-			s.metrics.IncrementFailedRequestNum("FetchOperatorBatchFeed")
-			errorResponse(c, fmt.Errorf("failed to compute batch header hash from batch header: %w", err))
-			return
-		}
-		batches[i] = &OperatorBatch{
-			BatchHeaderHash: hex.EncodeToString(batchHeaderHash[:]),
-			BatchHeader:     &d.BatchHeader,
-			DispersedAt:     d.DispersedAt,
-		}
-	}
-
-	response := &OperatorBatchFeedResponse{
-		OperatorIdentity: OperatorIdentity{
-			OperatorId: operatorId.Hex(),
-		},
-		Batches: batches,
-	}
-	if len(batches) > 0 {
-		response.OperatorSocket = dispersals[0].Socket
-		response.OperatorIdentity.OperatorAddress = dispersals[0].OperatorAddress.Hex()
-	}
-
-	s.metrics.IncrementSuccessfulRequestNum("FetchOperatorBatchFeed")
-	s.metrics.ObserveLatency("FetchOperatorBatchFeed", time.Since(handlerStart))
-	c.JSON(http.StatusOK, response)
-
 }
 
 // FetchBatchFeed godoc

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -18,6 +19,97 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
 )
+
+// FetchOperatorDispersalFeed godoc
+//
+//	@Summary	Fetch batches dispersed to an operator in a time window by specific direction
+//	@Tags		Operators
+//	@Produce	json
+//	@Param		operator_id	path		string	true	"The operator ID to fetch batch feed for"
+//	@Param		direction	query		string	false	"Direction to fetch: 'forward' (oldest to newest, ASC order) or 'backward' (newest to oldest, DESC order) [default: forward]"
+//	@Param		before		query		string	false	"Fetch batches before this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z) [default: now]"
+//	@Param		after		query		string	false	"Fetch batches after this time, exclusive (ISO 8601 format, example: 2006-01-02T15:04:05Z); must be smaller than `before` [default: `before`-1h]"
+//	@Param		limit		query		int		false	"Maximum number of batches to return; if limit <= 0 or >1000, it's treated as 1000 [default: 20; max: 1000]"
+//	@Success	200			{object}	OperatorDispersalFeedResponse
+//	@Failure	400			{object}	ErrorResponse	"error: Bad request"
+//	@Failure	404			{object}	ErrorResponse	"error: Not found"
+//	@Failure	500			{object}	ErrorResponse	"error: Server error"
+//	@Router		/operators/{operator_id}/dispersals [get]
+func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
+	handlerStart := time.Now()
+	var err error
+
+	params, err := ParseFeedParams(c, s.metrics, "FetchOperatorDispersalFeed")
+	if err != nil {
+		invalidParamsErrorResponse(c, err)
+		return
+	}
+
+	operatorId, err := core.OperatorIDFromHex(c.Param("operator_id"))
+	if err != nil {
+		s.metrics.IncrementInvalidArgRequestNum("FetchOperatorDispersalFeed")
+		errorResponse(c, errors.New("invalid operator id"))
+		return
+	}
+
+	var dispersals []*corev2.DispersalRequest
+
+	if params.direction == "forward" {
+		dispersals, err = s.blobMetadataStore.GetDispersalRequestByDispersedAt(
+			c.Request.Context(),
+			operatorId,
+			uint64(params.afterTime.UnixNano()),
+			uint64(params.beforeTime.UnixNano()),
+			params.limit,
+			true, // ascending=true
+		)
+	} else {
+		dispersals, err = s.blobMetadataStore.GetDispersalRequestByDispersedAt(
+			c.Request.Context(),
+			operatorId,
+			uint64(params.afterTime.UnixNano()),
+			uint64(params.beforeTime.UnixNano()),
+			params.limit,
+			false, // ascending=false
+		)
+	}
+
+	if err != nil {
+		s.metrics.IncrementFailedRequestNum("FetchOperatorDispersalFeed")
+		errorResponse(c, fmt.Errorf("failed to fetch dispersals from blob metadata store: %w", err))
+		return
+	}
+
+	batches := make([]*OperatorDispersal, len(dispersals))
+	for i, d := range dispersals {
+		batchHeaderHash, err := d.BatchHeader.Hash()
+		if err != nil {
+			s.metrics.IncrementFailedRequestNum("FetchOperatorDispersalFeed")
+			errorResponse(c, fmt.Errorf("failed to compute batch header hash from batch header: %w", err))
+			return
+		}
+		batches[i] = &OperatorDispersal{
+			BatchHeaderHash: hex.EncodeToString(batchHeaderHash[:]),
+			BatchHeader:     &d.BatchHeader,
+			DispersedAt:     d.DispersedAt,
+		}
+	}
+
+	response := &OperatorDispersalFeedResponse{
+		OperatorIdentity: OperatorIdentity{
+			OperatorId: operatorId.Hex(),
+		},
+		Dispersals: batches,
+	}
+	if len(batches) > 0 {
+		response.OperatorSocket = dispersals[0].Socket
+		response.OperatorIdentity.OperatorAddress = dispersals[0].OperatorAddress.Hex()
+	}
+
+	s.metrics.IncrementSuccessfulRequestNum("FetchOperatorDispersalFeed")
+	s.metrics.ObserveLatency("FetchOperatorDispersalFeed", time.Since(handlerStart))
+	c.JSON(http.StatusOK, response)
+}
 
 // FetchOperatorSigningInfo godoc
 //
@@ -240,60 +332,48 @@ func (s *ServerV2) FetchOperatorsNodeInfo(c *gin.Context) {
 	c.JSON(http.StatusOK, report)
 }
 
-// FetchOperatorsResponses godoc
+// FetchOperatorDispersalResponse godoc
 //
 //	@Summary	Fetch operator attestation response for a batch
 //	@Tags		Operators
 //	@Produce	json
+//	@Param		operator_id			path		string	true	"The operator ID to fetch batch feed for"
 //	@Param		batch_header_hash	path		string	true	"Batch header hash in hex string"
-//	@Param		operator_id			query		string	false	"Operator ID in hex string [default: all operators if unspecified]"
-//	@Success	200					{object}	OperatorDispersalResponses
+//	@Success	200					{object}	OperatorDispersalResponse
 //	@Failure	400					{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404					{object}	ErrorResponse	"error: Not found"
 //	@Failure	500					{object}	ErrorResponse	"error: Server error"
-//	@Router		/operators/{batch_header_hash} [get]
-func (s *ServerV2) FetchOperatorsResponses(c *gin.Context) {
+//	@Router		/operators/{operator_id}/dispersals/{batch_header_hash} [get]
+func (s *ServerV2) FetchOperatorDispersalResponse(c *gin.Context) {
 	handlerStart := time.Now()
 
 	batchHeaderHashHex := c.Param("batch_header_hash")
 	batchHeaderHash, err := dataapi.ConvertHexadecimalToBytes([]byte(batchHeaderHashHex))
 	if err != nil {
-		s.metrics.IncrementInvalidArgRequestNum("FetchOperatorsResponses")
+		s.metrics.IncrementInvalidArgRequestNum("FetchOperatorDispersalResponse")
 		errorResponse(c, errors.New("invalid batch header hash"))
 		return
 	}
-	operatorIdStr := c.DefaultQuery("operator_id", "")
 
-	operatorResponses := make([]*corev2.DispersalResponse, 0)
-	if operatorIdStr == "" {
-		res, err := s.blobMetadataStore.GetDispersalResponses(c.Request.Context(), batchHeaderHash)
-		if err != nil {
-			s.metrics.IncrementFailedRequestNum("FetchOperatorsResponses")
-			errorResponse(c, err)
-			return
-		}
-		operatorResponses = append(operatorResponses, res...)
-	} else {
-		operatorId, err := core.OperatorIDFromHex(operatorIdStr)
-		if err != nil {
-			s.metrics.IncrementInvalidArgRequestNum("FetchOperatorsResponses")
-			errorResponse(c, errors.New("invalid operatorId"))
-			return
-		}
+	operatorIdHex := c.Param("operator_id")
+	operatorId, err := core.OperatorIDFromHex(operatorIdHex)
+	if err != nil {
+		s.metrics.IncrementInvalidArgRequestNum("FetchOperatorDispersalResponse")
+		errorResponse(c, errors.New("invalid operatorId"))
+		return
+	}
 
-		res, err := s.blobMetadataStore.GetDispersalResponse(c.Request.Context(), batchHeaderHash, operatorId)
-		if err != nil {
-			s.metrics.IncrementFailedRequestNum("FetchOperatorsResponses")
-			errorResponse(c, err)
-			return
-		}
-		operatorResponses = append(operatorResponses, res)
+	res, err := s.blobMetadataStore.GetDispersalResponse(c.Request.Context(), batchHeaderHash, operatorId)
+	if err != nil {
+		s.metrics.IncrementFailedRequestNum("FetchOperatorDispersalResponse")
+		errorResponse(c, err)
+		return
 	}
-	response := &OperatorDispersalResponses{
-		Responses: operatorResponses,
+	response := &OperatorDispersalResponse{
+		Response: res,
 	}
-	s.metrics.IncrementSuccessfulRequestNum("FetchOperatorsResponses")
-	s.metrics.ObserveLatency("FetchOperatorsResponses", time.Since(handlerStart))
+	s.metrics.IncrementSuccessfulRequestNum("FetchOperatorDispersalResponse")
+	s.metrics.ObserveLatency("FetchOperatorDispersalResponse", time.Since(handlerStart))
 	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxOperatorResponseAge))
 	c.JSON(http.StatusOK, response)
 }

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -343,7 +343,7 @@ func (s *ServerV2) FetchOperatorsNodeInfo(c *gin.Context) {
 //	@Failure	400					{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404					{object}	ErrorResponse	"error: Not found"
 //	@Failure	500					{object}	ErrorResponse	"error: Server error"
-//	@Router		/operators/{operator_id}/dispersals/{batch_header_hash} [get]
+//	@Router		/operators/{operator_id}/dispersals/{batch_header_hash}/response [get]
 func (s *ServerV2) FetchOperatorDispersalResponse(c *gin.Context) {
 	handlerStart := time.Now()
 

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -316,7 +316,7 @@ func (s *ServerV2) Start() error {
 		operators := v2.Group("/operators")
 		{
 			operators.GET("/:operator_id/dispersals", s.FetchOperatorDispersalFeed)
-			operators.GET("/:operator_id/dispersals/:batch_header_hash", s.FetchOperatorDispersalResponse)
+			operators.GET("/:operator_id/dispersals/:batch_header_hash/response", s.FetchOperatorDispersalResponse)
 			operators.GET("/signing-info", s.FetchOperatorSigningInfo)
 			operators.GET("/stake", s.FetchOperatorsStake)
 			operators.GET("/node-info", s.FetchOperatorsNodeInfo)

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -118,15 +118,15 @@ type (
 		Batches []*BatchInfo `json:"batches"`
 	}
 
-	OperatorBatch struct {
+	OperatorDispersal struct {
 		BatchHeaderHash string              `json:"batch_header_hash"`
 		BatchHeader     *corev2.BatchHeader `json:"batch_header"`
 		DispersedAt     uint64
 	}
-	OperatorBatchFeedResponse struct {
-		OperatorIdentity OperatorIdentity `json:"operator_identity"`
-		OperatorSocket   string           `json:"operator_socket"`
-		Batches          []*OperatorBatch `json:"batches"`
+	OperatorDispersalFeedResponse struct {
+		OperatorIdentity OperatorIdentity     `json:"operator_identity"`
+		OperatorSocket   string               `json:"operator_socket"`
+		Dispersals       []*OperatorDispersal `json:"dispersals"`
 	}
 
 	MetricSummary struct {
@@ -164,9 +164,9 @@ type (
 		StakeRankedOperators map[string][]*OperatorStake `json:"stake_ranked_operators"`
 	}
 
-	// Operators' responses for a batch
-	OperatorDispersalResponses struct {
-		Responses []*corev2.DispersalResponse `json:"operator_dispersal_responses"`
+	// Operator's response for a batch
+	OperatorDispersalResponse struct {
+		Response *corev2.DispersalResponse `json:"operator_dispersal_response"`
 	}
 
 	OperatorLivenessResponse struct {
@@ -311,16 +311,16 @@ func (s *ServerV2) Start() error {
 		batches := v2.Group("/batches")
 		{
 			batches.GET("/feed", s.FetchBatchFeed)
-			batches.GET("/feed/:operator_id", s.FetchOperatorBatchFeed)
 			batches.GET("/:batch_header_hash", s.FetchBatch)
 		}
 		operators := v2.Group("/operators")
 		{
+			operators.GET("/:operator_id/dispersals", s.FetchOperatorDispersalFeed)
+			operators.GET("/:operator_id/dispersals/:batch_header_hash", s.FetchOperatorDispersalResponse)
 			operators.GET("/signing-info", s.FetchOperatorSigningInfo)
 			operators.GET("/stake", s.FetchOperatorsStake)
 			operators.GET("/node-info", s.FetchOperatorsNodeInfo)
 			operators.GET("/liveness", s.CheckOperatorsLiveness)
-			operators.GET("/response/:batch_header_hash", s.FetchOperatorsResponses)
 		}
 		metrics := v2.Group("/metrics")
 		{

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -2138,10 +2138,10 @@ func TestFetchOperatorDispersalResponse(t *testing.T) {
 	err = blobMetadataStore.PutDispersalResponse(ctx, dispersalResponse2)
 	assert.NoError(t, err)
 
-	r.GET("/v2/operators/:operator_id/dispersals/:batch_header_hash", testDataApiServerV2.FetchOperatorDispersalResponse)
+	r.GET("/v2/operators/:operator_id/dispersals/:batch_header_hash/response", testDataApiServerV2.FetchOperatorDispersalResponse)
 
 	// Fetch response of a specific operator
-	reqStr := fmt.Sprintf("/v2/operators/%s/dispersals/%s", operatorId.Hex(), batchHeaderHash)
+	reqStr := fmt.Sprintf("/v2/operators/%s/dispersals/%s/response", operatorId.Hex(), batchHeaderHash)
 	w := executeRequest(t, r, http.MethodGet, reqStr)
 	response := decodeResponseBody[serverv2.OperatorDispersalResponse](t, w)
 	require.Equal(t, dispersalResponse, response.Response)


### PR DESCRIPTION
## Why are these changes needed?
Make it more clear and intuitive by structuring APIs in a well-defined resource hierarchy.

- `/batches/feed/{operator_id}` -> `/operators/{operator_id}/dispersals`
- `/operators/{batch_header_hash}` -> `/operators/{operator_id}/dispersals/{batch_header_hash}/response`

Note the second change has dropped the ability to fetch all dispersals (from all operators) for a batch, which should be more natural to be organized under `/batches` API hierarchy.

### Tested
```
curl http://localhost:9000/api/v2/operators/13865da12cdefdbac46cb2f35f8a39f0ac4cdc79dde6d4499cbd234bc5a5a7a2/dispersals?after=2006-01-02T15:04:05Z
{"operator_identity":{"operator_id":"13865da12cdefdbac46cb2f35f8a39f0ac4cdc79dde6d4499cbd234bc5a5a7a2","operator_address":"0x0000000000000000000000000000000000000000"},"operator_socket":"54.163.153.160:30008;30009;30010;30011","dispersals":[{"batch_header_hash":"1ad8d29f3226202f6b1e5d2c2e72dbecfb4d6efb697000af03cb202f055e4b83","batch_header":{"BatchRoot":[34,161,92,215,36,198,235,249,36,34,177,14,227,177,110,217,74,194,242,37,133,3,6,222,133,94,14,125,166,152,95,114],"ReferenceBlockNumber":3446226},"DispersedAt":1741217772103506295},{"batch_header_hash":"1ad8d29f3226202f6b1e5d2c2e72dbecfb4d6efb697000af03cb202f055e4b83","batch_header":{"BatchRoot":[34,161,92,215,36,198,235,249,36,34,177,14,227,177,110,217,74,194,242,37,133,3,6,222,133,94,14,125,166,152,95,114],"ReferenceBlockNumber":3446226},"DispersedAt":1741217772103506295},{"batch_header_hash":"1524d4be0204aae8fdbd55abe376fc20540f677198f979d7e745326d3deb19cf","batch_header":{"BatchRoot":[4,57,86,249,31,78,200,60,77,2,114,62,252,224,97,161,210,129,12,85,75,180,156,59,202,222,156,187,249,110,230,44],"ReferenceBlockNumber":3446226},"DispersedAt":1741217782187085587},{"batch_header_hash":"1524d4be0204aae8fdbd55abe376fc20540f677198f979d7e745326d3deb19cf","batch_header":{"BatchRoot":[4,57,86,249,31,78,200,60,77,2,114,62,252,224,97,161,210,129,12,85,75,180,156,59,202,222,156,187,249,110,230,44],"ReferenceBlockNumber":3446226},"DispersedAt":1741217782187085587},{"batch_header_hash":"b0c66724898e8fe6b9594ea118fda19adaff6ce19d20cb5d4098acea3535e4c8","batch_header":{"BatchRoot":[148,37,120,147,199,173,34,216,141,80,157,217,252,230,238,254,161,214,128,117,14,56,70,74,27,82,175,198,4,60,31,198],"ReferenceBlockNumber":3446226},"DispersedAt":1741217792161028400},{"batch_header_hash":"b0c66724898e8fe6b9594ea118fda19adaff6ce19d20cb5d4098acea3535e4c8","batch_header":{"BatchRoot":[148,37,120,147,199,173,34,216,141,80,157,217,252,230,238,254,161,214,128,117,14,56,70,74,27,82,175,198,4,60,31,198],"ReferenceBlockNumber":3446226},"DispersedAt":1741217792161028400},{"batch_header_hash":"db187c6e57e79137e2948214a7d0932b266f32768ce75fc5b630fcf86c4a336a","batch_header":{"BatchRoot":[239,122,66,162,14,119,190,234,46,133,157,190,79,94,171,34,51,2,66,208,218,13,108,26,50,192,234,67,98,18,164,111],"ReferenceBlockNumber":3446226},"DispersedAt":1741217797911821957},{"batch_header_hash":"db187c6e57e79137e2948214a7d0932b266f32768ce75fc5b630fcf86c4a336a","batch_header":{"BatchRoot":[239,122,66,162,14,119,190,234,46,133,157,190,79,94,171,34,51,2,66,208,218,13,108,26,50,192,234,67,98,18,164,111],"ReferenceBlockNumber":3446226},"DispersedAt":1741217797911821957},{"batch_header_hash":"0af7f6cd1348ba606f4723ad16045af04ead5c2649ec3bc8efa4a17b420188f3","batch_header":{"BatchRoot":[171,107,60,34,217,91,63,230,26,81,34,244,8,46,11,222,135,103,245,113,91,200,169,243,195,252,226,241,194,255,135,109],"ReferenceBlockNumber":3446227},"DispersedAt":1741217802144232568},{"batch_header_hash":"0af7f6cd1348ba606f4723ad16045af04ead5c2649ec3bc8efa4a17b420188f3","batch_header":{"BatchRoot":[171,107,60,34,217,91,63,230,26,81,34,244,8,46,11,222,135,103,245,113,91,200,169,243,195,252,226,241,194,255,135,109],"ReferenceBlockNumber":3446227},"DispersedAt":1741217802144232568},{"batch_header_hash":"c2352ff61b92af06167fbcf6c0a979e1e34ee73bba81cbc105503f3ab85036ba","batch_header":{"BatchRoot":[108,103,250,129,36,183,21,102,97,5,253,110,220,242,78,53,187,243,62,143,118,165,213,5,213,85,29,219,20,111,186,185],"ReferenceBlockNumber":3446227},"DispersedAt":1741217807129646173},{"batch_header_hash":"c2352ff61b92af06167fbcf6c0a979e1e34ee73bba81cbc105503f3ab85036ba","batch_header":{"BatchRoot":[108,103,250,129,36,183,21,102,97,5,253,110,220,242,78,53,187,243,62,143,118,165,213,5,213,85,29,219,20,111,186,185],"ReferenceBlockNumber":3446227},"DispersedAt":1741217807129646173},{"batch_header_hash":"9ef8cb22c902c62796c7f095fc204e11f19a080c69ac27e961037ab5be64077c","batch_header":{"BatchRoot":[28,68,1,230,23,44,174,147,214,251,245,165,43,86,135,219,145,225,112,183,148,26,93,71,28,79,164,134,6,176,222,8],"ReferenceBlockNumber":3446227},"DispersedAt":1741217812151009098},{"batch_header_hash":"9ef8cb22c902c62796c7f095fc204e11f19a080c69ac27e961037ab5be64077c","batch_header":{"BatchRoot":[28,68,1,230,23,44,174,147,214,251,245,165,43,86,135,219,145,225,112,183,148,26,93,71,28,79,164,134,6,176,222,8],"ReferenceBlockNumber":3446227},"DispersedAt":1741217812151009098},{"batch_header_hash":"4e28428c9cbaf2c5ce199a1d72343d7c2f5aedec79e4072ad4d1e0a8fa32961c","batch_header":{"BatchRoot":[209,163,224,103,34,200,94,236,114,57,96,61,219,99,39,129,248,30,167,133,40,171,154,51,229,135,32,107,3,141,107,37],"ReferenceBlockNumber":3446227},"DispersedAt":1741217817588419886},{"batch_header_hash":"4e28428c9cbaf2c5ce199a1d72343d7c2f5aedec79e4072ad4d1e0a8fa32961c","batch_header":{"BatchRoot":[209,163,224,103,34,200,94,236,114,57,96,61,219,99,39,129,248,30,167,133,40,171,154,51,229,135,32,107,3,141,107,37],"ReferenceBlockNumber":3446227},"DispersedAt":1741217817588419886},{"batch_header_hash":"5a41fb4516b5cf92e764c1643311af533ab82d2ff327f026b77a759e668dbc3a","batch_header":{"BatchRoot":[6,215,6,86,11,126,243,93,3,152,191,45,34,64,37,142,175,139,166,81,151,236,196,98,117,198,163,29,59,49,123,178],"ReferenceBlockNumber":3446227},"DispersedAt":1741217822099425846},{"batch_header_hash":"5a41fb4516b5cf92e764c1643311af533ab82d2ff327f026b77a759e668dbc3a","batch_header":{"BatchRoot":[6,215,6,86,11,126,243,93,3,152,191,45,34,64,37,142,175,139,166,81,151,236,196,98,117,198,163,29,59,49,123,178],"ReferenceBlockNumber":3446227},"DispersedAt":1741217822099425846},{"batch_header_hash":"bab835abc304beae2d8462aafaf392752df11b43cab1276b1c96967e0adac83b","batch_header":{"BatchRoot":[173,117,115,211,21,63,179,143,75,127,182,248,220,114,243,68,199,188,149,237,219,70,53,180,78,21,248,233,150,157,136,86],"ReferenceBlockNumber":3446227},"DispersedAt":1741217827661156864},{"batch_header_hash":"bab835abc304beae2d8462aafaf392752df11b43cab1276b1c96967e0adac83b","batch_header":{"BatchRoot":[173,117,115,211,21,63,179,143,75,127,182,248,220,114,243,68,199,188,149,237,219,70,53,180,78,21,248,233,150,157,136,86],"ReferenceBlockNumber":3446227},"DispersedAt":1741217827661156864}]}
```
```
curl http://localhost:9000/api/v2/operators/13865da12cdefdbac46cb2f35f8a39f0ac4cdc79dde6d4499cbd234bc5a5a7a2/dispersals/ae3daea5dd02b836e937c32fcd837479646625d69a044ad84d14d4da5a31729e/response
{"operator_dispersal_response":{"OperatorID":[19,134,93,161,44,222,253,186,196,108,178,243,95,138,57,240,172,76,220,121,221,230,212,73,156,189,35,75,197,165,167,162],"OperatorAddress":"0x0000000000000000000000000000000000000000","Socket":"54.163.153.160:30008;30009;30010;30011","DispersedAt":1742347785668622625,"BatchRoot":[201,88,48,177,49,219,86,213,104,18,221,47,70,209,97,5,27,19,9,185,194,95,61,179,210,201,192,139,11,252,133,146],"ReferenceBlockNumber":3516304,"RespondedAt":1742347807913624257,"Signature":[171,197,23,112,84,17,8,184,33,91,231,250,143,71,131,230,134,1,250,65,29,211,82,103,97,92,179,9,142,89,3,203],"Error":""}}
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
