### PR TITLE
ci: only run buf-proto on protobuf file changes

### DIFF
--- a/.github/workflows/buf-proto.yaml
+++ b/.github/workflows/buf-proto.yaml
@@ -12,12 +12,19 @@
 name: Buf Proto
 on:
   push:
+    paths:
+      - "api/proto/**"
+      - "api/buf.yaml"
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  delete:
+    paths:
+      - "api/proto/**"
+      - "api/buf.yaml"
+
 permissions:
   contents: read
   pull-requests: write
+
 jobs:
   buf:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why are these changes needed?

This CI is running on every single PR right now, even those that don't change proto, and the buf bot publishes a message which just clutters PRs:
<img width="772" alt="image" src="https://github.com/user-attachments/assets/945c5624-e43e-4133-81ba-c47d3eaf3de6" />
https://github.com/Layr-Labs/eigenda/pull/1493#issuecomment-2825440837

Changed such that it only runs on changes to protobuf files, or to the buf.yaml config file itself.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
