### PR TITLE
feat: configuration for the validator's littDB cache size

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -120,7 +120,7 @@ type Config struct {
 	LittDBDoubleWriteProtection bool
 
 	// The size of the cache for storing chunks in littDB, in gigabytes.
-	LittDBChunkCacheSizeGB float64 // TODO flag
+	LittDBChunkCacheSizeGB float64
 }
 
 // NewConfig parses the Config from the provided flags or environment variables and

--- a/node/config.go
+++ b/node/config.go
@@ -118,6 +118,9 @@ type Config struct {
 
 	// A special test only setting. If true, then littDB will throw an error if the same data is written twice.
 	LittDBDoubleWriteProtection bool
+
+	// The size of the cache for storing chunks in littDB, in gigabytes.
+	LittDBChunkCacheSizeGB float64 // TODO flag
 }
 
 // NewConfig parses the Config from the provided flags or environment variables and
@@ -340,6 +343,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		StoreChunksRequestMaxPastAge:        ctx.GlobalDuration(flags.StoreChunksRequestMaxPastAgeFlag.Name),
 		StoreChunksRequestMaxFutureAge:      ctx.GlobalDuration(flags.StoreChunksRequestMaxFutureAgeFlag.Name),
 		LittDBEnabled:                       ctx.GlobalBool(flags.LittDBEnabledFlag.Name),
+		LittDBChunkCacheSizeGB:              ctx.GlobalFloat64(flags.LittDBCacheSizeGBFlag.Name),
 		DownloadPoolSize:                    ctx.GlobalInt(flags.DownloadPoolSizeFlag.Name),
 	}, nil
 }

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -409,6 +409,13 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_ENABLED"),
 	}
+	LittDBCacheSizeGBFlag = cli.IntFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "litt-db-cache-size-gb"),
+		Usage:    "The size of the LittDB cache in gigabytes.",
+		Required: false,
+		Value:    16 * units.GiB,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_CACHE_SIZE_GB"),
+	}
 	DownloadPoolSizeFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "download-pool-size"),
 		Usage:    "The size of the download pool. The default value is 16.",

--- a/node/validator_store.go
+++ b/node/validator_store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Layr-Labs/eigenda/litt/littbuilder"
 	"github.com/Layr-Labs/eigenda/litt/util"
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/docker/go-units"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -267,6 +268,11 @@ func NewValidatorStore(
 		chunkTable, err = littDB.GetTable(chunksTableName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get chunks table: %w", err)
+		}
+
+		err = chunkTable.SetCacheSize(uint64(config.LittDBChunkCacheSizeGB * units.GiB))
+		if err != nil {
+			return nil, fmt.Errorf("failed to set cache size for chunks table: %w", err)
 		}
 
 		// A prior implementation stored data here. Delete it if it exists.


### PR DESCRIPTION
## Why are these changes needed?

Add validator configuration to control the size of the littDB cache.