### PR TITLE
chore: reformat batch code

### DIFF
--- a/disperser/batcher/batcher.go
+++ b/disperser/batcher/batcher.go
@@ -119,7 +119,18 @@ func NewBatcher(
 		ChainStateTimeout:        timeoutConfig.ChainStateTimeout,
 	}
 	encodingWorkerPool := workerpool.New(config.NumConnections)
-	encodingStreamer, err := NewEncodingStreamer(streamerConfig, queue, chainState, encoderClient, assignmentCoordinator, batchTrigger, encodingWorkerPool, metrics.EncodingStreamerMetrics, metrics, logger)
+	encodingStreamer, err := NewEncodingStreamer(
+		streamerConfig,
+		queue,
+		chainState,
+		encoderClient,
+		assignmentCoordinator,
+		batchTrigger,
+		encodingWorkerPool,
+		metrics.EncodingStreamerMetrics,
+		metrics,
+		logger,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +182,11 @@ func (b *Batcher) RecoverState(ctx context.Context) error {
 			processing += 1
 		}
 	}
-	b.logger.Info("Recovering state took", "duration", time.Since(start), "numBlobs", len(metas), "expired", expired, "processing", processing)
+	b.logger.Info("Recovering state took",
+		"duration", time.Since(start),
+		"numBlobs", len(metas),
+		"expired", expired,
+		"processing", processing)
 	return nil
 }
 
@@ -200,10 +215,13 @@ func (b *Batcher) Start(ctx context.Context) error {
 			case <-ctx.Done():
 				return
 			case receiptOrErr := <-receiptChan:
-				b.logger.Info("received response from transaction manager", "receipt", receiptOrErr.Receipt, "err", receiptOrErr.Err)
+				b.logger.Info("received response from transaction manager",
+					"receipt", receiptOrErr.Receipt,
+					"err", receiptOrErr.Err)
 				err := b.ProcessConfirmedBatch(ctx, receiptOrErr)
 				if err != nil {
-					b.logger.Error("failed to process confirmed batch", "err", err)
+					b.logger.Error("failed to process confirmed batch",
+						"err", err)
 				}
 			}
 		}
