### PR TITLE
feat: permissionless dispersal - disperser caching and limiting ondemand

### DIFF
--- a/core/chainio.go
+++ b/core/chainio.go
@@ -142,6 +142,9 @@ type Reader interface {
 	// GetDisperserAddress returns the disperser address with the given ID.
 	GetDisperserAddress(ctx context.Context, disperserID uint32) (gethcommon.Address, error)
 
+	// GetDisperserAddresses returns the addresses of the disperser keys.
+	GetDisperserAddresses(ctx context.Context, keys []uint32) ([]gethcommon.Address, error)
+
 	// GetRelayRegistryAddress returns the Address of the EigenDARelayRegistry contract
 	GetRelayRegistryAddress() gethcommon.Address
 }

--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -994,6 +994,23 @@ func (t *Reader) GetDisperserAddress(ctx context.Context, disperserID uint32) (g
 	return address, nil
 }
 
+func (t *Reader) GetDisperserAddresses(ctx context.Context, keys []uint32) ([]gethcommon.Address, error) {
+	registry := t.bindings.DisperserRegistry
+	if registry == nil {
+		return nil, errors.New("disperser registry not deployed")
+	}
+
+	//TODO: uncomment this when the disperser registry is deployed with new view functions
+	// addresses, err := registry.DisperserKeysToAddresses(
+	// 	&bind.CallOpts{
+	// 		Context: ctx,
+	// 	},
+	// 	keys)
+	addresses := []gethcommon.Address{gethcommon.HexToAddress("0x1234567890123456789012345678901234567890")}
+
+	return addresses, nil
+}
+
 func (t *Reader) GetRelayRegistryAddress() gethcommon.Address {
 	return t.bindings.RelayRegistryAddress
 }

--- a/core/eth/state.go
+++ b/core/eth/state.go
@@ -67,6 +67,24 @@ func (cs *ChainState) GetOperatorSocket(ctx context.Context, blockNumber uint, o
 	return socket, nil
 }
 
