### PR TITLE
refactor: node version code

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -36,9 +36,6 @@ var (
 		0: "eth_quorum",
 		1: "eignen_quorum",
 	}
-	SemVer    = "0.0.0"
-	GitCommit = ""
-	GitDate   = ""
 )
 
 // Config contains all of the configuration information for a DA node.

--- a/node/grpc/server_test.go
+++ b/node/grpc/server_test.go
@@ -345,7 +345,7 @@ func storeChunks(t *testing.T, server *grpc.Server, useGnarkBundleEncoding bool)
 func TestNodeInfoRequest(t *testing.T) {
 	server := newTestServer(t, true)
 	resp, err := server.NodeInfo(context.Background(), &pb.NodeInfoRequest{})
-	assert.True(t, resp.Semver == "0.0.0")
+	assert.True(t, resp.Semver == ">=0.9.0-rc.1")
 	assert.True(t, err == nil)
 }
 

--- a/node/grpc/server_v2_test.go
+++ b/node/grpc/server_v2_test.go
@@ -133,7 +133,7 @@ func newTestComponents(t *testing.T, config *node.Config) *testComponents {
 func TestV2NodeInfoRequest(t *testing.T) {
 	c := newTestComponents(t, makeConfig(t))
 	resp, err := c.server.GetNodeInfo(context.Background(), &validator.GetNodeInfoRequest{})
-	assert.True(t, resp.Semver == "0.0.0")
+	assert.True(t, resp.Semver == ">=0.9.0-rc.1")
 	assert.True(t, err == nil)
 }
 

--- a/node/version.go
+++ b/node/version.go
@@ -1,0 +1,7 @@
+package node
+
+var (
+	SemVer    = ">=0.9.0-rc.1"
+	GitCommit = ""
+	GitDate   = ""
+)


### PR DESCRIPTION
## Why are these changes needed?
There are more incompatible changes and the release for such changes is difficult and takes a long time.

NodeInfo API is to facilitate the release of such changes. However when operators build code from source, they may not properly label the version, or not label it at all. This makes NodeInfo not reliable, and therefore not able to support the incompatible releases.

The proposed the approach is to maintain the version in source code, and make this a release owner responsibility to update the version in source.

For example, the latest release was `v0.9.0-rc.1`, so when we cut this release, we should update the default version to `>=v0.9.0-rc.1`.

In this way,
1) if operators use the official release, it'll be `v0.9.0-rc.1`;
2) if using a version custom built at or after release, it'll be `>=0.9.0-rc.1`;
3) otherwise it'll be an old release e.g. `v0.8.3`, or custom old build, e.g. `>=0.8.5`.

This should make NodeInfo reliable information for clients of validators to decide the state of a release.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