@@ -253,22 +271,28 @@ func (b *Batcher) updateConfirmationInfo(
 	txnReceipt *types.Receipt,
 ) ([]*disperser.BlobMetadata, error) {
 	if txnReceipt.BlockNumber == nil {
-		return nil, errors.New("HandleSingleBatch: error getting transaction receipt block number")
+		return nil, errors.New(
+			"HandleSingleBatch: error getting transaction receipt block number")
 	}
 	if len(batchData.blobs) == 0 {
-		return nil, errors.New("failed to process confirmed batch: no blobs from transaction manager metadata")
+		return nil, errors.New(
+			"failed to process confirmed batch: no blobs from transaction manager metadata")
 	}
 	if batchData.batchHeader == nil {
-		return nil, errors.New("failed to process confirmed batch: batch header from transaction manager metadata is nil")
+		return nil, errors.New(
+			"failed to process confirmed batch: batch header from transaction manager metadata is nil")
 	}
 	if len(batchData.blobHeaders) == 0 {
-		return nil, errors.New("failed to process confirmed batch: no blob headers from transaction manager metadata")
+		return nil, errors.New(
+			"failed to process confirmed batch: no blob headers from transaction manager metadata")
 	}
 	if batchData.merkleTree == nil {
-		return nil, errors.New("failed to process confirmed batch: merkle tree from transaction manager metadata is nil")
+		return nil, errors.New(
+			"failed to process confirmed batch: merkle tree from transaction manager metadata is nil")
 	}
 	if batchData.aggSig == nil {
-		return nil, errors.New("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
+		return nil, errors.New(
+			"failed to process confirmed batch: aggSig from transaction manager metadata is nil")
 	}
 	headerHash, err := batchData.batchHeader.GetBatchHeaderHash()
 	if err != nil {
@@ -291,14 +315,16 @@ func (b *Batcher) updateConfirmationInfo(
 			status = disperser.Confirmed
 			// generate inclusion proof
 			if blobIndex >= len(batchData.blobHeaders) {
-				b.logger.Error("HandleSingleBatch: error confirming blobs: blob header not found in batch", "index", blobIndex)
+				b.logger.Error("HandleSingleBatch: error confirming blobs: blob header not found in batch",
+					"index", blobIndex)
 				blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
 				continue
 			}
 
 			merkleProof, err := batchData.merkleTree.GenerateProofWithIndex(uint64(blobIndex), 0)
 			if err != nil {
-				b.logger.Error("HandleSingleBatch: failed to generate blob header inclusion proof", "err", err)
+				b.logger.Error("HandleSingleBatch: failed to generate blob header inclusion proof",
+					"err", err)
 				blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
 				continue
 			}
@@ -306,9 +332,11 @@ func (b *Batcher) updateConfirmationInfo(
 		}
 
 		confirmationInfo := &disperser.ConfirmationInfo{
-			BatchHeaderHash:         headerHash,
-			BlobIndex:               uint32(blobIndex),
-			SignatoryRecordHash:     core.ComputeSignatoryRecordHash(uint32(batchData.batchHeader.ReferenceBlockNumber), batchData.aggSig.NonSigners),
+			BatchHeaderHash: headerHash,
+			BlobIndex:       uint32(blobIndex),
+			SignatoryRecordHash: core.ComputeSignatoryRecordHash(
+				uint32(batchData.batchHeader.ReferenceBlockNumber),
+				batchData.aggSig.NonSigners),
 			ReferenceBlockNumber:    uint32(batchData.batchHeader.ReferenceBlockNumber),
 			BatchRoot:               batchData.batchHeader.BatchRoot[:],
 			BlobInclusionProof:      proof,
@@ -322,18 +350,24 @@ func (b *Batcher) updateConfirmationInfo(
 		}
 
 		if status == disperser.Confirmed {
-			if _, updateConfirmationInfoErr = b.Queue.MarkBlobConfirmed(ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
+			if _, updateConfirmationInfoErr = b.Queue.MarkBlobConfirmed(
+				ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
 				b.Metrics.UpdateCompletedBlob(int(metadata.RequestMetadata.BlobSize), disperser.Confirmed)
 			}
 		} else if status == disperser.InsufficientSignatures {
-			if _, updateConfirmationInfoErr = b.Queue.MarkBlobInsufficientSignatures(ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
+			if _, updateConfirmationInfoErr = b.Queue.MarkBlobInsufficientSignatures(
+				ctx, metadata, confirmationInfo); updateConfirmationInfoErr == nil {
 				b.Metrics.UpdateCompletedBlob(int(metadata.RequestMetadata.BlobSize), disperser.InsufficientSignatures)
 			}
 		} else {
-			updateConfirmationInfoErr = fmt.Errorf("HandleSingleBatch: trying to update confirmation info for blob in status other than confirmed or insufficient signatures: %s", status.String())
+			updateConfirmationInfoErr = fmt.Errorf(
+				"HandleSingleBatch: trying to update confirmation info for blob in status "+
+					"other than confirmed or insufficient signatures: %s",
+				status.String())
 		}
 		if updateConfirmationInfoErr != nil {
-			b.logger.Error("HandleSingleBatch: error updating blob confirmed metadata", "err", updateConfirmationInfoErr)
+			b.logger.Error("HandleSingleBatch: error updating blob confirmed metadata",
+				"err", updateConfirmationInfoErr)
 			blobsToRetry = append(blobsToRetry, batchData.blobs[blobIndex])
 		}
 		requestTime := time.Unix(0, int64(metadata.RequestMetadata.RequestedAt))
@@ -349,7 +383,8 @@ func (b *Batcher) updateConfirmationInfo(
 
 func (b *Batcher) ProcessConfirmedBatch(ctx context.Context, receiptOrErr *ReceiptOrErr) error {
 	if receiptOrErr.Metadata == nil {
-		return errors.New("failed to process confirmed batch: no metadata from transaction manager response")
+		return errors.New(
+			"failed to process confirmed batch: no metadata from transaction manager response")
 	}
 	confirmationMetadata := receiptOrErr.Metadata.(confirmationMetadata)
 	blobs := confirmationMetadata.blobs
@@ -364,7 +399,9 @@ func (b *Batcher) ProcessConfirmedBatch(ctx context.Context, receiptOrErr *Recei
 		_ = b.handleFailure(ctx, blobs, FailNoAggregatedSignature)
 		return errors.New("failed to process confirmed batch: aggSig from transaction manager metadata is nil")
 	}
-	b.logger.Info("received ConfirmBatch transaction receipt", "blockNumber", receiptOrErr.Receipt.BlockNumber, "txnHash", receiptOrErr.Receipt.TxHash.Hex())
+	b.logger.Info("received ConfirmBatch transaction receipt",
+		"blockNumber", receiptOrErr.Receipt.BlockNumber,
+		"txnHash", receiptOrErr.Receipt.TxHash.Hex())
 
 	// Mark the blobs as complete
 	stageTimer := time.Now()
@@ -374,10 +411,13 @@ func (b *Batcher) ProcessConfirmedBatch(ctx context.Context, receiptOrErr *Recei
 		return fmt.Errorf("failed to update confirmation info: %w", err)
 	}
 	if len(blobsToRetry) > 0 {
-		b.logger.Error("failed to update confirmation info", "failed", len(blobsToRetry), "total", len(blobs))
+		b.logger.Error("failed to update confirmation info",
+			"failed", len(blobsToRetry),
+			"total", len(blobs))
 		_ = b.handleFailure(ctx, blobsToRetry, FailUpdateConfirmationInfo)
 	}
-	b.logger.Debug("Update confirmation info took", "duration", time.Since(stageTimer).String())
+	b.logger.Debug("Update confirmation info took",
+		"duration", time.Since(stageTimer).String())
 	b.Metrics.ObserveLatency("UpdateConfirmationInfo", float64(time.Since(stageTimer).Milliseconds()))
 	batchSize := int64(0)
 	for _, blobMeta := range blobs {
@@ -388,14 +428,19 @@ func (b *Batcher) ProcessConfirmedBatch(ctx context.Context, receiptOrErr *Recei
 	return nil
 }
 
-func (b *Batcher) handleFailure(ctx context.Context, blobMetadatas []*disperser.BlobMetadata, reason FailReason) error {
+func (b *Batcher) handleFailure(
+	ctx context.Context,
+	blobMetadatas []*disperser.BlobMetadata,
+	reason FailReason,
+) error {
 	var result *multierror.Error
 	numPermanentFailures := 0
 	for _, metadata := range blobMetadatas {
 		b.EncodingStreamer.RemoveEncodedBlob(metadata)
 		retry, err := b.Queue.HandleBlobFailure(ctx, metadata, b.MaxNumRetriesPerBlob)
 		if err != nil {
-			b.logger.Error("HandleSingleBatch: error handling blob failure", "err", err)
+			b.logger.Error("HandleSingleBatch: error handling blob failure",
+				"err", err)
 			// Append the error
 			result = multierror.Append(result, err)
 		}
@@ -460,24 +505,28 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Debug("CreateBatch took", "duration", time.Since(stageTimer))
+	log.Debug("CreateBatch took",
+		"duration", time.Since(stageTimer))
 	b.observeBlobAge("batched", batch)
 
 	// Dispatch encoded batch
 	log.Debug("Dispatching encoded batch...")
 	stageTimer = time.Now()
 	update := b.Dispatcher.DisperseBatch(ctx, batch.State, batch.EncodedBlobs, batch.BatchHeader)
-	log.Debug("DisperseBatch took", "duration", time.Since(stageTimer))
+	log.Debug("DisperseBatch took",
+		"duration", time.Since(stageTimer))
 	b.observeBlobAge("attestation_requested", batch)
 	h, err := batch.State.OperatorState.Hash()
 	if err != nil {
-		log.Error("HandleSingleBatch: error getting operator state hash", "err", err)
+		log.Error("HandleSingleBatch: error getting operator state hash",
+			"err", err)
 	}
 	hStr := make([]string, 0, len(h))
 	for q, hash := range h {
 		hStr = append(hStr, fmt.Sprintf("%d: %x", q, hash))
 	}
-	log.Info("Dispatched encoded batch", "operatorStateHash", hStr)
+	log.Info("Dispatched encoded batch",
+		"operatorStateHash", hStr)
 
 	// Get the batch header hash
 	log.Debug("Getting batch header hash...")
@@ -511,7 +560,9 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 	}
 	b.Metrics.UpdateAttestation(operatorCount, signerCount, quorumAttestation.QuorumResults)
 	for _, quorumResult := range quorumAttestation.QuorumResults {
-		log.Info("Aggregated quorum result", "quorumID", quorumResult.QuorumID, "percentSigned", quorumResult.PercentSigned)
+		log.Info("Aggregated quorum result",
+			"quorumID", quorumResult.QuorumID,
+			"percentSigned", quorumResult.PercentSigned)
 	}
 
 	b.observeBlobAgeAndSize("attested", batch)
@@ -525,18 +576,25 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 
 	nonEmptyQuorums := []core.QuorumID{}
 	for quorumID := range passedQuorums {
-		log.Info("Quorums successfully attested", "quorumID", quorumID)
+		log.Info("Quorums successfully attested",
+			"quorumID", quorumID)
 		nonEmptyQuorums = append(nonEmptyQuorums, quorumID)
 	}
 
 	// Aggregate the signatures across only the non-empty quorums. Excluding empty quorums reduces the gas cost.
-	aggSig, err := b.Aggregator.AggregateSignatures(ctx, b.ChainState, batch.BatchHeader.ReferenceBlockNumber, quorumAttestation, nonEmptyQuorums)
+	aggSig, err := b.Aggregator.AggregateSignatures(
+		ctx,
+		b.ChainState,
+		batch.BatchHeader.ReferenceBlockNumber,
+		quorumAttestation,
+		nonEmptyQuorums)
 	if err != nil {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailAggregateSignatures)
 		return fmt.Errorf("HandleSingleBatch: error aggregating signatures: %w", err)
 	}
 
-	log.Debug("AggregateSignatures took", "duration", time.Since(stageTimer))
+	log.Debug("AggregateSignatures took",
+		"duration", time.Since(stageTimer))
 	b.Metrics.ObserveLatency("AggregateSignatures", float64(time.Since(stageTimer).Milliseconds()))
 
 	// Confirm the batch
@@ -547,14 +605,20 @@ func (b *Batcher) HandleSingleBatch(ctx context.Context) error {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailConfirmBatch)
 		return fmt.Errorf("HandleSingleBatch: error building confirmBatch transaction: %w", err)
 	}
-	err = b.TransactionManager.ProcessTransaction(ctx, NewTxnRequest(txn, "confirmBatch", big.NewInt(0), confirmationMetadata{
-		batchID:     uuid.Nil,
-		batchHeader: batch.BatchHeader,
-		blobs:       batch.BlobMetadata,
-		blobHeaders: batch.BlobHeaders,
-		merkleTree:  batch.MerkleTree,
-		aggSig:      aggSig,
-	}))
+	err = b.TransactionManager.ProcessTransaction(
+		ctx,
+		NewTxnRequest(
+			txn,
+			"confirmBatch",
+			big.NewInt(0),
+			confirmationMetadata{
+				batchID:     uuid.Nil,
+				batchHeader: batch.BatchHeader,
+				blobs:       batch.BlobMetadata,
+				blobHeaders: batch.BlobHeaders,
+				merkleTree:  batch.MerkleTree,
+				aggSig:      aggSig,
+			}))
 	if err != nil {
 		_ = b.handleFailure(ctx, batch.BlobMetadata, FailConfirmBatch)
 		return fmt.Errorf("HandleSingleBatch: error sending confirmBatch transaction: %w", err)
@@ -572,7 +636,8 @@ func (b *Batcher) parseBatchIDFromReceipt(txReceipt *types.Receipt) (uint32, err
 			b.logger.Debug("transaction receipt has no topics")
 			continue
 		}
-		b.logger.Debug("[getBatchIDFromReceipt] ", "sigHash", log.Topics[0].Hex())
+		b.logger.Debug("[getBatchIDFromReceipt] ",
+			"sigHash", log.Topics[0].Hex())
 
 		if log.Topics[0] == common.BatchConfirmedEventSigHash {
 			smAbi, err := abi.JSON(bytes.NewReader(common.ServiceManagerAbi))
@@ -591,7 +656,8 @@ func (b *Batcher) parseBatchIDFromReceipt(txReceipt *types.Receipt) (uint32, err
 			// There should be exactly one input in the data field, batchId.
 			// Labs/eigenda/blob/master/contracts/src/interfaces/IEigenDAServiceManager.sol#L17
 			if len(unpackedData) != 1 {
-				return 0, fmt.Errorf("BatchConfirmed log should contain exactly 1 inputs. Found %d", len(unpackedData))
+				return 0, fmt.Errorf(
+					"BatchConfirmed log should contain exactly 1 inputs. Found %d", len(unpackedData))
 			}
 			return unpackedData[0].(uint32), nil
 		}
@@ -617,7 +683,9 @@ func (b *Batcher) getBatchID(ctx context.Context, txReceipt *types.Receipt) (uin
 	txHash := txReceipt.TxHash
 	for i := 0; i < maxRetries; i++ {
 		retrySec := math.Pow(2, float64(i))
-		b.logger.Warn("failed to get transaction receipt, retrying...", "retryIn", retrySec, "err", err)
+		b.logger.Warn("failed to get transaction receipt, retrying...",
+			"retryIn", retrySec,
+			"err", err)
 		time.Sleep(time.Duration(retrySec) * baseDelay)
 
 		txReceipt, err = b.ethClient.TransactionReceipt(ctx, txHash)
@@ -632,7 +700,9 @@ func (b *Batcher) getBatchID(ctx context.Context, txReceipt *types.Receipt) (uin
 	}
 
 	if err != nil {
-		b.logger.Warn("failed to get transaction receipt after retries", "numRetries", maxRetries, "err", err)
+		b.logger.Warn("failed to get transaction receipt after retries",
+			"numRetries", maxRetries,
+			"err", err)
 		return 0, err
 	}
 
@@ -640,9 +710,13 @@ func (b *Batcher) getBatchID(ctx context.Context, txReceipt *types.Receipt) (uin
 }
 
 // numBlobsAttestedByQuorum returns two values:
-// 1. the number of blobs that have been successfully attested by all quorums
-// 2. map[QuorumID]struct{} contains quorums that have been successfully attested by the quorum (has at least one blob attested in the quorum)
-func numBlobsAttestedByQuorum(signedQuorums map[core.QuorumID]*core.QuorumResult, headers []*core.BlobHeader) (int, map[core.QuorumID]struct{}) {
+//  1. the number of blobs that have been successfully attested by all quorums
+//  2. map[QuorumID]struct{} contains quorums that have been successfully attested by the quorum
+//     (has at least one blob attested in the quorum)
+func numBlobsAttestedByQuorum(
+	signedQuorums map[core.QuorumID]*core.QuorumResult,
+	headers []*core.BlobHeader,
+) (int, map[core.QuorumID]struct{}) {
 	numPassed := 0
 	quorums := make(map[core.QuorumID]struct{})
 	for _, blob := range headers {

--- a/disperser/batcher/grpc/dispatcher.go
+++ b/disperser/batcher/grpc/dispatcher.go
@@ -30,7 +30,11 @@ type dispatcher struct {
 	metrics *batcher.DispatcherMetrics
 }
 
-func NewDispatcher(cfg *Config, logger logging.Logger, metrics *batcher.DispatcherMetrics) *dispatcher {
+func NewDispatcher(
+	cfg *Config,
+	logger logging.Logger,
+	metrics *batcher.DispatcherMetrics,
+) *dispatcher {
 	return &dispatcher{
 		Config:  cfg,
 		logger:  logger.With("component", "Dispatcher"),
@@ -40,7 +44,12 @@ func NewDispatcher(cfg *Config, logger logging.Logger, metrics *batcher.Dispatch
 
 var _ disperser.Dispatcher = (*dispatcher)(nil)
 
-func (c *dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOperatorState, blobs []core.EncodedBlob, batchHeader *core.BatchHeader) chan core.SigningMessage {
+func (c *dispatcher) DisperseBatch(
+	ctx context.Context,
+	state *core.IndexedOperatorState, 
+	blobs []core.EncodedBlob, 
+	batchHeader *core.BatchHeader,
+) chan core.SigningMessage {
 	update := make(chan core.SigningMessage, len(state.IndexedOperators))
 
 	// Disperse
@@ -49,7 +58,13 @@ func (c *dispatcher) DisperseBatch(ctx context.Context, state *core.IndexedOpera
 	return update
 }
 
-func (c *dispatcher) sendAllChunks(ctx context.Context, state *core.IndexedOperatorState, blobs []core.EncodedBlob, batchHeader *core.BatchHeader, update chan core.SigningMessage) {
+func (c *dispatcher) sendAllChunks(
+	ctx context.Context,
+	state *core.IndexedOperatorState,
+	blobs []core.EncodedBlob,
+	batchHeader *core.BatchHeader,
+	update chan core.SigningMessage,
+) {
 	for id, op := range state.IndexedOperators {
 		go func(op core.IndexedOperatorInfo, id core.OperatorID) {
 			blobMessages := make([]*core.EncodedBlobMessage, 0)
@@ -118,7 +133,12 @@ func (c *dispatcher) sendAllChunks(ctx context.Context, state *core.IndexedOpera
 	}
 }
 
-func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.EncodedBlobMessage, batchHeader *core.BatchHeader, op *core.IndexedOperatorInfo) (*core.Signature, error) {
+func (c *dispatcher) sendChunks(
+	ctx context.Context,
+	blobs []*core.EncodedBlobMessage,
+	batchHeader *core.BatchHeader,
+	op *core.IndexedOperatorInfo,
+) (*core.Signature, error) {
 	// TODO Add secure Grpc
 
 	conn, err := grpc.NewClient(
@@ -126,7 +146,9 @@ func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.EncodedBlobMe
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
-		c.logger.Warn("Disperser cannot connect to operator dispersal socket", "dispersal_socket", core.OperatorSocket(op.Socket).GetV1DispersalSocket(), "err", err)
+		c.logger.Warn("Disperser cannot connect to operator dispersal socket",
+				"dispersal_socket", core.OperatorSocket(op.Socket).GetV1DispersalSocket(),
+				"err", err)
 		return nil, err
 	}
 	defer conn.Close()
@@ -139,7 +161,13 @@ func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.EncodedBlobMe
 	if err != nil {
 		return nil, err
 	}
-	c.logger.Debug("sending chunks to operator", "operator", op.Socket, "num blobs", len(blobs), "size", totalSize, "request message size", proto.Size(request), "request serialization time", time.Since(start), "use Gnark chunk encoding", c.EnableGnarkBundleEncoding)
+	c.logger.Debug("sending chunks to operator",
+		"operator", op.Socket,
+		"num blobs", len(blobs),
+		"size", totalSize,
+		"request message size", proto.Size(request),
+		"request serialization time", time.Since(start),
+		"use Gnark chunk encoding", c.EnableGnarkBundleEncoding)
 	opt := grpc.MaxCallSendMsgSize(60 * 1024 * 1024 * 1024)
 	reply, err := gc.StoreChunks(ctx, request, opt)
 
@@ -155,7 +183,11 @@ func (c *dispatcher) sendChunks(ctx context.Context, blobs []*core.EncodedBlobMe
 	sig := &core.Signature{G1Point: point}
 	return sig, nil
 }
-func GetStoreChunksRequest(blobMessages []*core.EncodedBlobMessage, batchHeader *core.BatchHeader, useGnarkBundleEncoding bool) (*node.StoreChunksRequest, int64, error) {
+func GetStoreChunksRequest(
+	blobMessages []*core.EncodedBlobMessage,
+	batchHeader *core.BatchHeader,
+	useGnarkBundleEncoding bool,
+) (*node.StoreChunksRequest, int64, error) {
 	blobs := make([]*node.Blob, len(blobMessages))
 	totalSize := int64(0)
 	for i, blob := range blobMessages {
@@ -175,7 +207,11 @@ func GetStoreChunksRequest(blobMessages []*core.EncodedBlobMessage, batchHeader 
 	return request, totalSize, nil
 }
 
-func GetStoreBlobsRequest(blobMessages []*core.EncodedBlobMessage, batchHeader *core.BatchHeader, useGnarkBundleEncoding bool) (*node.StoreBlobsRequest, int64, error) {
+func GetStoreBlobsRequest(
+	blobMessages []*core.EncodedBlobMessage,
+	batchHeader *core.BatchHeader,
+	useGnarkBundleEncoding bool,
+) (*node.StoreBlobsRequest, int64, error) {
 	blobs := make([]*node.Blob, len(blobMessages))
 	totalSize := int64(0)
 	for i, blob := range blobMessages {

--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -163,10 +163,7 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 		op := op
 		host, _, _, v2DispersalPort, _, err := core.ParseOperatorSocket(op.Socket)
 		if err != nil {
-			d.logger.Warn("failed to parse operator socket, check if the socket format is correct",
-				"operator", opID.Hex(),
-				"socket", op.Socket,
-				"err", err)
+			d.logger.Warn("failed to parse operator socket, check if the socket format is correct", "operator", opID.Hex(), "socket", op.Socket, "err", err)
 			sigChan <- core.SigningMessage{
 				Signature:            nil,
 				Operator:             opID,
@@ -179,11 +176,7 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 
 		client, err := d.nodeClientManager.GetClient(host, v2DispersalPort)
 		if err != nil {
-			d.logger.Warn("failed to get node client; node may not be reachable",
-				"operator", opID.Hex(),
-				"host", host,
-				"v2DispersalPort", v2DispersalPort,
-				"err", err)
+			d.logger.Warn("failed to get node client; node may not be reachable", "operator", opID.Hex(), "host", host, "v2DispersalPort", v2DispersalPort, "err", err)
 			sigChan <- core.SigningMessage{
 				Signature:            nil,
 				Operator:             opID,
@@ -253,20 +246,12 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 					break
 				}
 
-				d.logger.Warn("failed to send chunks",
-					"operator", opID.Hex(),
-					"NumAttempts", i,
-					"batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]),
-					"err", err)
+				d.logger.Warn("failed to send chunks", "operator", opID.Hex(), "NumAttempts", i, "batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]), "err", err)
 				time.Sleep(time.Duration(math.Pow(2, float64(i))) * time.Second) // Wait before retrying
 			}
 
 			if lastErr != nil {
-				d.logger.Warn("failed to send chunks",
-					"operator", opID.Hex(),
-					"NumAttempts", i,
-					"batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]),
-					"err", lastErr)
+				d.logger.Warn("failed to send chunks", "operator", opID.Hex(), "NumAttempts", i, "batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]), "err", lastErr)
 				sigChan <- core.SigningMessage{
 					Signature:            nil,
 					Operator:             opID,
@@ -285,11 +270,7 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 }
 
 // HandleSignatures receives signatures from operators, validates, and aggregates them
-func (d *Dispatcher) HandleSignatures(
-	ctx context.Context,
-	batchData *batchData,
-	sigChan chan core.SigningMessage,
-) error {
+func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData, sigChan chan core.SigningMessage) error {
 	if batchData == nil {
 		return errors.New("batchData is required")
 	}
@@ -323,12 +304,7 @@ func (d *Dispatcher) HandleSignatures(
 
 	// TODO(ian-shim): periodically update the attestation with intermediate quorum results
 
-	quorumAttestation, err := d.aggregator.ReceiveSignatures(
-		ctx,
-		batchData.OperatorState,
-		batchData.BatchHeaderHash,
-		sigChan,
-	)
+	quorumAttestation, err := d.aggregator.ReceiveSignatures(ctx, batchData.OperatorState, batchData.BatchHeaderHash, sigChan)
 	if err != nil {
 		dbErr := d.failBatch(ctx, batchData)
 		if dbErr != nil {
@@ -374,20 +350,13 @@ func (d *Dispatcher) HandleSignatures(
 	}
 	slices.Sort(nonZeroQuorums)
 
-	aggSig, err := d.aggregator.AggregateSignatures(
-		ctx,
-		d.chainState,
-		uint(batchData.Batch.BatchHeader.ReferenceBlockNumber),
-		quorumAttestation,
-		nonZeroQuorums,
-	)
+	aggSig, err := d.aggregator.AggregateSignatures(ctx, d.chainState, uint(batchData.Batch.BatchHeader.ReferenceBlockNumber), quorumAttestation, nonZeroQuorums)
 	aggregateSignaturesFinished := time.Now()
 	d.metrics.reportAggregateSignaturesLatency(aggregateSignaturesFinished.Sub(receiveSignaturesFinished))
 	if err != nil {
 		dbErr := d.failBatch(ctx, batchData)
 		if dbErr != nil {
-			return fmt.Errorf("failed to update blob statuses for batch %s to failed: %w",
-				batchHeaderHash, dbErr)
+			return fmt.Errorf("failed to update blob statuses for batch %s to failed: %w", batchHeaderHash, dbErr)
 		}
 		return fmt.Errorf("failed to aggregate signatures for batch %s: %w", batchHeaderHash, err)
 	}
@@ -408,8 +377,7 @@ func (d *Dispatcher) HandleSignatures(
 	if err != nil {
 		dbErr := d.failBatch(ctx, batchData)
 		if dbErr != nil {
-			return fmt.Errorf("failed to update blob statuses for batch %s to failed: %w",
-				batchHeaderHash, dbErr)
+			return fmt.Errorf("failed to update blob statuses for batch %s to failed: %w", batchHeaderHash, dbErr)
 		}
 		return fmt.Errorf("failed to put attestation for batch %s: %w", batchHeaderHash, err)
 	}
@@ -447,12 +415,7 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 	defer func() {
 		d.metrics.reportNewBatchLatency(time.Since(newBatchStart))
 	}()
-	blobMetadatas, cursor, err := d.blobMetadataStore.GetBlobMetadataByStatusPaginated(
-		ctx,
-		v2.Encoded,
-		d.cursor,
-		d.MaxBatchSize,
-	)
+	blobMetadatas, cursor, err := d.blobMetadataStore.GetBlobMetadataByStatusPaginated(ctx, v2.Encoded, d.cursor, d.MaxBatchSize)
 	getBlobMetadataFinished := time.Now()
 	d.metrics.reportGetBlobMetadataLatency(getBlobMetadataFinished.Sub(newBatchStart))
 	if err != nil {
@@ -464,9 +427,7 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 	if len(blobMetadatas) == 0 {
 		return nil, errNoBlobsToDispatch
 	}
-	d.logger.Debug("got new metadatas to make batch",
-		"numBlobs", len(blobMetadatas),
-		"referenceBlockNumber", referenceBlockNumber)
+	d.logger.Debug("got new metadatas to make batch", "numBlobs", len(blobMetadatas), "referenceBlockNumber", referenceBlockNumber)
 
 	state, err := d.GetOperatorState(ctx, blobMetadatas, referenceBlockNumber)
 	getOperatorStateFinished := time.Now()
@@ -614,11 +575,7 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 }
 
 // GetOperatorState returns the operator state for the given quorums at the given block number
-func (d *Dispatcher) GetOperatorState(
-	ctx context.Context,
-	metadatas []*v2.BlobMetadata,
-	blockNumber uint64,
-) (*core.IndexedOperatorState, error) {
+func (d *Dispatcher) GetOperatorState(ctx context.Context, metadatas []*v2.BlobMetadata, blockNumber uint64) (*core.IndexedOperatorState, error) {
 	quorums := make(map[core.QuorumID]struct{}, 0)
 	for _, m := range metadatas {
 		for _, quorum := range m.BlobHeader.QuorumNumbers {
@@ -637,11 +594,7 @@ func (d *Dispatcher) GetOperatorState(
 	return d.chainState.GetIndexedOperatorState(ctx, uint(blockNumber), quorumIds)
 }
 
-func (d *Dispatcher) sendChunks(
-	ctx context.Context,
-	client clients.NodeClient,
-	batch *corev2.Batch,
-) (*core.Signature, error) {
+func (d *Dispatcher) sendChunks(ctx context.Context, client clients.NodeClient, batch *corev2.Batch) (*core.Signature, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, d.NodeRequestTimeout)
 	defer cancel()
 
@@ -660,11 +613,7 @@ func (d *Dispatcher) sendChunks(
 // If the blob is removed from the blob set after the time it is retrieved as part of a batch
 // for processing by `NewBatch` (when it's in `ENCODED` state) and before the time the batch
 // is deduplicated against the blobSet, it will be dispatched again in a different batch.
-func (d *Dispatcher) updateBatchStatus(
-	ctx context.Context,
-	batch *batchData,
-	quorumResults map[core.QuorumID]uint8,
-) error {
+func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, quorumResults map[core.QuorumID]uint8) error {
 	var multierr error
 	for i, cert := range batch.Batch.BlobCertificates {
 		blobKey := batch.BlobKeys[i]
@@ -672,8 +621,7 @@ func (d *Dispatcher) updateBatchStatus(
 			d.logger.Error("invalid blob certificate in batch")
 			err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 			if err != nil {
-				multierr = multierror.Append(multierr,
-					fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+				multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 			} else {
 				d.blobSet.RemoveBlob(blobKey)
 			}
@@ -695,8 +643,7 @@ func (d *Dispatcher) updateBatchStatus(
 		if failed {
 			err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 			if err != nil {
-				multierr = multierror.Append(multierr,
-					fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+				multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 			} else {
 				d.blobSet.RemoveBlob(blobKey)
 			}
@@ -708,8 +655,7 @@ func (d *Dispatcher) updateBatchStatus(
 
 		err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Complete)
 		if err != nil {
-			multierr = multierror.Append(multierr,
-				fmt.Errorf("failed to update blob status for blob %s to complete: %w", blobKey.Hex(), err))
+			multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to complete: %w", blobKey.Hex(), err))
 		} else {
 			d.blobSet.RemoveBlob(blobKey)
 		}
@@ -728,8 +674,7 @@ func (d *Dispatcher) failBatch(ctx context.Context, batch *batchData) error {
 	for _, blobKey := range batch.BlobKeys {
 		err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 		if err != nil {
-			multierr = multierror.Append(multierr,
-				fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+			multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 		}
 		if metadata, ok := batch.Metadata[blobKey]; ok {
 			d.metrics.reportCompletedBlob(int(metadata.BlobSize), v2.Failed)

--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -163,7 +163,10 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 		op := op
 		host, _, _, v2DispersalPort, _, err := core.ParseOperatorSocket(op.Socket)
 		if err != nil {
-			d.logger.Warn("failed to parse operator socket, check if the socket format is correct", "operator", opID.Hex(), "socket", op.Socket, "err", err)
+			d.logger.Warn("failed to parse operator socket, check if the socket format is correct", 
+			"operator", opID.Hex(), 
+			"socket", op.Socket, 
+			"err", err)
 			sigChan <- core.SigningMessage{
 				Signature:            nil,
 				Operator:             opID,
@@ -176,7 +179,11 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 
 		client, err := d.nodeClientManager.GetClient(host, v2DispersalPort)
 		if err != nil {
-			d.logger.Warn("failed to get node client; node may not be reachable", "operator", opID.Hex(), "host", host, "v2DispersalPort", v2DispersalPort, "err", err)
+			d.logger.Warn("failed to get node client; node may not be reachable", 
+			"operator", opID.Hex(), 
+			"host", host, 
+			"v2DispersalPort", v2DispersalPort, 
+			"err", err)
 			sigChan <- core.SigningMessage{
 				Signature:            nil,
 				Operator:             opID,
@@ -246,12 +253,20 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 					break
 				}
 
-				d.logger.Warn("failed to send chunks", "operator", opID.Hex(), "NumAttempts", i, "batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]), "err", err)
+				d.logger.Warn("failed to send chunks", 
+				"operator", opID.Hex(), 
+				"NumAttempts", i, 
+				"batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]), 
+				"err", err)
 				time.Sleep(time.Duration(math.Pow(2, float64(i))) * time.Second) // Wait before retrying
 			}
 
 			if lastErr != nil {
-				d.logger.Warn("failed to send chunks", "operator", opID.Hex(), "NumAttempts", i, "batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]), "err", lastErr)
+				d.logger.Warn("failed to send chunks", 
+			"operator", opID.Hex(), 
+			"NumAttempts", i, 
+			"batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]), 
+			"err", lastErr)
 				sigChan <- core.SigningMessage{
 					Signature:            nil,
 					Operator:             opID,
@@ -270,7 +285,8 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 }
 
 // HandleSignatures receives signatures from operators, validates, and aggregates them
-func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData, sigChan chan core.SigningMessage) error {
+func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData,
+	sigChan chan core.SigningMessage) error {
 	if batchData == nil {
 		return errors.New("batchData is required")
 	}
@@ -283,7 +299,9 @@ func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData,
 	for _, key := range batchData.BlobKeys {
 		err := d.blobMetadataStore.UpdateBlobStatus(ctx, key, v2.GatheringSignatures)
 		if err != nil {
-			d.logger.Error("failed to update blob status for blob %s to gathering signatures", "blobKey", key.Hex(), "err", err)
+			d.logger.Error("failed to update blob status for blob %s to gathering signatures", 
+			"blobKey", key.Hex(), 
+			"err", err)
 		}
 	}
 
@@ -304,7 +322,8 @@ func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData,
 
 	// TODO(ian-shim): periodically update the attestation with intermediate quorum results
 
-	quorumAttestation, err := d.aggregator.ReceiveSignatures(ctx, batchData.OperatorState, batchData.BatchHeaderHash, sigChan)
+	quorumAttestation, err := d.aggregator.ReceiveSignatures(ctx, batchData.OperatorState,
+		batchData.BatchHeaderHash, sigChan)
 	if err != nil {
 		dbErr := d.failBatch(ctx, batchData)
 		if dbErr != nil {
@@ -350,7 +369,8 @@ func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData,
 	}
 	slices.Sort(nonZeroQuorums)
 
-	aggSig, err := d.aggregator.AggregateSignatures(ctx, d.chainState, uint(batchData.Batch.BatchHeader.ReferenceBlockNumber), quorumAttestation, nonZeroQuorums)
+	aggSig, err := d.aggregator.AggregateSignatures(ctx, d.chainState,
+		uint(batchData.Batch.BatchHeader.ReferenceBlockNumber), quorumAttestation, nonZeroQuorums)
 	aggregateSignaturesFinished := time.Now()
 	d.metrics.reportAggregateSignaturesLatency(aggregateSignaturesFinished.Sub(receiveSignaturesFinished))
 	if err != nil {
@@ -415,7 +435,8 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 	defer func() {
 		d.metrics.reportNewBatchLatency(time.Since(newBatchStart))
 	}()
-	blobMetadatas, cursor, err := d.blobMetadataStore.GetBlobMetadataByStatusPaginated(ctx, v2.Encoded, d.cursor, d.MaxBatchSize)
+	blobMetadatas, cursor, err := d.blobMetadataStore.GetBlobMetadataByStatusPaginated(ctx,
+		v2.Encoded, d.cursor, d.MaxBatchSize)
 	getBlobMetadataFinished := time.Now()
 	d.metrics.reportGetBlobMetadataLatency(getBlobMetadataFinished.Sub(newBatchStart))
 	if err != nil {
@@ -427,7 +448,9 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 	if len(blobMetadatas) == 0 {
 		return nil, errNoBlobsToDispatch
 	}
-	d.logger.Debug("got new metadatas to make batch", "numBlobs", len(blobMetadatas), "referenceBlockNumber", referenceBlockNumber)
+	d.logger.Debug("got new metadatas to make batch",
+		"numBlobs", len(blobMetadatas),
+		"referenceBlockNumber", referenceBlockNumber)
 
 	state, err := d.GetOperatorState(ctx, blobMetadatas, referenceBlockNumber)
 	getOperatorStateFinished := time.Now()
@@ -575,7 +598,8 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 }
 
 // GetOperatorState returns the operator state for the given quorums at the given block number
-func (d *Dispatcher) GetOperatorState(ctx context.Context, metadatas []*v2.BlobMetadata, blockNumber uint64) (*core.IndexedOperatorState, error) {
+func (d *Dispatcher) GetOperatorState(ctx context.Context, metadatas []*v2.BlobMetadata,
+	blockNumber uint64) (*core.IndexedOperatorState, error) {
 	quorums := make(map[core.QuorumID]struct{}, 0)
 	for _, m := range metadatas {
 		for _, quorum := range m.BlobHeader.QuorumNumbers {
@@ -594,7 +618,8 @@ func (d *Dispatcher) GetOperatorState(ctx context.Context, metadatas []*v2.BlobM
 	return d.chainState.GetIndexedOperatorState(ctx, uint(blockNumber), quorumIds)
 }
 
-func (d *Dispatcher) sendChunks(ctx context.Context, client clients.NodeClient, batch *corev2.Batch) (*core.Signature, error) {
+func (d *Dispatcher) sendChunks(ctx context.Context, client clients.NodeClient,
+	batch *corev2.Batch) (*core.Signature, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, d.NodeRequestTimeout)
 	defer cancel()
 
@@ -613,7 +638,8 @@ func (d *Dispatcher) sendChunks(ctx context.Context, client clients.NodeClient, 
 // If the blob is removed from the blob set after the time it is retrieved as part of a batch
 // for processing by `NewBatch` (when it's in `ENCODED` state) and before the time the batch
 // is deduplicated against the blobSet, it will be dispatched again in a different batch.
-func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, quorumResults map[core.QuorumID]uint8) error {
+func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData,
+	quorumResults map[core.QuorumID]uint8) error {
 	var multierr error
 	for i, cert := range batch.Batch.BlobCertificates {
 		blobKey := batch.BlobKeys[i]
@@ -621,7 +647,8 @@ func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, qu
 			d.logger.Error("invalid blob certificate in batch")
 			err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 			if err != nil {
-				multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+				multierr = multierror.Append(multierr, 
+					fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 			} else {
 				d.blobSet.RemoveBlob(blobKey)
 			}
@@ -643,7 +670,8 @@ func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, qu
 		if failed {
 			err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 			if err != nil {
-				multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+				multierr = multierror.Append(multierr, 
+					fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 			} else {
 				d.blobSet.RemoveBlob(blobKey)
 			}
@@ -655,7 +683,8 @@ func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, qu
 
 		err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Complete)
 		if err != nil {
-			multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to complete: %w", blobKey.Hex(), err))
+			multierr = multierror.Append(multierr, 
+				fmt.Errorf("failed to update blob status for blob %s to complete: %w", blobKey.Hex(), err))
 		} else {
 			d.blobSet.RemoveBlob(blobKey)
 		}
@@ -674,7 +703,8 @@ func (d *Dispatcher) failBatch(ctx context.Context, batch *batchData) error {
 	for _, blobKey := range batch.BlobKeys {
 		err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 		if err != nil {
-			multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+			multierr = multierror.Append(multierr, 
+				fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 		}
 		if metadata, ok := batch.Metadata[blobKey]; ok {
 			d.metrics.reportCompletedBlob(int(metadata.BlobSize), v2.Failed)

--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -163,7 +163,10 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 		op := op
 		host, _, _, v2DispersalPort, _, err := core.ParseOperatorSocket(op.Socket)
 		if err != nil {
-			d.logger.Warn("failed to parse operator socket, check if the socket format is correct", "operator", opID.Hex(), "socket", op.Socket, "err", err)
+			d.logger.Warn("failed to parse operator socket, check if the socket format is correct",
+				"operator", opID.Hex(),
+				"socket", op.Socket,
+				"err", err)
 			sigChan <- core.SigningMessage{
 				Signature:            nil,
 				Operator:             opID,
@@ -176,7 +179,11 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 
 		client, err := d.nodeClientManager.GetClient(host, v2DispersalPort)
 		if err != nil {
-			d.logger.Warn("failed to get node client; node may not be reachable", "operator", opID.Hex(), "host", host, "v2DispersalPort", v2DispersalPort, "err", err)
+			d.logger.Warn("failed to get node client; node may not be reachable",
+				"operator", opID.Hex(),
+				"host", host,
+				"v2DispersalPort", v2DispersalPort,
+				"err", err)
 			sigChan <- core.SigningMessage{
 				Signature:            nil,
 				Operator:             opID,
@@ -246,12 +253,20 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 					break
 				}
 
-				d.logger.Warn("failed to send chunks", "operator", opID.Hex(), "NumAttempts", i, "batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]), "err", err)
+				d.logger.Warn("failed to send chunks",
+					"operator", opID.Hex(),
+					"NumAttempts", i,
+					"batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]),
+					"err", err)
 				time.Sleep(time.Duration(math.Pow(2, float64(i))) * time.Second) // Wait before retrying
 			}
 
 			if lastErr != nil {
-				d.logger.Warn("failed to send chunks", "operator", opID.Hex(), "NumAttempts", i, "batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]), "err", lastErr)
+				d.logger.Warn("failed to send chunks",
+					"operator", opID.Hex(),
+					"NumAttempts", i,
+					"batchHeader", hex.EncodeToString(batchData.BatchHeaderHash[:]),
+					"err", lastErr)
 				sigChan <- core.SigningMessage{
 					Signature:            nil,
 					Operator:             opID,
@@ -270,7 +285,11 @@ func (d *Dispatcher) HandleBatch(ctx context.Context) (chan core.SigningMessage,
 }
 
 // HandleSignatures receives signatures from operators, validates, and aggregates them
-func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData, sigChan chan core.SigningMessage) error {
+func (d *Dispatcher) HandleSignatures(
+	ctx context.Context,
+	batchData *batchData,
+	sigChan chan core.SigningMessage,
+) error {
 	if batchData == nil {
 		return errors.New("batchData is required")
 	}
@@ -304,7 +323,12 @@ func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData,
 
 	// TODO(ian-shim): periodically update the attestation with intermediate quorum results
 
-	quorumAttestation, err := d.aggregator.ReceiveSignatures(ctx, batchData.OperatorState, batchData.BatchHeaderHash, sigChan)
+	quorumAttestation, err := d.aggregator.ReceiveSignatures(
+		ctx,
+		batchData.OperatorState,
+		batchData.BatchHeaderHash,
+		sigChan,
+	)
 	if err != nil {
 		dbErr := d.failBatch(ctx, batchData)
 		if dbErr != nil {
@@ -350,13 +374,20 @@ func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData,
 	}
 	slices.Sort(nonZeroQuorums)
 
-	aggSig, err := d.aggregator.AggregateSignatures(ctx, d.chainState, uint(batchData.Batch.BatchHeader.ReferenceBlockNumber), quorumAttestation, nonZeroQuorums)
+	aggSig, err := d.aggregator.AggregateSignatures(
+		ctx,
+		d.chainState,
+		uint(batchData.Batch.BatchHeader.ReferenceBlockNumber),
+		quorumAttestation,
+		nonZeroQuorums,
+	)
 	aggregateSignaturesFinished := time.Now()
 	d.metrics.reportAggregateSignaturesLatency(aggregateSignaturesFinished.Sub(receiveSignaturesFinished))
 	if err != nil {
 		dbErr := d.failBatch(ctx, batchData)
 		if dbErr != nil {
-			return fmt.Errorf("failed to update blob statuses for batch %s to failed: %w", batchHeaderHash, dbErr)
+			return fmt.Errorf("failed to update blob statuses for batch %s to failed: %w",
+				batchHeaderHash, dbErr)
 		}
 		return fmt.Errorf("failed to aggregate signatures for batch %s: %w", batchHeaderHash, err)
 	}
@@ -377,7 +408,8 @@ func (d *Dispatcher) HandleSignatures(ctx context.Context, batchData *batchData,
 	if err != nil {
 		dbErr := d.failBatch(ctx, batchData)
 		if dbErr != nil {
-			return fmt.Errorf("failed to update blob statuses for batch %s to failed: %w", batchHeaderHash, dbErr)
+			return fmt.Errorf("failed to update blob statuses for batch %s to failed: %w",
+				batchHeaderHash, dbErr)
 		}
 		return fmt.Errorf("failed to put attestation for batch %s: %w", batchHeaderHash, err)
 	}
@@ -415,7 +447,12 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 	defer func() {
 		d.metrics.reportNewBatchLatency(time.Since(newBatchStart))
 	}()
-	blobMetadatas, cursor, err := d.blobMetadataStore.GetBlobMetadataByStatusPaginated(ctx, v2.Encoded, d.cursor, d.MaxBatchSize)
+	blobMetadatas, cursor, err := d.blobMetadataStore.GetBlobMetadataByStatusPaginated(
+		ctx,
+		v2.Encoded,
+		d.cursor,
+		d.MaxBatchSize,
+	)
 	getBlobMetadataFinished := time.Now()
 	d.metrics.reportGetBlobMetadataLatency(getBlobMetadataFinished.Sub(newBatchStart))
 	if err != nil {
@@ -427,7 +464,9 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 	if len(blobMetadatas) == 0 {
 		return nil, errNoBlobsToDispatch
 	}
-	d.logger.Debug("got new metadatas to make batch", "numBlobs", len(blobMetadatas), "referenceBlockNumber", referenceBlockNumber)
+	d.logger.Debug("got new metadatas to make batch",
+		"numBlobs", len(blobMetadatas),
+		"referenceBlockNumber", referenceBlockNumber)
 
 	state, err := d.GetOperatorState(ctx, blobMetadatas, referenceBlockNumber)
 	getOperatorStateFinished := time.Now()
@@ -575,7 +614,11 @@ func (d *Dispatcher) NewBatch(ctx context.Context, referenceBlockNumber uint64) 
 }
 
 // GetOperatorState returns the operator state for the given quorums at the given block number
-func (d *Dispatcher) GetOperatorState(ctx context.Context, metadatas []*v2.BlobMetadata, blockNumber uint64) (*core.IndexedOperatorState, error) {
+func (d *Dispatcher) GetOperatorState(
+	ctx context.Context,
+	metadatas []*v2.BlobMetadata,
+	blockNumber uint64,
+) (*core.IndexedOperatorState, error) {
 	quorums := make(map[core.QuorumID]struct{}, 0)
 	for _, m := range metadatas {
 		for _, quorum := range m.BlobHeader.QuorumNumbers {
@@ -594,7 +637,11 @@ func (d *Dispatcher) GetOperatorState(ctx context.Context, metadatas []*v2.BlobM
 	return d.chainState.GetIndexedOperatorState(ctx, uint(blockNumber), quorumIds)
 }
 
-func (d *Dispatcher) sendChunks(ctx context.Context, client clients.NodeClient, batch *corev2.Batch) (*core.Signature, error) {
+func (d *Dispatcher) sendChunks(
+	ctx context.Context,
+	client clients.NodeClient,
+	batch *corev2.Batch,
+) (*core.Signature, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, d.NodeRequestTimeout)
 	defer cancel()
 
@@ -613,7 +660,11 @@ func (d *Dispatcher) sendChunks(ctx context.Context, client clients.NodeClient, 
 // If the blob is removed from the blob set after the time it is retrieved as part of a batch
 // for processing by `NewBatch` (when it's in `ENCODED` state) and before the time the batch
 // is deduplicated against the blobSet, it will be dispatched again in a different batch.
-func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, quorumResults map[core.QuorumID]uint8) error {
+func (d *Dispatcher) updateBatchStatus(
+	ctx context.Context,
+	batch *batchData,
+	quorumResults map[core.QuorumID]uint8,
+) error {
 	var multierr error
 	for i, cert := range batch.Batch.BlobCertificates {
 		blobKey := batch.BlobKeys[i]
@@ -621,7 +672,8 @@ func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, qu
 			d.logger.Error("invalid blob certificate in batch")
 			err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 			if err != nil {
-				multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+				multierr = multierror.Append(multierr,
+					fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 			} else {
 				d.blobSet.RemoveBlob(blobKey)
 			}
@@ -643,7 +695,8 @@ func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, qu
 		if failed {
 			err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 			if err != nil {
-				multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+				multierr = multierror.Append(multierr,
+					fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 			} else {
 				d.blobSet.RemoveBlob(blobKey)
 			}
@@ -655,7 +708,8 @@ func (d *Dispatcher) updateBatchStatus(ctx context.Context, batch *batchData, qu
 
 		err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Complete)
 		if err != nil {
-			multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to complete: %w", blobKey.Hex(), err))
+			multierr = multierror.Append(multierr,
+				fmt.Errorf("failed to update blob status for blob %s to complete: %w", blobKey.Hex(), err))
 		} else {
 			d.blobSet.RemoveBlob(blobKey)
 		}
@@ -674,7 +728,8 @@ func (d *Dispatcher) failBatch(ctx context.Context, batch *batchData) error {
 	for _, blobKey := range batch.BlobKeys {
 		err := d.blobMetadataStore.UpdateBlobStatus(ctx, blobKey, v2.Failed)
 		if err != nil {
-			multierr = multierror.Append(multierr, fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
+			multierr = multierror.Append(multierr,
+				fmt.Errorf("failed to update blob status for blob %s to failed: %w", blobKey.Hex(), err))
 		}
 		if metadata, ok := batch.Metadata[blobKey]; ok {
 			d.metrics.reportCompletedBlob(int(metadata.BlobSize), v2.Failed)


### PR DESCRIPTION
## Why are these changes needed?

Fix really long lines in the batching code. There shouldn't be any functional changes in this PR.
