### PR TITLE
perf: apply query limit to the feed fetch

### DIFF
--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -897,7 +897,7 @@ func (s *BlobMetadataStore) GetDispersalRequestByDispersedAt(
 	for {
 		remaining := math.MaxInt
 		if limit > 0 {
-			remaining = limit - len(result)
+			remaining = limit - len(dispersals)
 		}
 		res, err := s.dynamoDBClient.QueryIndexWithPagination(
 			ctx,

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -334,6 +334,10 @@ func (s *BlobMetadataStore) queryBucketBlobMetadata(
 ) ([]*v2.BlobMetadata, error) {
 	var lastEvaledKey map[string]types.AttributeValue
 	for {
+		remaining := math.MaxInt
+		if limit > 0 {
+			remaining = limit - len(result)
+		}
 		res, err := s.dynamoDBClient.QueryIndexWithPagination(
 			ctx,
 			s.tableName,
@@ -344,7 +348,7 @@ func (s *BlobMetadataStore) queryBucketBlobMetadata(
 				":start": &types.AttributeValueMemberS{Value: startKey},
 				":end":   &types.AttributeValueMemberS{Value: endKey},
 			},
-			0, // no limit within a bucket
+			remaining,
 			lastEvaledKey,
 			ascending,
 		)
@@ -505,7 +509,7 @@ func (s *BlobMetadataStore) queryBucketAttestation(
 				":start": &types.AttributeValueMemberN{Value: strconv.FormatInt(int64(start), 10)},
 				":end":   &types.AttributeValueMemberN{Value: strconv.FormatInt(int64(end), 10)},
 			},
-			0, // no limit within a bucket
+			numToReturn,
 			lastEvaledKey,
 			ascending,
 		)
@@ -891,6 +895,10 @@ func (s *BlobMetadataStore) GetDispersalRequestByDispersedAt(
 	// This needs to be processed in a loop because DynamoDb has a limit on the response
 	// size of a query (1MB) and we may have more data than that.
 	for {
+		remaining := math.MaxInt
+		if limit > 0 {
+			remaining = limit - len(result)
+		}
 		res, err := s.dynamoDBClient.QueryIndexWithPagination(
 			ctx,
 			s.tableName,
@@ -901,7 +909,7 @@ func (s *BlobMetadataStore) GetDispersalRequestByDispersedAt(
 				":start": &types.AttributeValueMemberN{Value: strconv.FormatInt(int64(adjustedStart), 10)},
 				":end":   &types.AttributeValueMemberN{Value: strconv.FormatInt(int64(adjustedEnd), 10)},
 			},
-			0, // no limit within one try
+			remaining,
 			lastEvaledKey,
 			ascending,
 		)

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -348,7 +348,7 @@ func (s *BlobMetadataStore) queryBucketBlobMetadata(
 				":start": &types.AttributeValueMemberS{Value: startKey},
 				":end":   &types.AttributeValueMemberS{Value: endKey},
 			},
-			remaining,
+			int32(remaining),
 			lastEvaledKey,
 			ascending,
 		)
@@ -509,7 +509,7 @@ func (s *BlobMetadataStore) queryBucketAttestation(
 				":start": &types.AttributeValueMemberN{Value: strconv.FormatInt(int64(start), 10)},
 				":end":   &types.AttributeValueMemberN{Value: strconv.FormatInt(int64(end), 10)},
 			},
-			numToReturn,
+			int32(numToReturn),
 			lastEvaledKey,
 			ascending,
 		)
@@ -909,7 +909,7 @@ func (s *BlobMetadataStore) GetDispersalRequestByDispersedAt(
 				":start": &types.AttributeValueMemberN{Value: strconv.FormatInt(int64(adjustedStart), 10)},
 				":end":   &types.AttributeValueMemberN{Value: strconv.FormatInt(int64(adjustedEnd), 10)},
 			},
-			remaining,
+			int32(remaining),
 			lastEvaledKey,
 			ascending,
 		)


### PR DESCRIPTION
## Why are these changes needed?
We can actually apply this limit, based on documentation https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html

`A single Query operation will read up to the maximum number of items set (if using the Limit parameter) or a maximum of 1 MB of data and then apply any filtering to the results using FilterExpression.`

That is, if we are not using filter expression, which is the case here, it'll return exactly `limit` items (if there are actually at least `limit` items and it doesn't go above 1MB).

(this nuance wasn't understood well when the code was written initially)


<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
