### PR TITLE
fix: use time series to derive avg throughput and total bytes

### DIFF
--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -2576,7 +2576,7 @@ func TestFetchMetricsSummary(t *testing.T) {
 	r := setUpRouter()
 
 	s := new(model.SampleStream)
-	err := s.UnmarshalJSON([]byte(mockPrometheusResponse))
+	err := s.UnmarshalJSON([]byte(mockPrometheusRespAvgThroughput))
 	assert.NoError(t, err)
 
 	matrix := make(model.Matrix, 0)
@@ -2588,7 +2588,7 @@ func TestFetchMetricsSummary(t *testing.T) {
 	w := executeRequest(t, r, http.MethodGet, "/v2/metrics/summary")
 	response := decodeResponseBody[serverv2.MetricSummary](t, w)
 
-	assert.Equal(t, 16555.555555555555, response.AverageBytesPerSecond)
+	assert.Equal(t, 10422.560745809731, response.AverageBytesPerSecond)
 }
 
 func TestFetchMetricsThroughputTimeseries(t *testing.T) {

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -55,9 +55,6 @@ import (
 )
 
 var (
-	//go:embed testdata/prometheus-response-sample.json
-	mockPrometheusResponse string
-
 	//go:embed testdata/prometheus-resp-avg-throughput.json
 	mockPrometheusRespAvgThroughput string
 


### PR DESCRIPTION
## Why are these changes needed?
Using this metric and query to figure out total bytes posted (and derived avg throughput) seems to have some issue: `fmt.Sprintf("eigenda_dispatcher_completed_blobs_total{state=\"complete\",data=\"size\",cluster=\"%s\"}", pc.cluster)`

This PR makes an alternative approach:
- Fetch throughput time series in the time window
- Compute avg throughput, via averaging the data points from time series
- Compute total bytes posted, by using `avgThroughput * timeDuration`

**Tested**

**Before**:
`{"total_bytes_posted":5216883703808,"average_bytes_per_second":10527844.223598072,"start_timestamp_sec":1745461794,"end_timestamp_sec":1745957326}`

**After**:
`{"total_bytes_posted":28974794807748,"average_bytes_per_second":58983931.84431834,"start_timestamp_sec":1745557770,"end_timestamp_sec":1746049002}`

The `After` matches the graph (but the `Before` has a avg throughput lower than the actual):

![da throughput](https://github.com/user-attachments/assets/c05e2685-ddaf-4268-8f34-6affeea60a93)



<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
