### PR TITLE
perf: make dispersal feed based on responses not requests

### DIFF
--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -55,13 +55,13 @@ func checkAttestationsDesc(t *testing.T, items []*corev2.Attestation) {
 	}
 }
 
-func checkDispersalsAsc(t *testing.T, items []*corev2.DispersalRequest) {
+func checkDispersalsAsc(t *testing.T, items []*corev2.DispersalResponse) {
 	if len(items) > 1 {
 		for i := 1; i < len(items); i++ {
 			assert.Less(
 				t,
-				items[i-1].DispersedAt, // previous should be less
-				items[i].DispersedAt,   // than current
+				items[i-1].RespondedAt, // previous should be less
+				items[i].RespondedAt,   // than current
 				"DispersalRequests should be in ascending order",
 			)
 
@@ -69,12 +69,12 @@ func checkDispersalsAsc(t *testing.T, items []*corev2.DispersalRequest) {
 	}
 }
 
-func checkDispersalsDesc(t *testing.T, items []*corev2.DispersalRequest) {
+func checkDispersalsDesc(t *testing.T, items []*corev2.DispersalResponse) {
 	for i := 1; i < len(items); i++ {
 		assert.Greater(
 			t,
-			items[i-1].DispersedAt, // previous should be greater
-			items[i].DispersedAt,   // than current
+			items[i-1].RespondedAt, // previous should be greater
+			items[i].RespondedAt,   // than current
 			"DispersalRequests should be in descending order",
 		)
 	}
@@ -1681,7 +1681,7 @@ func TestBlobMetadataStoreDispersals(t *testing.T) {
 	})
 }
 
-func TestBlobMetadataStoreDispersalsByDispersedAt(t *testing.T) {
+func TestBlobMetadataStoreDispersalsByRespondedAt(t *testing.T) {
 	ctx := context.Background()
 
 	numRequests := 60
@@ -1690,29 +1690,35 @@ func TestBlobMetadataStoreDispersalsByDispersedAt(t *testing.T) {
 	firstRequestTs := now - uint64(int64(numRequests)*time.Second.Nanoseconds())
 	nanoSecsPerRequest := uint64(time.Second.Nanoseconds()) // 1 batch/s
 
-	dispersedAt := make([]uint64, numRequests)
+	respondedAt := make([]uint64, numRequests)
 	dynamoKeys := make([]commondynamodb.Key, numRequests)
 	for i := 0; i < numRequests; i++ {
-		dispersedAt[i] = firstRequestTs + uint64(i)*nanoSecsPerRequest
+		respondedAt[i] = firstRequestTs + uint64(i)*nanoSecsPerRequest
 		dispersalRequest := &corev2.DispersalRequest{
 			OperatorID:      opID,
 			OperatorAddress: gethcommon.HexToAddress("0x1234567"),
 			Socket:          "socket",
-			DispersedAt:     dispersedAt[i],
+			DispersedAt:     respondedAt[i] - 10,
 			BatchHeader: corev2.BatchHeader{
 				BatchRoot:            [32]byte{1, 2, 3},
 				ReferenceBlockNumber: uint64(i + 100),
 			},
 		}
+		dispersalResponse := &corev2.DispersalResponse{
+			DispersalRequest: dispersalRequest,
+			RespondedAt:      respondedAt[i],
+			Signature:        [32]byte{1, 1, 1},
+			Error:            "error",
+		}
 
-		err := blobMetadataStore.PutDispersalRequest(ctx, dispersalRequest)
+		err := blobMetadataStore.PutDispersalResponse(ctx, dispersalResponse)
 		require.NoError(t, err)
 
 		bhh, err := dispersalRequest.BatchHeader.Hash()
 		require.NoError(t, err)
 		dynamoKeys[i] = commondynamodb.Key{
 			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
-			"SK": &types.AttributeValueMemberS{Value: "DispersalRequest#" + opID.Hex()},
+			"SK": &types.AttributeValueMemberS{Value: "DispersalResponse#" + opID.Hex()},
 		}
 	}
 	defer deleteItems(t, dynamoKeys)
@@ -1720,16 +1726,16 @@ func TestBlobMetadataStoreDispersalsByDispersedAt(t *testing.T) {
 	// Test empty range
 	t.Run("empty range", func(t *testing.T) {
 		// Test invalid time range
-		_, err := blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, 1, 1, 0, true)
+		_, err := blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, 1, 1, 0, true)
 		require.Error(t, err)
 		assert.Equal(t, "no time point in exclusive time range (1, 1)", err.Error())
 
-		_, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, 1, 2, 0, true)
+		_, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, 1, 2, 0, true)
 		require.Error(t, err)
 		assert.Equal(t, "no time point in exclusive time range (1, 2)", err.Error())
 
 		// Test empty range
-		dispersals, err := blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, now, now+1024, 0, true)
+		dispersals, err := blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, now, now+1024, 0, true)
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(dispersals))
 	})
