### PR TITLE
fix: change implementation of unsafe string.

### DIFF
--- a/litt/util/unsafe_string.go
+++ b/litt/util/unsafe_string.go
@@ -5,5 +5,8 @@ import "unsafe"
 // UnsafeBytesToString converts a byte slice to a string without copying the data.
 // Note that once converted in this way, it is not safe to modify the byte slice for any reason.
 func UnsafeBytesToString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(&b[0], len(b))
 }


### PR DESCRIPTION
## Why are these changes needed?

Use a more canonical strategy for converting a byte array to an unsafe string.
