### PR TITLE
fix: Update GitHub Actions checkout from v3 to v4

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -22,10 +22,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checkout wiki
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{github.repository}}.wiki
         token: ${{ github.token }}


### PR DESCRIPTION
## Why are these changes needed?

Updates the checkout action from v3 to v4 in test-coverage workflow.

Changes:
- Upgraded actions/checkout@v3 to actions/checkout@v4 for both code and wiki checkouts
- This update brings the latest improvements and security fixes from the checkout action