@@ -1737,23 +1743,23 @@ func TestBlobMetadataStoreDispersalsByDispersedAt(t *testing.T) {
 	// Test full range query
 	t.Run("ascending full range", func(t *testing.T) {
 		// Test without limit
-		dispersals, err := blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs-1, now, 0, true)
+		dispersals, err := blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs-1, now, 0, true)
 		require.NoError(t, err)
 		require.Equal(t, numRequests, len(dispersals))
 		checkDispersalsAsc(t, dispersals)
 
 		// Test with limit
-		dispersals, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs-1, now, 10, true)
+		dispersals, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs-1, now, 10, true)
 		require.NoError(t, err)
 		require.Equal(t, 10, len(dispersals))
 		checkDispersalsAsc(t, dispersals)
 
 		// Test min/max timestamp range
-		dispersals, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, 0, now, 0, true)
+		dispersals, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, 0, now, 0, true)
 		require.NoError(t, err)
 		require.Equal(t, numRequests, len(dispersals))
 		checkDispersalsAsc(t, dispersals)
-		dispersals, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs-1, math.MaxInt64, 0, true)
+		dispersals, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs-1, math.MaxInt64, 0, true)
 		require.NoError(t, err)
 		require.Equal(t, numRequests, len(dispersals))
 		checkDispersalsAsc(t, dispersals)
@@ -1762,23 +1768,23 @@ func TestBlobMetadataStoreDispersalsByDispersedAt(t *testing.T) {
 	// Test full range query
 	t.Run("descending full range", func(t *testing.T) {
 		// Test without limit
-		dispersals, err := blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs-1, now, 0, false)
+		dispersals, err := blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs-1, now, 0, false)
 		require.NoError(t, err)
 		require.Equal(t, numRequests, len(dispersals))
 		checkDispersalsDesc(t, dispersals)
 
 		// Test with limit
-		dispersals, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs, now, 10, false)
+		dispersals, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs, now, 10, false)
 		require.NoError(t, err)
 		require.Equal(t, 10, len(dispersals))
 		checkDispersalsDesc(t, dispersals)
 
 		// Test min/max timestamp range
-		dispersals, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, 0, now, 0, false)
+		dispersals, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, 0, now, 0, false)
 		require.NoError(t, err)
 		require.Equal(t, numRequests, len(dispersals))
 		checkDispersalsDesc(t, dispersals)
-		dispersals, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs-1, math.MaxInt64, 0, false)
+		dispersals, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs-1, math.MaxInt64, 0, false)
 		require.NoError(t, err)
 		require.Equal(t, numRequests, len(dispersals))
 		checkDispersalsDesc(t, dispersals)
