### PR TITLE
fix: links to images in docs

### DIFF
--- a/docs/spec/src/protocol/architecture.md
+++ b/docs/spec/src/protocol/architecture.md
@@ -1,6 +1,6 @@
 # System Architecture
 
-![image](../../../assets/architecture.png)
+![image](../assets/architecture.png)
 
 ## Core Components
 

--- a/docs/spec/src/protocol/contracts.md
+++ b/docs/spec/src/protocol/contracts.md
@@ -11,7 +11,7 @@ This page describe EigenDA contracts that are manage by EigenDA related actors (
 
 The smart contracts can be found [here](https://github.com/Layr-Labs/eigenda/tree/master/contracts/src/core).
 
-![image.png](../assets/eigenda-contracts.png)
+
 
 #### EigenDACertVerifier
 


### PR DESCRIPTION
## Why are these changes needed?

Fixing links to images in docs

## Checks
WF: IMO tests below are likely not relevant for this small docs fix.

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [x] This PR is not tested :(
