### PR TITLE
perf: add KV cache for lookup requests in data apis

### DIFF
--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -126,7 +126,7 @@ func RunDataApi(ctx *cli.Context) error {
 	if config.ServerVersion == 2 {
 		blobMetadataStorev2 := blobstorev2.NewBlobMetadataStore(dynamoClient, logger, config.BlobstoreConfig.TableName)
 		metrics = dataapi.NewMetrics(config.ServerVersion, blobMetadataStorev2, config.MetricsConfig.HTTPPort, logger)
-		serverv2 := serverv2.NewServerV2(
+		serverv2, err := serverv2.NewServerV2(
 			dataapi.Config{
 				ServerMode:         config.ServerMode,
 				SocketAddr:         config.SocketAddr,
@@ -144,6 +144,9 @@ func RunDataApi(ctx *cli.Context) error {
 			logger,
 			metrics,
 		)
+		if err != nil {
+			return err
+		}
 
 		// Enable Metrics Block
 		if config.MetricsConfig.EnableMetrics {

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -293,7 +293,7 @@ const docTemplateV2 = `{
                 "tags": [
                     "Blobs"
                 ],
-                "summary": "Fetch blob certificate by blob key v2",
+                "summary": "Fetch blob certificate by blob key",
                 "parameters": [
                     {
                         "type": "string",

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -290,7 +290,7 @@
                 "tags": [
                     "Blobs"
                 ],
-                "summary": "Fetch blob certificate by blob key v2",
+                "summary": "Fetch blob certificate by blob key",
                 "parameters": [
                     {
                         "type": "string",

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -698,7 +698,7 @@ paths:
           description: 'error: Server error'
           schema:
             $ref: '#/definitions/v2.ErrorResponse'
-      summary: Fetch blob certificate by blob key v2
+      summary: Fetch blob certificate by blob key
       tags:
       - Blobs
   /blobs/feed:

--- a/disperser/dataapi/v2/batches.go
+++ b/disperser/dataapi/v2/batches.go
@@ -194,8 +194,8 @@ func (s *ServerV2) FetchBatch(c *gin.Context) {
 		errorResponse(c, errors.New("invalid batch header hash"))
 		return
 	}
-	signedBatch, ok := s.signedBatchCache.Get(batchHeaderHashHex)
-	if !ok {
+	signedBatch, cached := s.signedBatchCache.Get(batchHeaderHashHex)
+	if !cached {
 		batchHeader, attestation, err := s.blobMetadataStore.GetSignedBatch(c.Request.Context(), batchHeaderHash)
 		if err != nil {
 			s.metrics.IncrementFailedRequestNum("FetchBatch")

--- a/disperser/dataapi/v2/batches.go
+++ b/disperser/dataapi/v2/batches.go
@@ -207,6 +207,8 @@ func (s *ServerV2) FetchBatch(c *gin.Context) {
 			Attestation: attestation,
 		}
 		s.signedBatchCache.Add(batchHeaderHashHex, signedBatch)
+	} else {
+		s.metrics.IncrementCacheHit("FetchBatch")
 	}
 	// TODO: support fetch of blob inclusion info
 	batchResponse := &BatchResponse{

--- a/disperser/dataapi/v2/blobs.go
+++ b/disperser/dataapi/v2/blobs.go
@@ -185,8 +185,8 @@ func (s *ServerV2) FetchBlob(c *gin.Context) {
 		errorResponse(c, err)
 		return
 	}
-	metadata, ok := s.blobMetadataCache.Get(blobKey.Hex())
-	if !ok {
+	metadata, cached := s.blobMetadataCache.Get(blobKey.Hex())
+	if !cached {
 		metadata, err = s.blobMetadataStore.GetBlobMetadata(c.Request.Context(), blobKey)
 		if err != nil {
 			s.metrics.IncrementFailedRequestNum("FetchBlob")
@@ -236,8 +236,8 @@ func (s *ServerV2) FetchBlobCertificate(c *gin.Context) {
 		errorResponse(c, err)
 		return
 	}
-	cert, ok := s.blobCertificateCache.Get(blobKey.Hex())
-	if !ok {
+	cert, cached := s.blobCertificateCache.Get(blobKey.Hex())
+	if !cached {
 		cert, _, err = s.blobMetadataStore.GetBlobCertificate(c.Request.Context(), blobKey)
 		if err != nil {
 			s.metrics.IncrementFailedRequestNum("FetchBlobCertificate")
@@ -279,8 +279,8 @@ func (s *ServerV2) FetchBlobAttestationInfo(c *gin.Context) {
 		return
 	}
 
-	response, ok := s.blobAttestationInfoResponseCache.Get(blobKey.Hex())
-	if !ok {
+	response, cached := s.blobAttestationInfoResponseCache.Get(blobKey.Hex())
+	if !cached {
 		response, err = s.getBlobAttestationInfoResponse(ctx, blobKey)
 		if err != nil {
 			s.metrics.IncrementFailedRequestNum("FetchBlobAttestationInfo")
@@ -300,8 +300,8 @@ func (s *ServerV2) FetchBlobAttestationInfo(c *gin.Context) {
 
 func (s *ServerV2) getBlobAttestationInfoResponse(ctx context.Context, blobKey corev2.BlobKey) (*BlobAttestationInfoResponse, error) {
 	var err error
-	attestationInfo, ok := s.blobAttestationInfoCache.Get(blobKey.Hex())
-	if !ok {
+	attestationInfo, cached := s.blobAttestationInfoCache.Get(blobKey.Hex())
+	if !cached {
 		attestationInfo, err = s.blobMetadataStore.GetBlobAttestationInfo(ctx, blobKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch blob attestation info: %w", err)
@@ -315,8 +315,8 @@ func (s *ServerV2) getBlobAttestationInfoResponse(ctx context.Context, blobKey c
 	}
 
 	// Get quorums that this blob was dispersed to
-	metadata, ok := s.blobMetadataCache.Get(blobKey.Hex())
-	if !ok {
+	metadata, cached := s.blobMetadataCache.Get(blobKey.Hex())
+	if !cached {
 		metadata, err = s.blobMetadataStore.GetBlobMetadata(ctx, blobKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch blob metadata: %w", err)

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -12,6 +13,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/disperser/common/semver"
+	commonv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
 	disperserv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
 	"github.com/Layr-Labs/eigenda/disperser/common/v2/blobstore"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi"
@@ -20,6 +22,7 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/logger"
 	"github.com/gin-gonic/gin"
+	lru "github.com/hashicorp/golang-lru/v2"
 	swaggerfiles "github.com/swaggo/files"
 	ginswagger "github.com/swaggo/gin-swagger"
 )
@@ -43,6 +46,10 @@ const (
 	// Suppose 1 batch/s, we cache 2 days worth of batch attestations.
 	// Suppose 1KB for each attestation, this will be 173MB memory.
 	maxNumBatchesToCache = 3600 * 24 * 2
+
+	// Cache ~1h worth of blobs and batches for KV lookups
+	maxNumKVBlobsToCache   = 100 * 3600
+	maxNumKVBatchesToCache = 3600
 
 	cacheControlParam       = "Cache-Control"
 	maxFeedBlobAge          = 300 // this is completely static
@@ -210,7 +217,16 @@ type ServerV2 struct {
 	operatorHandler *dataapi.OperatorHandler
 	metricsHandler  *dataapi.MetricsHandler
 
+	// Feed cache
 	batchFeedCache *FeedCache[corev2.Attestation]
+
+	// KV cache
+	// The blob caches are keyed by blobkey
+	blobMetadataCache        *lru.Cache[string, *commonv2.BlobMetadata]
+	blobAttestationInfoCache *lru.Cache[string, *commonv2.BlobAttestationInfo]
+	blobCertificateCache     *lru.Cache[string, *corev2.BlobCertificate]
+	// The batch caches are keyed by batch header hash
+	signedBatchCache *lru.Cache[string, *SignedBatch]
 }
 
 func NewServerV2(
@@ -223,7 +239,7 @@ func NewServerV2(
 	indexedChainState core.IndexedChainState,
 	logger logging.Logger,
 	metrics *dataapi.Metrics,
-) *ServerV2 {
+) (*ServerV2, error) {
 	l := logger.With("component", "DataAPIServerV2")
 
 	getBatchTimestampFn := func(item *corev2.Attestation) time.Time {
@@ -246,22 +262,44 @@ func NewServerV2(
 		metrics.BatchFeedCacheMetrics,
 	)
 
-	return &ServerV2{
-		logger:            l,
-		serverMode:        config.ServerMode,
-		socketAddr:        config.SocketAddr,
-		allowOrigins:      config.AllowOrigins,
-		blobMetadataStore: blobMetadataStore,
-		promClient:        promClient,
-		subgraphClient:    subgraphClient,
-		chainReader:       chainReader,
-		chainState:        chainState,
-		indexedChainState: indexedChainState,
-		metrics:           metrics,
-		operatorHandler:   dataapi.NewOperatorHandler(l, metrics, chainReader, chainState, indexedChainState, subgraphClient),
-		metricsHandler:    dataapi.NewMetricsHandler(promClient, dataapi.V2),
-		batchFeedCache:    batchFeedCache,
+	blobMetadataCache, err := lru.New[string, *commonv2.BlobMetadata](maxNumKVBlobsToCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create blobMetadataCache: %w", err)
 	}
+	blobAttestationInfoCache, err := lru.New[string, *commonv2.BlobAttestationInfo](maxNumKVBlobsToCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create blobAttestationInfoCache: %w", err)
+	}
+	blobCertificateCache, err := lru.New[string, *corev2.BlobCertificate](maxNumKVBlobsToCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create blobCertificateCache: %w", err)
+	}
+
+	signedBatchCache, err := lru.New[string, *SignedBatch](maxNumKVBatchesToCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create signedBatchCache: %w", err)
+	}
+
+	return &ServerV2{
+		logger:                   l,
+		serverMode:               config.ServerMode,
+		socketAddr:               config.SocketAddr,
+		allowOrigins:             config.AllowOrigins,
+		blobMetadataStore:        blobMetadataStore,
+		promClient:               promClient,
+		subgraphClient:           subgraphClient,
+		chainReader:              chainReader,
+		chainState:               chainState,
+		indexedChainState:        indexedChainState,
+		metrics:                  metrics,
+		operatorHandler:          dataapi.NewOperatorHandler(l, metrics, chainReader, chainState, indexedChainState, subgraphClient),
+		metricsHandler:           dataapi.NewMetricsHandler(promClient, dataapi.V2),
+		batchFeedCache:           batchFeedCache,
+		blobMetadataCache:        blobMetadataCache,
+		blobAttestationInfoCache: blobAttestationInfoCache,
+		blobCertificateCache:     blobCertificateCache,
+		signedBatchCache:         signedBatchCache,
+	}, nil
 }
 
 func (s *ServerV2) Start() error {

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -221,13 +221,13 @@ type ServerV2 struct {
 	// Feed cache
 	batchFeedCache *FeedCache[corev2.Attestation]
 
-	// KV cache
-	// The blob caches are keyed by blobkey
+	// KV caches for blobs, keyed by blobkey
 	blobMetadataCache                *lru.Cache[string, *commonv2.BlobMetadata]
 	blobAttestationInfoCache         *lru.Cache[string, *commonv2.BlobAttestationInfo]
 	blobCertificateCache             *lru.Cache[string, *corev2.BlobCertificate]
 	blobAttestationInfoResponseCache *lru.Cache[string, *BlobAttestationInfoResponse]
-	// The batch caches are keyed by batch header hash
+
+	// KV caches for batches, keyed by batch header hash
 	signedBatchCache *lru.Cache[string, *SignedBatch]
 }
 

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -222,7 +222,11 @@ func setup(m *testing.M) {
 		panic("failed to create dynamodb client: " + err.Error())
 	}
 	blobMetadataStore = blobstorev2.NewBlobMetadataStore(dynamoClient, logger, metadataTableName)
-	testDataApiServerV2 = serverv2.NewServerV2(config, blobMetadataStore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger))
+	testDataApiServerV2, err = serverv2.NewServerV2(config, blobMetadataStore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger))
+	if err != nil {
+		teardown()
+		panic("failed to create dynamodb client: " + err.Error())
+	}
 }
 
 // makeCommitment returns a test hardcoded BlobCommitments
@@ -1319,7 +1323,9 @@ func TestFetchBatchFeed(t *testing.T) {
 	// Create a local server so the internal state (e.g. cache) will be re-created.
 	// This is needed because /v2/operators/signing-info API shares the cache state with
 	// /v2/batches/feed API.
-	testDataApiServerV2 := serverv2.NewServerV2(config, blobMetadataStore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger))
+	testDataApiServerV2, err := serverv2.NewServerV2(config, blobMetadataStore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger))
+	require.NoError(t, err)
+
 	r.GET("/v2/batches/feed", testDataApiServerV2.FetchBatchFeed)
 
 	t.Run("invalid params", func(t *testing.T) {
@@ -1794,7 +1800,9 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 	// Create a local server so the internal state (e.g. cache) will be re-created.
 	// This is needed because /v2/operators/signing-info API shares the cache state with
 	// /v2/batches/feed API.
-	testDataApiServerV2 := serverv2.NewServerV2(config, blobMetadataStore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger))
+	testDataApiServerV2, err := serverv2.NewServerV2(config, blobMetadataStore, prometheusClient, subgraphClient, mockTx, mockChainState, mockIndexedChainState, mockLogger, dataapi.NewMetrics(serverVersion, nil, "9001", mockLogger))
+	require.NoError(t, err)
+
 	r.GET("/v2/operators/signing-info", testDataApiServerV2.FetchOperatorSigningInfo)
 
 	t.Run("invalid params", func(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
Cache the lookup requests will improve latency, and more importantly reduce the traffic hitting the database (which is shared between dataapi and disperser so will need protection from unnecessary interference).

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