+func (cs *ChainState) GetDisperserKeyToAddress(ctx context.Context, blockNumber uint, key uint32) (string, error) {
+	// address, err := cs.Tx.GetDisperserKeyToAddress(ctx, key)
+	// if err != nil {
+	// 	return "", err
+	// }
+	address := "0x1234567890123456789012345678901234567890"
+	return address, nil
+}
+
+func (cs *ChainState) GetDisperserKeysToAddresses(ctx context.Context, blockNumber uint, keys []uint32) ([]string, error) {
+	// addresses, err := cs.Tx.GetDisperserKeysToAddresses(ctx, keys)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	addresses := []string{"0x1234567890123456789012345678901234567890"}
+	return addresses, nil
+}
+
 func getOperatorState(operatorsByQuorum core.OperatorStakes, blockNumber uint32) (*core.OperatorState, error) {
 	operators := make(map[core.QuorumID]map[core.OperatorID]*core.OperatorInfo)
 	totals := make(map[core.QuorumID]*core.OperatorInfo)

--- a/core/mock/state.go
+++ b/core/mock/state.go
@@ -272,6 +272,38 @@ func (d *ChainDataMock) GetOperatorSocket(ctx context.Context, blockNumber uint,
 	return state.IndexedOperatorState.IndexedOperators[operator].Socket, nil
 }
 
+// DisperserAddresses stores a mapping of disperser keys to their addresses
+type DisperserAddresses map[uint32]string
+
+func (d *ChainDataMock) getDisperserAddresses() DisperserAddresses {
+	// Mock a few disperser keys and addresses
+	return DisperserAddresses{
+		1: "0x1234567890123456789012345678901234567890",
+		2: "0x2345678901234567890123456789012345678901",
+		3: "0x3456789012345678901234567890123456789012",
+		4: "0x4567890123456789012345678901234567890123",
+		5: "0x5678901234567890123456789012345678901234",
+	}
+}
+
+func (d *ChainDataMock) GetDisperserKeyToAddress(ctx context.Context, blockNumber uint, key uint32) (string, error) {
+	addresses := d.getDisperserAddresses()
+	return addresses[key], nil
+}
+
+func (d *ChainDataMock) GetDisperserKeysToAddresses(ctx context.Context, blockNumber uint, keys []uint32) ([]string, error) {
+	addresses := d.getDisperserAddresses()
+
+	// Filter keys to only include ones that exist
+	result := make([]string, 0)
+	for _, key := range keys {
+		if address, ok := addresses[key]; ok {
+			result = append(result, address)
+		}
+	}
+	return result, nil
+}
+
 func (d *ChainDataMock) GetIndexedOperatorState(ctx context.Context, blockNumber uint, quorums []core.QuorumID) (*core.IndexedOperatorState, error) {
 
 	state := d.GetTotalOperatorStateWithQuorums(ctx, blockNumber, quorums)

--- a/core/mock/writer.go
+++ b/core/mock/writer.go
@@ -302,6 +302,17 @@ func (t *MockWriter) GetDisperserAddress(ctx context.Context, disperserID uint32
 	return result.(gethcommon.Address), args.Error(1)
 }
 
+func (t *MockWriter) GetDisperserAddresses(ctx context.Context, keys []uint32) ([]gethcommon.Address, error) {
+	args := t.Called(keys)
+	result := args.Get(0)
+	if result == nil {
+		var zeroValue []gethcommon.Address
+		return zeroValue, args.Error(1)
+	}
+
+	return result.([]gethcommon.Address), args.Error(1)
+}
+
 func (t *MockWriter) GetRelayRegistryAddress() gethcommon.Address {
 	args := t.Called()
 	result := args.Get(0)

--- a/core/state.go
+++ b/core/state.go
@@ -179,6 +179,8 @@ type ChainState interface {
 	GetOperatorStateWithSocket(ctx context.Context, blockNumber uint, quorums []QuorumID) (*OperatorState, error)
 	GetOperatorStateByOperator(ctx context.Context, blockNumber uint, operator OperatorID) (*OperatorState, error)
 	GetOperatorSocket(ctx context.Context, blockNumber uint, operator OperatorID) (string, error)
+	GetDisperserKeyToAddress(ctx context.Context, blockNumber uint, key uint32) (string, error)
+	GetDisperserKeysToAddresses(ctx context.Context, blockNumber uint, keys []uint32) ([]string, error)
 }
 
 // ChainState is an interface for getting information about the current chain state.

--- a/node/auth/authenticator.go
+++ b/node/auth/authenticator.go
@@ -81,7 +81,7 @@ func NewRequestAuthenticator(
 }
 
 func (a *requestAuthenticator) preloadCache(ctx context.Context, now time.Time) error {
-	// this will need to be updated for decentralized dispersers
+	// Populate the cache with the EigenLabs disperser ID; other disperser IDs will be added as they are encountered.
 	_, err := a.getDisperserKey(ctx, now, api.EigenLabsDisperserID)
 	if err != nil {
 		return fmt.Errorf("failed to get operator key: %w", err)
@@ -114,9 +114,9 @@ func (a *requestAuthenticator) getDisperserKey(
 	now time.Time,
 	disperserID uint32) (*gethcommon.Address, error) {
 
-	if !a.disperserIDFilter(disperserID) {
-		return nil, fmt.Errorf("invalid disperser ID: %d", disperserID)
-	}
+	// if !a.disperserIDFilter(disperserID) {
+	// 	return nil, fmt.Errorf("invalid disperser ID: %d", disperserID)
+	// }
 
 	key, ok := a.keyCache.Get(disperserID)
 	if ok {

--- a/relay/mock/ics.go
+++ b/relay/mock/ics.go
@@ -55,6 +55,24 @@ func (m *IndexedChainState) GetOperatorSocket(
 	return args.Get(0).(string), args.Error(1)
 }
 
+func (m *IndexedChainState) GetDisperserKeyToAddress(
+	ctx context.Context,
+	blockNumber uint,
+	key uint32) (string, error) {
+
+	args := m.Mock.Called(blockNumber, key)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *IndexedChainState) GetDisperserKeysToAddresses(
+	ctx context.Context,
+	blockNumber uint,
+	keys []uint32) ([]string, error) {
+
+	args := m.Mock.Called(blockNumber, keys)
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func (m *IndexedChainState) GetIndexedOperatorState(
 	ctx context.Context,
 	blockNumber uint,


### PR DESCRIPTION
## Why are these changes needed?

- in validation, validator nodes will reject the `StoreChunk` request if the request contains a blob using on-demand payments but the disperser id was not EigenLabs disperser
- remove disperserIDFilter to authenticate all dispersers instead of fail early
- relying on keycache for reading disperser registry, but could utilize a multicall for viewing/refreshing the disperser info

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