@@ -1787,55 +1793,55 @@ func TestBlobMetadataStoreDispersalsByDispersedAt(t *testing.T) {
 	// Test range boundaries
 	t.Run("ascending range boundaries", func(t *testing.T) {
 		// Test exclusive start
-		dispersals, err := blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs, now, 0, true)
+		dispersals, err := blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs, now, 0, true)
 		require.NoError(t, err)
 		require.Equal(t, numRequests-1, len(dispersals))
-		assert.Equal(t, dispersedAt[1], dispersals[0].DispersedAt)
-		assert.Equal(t, dispersedAt[numRequests-1], dispersals[numRequests-2].DispersedAt)
+		assert.Equal(t, respondedAt[1], dispersals[0].RespondedAt)
+		assert.Equal(t, respondedAt[numRequests-1], dispersals[numRequests-2].RespondedAt)
 		checkDispersalsAsc(t, dispersals)
 
 		// Test exclusive end
-		dispersals, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs-1, dispersedAt[4], 0, true)
+		dispersals, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs-1, respondedAt[4], 0, true)
 		require.NoError(t, err)
 		require.Equal(t, 4, len(dispersals))
-		assert.Equal(t, dispersedAt[0], dispersals[0].DispersedAt)
-		assert.Equal(t, dispersedAt[3], dispersals[3].DispersedAt)
+		assert.Equal(t, respondedAt[0], dispersals[0].RespondedAt)
+		assert.Equal(t, respondedAt[3], dispersals[3].RespondedAt)
 		checkDispersalsAsc(t, dispersals)
 	})
 
 	// Test range boundaries
 	t.Run("descending range boundaries", func(t *testing.T) {
 		// Test exclusive start
-		dispersals, err := blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs, now, 0, false)
+		dispersals, err := blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs, now, 0, false)
 		require.NoError(t, err)
 		require.Equal(t, numRequests-1, len(dispersals))
-		assert.Equal(t, dispersedAt[numRequests-1], dispersals[0].DispersedAt)
-		assert.Equal(t, dispersedAt[1], dispersals[numRequests-2].DispersedAt)
+		assert.Equal(t, respondedAt[numRequests-1], dispersals[0].RespondedAt)
+		assert.Equal(t, respondedAt[1], dispersals[numRequests-2].RespondedAt)
 		checkDispersalsDesc(t, dispersals)
 
 		// Test exclusive end
-		dispersals, err = blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, firstRequestTs-1, dispersedAt[4], 0, false)
+		dispersals, err = blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, firstRequestTs-1, respondedAt[4], 0, false)
 		require.NoError(t, err)
 		require.Equal(t, 4, len(dispersals))
