### PR TITLE
Update alpine version for continued security support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,50 +104,50 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     make build
 
 # Final stages for each component
-FROM alpine:3.18 AS churner
+FROM alpine:3.20 AS churner
 COPY --from=churner-builder /app/operators/bin/churner /usr/local/bin
 ENTRYPOINT ["churner"]
 
-FROM alpine:3.18 AS encoder
+FROM alpine:3.20 AS encoder
 COPY --from=encoder-builder /app/disperser/bin/encoder /usr/local/bin
 ENTRYPOINT ["encoder"]
 
-FROM alpine:3.18 AS apiserver
+FROM alpine:3.20 AS apiserver
 COPY --from=apiserver-builder /app/disperser/bin/apiserver /usr/local/bin
 ENTRYPOINT ["apiserver"]
 
-FROM alpine:3.18 AS dataapi
+FROM alpine:3.20 AS dataapi
 COPY --from=dataapi-builder /app/disperser/bin/dataapi /usr/local/bin
 ENTRYPOINT ["dataapi"]
 
-FROM alpine:3.18 AS batcher
+FROM alpine:3.20 AS batcher
 COPY --from=batcher-builder /app/disperser/bin/batcher /usr/local/bin
 ENTRYPOINT ["batcher"]
 
-FROM alpine:3.18 AS retriever
+FROM alpine:3.20 AS retriever
 COPY --from=retriever-builder /app/retriever/bin/retriever /usr/local/bin
 ENTRYPOINT ["retriever"]
 
-FROM alpine:3.18 AS node
+FROM alpine:3.20 AS node
 COPY --from=node-builder /app/node/bin/node /usr/local/bin
 ENTRYPOINT ["node"]
 
-FROM alpine:3.18 AS nodeplugin
+FROM alpine:3.20 AS nodeplugin
 COPY --from=node-plugin-builder /app/node/bin/nodeplugin /usr/local/bin
 ENTRYPOINT ["nodeplugin"]
 
-FROM alpine:3.18 AS controller
+FROM alpine:3.20 AS controller
 COPY --from=controller-builder /app/disperser/bin/controller /usr/local/bin
 ENTRYPOINT ["controller"]
 
-FROM alpine:3.18 AS relay
+FROM alpine:3.20 AS relay
 COPY --from=relay-builder /app/relay/bin/relay /usr/local/bin
 ENTRYPOINT ["relay"]
 
-FROM alpine:3.18 AS generator
+FROM alpine:3.20 AS generator
 COPY --from=generator-builder /app/tools/traffic/bin/generator /usr/local/bin
 ENTRYPOINT ["generator"]
 
-FROM alpine:3.18 AS generator2
+FROM alpine:3.20 AS generator2
 COPY --from=generator2-builder /app/test/v2/bin/load /usr/local/bin
 ENTRYPOINT ["load", "-", "-"]


### PR DESCRIPTION
## Why are these changes needed?

Alpine ends support for 3.18 in May 2025. So bumping to 3.20 which ends support in 2026-04-01.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
