### PR TITLE
fix: Make local copy of loop variable

### DIFF
--- a/api/clients/v2/retrieval_client.go
+++ b/api/clients/v2/retrieval_client.go
@@ -108,6 +108,7 @@ func (r *retrievalClient) GetBlob(
 	chunksChan := make(chan clients.RetrievedChunks, len(operators))
 	pool := workerpool.New(r.numConnections)
 	for opID := range operators {
+		opID := opID
 		opInfo := operatorState.Operators[quorumID][opID]
 		pool.Submit(func() {
 			r.getChunksFromOperator(ctx, opID, opInfo, blobKey, quorumID, chunksChan)

--- a/api/clients/v2/retrieval_client.go
+++ b/api/clients/v2/retrieval_client.go
@@ -108,10 +108,11 @@ func (r *retrievalClient) GetBlob(
 	chunksChan := make(chan clients.RetrievedChunks, len(operators))
 	pool := workerpool.New(r.numConnections)
 	for opID := range operators {
-		opID := opID
-		opInfo := operatorState.Operators[quorumID][opID]
+		// make sure the value doesn't change before being submitted to the pool
+		boundOperatorId := opID
+		opInfo := operatorState.Operators[quorumID][boundOperatorId]
 		pool.Submit(func() {
-			r.getChunksFromOperator(ctx, opID, opInfo, blobKey, quorumID, chunksChan)
+			r.getChunksFromOperator(ctx, boundOperatorId, opInfo, blobKey, quorumID, chunksChan)
 		})
 	}
 


### PR DESCRIPTION
## Bug

- When doing distributed retrieval, these warnings show up
```
Apr 10 19:21:09.761 WRN v2/retrieval_client.go:138 failed to verify chunks from operator component=RetrievalClient operator=ea77395332488b77d4040e93c31bd5802e735ad4daa4f4514ee677390ce88205 err="invalid number of frames and indices: 754 != 930"
```
- The problem was using loop variables in submitted work to the pool
- Responses from different validators were getting scrambled up

## Fix

- Make a local copy