-		assert.Equal(t, dispersedAt[3], dispersals[0].DispersedAt)
-		assert.Equal(t, dispersedAt[0], dispersals[3].DispersedAt)
+		assert.Equal(t, respondedAt[3], dispersals[0].RespondedAt)
+		assert.Equal(t, respondedAt[0], dispersals[3].RespondedAt)
 		checkDispersalsDesc(t, dispersals)
 	})
 
 	// Test pagination
 	t.Run("pagination", func(t *testing.T) {
 		for i := 1; i < numRequests; i++ {
-			dispersals, err := blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, dispersedAt[i-1], dispersedAt[i]+1, 0, true)
+			dispersals, err := blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, respondedAt[i-1], respondedAt[i]+1, 0, true)
 			require.NoError(t, err)
 			require.Equal(t, 1, len(dispersals))
-			assert.Equal(t, dispersedAt[i], dispersals[0].DispersedAt)
+			assert.Equal(t, respondedAt[i], dispersals[0].RespondedAt)
 		}
 
 		for i := 1; i < numRequests; i++ {
-			dispersals, err := blobMetadataStore.GetDispersalRequestByDispersedAt(ctx, opID, dispersedAt[i-1], dispersedAt[i]+1, 0, false)
+			dispersals, err := blobMetadataStore.GetDispersalsByRespondedAt(ctx, opID, respondedAt[i-1], respondedAt[i]+1, 0, false)
 			require.NoError(t, err)
 			require.Equal(t, 1, len(dispersals))
-			assert.Equal(t, dispersedAt[i], dispersals[0].DispersedAt)
+			assert.Equal(t, respondedAt[i], dispersals[0].RespondedAt)
 		}
 	})
 }

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -1499,8 +1499,11 @@ const docTemplateV2 = `{
                 "batch_header_hash": {
                     "type": "string"
                 },
-                "dispersedAt": {
+                "dispersed_at": {
                     "type": "integer"
+                },
+                "signature": {
+                    "type": "string"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -1496,8 +1496,11 @@
                 "batch_header_hash": {
                     "type": "string"
                 },
-                "dispersedAt": {
+                "dispersed_at": {
                     "type": "integer"
+                },
+                "signature": {
+                    "type": "string"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -437,8 +437,10 @@ definitions:
         $ref: '#/definitions/github_com_Layr-Labs_eigenda_core_v2.BatchHeader'
       batch_header_hash:
         type: string
-      dispersedAt:
+      dispersed_at:
         type: integer
+      signature:
+        type: string
     type: object
   v2.OperatorDispersalFeedResponse:
     properties:

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -81,7 +81,6 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 	}
 
 	batches := make([]*OperatorDispersal, len(dispersals))
-	var zeroSignature [32]byte
 	for i, d := range dispersals {
 		batchHeaderHash, err := d.BatchHeader.Hash()
 		if err != nil {
@@ -89,9 +88,9 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 			errorResponse(c, fmt.Errorf("failed to compute batch header hash from batch header: %w", err))
 			return
 		}
-		sig := hex.EncodeToString(d.Signature[:])
-		if d.Signature == zeroSignature {
-			sig = ""
+		var sig string
+		if d.Signature != [32]byte{} {
+			sig = hex.EncodeToString(d.Signature[:])
 		}
 		batches[i] = &OperatorDispersal{
 			BatchHeaderHash: hex.EncodeToString(batchHeaderHash[:]),

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -81,6 +81,7 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 	}
 
 	batches := make([]*OperatorDispersal, len(dispersals))
+	var zeroSignature [32]byte
 	for i, d := range dispersals {
 		batchHeaderHash, err := d.BatchHeader.Hash()
 		if err != nil {
@@ -88,11 +89,15 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 			errorResponse(c, fmt.Errorf("failed to compute batch header hash from batch header: %w", err))
 			return
 		}
+		sig := hex.EncodeToString(d.Signature[:])
+		if d.Signature == zeroSignature {
+			sig = ""
+		}
 		batches[i] = &OperatorDispersal{
 			BatchHeaderHash: hex.EncodeToString(batchHeaderHash[:]),
 			BatchHeader:     &d.BatchHeader,
 			DispersedAt:     d.DispersedAt,
-			Signature:       hex.EncodeToString(d.Signature[:]),
+			Signature:       sig,
 		}
 	}
 

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -52,10 +52,10 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 		return
 	}
 
-	var dispersals []*corev2.DispersalRequest
+	var dispersals []*corev2.DispersalResponse
 
 	if params.direction == "forward" {
-		dispersals, err = s.blobMetadataStore.GetDispersalRequestByDispersedAt(
+		dispersals, err = s.blobMetadataStore.GetDispersalsByRespondedAt(
 			c.Request.Context(),
 			operatorId,
 			uint64(params.afterTime.UnixNano()),
@@ -64,7 +64,7 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 			true, // ascending=true
 		)
 	} else {
-		dispersals, err = s.blobMetadataStore.GetDispersalRequestByDispersedAt(
+		dispersals, err = s.blobMetadataStore.GetDispersalsByRespondedAt(
 			c.Request.Context(),
 			operatorId,
 			uint64(params.afterTime.UnixNano()),
@@ -92,6 +92,7 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 			BatchHeaderHash: hex.EncodeToString(batchHeaderHash[:]),
 			BatchHeader:     &d.BatchHeader,
 			DispersedAt:     d.DispersedAt,
+			Signature:       hex.EncodeToString(d.Signature[:]),
 		}
 	}
 

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -140,7 +140,8 @@ type (
 	OperatorDispersal struct {
 		BatchHeaderHash string              `json:"batch_header_hash"`
 		BatchHeader     *corev2.BatchHeader `json:"batch_header"`
-		DispersedAt     uint64
+		DispersedAt     uint64              `json:"dispersed_at"`
+		Signature       string              `json:"signature"`
 	}
 	OperatorDispersalFeedResponse struct {
 		OperatorIdentity OperatorIdentity     `json:"operator_identity"`

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -380,6 +380,7 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 
 	dispersedAt := make([]uint64, numRequests)
 	batchHeaders := make([]*corev2.BatchHeader, numRequests)
+	signatures := make([][32]byte, numRequests)
 	dynamoKeys := make([]commondynamodb.Key, numRequests)
 	for i := 0; i < numRequests; i++ {
 		dispersedAt[i] = firstRequestTs + uint64(i)*nanoSecsPerRequest
@@ -394,11 +395,15 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 			DispersedAt:     dispersedAt[i],
 			BatchHeader:     *batchHeaders[i],
 		}
+		signatures[i] = [32]byte{}
+		if i%2 == 0 {
+			signatures[i] = [32]byte{1, 1, uint8(i)}
+		}
 		dispersalResponse := &corev2.DispersalResponse{
 			DispersalRequest: dispersalRequest,
 			RespondedAt:      dispersedAt[i],
-			Signature:        [32]byte{1, 1, 1},
-			Error:            "error",
+			Signature:        signatures[i],
+			Error:            "",
 		}
 
 		err := blobMetadataStore.PutDispersalResponse(ctx, dispersalResponse)
@@ -522,6 +527,11 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 			assert.Equal(t, dispersedAt[1+i], response.Dispersals[i].DispersedAt)
 			assert.Equal(t, batchHeaders[1+i].ReferenceBlockNumber, response.Dispersals[i].BatchHeader.ReferenceBlockNumber)
 			assert.Equal(t, batchHeaders[1+i].BatchRoot, response.Dispersals[i].BatchHeader.BatchRoot)
+			if (1+i)%2 == 0 {
+				assert.Equal(t, hex.EncodeToString(signatures[1+i][:]), response.Dispersals[i].Signature)
+			} else {
+				assert.Equal(t, "", response.Dispersals[i].Signature)
+			}
 		}
 	})
 

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -394,15 +394,21 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 			DispersedAt:     dispersedAt[i],
 			BatchHeader:     *batchHeaders[i],
 		}
+		dispersalResponse := &corev2.DispersalResponse{
+			DispersalRequest: dispersalRequest,
+			RespondedAt:      dispersedAt[i],
+			Signature:        [32]byte{1, 1, 1},
+			Error:            "error",
+		}
 
-		err := blobMetadataStore.PutDispersalRequest(ctx, dispersalRequest)
+		err := blobMetadataStore.PutDispersalResponse(ctx, dispersalResponse)
 		require.NoError(t, err)
 
 		bhh, err := dispersalRequest.BatchHeader.Hash()
 		require.NoError(t, err)
 		dynamoKeys[i] = commondynamodb.Key{
 			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
-			"SK": &types.AttributeValueMemberS{Value: "DispersalRequest#" + opID.Hex()},
+			"SK": &types.AttributeValueMemberS{Value: "DispersalResponse#" + opID.Hex()},
 		}
 	}
 	defer deleteItems(t, dynamoKeys)


### PR DESCRIPTION
## Why are these changes needed?
Responses have pre-joined both requests and response so the clients won't need to make additional (potentially a lot!) lookups to dataapi.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
