### PR TITLE
chore(proto): push protos to buf BSR registry

### DIFF
--- a/.github/workflows/buf-proto.yaml
+++ b/.github/workflows/buf-proto.yaml
@@ -1,0 +1,33 @@
+# Copied from https://buf.build/docs/ci-cd/github-actions/
+#
+# With the default configuration above, the Action does the following:
+# - On a pull request, it runs all checks (buf build, buf lint, buf format, and buf breaking) and posts a summary comment on the PR.
+# - When you push a Git commit, tag, or branch to GitHub, it pushes named modules to the BSR using buf push.
+# - When you delete a Git branch or tag, it archives the corresponding label on the BSR.
+#
+# This workflow could be merged with compile-protobufs.yaml, but we keep them separate for now,
+# given that this workflow requires PR write permissions.
+# If buf works well I think we should eventually migrate all manual protoc stuff to using buf.
+# This would give us versioned golang bindings, as well as better documentation, and a bunch of other stuff.
+name: Buf Proto
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  delete:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1
+        with:
+          token: ${{ secrets.BUF_TOKEN }}
+          # Change setup_only to true if you only want to set up the Action and not execute other commands.
+          # Otherwise, you can delete this line--the default is false.
+          setup_only: false
+          # Optional GitHub token for API requests. Ensures requests aren't rate limited.
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/api/buf.yaml
+++ b/api/buf.yaml
@@ -1,0 +1,15 @@
+# We currently only push the eigenda proto files to the buf registry
+# in order for it to generate rust prost/tonic bindings for us.
+# We also get nice documentation and versioning: see https://buf.build/layrlabs/eigenda.
+
+# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yaml
+version: v2
+modules:
+  - path: proto
+    name: buf.build/layrlabs/eigenda
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Closes DAINT-395.

Goal was just to add rust bindings, but ended up (re)discovering buf's protobuf registry [BSR](https://buf.build/product/bsr).
This is actually super nice, full-fledged product offering (they did raise 68M+..), which is also free for open-source repos.
We get nicer documentation, linting, auto-gen, sdks in every language for free, and more.
So this not only solves the original problem ([generating rust bindings](https://buf.build/blog/bsr-generated-sdks-for-rust)), but versions them, and also generates golang sdks which we could eventually migrate to.

Created an eigenda org here: https://buf.build/layrlabs/eigenda
Tested the rust bindings which work fine; added a README documenting a basic v1 dispersal example in https://buf.build/layrlabs/eigenda/sdks/main:community/neoeinstein-tonic

Also added a CI to buf lint, format, breaking (will catch breaking upgrades to our proto files and force a version upgrade).
Following https://buf.build/docs/ci-cd/github-actions/
Still missing a `secrets.BUF_TOKEN` auth token, which I can't add to this repo because I don't have admin access on github. Asked @anupsv to create that token.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
