### PR TITLE
feat: cert verifier router

### DIFF
--- a/contracts/src/core/EigenDACertVerifier.sol
+++ b/contracts/src/core/EigenDACertVerifier.sol
@@ -9,6 +9,7 @@ import {EigenDACertVerificationUtils} from "../libraries/EigenDACertVerification
 import {OperatorStateRetriever} from "../../lib/eigenlayer-middleware/src/OperatorStateRetriever.sol";
 import {IRegistryCoordinator} from "../../lib/eigenlayer-middleware/src/RegistryCoordinator.sol";
 import {IEigenDARelayRegistry} from "../interfaces/IEigenDARelayRegistry.sol";
+import {IEigenDAThresholdRegistry} from "../interfaces/IEigenDAThresholdRegistry.sol";
 import "../interfaces/IEigenDAStructs.sol";
 
 /**
@@ -16,7 +17,8 @@ import "../interfaces/IEigenDAStructs.sol";
  * @notice For V2 verification this contract is deployed with immutable security thresholds and required quorum numbers,
  *         to change these values or verification behavior a new CertVerifier must be deployed
  */
-contract EigenDACertVerifier is IEigenDACertVerifier {
+contract EigenDACertVerifier is IEigenDACertVerifier, IEigenDAThresholdRegistry {
+
     /// @notice The EigenDAThresholdRegistry contract address
     IEigenDAThresholdRegistry public immutable eigenDAThresholdRegistry;
 

--- a/contracts/src/core/EigenDACertVerifier.sol
+++ b/contracts/src/core/EigenDACertVerifier.sol
@@ -18,7 +18,6 @@ import "../interfaces/IEigenDAStructs.sol";
  *         to change these values or verification behavior a new CertVerifier must be deployed
  */
 contract EigenDACertVerifier is IEigenDACertVerifier, IEigenDAThresholdRegistry {
-
     /// @notice The EigenDAThresholdRegistry contract address
     IEigenDAThresholdRegistry public immutable eigenDAThresholdRegistry;
 

--- a/contracts/src/interfaces/IEigenDACertVerifier.sol
+++ b/contracts/src/interfaces/IEigenDACertVerifier.sol
@@ -90,16 +90,5 @@ interface IEigenDACertVerifier is IEigenDACertVerifierBase {
      * @param version The version of the blob to verify
      * @param securityThresholds The security thresholds to verify against
      */
-<<<<<<< HEAD
-<<<<<<< HEAD
     function verifyDACertSecurityParams(uint16 version, SecurityThresholds memory securityThresholds) external view;
-=======
-    function verifyDACertSecurityParams(
-        uint16 version,
-        SecurityThresholds memory securityThresholds
-    ) external view;
->>>>>>> de14d145 (feat: cert verifier router)
-=======
-    function verifyDACertSecurityParams(uint16 version, SecurityThresholds memory securityThresholds) external view;
->>>>>>> d72f87a1 (chore: forge fmt)
 }

--- a/contracts/src/interfaces/IEigenDACertVerifier.sol
+++ b/contracts/src/interfaces/IEigenDACertVerifier.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import {IEigenDAThresholdRegistry} from "./IEigenDAThresholdRegistry.sol";
 import "./IEigenDAStructs.sol";
 
-interface IEigenDACertVerifier is IEigenDAThresholdRegistry {
+interface IEigenDACertVerifierBase {
+
     /**
      * @notice Verifies a the blob cert is valid for the required quorums
      * @param blobHeader The blob header to verify
@@ -73,6 +73,9 @@ interface IEigenDACertVerifier is IEigenDAThresholdRegistry {
         view
         returns (NonSignerStakesAndSignature memory);
 
+}
+
+interface IEigenDACertVerifier is IEigenDACertVerifierBase {
     /**
      * @notice Verifies the security parameters for a blob cert
      * @param blobParams The blob params to verify
@@ -88,5 +91,12 @@ interface IEigenDACertVerifier is IEigenDAThresholdRegistry {
      * @param version The version of the blob to verify
      * @param securityThresholds The security thresholds to verify against
      */
+<<<<<<< HEAD
     function verifyDACertSecurityParams(uint16 version, SecurityThresholds memory securityThresholds) external view;
+=======
+    function verifyDACertSecurityParams(
+        uint16 version,
+        SecurityThresholds memory securityThresholds
+    ) external view;
+>>>>>>> de14d145 (feat: cert verifier router)
 }

--- a/contracts/src/interfaces/IEigenDACertVerifier.sol
+++ b/contracts/src/interfaces/IEigenDACertVerifier.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.9;
 import "./IEigenDAStructs.sol";
 
 interface IEigenDACertVerifierBase {
-
     /**
      * @notice Verifies a the blob cert is valid for the required quorums
      * @param blobHeader The blob header to verify
@@ -72,7 +71,6 @@ interface IEigenDACertVerifierBase {
         external
         view
         returns (NonSignerStakesAndSignature memory);
-
 }
 
 interface IEigenDACertVerifier is IEigenDACertVerifierBase {
@@ -92,6 +90,7 @@ interface IEigenDACertVerifier is IEigenDACertVerifierBase {
      * @param securityThresholds The security thresholds to verify against
      */
 <<<<<<< HEAD
+<<<<<<< HEAD
     function verifyDACertSecurityParams(uint16 version, SecurityThresholds memory securityThresholds) external view;
 =======
     function verifyDACertSecurityParams(
@@ -99,4 +98,7 @@ interface IEigenDACertVerifier is IEigenDACertVerifierBase {
         SecurityThresholds memory securityThresholds
     ) external view;
 >>>>>>> de14d145 (feat: cert verifier router)
+=======
+    function verifyDACertSecurityParams(uint16 version, SecurityThresholds memory securityThresholds) external view;
+>>>>>>> d72f87a1 (chore: forge fmt)
 }

--- a/contracts/src/interfaces/IEigenDACertVerifier.sol
+++ b/contracts/src/interfaces/IEigenDACertVerifier.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.9;
 
 import "./IEigenDAStructs.sol";
 
+/// @dev It is impossible to implement all of IEigenDACertVerifier in the CertVerifierRouter, and so a subset of the interface is defined here.
 interface IEigenDACertVerifierBase {
     /**
      * @notice Verifies a the blob cert is valid for the required quorums

--- a/contracts/src/interfaces/IEigenDACertVerifierRouter.sol
+++ b/contracts/src/interfaces/IEigenDACertVerifierRouter.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IEigenDACertVerifierBase} from "src/interfaces/IEigenDACertVerifier.sol";
+
+interface IEigenDACertVerifierRouter is IEigenDACertVerifierBase {
+    function addCertVerifier(uint32 referenceBlockNumber, address certVerifier) external;
+
+    function getCertVerifierAt(uint32 rbn) external view returns (IEigenDACertVerifierBase);
+
+    function certVerifiers(uint32 referenceBlockNumber) external view returns (IEigenDACertVerifierBase);
+
+    function certVerifierRBNs(uint256 index) external view returns (uint32);
+}

--- a/contracts/src/periphery/CertVerifierRouter.sol
+++ b/contracts/src/periphery/CertVerifierRouter.sol
@@ -13,17 +13,10 @@ contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
     ///      These values contain all added indexes for the certVerifiers mapping.
     uint64[] public certVerifierRBNs;
 
-    /// @notice The number of blocks the reference block number must be in the future for a cert verifier to be added.
-    uint256 public immutable DELAY_BLOCKS;
-
     event CertVerifierAdded(uint64 indexed referenceBlockNumber, address indexed certVerifier);
 
-    constructor(uint256 delayBlocks) Ownable() {
-        DELAY_BLOCKS = delayBlocks;
-    }
-
     function addCertVerifier(uint64 referenceBlockNumber, address certVerifier) external onlyOwner {
-        require(referenceBlockNumber > block.number + DELAY_BLOCKS, "Reference block number must be in the future");
+        require(referenceBlockNumber > block.number, "Reference block number must be in the future");
         require(
             referenceBlockNumber > certVerifierRBNs[certVerifierRBNs.length - 1],
             "Reference block number must be greater than the last registered RBN"
@@ -106,7 +99,7 @@ contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
 
         for (uint256 i = certVerifierRBNs.length - 1; i >= 0; i--) {
             uint64 certVerifierRBNMem = certVerifierRBNs[i];
-            if (certVerifierRBNMem == referenceBlockNumber) {
+            if (certVerifierRBNMem <= referenceBlockNumber) {
                 return certVerifierRBNMem;
             }
         }

--- a/contracts/src/periphery/CertVerifierRouter.sol
+++ b/contracts/src/periphery/CertVerifierRouter.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IEigenDACertVerifierBase} from "src/interfaces/IEigenDACertVerifier.sol";
+import {Ownable} from "lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+import "src/interfaces/IEigenDAStructs.sol";
+
+contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
+    mapping(uint64 => IEigenDACertVerifierBase) public certVerifiers;
+    uint64[] public certVerifierRBNs;
+
+    uint256 public immutable DELAY_BLOCKS;
+
+    event CertVerifierAdded(uint64 indexed referenceBlockNumber, address indexed certVerifier);
+
+    constructor(
+        uint256 delayBlocks
+    ) Ownable() {
+        DELAY_BLOCKS = delayBlocks;
+    }
+
+    function addCertVerifier(
+        uint64 referenceBlockNumber,
+        address certVerifier
+    ) external onlyOwner {
+        require(referenceBlockNumber > block.number + DELAY_BLOCKS, "Reference block number must be in the future");
+        require(referenceBlockNumber > certVerifierRBNs[certVerifierRBNs.length - 1], "Reference block number must be greater than the last registered RBN");
+        require(certVerifiers[referenceBlockNumber] == IEigenDACertVerifierBase(address(0)), "Cert verifier already exists");
+        certVerifiers[referenceBlockNumber] = IEigenDACertVerifierBase(certVerifier);
+        certVerifierRBNs.push(referenceBlockNumber);
+        emit CertVerifierAdded(referenceBlockNumber, certVerifier);
+    }
+
+    function verifyDACertV1(
+        BlobHeader calldata blobHeader,
+        BlobVerificationProof calldata blobVerificationProof
+    ) external view {
+        uint64 referenceBlockNumber = blobVerificationProof.batchMetadata.batchHeader.referenceBlockNumber;
+        uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
+        certVerifiers[closestRBN].verifyDACertV1(blobHeader, blobVerificationProof);
+    }
+
+
+    function verifyDACertsV1(
+        BlobHeader[] calldata blobHeaders,
+        BlobVerificationProof[] calldata blobVerificationProofs
+    ) external view {
+        require(blobHeaders.length == blobVerificationProofs.length, "Blob headers and proofs length mismatch");
+        uint64 referenceBlockNumber = blobVerificationProofs[0].batchMetadata.batchHeader.referenceBlockNumber;
+        uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
+        certVerifiers[closestRBN].verifyDACertsV1(blobHeaders, blobVerificationProofs);
+    }
+
+    function verifyDACertV2(
+        BatchHeaderV2 calldata batchHeader,
+        BlobInclusionInfo calldata blobInclusionInfo,
+        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature,
+        bytes memory signedQuorumNumbers
+    ) external view {
+        uint64 referenceBlockNumber = batchHeader.referenceBlockNumber;
+        uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
+        certVerifiers[closestRBN].verifyDACertV2(
+            batchHeader,
+            blobInclusionInfo,
+            nonSignerStakesAndSignature,
+            signedQuorumNumbers
+        );
+    }
+
+    function verifyDACertV2FromSignedBatch(
+        SignedBatch calldata signedBatch,
+        BlobInclusionInfo calldata blobInclusionInfo
+    ) external view {
+        uint64 referenceBlockNumber = signedBatch.batchHeader.referenceBlockNumber;
+        uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
+        certVerifiers[closestRBN].verifyDACertV2FromSignedBatch(
+            signedBatch,
+            blobInclusionInfo
+        );
+    }
+
+    function verifyDACertV2ForZKProof(
+        BatchHeaderV2 calldata batchHeader,
+        BlobInclusionInfo calldata blobInclusionInfo,
+        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature,
+        bytes memory signedQuorumNumbers
+    ) external view returns (bool) {
+        uint64 referenceBlockNumber = batchHeader.referenceBlockNumber;
+        uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
+        return certVerifiers[closestRBN].verifyDACertV2ForZKProof(
+            batchHeader,
+            blobInclusionInfo,
+            nonSignerStakesAndSignature,
+            signedQuorumNumbers
+        );
+    }
+
+    function getNonSignerStakesAndSignature(
+        SignedBatch calldata signedBatch
+    ) external view returns (NonSignerStakesAndSignature memory) {
+        uint64 referenceBlockNumber = signedBatch.batchHeader.referenceBlockNumber;
+        uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
+        return certVerifiers[closestRBN].getNonSignerStakesAndSignature(signedBatch);
+    }
+
+
+    /// @notice Given an RBN, find the closest RBN registered in this contract that is less than or equal to the given RBN.
+    /// @param referenceBlockNumber The reference block number to find the closest RBN for
+    /// @return closestRBN The closest RBN registered in this contract that is less than or equal to the given RBN.
+    function _findClosestRegisteredRBN(
+        uint64 referenceBlockNumber
+    ) internal view returns (uint64) {
+        // It is assumed that the latest RBNs are the most likely to be used.
+        require(certVerifierRBNs.length > 0, "No cert verifiers available");
+
+        for (uint256 i = certVerifierRBNs.length - 1; i >= 0; i--) {
+            uint64 certVerifierRBNMem = certVerifierRBNs[i];
+            if (certVerifierRBNMem == referenceBlockNumber) {
+                return certVerifierRBNMem;
+            }
+        }
+        revert("No cert verifier found for the given reference block number");
+    }
+
+}

--- a/contracts/src/periphery/CertVerifierRouter.sol
+++ b/contracts/src/periphery/CertVerifierRouter.sol
@@ -13,38 +13,37 @@ contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
 
     event CertVerifierAdded(uint64 indexed referenceBlockNumber, address indexed certVerifier);
 
-    constructor(
-        uint256 delayBlocks
-    ) Ownable() {
+    constructor(uint256 delayBlocks) Ownable() {
         DELAY_BLOCKS = delayBlocks;
     }
 
-    function addCertVerifier(
-        uint64 referenceBlockNumber,
-        address certVerifier
-    ) external onlyOwner {
+    function addCertVerifier(uint64 referenceBlockNumber, address certVerifier) external onlyOwner {
         require(referenceBlockNumber > block.number + DELAY_BLOCKS, "Reference block number must be in the future");
-        require(referenceBlockNumber > certVerifierRBNs[certVerifierRBNs.length - 1], "Reference block number must be greater than the last registered RBN");
-        require(certVerifiers[referenceBlockNumber] == IEigenDACertVerifierBase(address(0)), "Cert verifier already exists");
+        require(
+            referenceBlockNumber > certVerifierRBNs[certVerifierRBNs.length - 1],
+            "Reference block number must be greater than the last registered RBN"
+        );
+        require(
+            certVerifiers[referenceBlockNumber] == IEigenDACertVerifierBase(address(0)), "Cert verifier already exists"
+        );
         certVerifiers[referenceBlockNumber] = IEigenDACertVerifierBase(certVerifier);
         certVerifierRBNs.push(referenceBlockNumber);
         emit CertVerifierAdded(referenceBlockNumber, certVerifier);
     }
 
-    function verifyDACertV1(
-        BlobHeader calldata blobHeader,
-        BlobVerificationProof calldata blobVerificationProof
-    ) external view {
+    function verifyDACertV1(BlobHeader calldata blobHeader, BlobVerificationProof calldata blobVerificationProof)
+        external
+        view
+    {
         uint64 referenceBlockNumber = blobVerificationProof.batchMetadata.batchHeader.referenceBlockNumber;
         uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
         certVerifiers[closestRBN].verifyDACertV1(blobHeader, blobVerificationProof);
     }
 
-
-    function verifyDACertsV1(
-        BlobHeader[] calldata blobHeaders,
-        BlobVerificationProof[] calldata blobVerificationProofs
-    ) external view {
+    function verifyDACertsV1(BlobHeader[] calldata blobHeaders, BlobVerificationProof[] calldata blobVerificationProofs)
+        external
+        view
+    {
         require(blobHeaders.length == blobVerificationProofs.length, "Blob headers and proofs length mismatch");
         uint64 referenceBlockNumber = blobVerificationProofs[0].batchMetadata.batchHeader.referenceBlockNumber;
         uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
@@ -60,10 +59,7 @@ contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
         uint64 referenceBlockNumber = batchHeader.referenceBlockNumber;
         uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
         certVerifiers[closestRBN].verifyDACertV2(
-            batchHeader,
-            blobInclusionInfo,
-            nonSignerStakesAndSignature,
-            signedQuorumNumbers
+            batchHeader, blobInclusionInfo, nonSignerStakesAndSignature, signedQuorumNumbers
         );
     }
 
@@ -73,10 +69,7 @@ contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
     ) external view {
         uint64 referenceBlockNumber = signedBatch.batchHeader.referenceBlockNumber;
         uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
-        certVerifiers[closestRBN].verifyDACertV2FromSignedBatch(
-            signedBatch,
-            blobInclusionInfo
-        );
+        certVerifiers[closestRBN].verifyDACertV2FromSignedBatch(signedBatch, blobInclusionInfo);
     }
 
     function verifyDACertV2ForZKProof(
@@ -88,28 +81,24 @@ contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
         uint64 referenceBlockNumber = batchHeader.referenceBlockNumber;
         uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
         return certVerifiers[closestRBN].verifyDACertV2ForZKProof(
-            batchHeader,
-            blobInclusionInfo,
-            nonSignerStakesAndSignature,
-            signedQuorumNumbers
+            batchHeader, blobInclusionInfo, nonSignerStakesAndSignature, signedQuorumNumbers
         );
     }
 
-    function getNonSignerStakesAndSignature(
-        SignedBatch calldata signedBatch
-    ) external view returns (NonSignerStakesAndSignature memory) {
+    function getNonSignerStakesAndSignature(SignedBatch calldata signedBatch)
+        external
+        view
+        returns (NonSignerStakesAndSignature memory)
+    {
         uint64 referenceBlockNumber = signedBatch.batchHeader.referenceBlockNumber;
         uint64 closestRBN = _findClosestRegisteredRBN(referenceBlockNumber);
         return certVerifiers[closestRBN].getNonSignerStakesAndSignature(signedBatch);
     }
 
-
     /// @notice Given an RBN, find the closest RBN registered in this contract that is less than or equal to the given RBN.
     /// @param referenceBlockNumber The reference block number to find the closest RBN for
     /// @return closestRBN The closest RBN registered in this contract that is less than or equal to the given RBN.
-    function _findClosestRegisteredRBN(
-        uint64 referenceBlockNumber
-    ) internal view returns (uint64) {
+    function _findClosestRegisteredRBN(uint64 referenceBlockNumber) internal view returns (uint64) {
         // It is assumed that the latest RBNs are the most likely to be used.
         require(certVerifierRBNs.length > 0, "No cert verifiers available");
 
@@ -121,5 +110,4 @@ contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
         }
         revert("No cert verifier found for the given reference block number");
     }
-
 }

--- a/contracts/src/periphery/CertVerifierRouter.sol
+++ b/contracts/src/periphery/CertVerifierRouter.sol
@@ -23,9 +23,6 @@ contract CertVerifierRouter is IEigenDACertVerifierBase, Ownable {
             referenceBlockNumber > certVerifierRBNs[certVerifierRBNs.length - 1],
             "Reference block number must be greater than the last registered RBN"
         );
-        require(
-            certVerifiers[referenceBlockNumber] == IEigenDACertVerifierBase(address(0)), "Cert verifier already exists"
-        );
         certVerifiers[referenceBlockNumber] = IEigenDACertVerifierBase(certVerifier);
         certVerifierRBNs.push(referenceBlockNumber);
         emit CertVerifierAdded(referenceBlockNumber, certVerifier);

--- a/contracts/src/periphery/EigenDACertVerifierUpdateableSecurity.sol
+++ b/contracts/src/periphery/EigenDACertVerifierUpdateableSecurity.sol
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IEigenDACertVerifier} from "src/interfaces/IEigenDACertVerifier.sol";
+import {IEigenDAThresholdRegistry} from "src/interfaces/IEigenDAThresholdRegistry.sol";
+import {IEigenDABatchMetadataStorage} from "src/interfaces/IEigenDABatchMetadataStorage.sol";
+import {IEigenDASignatureVerifier} from "src/interfaces/IEigenDASignatureVerifier.sol";
+import {EigenDACertVerificationUtils} from "src/libraries/EigenDACertVerificationUtils.sol";
+import {OperatorStateRetriever} from "lib/eigenlayer-middleware/src/OperatorStateRetriever.sol";
+import {IRegistryCoordinator} from "lib/eigenlayer-middleware/src/RegistryCoordinator.sol";
+import {IEigenDARelayRegistry} from "src/interfaces/IEigenDARelayRegistry.sol";
+import {IEigenDAThresholdRegistry} from "src/interfaces/IEigenDAThresholdRegistry.sol";
+import "src/interfaces/IEigenDAStructs.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+/**
+ * @title A CertVerifier is an immutable contract that is used by a consumer to verify EigenDA blob certificates
+ * @notice For V2 verification this contract is deployed with immutable security thresholds and required quorum numbers,
+ *         to change these values or verification behavior a new CertVerifier must be deployed
+ */
+contract EigenDACertVerifierUpdateableSecurity is IEigenDACertVerifier, OwnableUpgradeable {
+    /// @notice The EigenDAThresholdRegistry contract address
+    IEigenDAThresholdRegistry public immutable eigenDAThresholdRegistry;
+
+    /// @notice The EigenDABatchMetadataStorage contract address
+    /// @dev On L1 this contract is the EigenDA Service Manager contract
+    IEigenDABatchMetadataStorage public immutable eigenDABatchMetadataStorage;
+
+    /// @notice The EigenDASignatureVerifier contract address
+    /// @dev On L1 this contract is the EigenDA Service Manager contract
+    IEigenDASignatureVerifier public immutable eigenDASignatureVerifier;
+
+    /// @notice The EigenDARelayRegistry contract address
+    IEigenDARelayRegistry public immutable eigenDARelayRegistry;
+
+    /// @notice The EigenDA middleware OperatorStateRetriever contract address
+    OperatorStateRetriever public immutable operatorStateRetriever;
+
+    /// @notice The EigenDA middleware RegistryCoordinator contract address
+    IRegistryCoordinator public immutable registryCoordinator;
+
+    mapping(uint32 => SecurityThresholds) public securityThresholdsV2;
+    mapping(uint32 => bytes) public quorumNumbersRequiredV2;
+    uint32[] public rbns;
+
+    event SecurityThresholdsAndQuorumNumbersAdded(
+        uint32 indexed rbn, uint8 indexed confirmationThreshold, uint8 indexed adversaryThreshold, bytes quorumNumbers
+    );
+
+    constructor(
+        IEigenDAThresholdRegistry _eigenDAThresholdRegistry,
+        IEigenDABatchMetadataStorage _eigenDABatchMetadataStorage,
+        IEigenDASignatureVerifier _eigenDASignatureVerifier,
+        IEigenDARelayRegistry _eigenDARelayRegistry,
+        OperatorStateRetriever _operatorStateRetriever,
+        IRegistryCoordinator _registryCoordinator
+    ) {
+        _disableInitializers;
+        eigenDAThresholdRegistry = _eigenDAThresholdRegistry;
+        eigenDABatchMetadataStorage = _eigenDABatchMetadataStorage;
+        eigenDASignatureVerifier = _eigenDASignatureVerifier;
+        eigenDARelayRegistry = _eigenDARelayRegistry;
+        operatorStateRetriever = _operatorStateRetriever;
+        registryCoordinator = _registryCoordinator;
+    }
+
+    function initialize(address _initialOwner) external initializer {
+        _transferOwnership(_initialOwner);
+    }
+
+    function addSecurityThresholdsAndQuorum(
+        uint32 referenceBlockNumber,
+        SecurityThresholds memory securityThresholds,
+        bytes memory quorumNumbers
+    ) external onlyOwner {
+        require(referenceBlockNumber > block.number, "Reference block number must be in the future");
+        require(
+            rbns.length == 0 || referenceBlockNumber > rbns[rbns.length - 1],
+            "Reference block number must be greater than the last registered RBN"
+        );
+        securityThresholdsV2[referenceBlockNumber] = securityThresholds;
+        quorumNumbersRequiredV2[referenceBlockNumber] = quorumNumbers;
+        rbns.push(referenceBlockNumber);
+        emit SecurityThresholdsAndQuorumNumbersAdded(
+            referenceBlockNumber,
+            securityThresholds.confirmationThreshold,
+            securityThresholds.adversaryThreshold,
+            quorumNumbers
+        );
+    }
+
+    function getSecurityParamsAt(uint32 rbn) external view returns (SecurityThresholds memory) {
+        return securityThresholdsV2[rbn];
+    }
+
+    function getQuorumNumbersAt(uint32 rbn) external view returns (bytes memory) {
+        return quorumNumbersRequiredV2[rbn];
+    }
+
+    ///////////////////////// V1 ///////////////////////////////
+
+    /**
+     * @notice Verifies a the blob cert is valid for the required quorums
+     * @param blobHeader The blob header to verify
+     * @param blobVerificationProof The blob cert verification proof to verify
+     */
+    function verifyDACertV1(BlobHeader calldata blobHeader, BlobVerificationProof calldata blobVerificationProof)
+        public
+        view
+    {
+        uint32 closestRbn =
+            _findClosestRegisteredRBN(blobVerificationProof.batchMetadata.batchHeader.referenceBlockNumber);
+        EigenDACertVerificationUtils._verifyDACertV1ForQuorums(
+            eigenDAThresholdRegistry,
+            eigenDABatchMetadataStorage,
+            blobHeader,
+            blobVerificationProof,
+            quorumNumbersRequiredV2[closestRbn]
+        );
+    }
+
+    /**
+     * @notice Verifies a batch of blob certs for the required quorums
+     * @param blobHeaders The blob headers to verify
+     * @param blobVerificationProofs The blob cert verification proofs to verify against
+     */
+    function verifyDACertsV1(BlobHeader[] calldata blobHeaders, BlobVerificationProof[] calldata blobVerificationProofs)
+        external
+        view
+    {
+        for (uint256 i; i < blobHeaders.length; i++) {
+            verifyDACertV1(blobHeaders[i], blobVerificationProofs[i]);
+        }
+    }
+
+    ///////////////////////// V2 ///////////////////////////////
+
+    /**
+     * @notice Verifies a blob cert using the immutable required quorums and security thresholds set in the constructor
+     * @param batchHeader The batch header of the blob
+     * @param blobInclusionInfo The inclusion proof for the blob cert
+     * @param nonSignerStakesAndSignature The nonSignerStakesAndSignature to verify the blob cert against
+     * @param signedQuorumNumbers The signed quorum numbers corresponding to the nonSignerStakesAndSignature
+     */
+    function verifyDACertV2(
+        BatchHeaderV2 calldata batchHeader,
+        BlobInclusionInfo calldata blobInclusionInfo,
+        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature,
+        bytes memory signedQuorumNumbers
+    ) external view {
+        uint32 closestRbn = _findClosestRegisteredRBN(batchHeader.referenceBlockNumber);
+        EigenDACertVerificationUtils._verifyDACertV2ForQuorums(
+            eigenDAThresholdRegistry,
+            eigenDASignatureVerifier,
+            eigenDARelayRegistry,
+            batchHeader,
+            blobInclusionInfo,
+            nonSignerStakesAndSignature,
+            securityThresholdsV2[closestRbn],
+            quorumNumbersRequiredV2[closestRbn],
+            signedQuorumNumbers
+        );
+    }
+
+    /**
+     * @notice Verifies a blob cert using the immutable required quorums and security thresholds set in the constructor
+     * @param signedBatch The signed batch to verify the blob cert against
+     * @param blobInclusionInfo The inclusion proof for the blob cert
+     */
+    function verifyDACertV2FromSignedBatch(
+        SignedBatch calldata signedBatch,
+        BlobInclusionInfo calldata blobInclusionInfo
+    ) external view {
+        uint32 closestRbn = _findClosestRegisteredRBN(signedBatch.batchHeader.referenceBlockNumber);
+        EigenDACertVerificationUtils._verifyDACertV2ForQuorumsFromSignedBatch(
+            eigenDAThresholdRegistry,
+            eigenDASignatureVerifier,
+            eigenDARelayRegistry,
+            operatorStateRetriever,
+            registryCoordinator,
+            signedBatch,
+            blobInclusionInfo,
+            securityThresholdsV2[closestRbn],
+            quorumNumbersRequiredV2[closestRbn]
+        );
+    }
+
+    /**
+     * @notice Thin try/catch wrapper around verifyDACertV2 that returns false instead of panicing
+     * @dev The Steel library (https://github.com/risc0/risc0-ethereum/tree/main/crates/steel)
+     *      currently has a limitation that it can only create zk proofs for functions that return a value
+     * @param batchHeader The batch header of the blob
+     * @param blobInclusionInfo The inclusion proof for the blob cert
+     * @param nonSignerStakesAndSignature The nonSignerStakesAndSignature to verify the blob cert against
+     * @param signedQuorumNumbers The signed quorum numbers corresponding to the nonSignerStakesAndSignature
+     */
+    function verifyDACertV2ForZKProof(
+        BatchHeaderV2 calldata batchHeader,
+        BlobInclusionInfo calldata blobInclusionInfo,
+        NonSignerStakesAndSignature calldata nonSignerStakesAndSignature,
+        bytes memory signedQuorumNumbers
+    ) external view returns (bool) {
+        uint32 closestRbn = _findClosestRegisteredRBN(batchHeader.referenceBlockNumber);
+        try EigenDACertVerificationUtils.verifyDACertV2ForQuorumsExternal(
+            eigenDAThresholdRegistry,
+            eigenDASignatureVerifier,
+            eigenDARelayRegistry,
+            batchHeader,
+            blobInclusionInfo,
+            nonSignerStakesAndSignature,
+            securityThresholdsV2[closestRbn],
+            quorumNumbersRequiredV2[closestRbn],
+            signedQuorumNumbers
+        ) {
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    ///////////////////////// HELPER FUNCTIONS ///////////////////////////////
+
+    /**
+     * @notice Returns the nonSignerStakesAndSignature for a given blob cert and signed batch
+     * @param signedBatch The signed batch to get the nonSignerStakesAndSignature for
+     * @return nonSignerStakesAndSignature The nonSignerStakesAndSignature for the given signed batch attestation
+     */
+    function getNonSignerStakesAndSignature(SignedBatch calldata signedBatch)
+        external
+        view
+        returns (NonSignerStakesAndSignature memory)
+    {
+        (NonSignerStakesAndSignature memory nonSignerStakesAndSignature,) = EigenDACertVerificationUtils
+            ._getNonSignerStakesAndSignature(operatorStateRetriever, registryCoordinator, signedBatch);
+        return nonSignerStakesAndSignature;
+    }
+
+    /**
+     * @notice Verifies the security parameters for a blob cert
+     * @param blobParams The blob params to verify
+     * @param securityThresholds The security thresholds to verify against
+     */
+    function verifyDACertSecurityParams(
+        VersionedBlobParams memory blobParams,
+        SecurityThresholds memory securityThresholds
+    ) external pure {
+        EigenDACertVerificationUtils._verifyDACertSecurityParams(blobParams, securityThresholds);
+    }
+
+    /**
+     * @notice Verifies the security parameters for a blob cert
+     * @param version The version of the blob to verify
+     * @param securityThresholds The security thresholds to verify against
+     */
+    function verifyDACertSecurityParams(uint16 version, SecurityThresholds memory securityThresholds) external view {
+        EigenDACertVerificationUtils._verifyDACertSecurityParams(
+            eigenDAThresholdRegistry.getBlobParams(version), securityThresholds
+        );
+    }
+
+    /// @notice Given an RBN, find the closest RBN registered in this contract that is less than or equal to the given RBN.
+    /// @param referenceBlockNumber The reference block number to find the closest RBN for
+    /// @return closestRBN The closest RBN registered in this contract that is less than or equal to the given RBN.
+    function _findClosestRegisteredRBN(uint32 referenceBlockNumber) internal view returns (uint32) {
+        // It is assumed that the latest RBNs are the most likely to be used.
+        require(rbns.length > 0, "No rbn available");
+
+        uint256 rbnMaxIndex = rbns.length - 1; // cache to memory
+        for (uint256 i; i < rbns.length; i++) {
+            uint32 rbnMem = rbns[rbnMaxIndex - i];
+            if (rbnMem <= referenceBlockNumber) {
+                return rbnMem;
+            }
+        }
+        revert("No rbn found");
+    }
+}

--- a/contracts/src/periphery/EigenDACertVerifierUpdateableSecurity.sol
+++ b/contracts/src/periphery/EigenDACertVerifierUpdateableSecurity.sol
@@ -55,7 +55,7 @@ contract EigenDACertVerifierUpdateableSecurity is IEigenDACertVerifier, OwnableU
         OperatorStateRetriever _operatorStateRetriever,
         IRegistryCoordinator _registryCoordinator
     ) {
-        _disableInitializers;
+        _disableInitializers();
         eigenDAThresholdRegistry = _eigenDAThresholdRegistry;
         eigenDABatchMetadataStorage = _eigenDABatchMetadataStorage;
         eigenDASignatureVerifier = _eigenDASignatureVerifier;

--- a/contracts/test/unit/EigenDACertVerifierRouter.t.sol
+++ b/contracts/test/unit/EigenDACertVerifierRouter.t.sol
@@ -115,6 +115,22 @@ contract TestEigenDACertVerifierRouter is Test {
         certVerifierRouter.verifyDACertsV1(blobHeaders, blobVerificationProofs);
     }
 
+    function testVerifyDACertsV1RevertsForSingleRouteFailure(uint256 x) public {
+        BlobHeader[] memory blobHeaders = new BlobHeader[](2);
+        BlobVerificationProof[] memory blobVerificationProofs = new BlobVerificationProof[](2);
+        blobVerificationProofs[0].batchMetadata.batchHeader.referenceBlockNumber = uint32(block.number + 1);
+        blobVerificationProofs[1].batchMetadata.batchHeader.referenceBlockNumber = uint32(block.number + 2);
+        certVerifierRouter.addCertVerifier(
+            blobVerificationProofs[0].batchMetadata.batchHeader.referenceBlockNumber, address(certVerifierMocks[0])
+        );
+        certVerifierRouter.addCertVerifier(
+            blobVerificationProofs[1].batchMetadata.batchHeader.referenceBlockNumber, address(certVerifierMocks[1])
+        );
+        certVerifierMocks[x % 2].setRevertOnCall(true);
+        vm.expectRevert("Mock: verifyDACertV1 reverted");
+        certVerifierRouter.verifyDACertsV1(blobHeaders, blobVerificationProofs);
+    }
+
     function testVerifyDACertV2() public {
         BatchHeaderV2 memory batchHeader;
         BlobInclusionInfo memory blobInclusionInfo;

--- a/contracts/test/unit/EigenDACertVerifierRouter.t.sol
+++ b/contracts/test/unit/EigenDACertVerifierRouter.t.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.12;
+
+import {EigenDACertVerifierRouter} from "src/periphery/EigenDACertVerifierRouter.sol";
+import {IEigenDACertVerifierBase} from "src/interfaces/IEigenDACertVerifier.sol";
+
+import {
+    BlobHeader,
+    BlobVerificationProof,
+    BatchHeaderV2,
+    BlobInclusionInfo,
+    NonSignerStakesAndSignature,
+    SignedBatch
+} from "src/interfaces/IEigenDAStructs.sol";
+
+import "forge-std/Test.sol";
+
+contract TestEigenDACertVerifierRouter is Test {
+    EigenDACertVerifierRouter certVerifierRouter;
+    EigenDACertVerifierMock[] certVerifierMocks;
+
+    uint256 numCertVerifiers = 3;
+    uint32 startBlockNumber = 100;
+
+    event CertVerifierAdded(uint32 indexed referenceBlockNumber, address indexed certVerifier);
+
+    function setUp() public {
+        vm.roll(startBlockNumber);
+        certVerifierRouter = new EigenDACertVerifierRouter();
+        for (uint256 i; i < numCertVerifiers; i++) {
+            certVerifierMocks.push(new EigenDACertVerifierMock());
+        }
+    }
+
+    function testAddCertVerifier() public {
+        uint32 referenceBlockNumber = uint32(startBlockNumber + 1);
+        vm.expectEmit(address(certVerifierRouter));
+        emit CertVerifierAdded(referenceBlockNumber, address(certVerifierMocks[0]));
+        certVerifierRouter.addCertVerifier(referenceBlockNumber, address(certVerifierMocks[0]));
+        assertEq(address(certVerifierRouter.certVerifiers(referenceBlockNumber)), address(certVerifierMocks[0]));
+        assertEq(certVerifierRouter.certVerifierRBNs(0), referenceBlockNumber);
+    }
+
+    function testAddCertVerifierReverts() public {
+        vm.roll(startBlockNumber);
+        vm.expectRevert("Reference block number must be in the future");
+        certVerifierRouter.addCertVerifier(startBlockNumber - 1, address(certVerifierMocks[0]));
+
+        certVerifierRouter.addCertVerifier(startBlockNumber + 1, address(certVerifierMocks[0]));
+        vm.expectRevert("Reference block number must be greater than the last registered RBN");
+        certVerifierRouter.addCertVerifier(101, address(certVerifierMocks[0]));
+    }
+
+    function setupMultipleCertVerifiers() internal {
+        for (uint32 i; i < numCertVerifiers; i++) {
+            certVerifierRouter.addCertVerifier(startBlockNumber + i + 1, address(certVerifierMocks[i]));
+        }
+    }
+
+    function testMultipleCertVerifiers() public {
+        setupMultipleCertVerifiers();
+        for (uint32 i; i < numCertVerifiers; i++) {
+            assertEq(address(certVerifierRouter.certVerifiers(startBlockNumber + i + 1)), address(certVerifierMocks[i]));
+            assertEq(certVerifierRouter.certVerifierRBNs(i), startBlockNumber + i + 1);
+        }
+    }
+
+    /// @dev just makes tests less verbose as we are just trying to test routing.
+    function verifyRoutingHelper(uint32 rbn) internal view {
+        BlobHeader memory blobHeader;
+        BlobVerificationProof memory blobVerificationProof;
+        blobVerificationProof.batchMetadata.batchHeader.referenceBlockNumber = rbn;
+        certVerifierRouter.verifyDACertV1(blobHeader, blobVerificationProof);
+    }
+
+    function testRouting(uint32 blockIncrement) public {
+        blockIncrement = uint32(bound(blockIncrement, 0, numCertVerifiers - 1));
+        setupMultipleCertVerifiers();
+        certVerifierMocks[blockIncrement].setRevertOnCall(true);
+
+        vm.expectRevert("Mock: verifyDACertV1 reverted");
+        verifyRoutingHelper(startBlockNumber + blockIncrement + 1);
+    }
+
+    function testRoutingFails() public {
+        vm.expectRevert("No cert verifiers available");
+        verifyRoutingHelper(startBlockNumber);
+
+        setupMultipleCertVerifiers();
+        vm.expectRevert("No cert verifier found for the given reference block number");
+        verifyRoutingHelper(startBlockNumber);
+    }
+
+    function testVerifyDACertV1() public {
+        BlobHeader memory blobHeader;
+        BlobVerificationProof memory blobVerificationProof;
+        blobVerificationProof.batchMetadata.batchHeader.referenceBlockNumber = uint32(block.number + 1);
+        certVerifierRouter.addCertVerifier(
+            blobVerificationProof.batchMetadata.batchHeader.referenceBlockNumber, address(certVerifierMocks[0])
+        );
+        certVerifierRouter.verifyDACertV1(blobHeader, blobVerificationProof);
+    }
+
+    function testVerifyDACertsV1() public {
+        BlobHeader[] memory blobHeaders = new BlobHeader[](2);
+        BlobVerificationProof[] memory blobVerificationProofs = new BlobVerificationProof[](2);
+        blobVerificationProofs[0].batchMetadata.batchHeader.referenceBlockNumber = uint32(block.number + 1);
+        blobVerificationProofs[1].batchMetadata.batchHeader.referenceBlockNumber = uint32(block.number + 2);
+        certVerifierRouter.addCertVerifier(
+            blobVerificationProofs[0].batchMetadata.batchHeader.referenceBlockNumber, address(certVerifierMocks[0])
+        );
+        certVerifierRouter.addCertVerifier(
+            blobVerificationProofs[1].batchMetadata.batchHeader.referenceBlockNumber, address(certVerifierMocks[1])
+        );
+        certVerifierRouter.verifyDACertsV1(blobHeaders, blobVerificationProofs);
+    }
+
+    function testVerifyDACertV2() public {
+        BatchHeaderV2 memory batchHeader;
+        BlobInclusionInfo memory blobInclusionInfo;
+        NonSignerStakesAndSignature memory nonSignerStakesAndSignature;
+        bytes memory signedQuorumNumbers = new bytes(0);
+        batchHeader.referenceBlockNumber = uint32(block.number + 1);
+        certVerifierRouter.addCertVerifier(batchHeader.referenceBlockNumber, address(certVerifierMocks[0]));
+        certVerifierRouter.verifyDACertV2(
+            batchHeader, blobInclusionInfo, nonSignerStakesAndSignature, signedQuorumNumbers
+        );
+    }
+
+    function testVerifyDACertV2FromSignedBatch() public {
+        SignedBatch memory signedBatch;
+        BlobInclusionInfo memory blobInclusionInfo;
+        signedBatch.batchHeader.referenceBlockNumber = uint32(block.number + 1);
+        certVerifierRouter.addCertVerifier(signedBatch.batchHeader.referenceBlockNumber, address(certVerifierMocks[0]));
+        certVerifierRouter.verifyDACertV2FromSignedBatch(signedBatch, blobInclusionInfo);
+    }
+
+    function testVerifyDACertV2ForZKProof() public {
+        BatchHeaderV2 memory batchHeader;
+        BlobInclusionInfo memory blobInclusionInfo;
+        NonSignerStakesAndSignature memory nonSignerStakesAndSignature;
+        bytes memory signedQuorumNumbers = new bytes(0);
+        batchHeader.referenceBlockNumber = uint32(block.number + 1);
+        certVerifierRouter.addCertVerifier(batchHeader.referenceBlockNumber, address(certVerifierMocks[0]));
+        certVerifierRouter.verifyDACertV2ForZKProof(
+            batchHeader, blobInclusionInfo, nonSignerStakesAndSignature, signedQuorumNumbers
+        );
+    }
+
+    function testGetNonSignerStakesAndSignature() public {
+        SignedBatch memory signedBatch;
+        signedBatch.batchHeader.referenceBlockNumber = uint32(block.number + 1);
+        certVerifierRouter.addCertVerifier(signedBatch.batchHeader.referenceBlockNumber, address(certVerifierMocks[0]));
+        certVerifierRouter.getNonSignerStakesAndSignature(signedBatch);
+    }
+}
+
+contract EigenDACertVerifierMock is IEigenDACertVerifierBase {
+    bool revertOnCall;
+
+    function setRevertOnCall(bool _revertOnCall) external {
+        revertOnCall = _revertOnCall;
+    }
+
+    function verifyDACertV1(BlobHeader calldata, BlobVerificationProof calldata) external view override {
+        require(!revertOnCall, "Mock: verifyDACertV1 reverted");
+    }
+
+    function verifyDACertsV1(BlobHeader[] calldata, BlobVerificationProof[] calldata) external view override {
+        require(!revertOnCall, "Mock: verifyDACertsV1 reverted");
+    }
+
+    function verifyDACertV2(
+        BatchHeaderV2 calldata,
+        BlobInclusionInfo calldata,
+        NonSignerStakesAndSignature calldata,
+        bytes memory
+    ) external view override {
+        require(!revertOnCall, "Mock: verifyDACertV2 reverted");
+    }
+
+    function verifyDACertV2FromSignedBatch(SignedBatch calldata, BlobInclusionInfo calldata) external view override {
+        require(!revertOnCall, "Mock: verifyDACertV2FromSignedBatch reverted");
+    }
+
+    function verifyDACertV2ForZKProof(
+        BatchHeaderV2 calldata,
+        BlobInclusionInfo calldata,
+        NonSignerStakesAndSignature calldata,
+        bytes memory
+    ) external view override returns (bool success) {
+        require(!revertOnCall, "Mock: verifyDACertV2ForZKProof reverted");
+        return true;
+    }
+
+    function getNonSignerStakesAndSignature(SignedBatch calldata)
+        external
+        view
+        override
+        returns (NonSignerStakesAndSignature memory nonSignerStakesAndSignature)
+    {
+        require(!revertOnCall, "Mock: getNonSignerStakesAndSignature reverted");
+        return nonSignerStakesAndSignature;
+    }
+}


### PR DESCRIPTION
## Why are these changes needed?

Adds a cert verifier router.

The router maintains a mapping of reference block numbers (RBNs) to cert verifier contracts. The owner of the router can add cert verifiers to this mapping with the following restrictions:

* the RBN must be greater than the current block number
* the RBN must be greater than the last added RBN.

The router supports a subset of the IEigenDACertVerifier interface, which is now separated temporarily into IEigenDACertVerifierBase. In the future, we can discuss how to remove this not optimal pattern, but the router cannot possibly implement all of IEIgenDACertVerifier because it does not have the required context, and so a separation is necessary for immediate implementation. This should not end up being a big issue since no functionality is removed from the original contracts.

The router primarily redirects verification calls by extracting the RBN from batch headers in calldata, finding the largest registered RBN less than the extracted RBN, and redirecting the call to the contract associated with that RBN. 

The key questions we might want to ask about this implementation is:

* Is the IEigenDACertVerifierBase interface enough for all stakeholder needs?
* How can we reason about the security of this implementation?

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
