### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/common/testutils/random/test_random.go
+++ b/common/testutils/random/test_random.go
@@ -122,15 +122,9 @@ func (r *TestRandom) Gaussian(mean float64, stddev float64) float64 {
 
 // BoundedGaussian generates a random float64 from a Gaussian distribution with the given mean and standard deviation,
 // but bounded by the given min and max values. If a generated value exceeds the bounds, the bound is returned instead.
-func (r *TestRandom) BoundedGaussian(mean float64, stddev float64, min float64, max float64) float64 {
+func (r *TestRandom) BoundedGaussian(mean float64, stddev float64, minFloat float64, maxFloat float64) float64 {
 	val := r.Gaussian(mean, stddev)
-	if val < min {
-		return min
-	}
-	if val > max {
-		return max
-	}
-	return val
+	return min(max(val, minFloat), maxFloat)
 }
 
 var _ io.Reader = &randIOReader{}


### PR DESCRIPTION
## Why are these changes needed?

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
