### PR TITLE
fix: set the right cache control ttl for v2 APIs

### DIFF
--- a/disperser/dataapi/v2/accounts.go
+++ b/disperser/dataapi/v2/accounts.go
@@ -99,5 +99,6 @@ func (s *ServerV2) FetchAccountBlobFeed(c *gin.Context) {
 
 	s.metrics.IncrementSuccessfulRequestNum("FetchAccountBlobFeed")
 	s.metrics.ObserveLatency("FetchAccountBlobFeed", time.Since(handlerStart))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxBlobFeedAge))
 	c.JSON(http.StatusOK, response)
 }

--- a/disperser/dataapi/v2/batches.go
+++ b/disperser/dataapi/v2/batches.go
@@ -170,6 +170,7 @@ func (s *ServerV2) FetchBatchFeed(c *gin.Context) {
 
 	s.metrics.IncrementSuccessfulRequestNum("FetchBatchFeed")
 	s.metrics.ObserveLatency("FetchBatchFeed", time.Since(handlerStart))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxBatchFeedAge))
 	c.JSON(http.StatusOK, response)
 }
 
@@ -234,6 +235,6 @@ func (s *ServerV2) FetchBatch(c *gin.Context) {
 	}
 	s.metrics.IncrementSuccessfulRequestNum("FetchBatch")
 	s.metrics.ObserveLatency("FetchBatch", time.Since(handlerStart))
-	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxFeedBlobAge))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxBatchDataAge))
 	c.JSON(http.StatusOK, batchResponse)
 }

--- a/disperser/dataapi/v2/blobs.go
+++ b/disperser/dataapi/v2/blobs.go
@@ -212,7 +212,7 @@ func (s *ServerV2) FetchBlob(c *gin.Context) {
 	}
 	s.metrics.IncrementSuccessfulRequestNum("FetchBlob")
 	s.metrics.ObserveLatency("FetchBlob", time.Since(handlerStart))
-	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxFeedBlobAge))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxBlobDataAge))
 	c.JSON(http.StatusOK, response)
 }
 
@@ -253,7 +253,7 @@ func (s *ServerV2) FetchBlobCertificate(c *gin.Context) {
 	}
 	s.metrics.IncrementSuccessfulRequestNum("FetchBlobCertificate")
 	s.metrics.ObserveLatency("FetchBlobCertificate", time.Since(handlerStart))
-	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxFeedBlobAge))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxBlobDataAge))
 	c.JSON(http.StatusOK, response)
 }
 
@@ -294,7 +294,7 @@ func (s *ServerV2) FetchBlobAttestationInfo(c *gin.Context) {
 
 	s.metrics.IncrementSuccessfulRequestNum("FetchBlobAttestationInfo")
 	s.metrics.ObserveLatency("FetchBlobAttestationInfo", time.Since(handlerStart))
-	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxFeedBlobAge))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxBlobDataAge))
 	c.JSON(http.StatusOK, response)
 }
 
@@ -452,7 +452,7 @@ func (s *ServerV2) sendBlobFeedResponse(
 		Blobs:  blobInfo,
 		Cursor: cursorStr,
 	}
-	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxFeedBlobAge))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxBlobFeedAge))
 	s.metrics.IncrementSuccessfulRequestNum("FetchBlobFeed")
 	s.metrics.ObserveLatency("FetchBlobFeed", time.Since(handlerStart))
 	c.JSON(http.StatusOK, response)

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -108,6 +108,7 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 
 	s.metrics.IncrementSuccessfulRequestNum("FetchOperatorDispersalFeed")
 	s.metrics.ObserveLatency("FetchOperatorDispersalFeed", time.Since(handlerStart))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxDispersalFeedAge))
 	c.JSON(http.StatusOK, response)
 }
 
@@ -232,6 +233,7 @@ func (s *ServerV2) FetchOperatorSigningInfo(c *gin.Context) {
 
 	s.metrics.IncrementSuccessfulRequestNum("FetchOperatorSigningInfo")
 	s.metrics.ObserveLatency("FetchOperatorSigningInfo", time.Since(handlerStart))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxSigningInfoAge))
 	c.JSON(http.StatusOK, response)
 }
 
@@ -374,7 +376,7 @@ func (s *ServerV2) FetchOperatorDispersalResponse(c *gin.Context) {
 	}
 	s.metrics.IncrementSuccessfulRequestNum("FetchOperatorDispersalResponse")
 	s.metrics.ObserveLatency("FetchOperatorDispersalResponse", time.Since(handlerStart))
-	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxOperatorResponseAge))
+	c.Writer.Header().Set(cacheControlParam, fmt.Sprintf("max-age=%d", maxOperatorDispersalResponseAge))
 	c.JSON(http.StatusOK, response)
 }
 

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -69,7 +69,7 @@ const (
 	maxBlobFeedAge      = 5
 	maxBatchFeedAge     = 5
 	maxDispersalFeedAge = 5
-	maxSigningInfoAge   = 15
+	maxSigningInfoAge   = 5
 )
 
 type (

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -52,13 +52,24 @@ const (
 	// Cache ~1h worth of batches for KV lookups
 	maxNumKVBatchesToCache = 3600
 
-	cacheControlParam       = "Cache-Control"
-	maxFeedBlobAge          = 300 // this is completely static
-	maxOperatorsStakeAge    = 300 // not expect the stake change to happen frequently
-	maxOperatorResponseAge  = 300 // this is completely static
-	maxOperatorPortCheckAge = 60
-	maxMetricAge            = 10
-	maxThroughputAge        = 10
+	cacheControlParam = "Cache-Control"
+
+	// Static content
+	maxBlobDataAge                  = 300
+	maxBatchDataAge                 = 300
+	maxOperatorDispersalResponseAge = 300
+
+	// Rarely changing content
+	maxOperatorsStakeAge    = 300 // not expect the stake changes frequently
+	maxOperatorPortCheckAge = 60  // not expect validator port changes frequently, but it's consequential to have right port
+
+	// Live content
+	maxMetricAge        = 5
+	maxThroughputAge    = 5
+	maxBlobFeedAge      = 5
+	maxBatchFeedAge     = 5
+	maxDispersalFeedAge = 5
+	maxSigningInfoAge   = 15
 )
 
 type (


### PR DESCRIPTION
## Why are these changes needed?
Audit the cache control of v2 dataapi, and get them right (tradeoff of freshness and cache hit)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
