### PR TITLE
feat: LittDB caching

### DIFF
--- a/common/cache/cache_metrics.go
+++ b/common/cache/cache_metrics.go
@@ -1,0 +1,108 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/Layr-Labs/eigenda/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// CacheMetrics is a struct that holds metrics for a cache. A nil CacheMetrics instance acts as a no-op.
+type CacheMetrics struct {
+	keyCount        *prometheus.GaugeVec
+	weight          *prometheus.GaugeVec
+	keysAdded       *prometheus.CounterVec
+	weightAdded     *prometheus.CounterVec
+	evictionLatency *prometheus.SummaryVec
+}
+
+// NewCacheMetrics creates a new CacheMetrics instance. If the registry is nil, it returns nil.
+// The cacheName does not need to include the suffix "_cache" as this is added automatically.
+func NewCacheMetrics(registry *prometheus.Registry, namespace string, cacheName string) *CacheMetrics {
+	if registry == nil {
+		return nil
+	}
+
+	evictionLatency := promauto.With(registry).NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: namespace,
+			Name:      cacheName + "_cache_eviction_latency_ms",
+			Help:      "Reports on the eviction latency of the cache.",
+		},
+		[]string{},
+	)
+
+	keyCount := promauto.With(registry).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      cacheName + "_cache_key_count",
+			Help:      "Reports on the number of keys in the cache",
+		},
+		[]string{},
+	)
+
+	weight := promauto.With(registry).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      cacheName + "_cache_weight",
+			Help:      "Reports on the weight of the cache",
+		},
+		[]string{},
+	)
+
+	keysAdded := promauto.With(registry).NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      cacheName + "_cache_keys_added",
+			Help:      "Reports on the number of keys added to the cache",
+		},
+		[]string{},
+	)
+
+	weightAdded := promauto.With(registry).NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      cacheName + "_cache_weight_added",
+			Help:      "Reports on the weight of the entries added to the cache",
+		},
+		[]string{},
+	)
+
+	return &CacheMetrics{
+		keyCount:        keyCount,
+		weight:          weight,
+		keysAdded:       keysAdded,
+		weightAdded:     weightAdded,
+		evictionLatency: evictionLatency,
+	}
+}
+
+// reportInsertion is used to report an entry being inserted into the cache.
+func (m *CacheMetrics) reportInsertion(weight uint64) {
+	if m == nil {
+		return
+	}
+
+	m.keysAdded.WithLabelValues().Inc()
+	m.weightAdded.WithLabelValues().Add(float64(weight))
+}
+
+// reportEviction is used to report an entry being evicted from the cache.
+func (m *CacheMetrics) reportEviction(age time.Duration) {
+	if m == nil {
+		return
+	}
+
+	m.evictionLatency.WithLabelValues().Observe(common.ToMilliseconds(age))
+}
+
+// reportCurrentSize is used to report the current size/weight of the cache.
+func (m *CacheMetrics) reportCurrentSize(size int, weight uint64) {
+	if m == nil {
+		return
+	}
+
+	m.keyCount.WithLabelValues().Set(float64(size))
+	m.weight.WithLabelValues().Set(float64(weight))
+}

--- a/common/cache/fifo_cache_test.go
+++ b/common/cache/fifo_cache_test.go
@@ -12,7 +12,7 @@ func TestExpirationOrder(t *testing.T) {
 	tu.InitializeRandom()
 
 	maxWeight := uint64(10 + rand.Intn(10))
-	c := NewFIFOCache[int, int](maxWeight, nil)
+	c := NewFIFOCache[int, int](maxWeight, nil, nil)
 
 	require.Equal(t, uint64(0), c.Weight())
 	require.Equal(t, 0, c.Size())
@@ -84,7 +84,7 @@ func TestWeightedValues(t *testing.T) {
 		return uint64(key)
 	}
 
-	c := NewFIFOCache[int, int](maxWeight, weightCalculator)
+	c := NewFIFOCache[int, int](maxWeight, weightCalculator, nil)
 
 	expectedValues := make(map[int]int)
 

--- a/litt/cache/cached_table.go
+++ b/litt/cache/cached_table.go
@@ -111,7 +111,7 @@ func (c *cachedTable) CacheAwareGet(
 		return nil, false, false, err
 	}
 
-	if exists {
+	if exists && value != nil {
 		c.readCache.Put(stringKey, value)
 	}
 

--- a/litt/disktable/disk_table.go
+++ b/litt/disktable/disk_table.go
@@ -581,7 +581,7 @@ func (d *DiskTable) CacheAwareGet(
 
 	if ok, err := d.fatalErrorHandler.IsOk(); !ok {
 		return nil, false, false, fmt.Errorf(
-			"Cannot process Get() request, DB is in panicked state due to error: %w", err)
+			"Cannot process CacheAwareGet() request, DB is in panicked state due to error: %w", err)
 	}
 
 	var cacheHit bool
@@ -624,6 +624,8 @@ func (d *DiskTable) CacheAwareGet(
 	// Reserve the segment that contains the data.
 	seg, ok := d.controlLoop.getReservedSegment(address.Index())
 	if !ok {
+		// This can happen if there is a race between this thread and the GC thread, i.e.
+		// if we start reading a value just as the garbage collector decides to delete it.
 		return nil, false, false, nil
 	}
 	defer seg.Release()
@@ -738,7 +740,8 @@ func (d *DiskTable) Flush() error {
 
 func (d *DiskTable) SetWriteCacheSize(size uint64) error {
 	if ok, err := d.fatalErrorHandler.IsOk(); !ok {
-		return fmt.Errorf("Cannot process SetCacheSize() request, DB is in panicked state due to error: %w", err)
+		return fmt.Errorf(
+			"Cannot process SetWriteCacheSize() request, DB is in panicked state due to error: %w", err)
 	}
 
 	// this implementation does not provide a cache, if a cache is needed then it must be provided by a wrapper
@@ -747,7 +750,8 @@ func (d *DiskTable) SetWriteCacheSize(size uint64) error {
 
 func (d *DiskTable) SetReadCacheSize(size uint64) error {
 	if ok, err := d.fatalErrorHandler.IsOk(); !ok {
-		return fmt.Errorf("Cannot process SetCacheSize() request, DB is in panicked state due to error: %w", err)
+		return fmt.Errorf(
+			"Cannot process SetReadCacheSize() request, DB is in panicked state due to error: %w", err)
 	}
 
 	// this implementation does not provide a cache, if a cache is needed then it must be provided by a wrapper

--- a/litt/disktable/disk_table.go
+++ b/litt/disktable/disk_table.go
@@ -618,7 +618,7 @@ func (d *DiskTable) CacheAwareGet(
 
 	if onlyReadFromCache {
 		// The value exists but we are not allowed to read it from disk.
-		return nil, true, true, nil
+		return nil, true, false, nil
 	}
 
 	// Reserve the segment that contains the data.
@@ -667,6 +667,12 @@ func (d *DiskTable) PutBatch(batch []*types.KVPair) error {
 		}
 		if len(kv.Value) > math.MaxUint32 {
 			return fmt.Errorf("value is too large, length must not exceed 2^32 bytes: %d bytes", len(kv.Value))
+		}
+		if kv.Key == nil {
+			return fmt.Errorf("nil keys are not supported")
+		}
+		if kv.Value == nil {
+			return fmt.Errorf("nil values are not supported")
 		}
 
 		d.unflushedDataCache.Store(util.UnsafeBytesToString(kv.Key), kv.Value)

--- a/litt/littbuilder/build_utils.go
+++ b/litt/littbuilder/build_utils.go
@@ -218,9 +218,13 @@ func buildTable(
 		return nil, fmt.Errorf("error creating table: %w", err)
 	}
 
-	tableCache := cache.NewFIFOCache[string, []byte](config.CacheSize, cacheWeight)
-	tableCache = cache.NewThreadSafeCache(tableCache)
-	cachedTable := tablecache.NewCachedTable(table, tableCache)
+	writeCache := cache.NewFIFOCache[string, []byte](config.WriteCacheSize, cacheWeight)
+	writeCache = cache.NewThreadSafeCache(writeCache)
+
+	readCache := cache.NewFIFOCache[string, []byte](config.ReadCacheSize, cacheWeight)
+	readCache = cache.NewThreadSafeCache(readCache)
+
+	cachedTable := tablecache.NewCachedTable(table, writeCache, readCache)
 
 	return cachedTable, nil
 }

--- a/litt/littbuilder/build_utils.go
+++ b/litt/littbuilder/build_utils.go
@@ -218,10 +218,10 @@ func buildTable(
 		return nil, fmt.Errorf("error creating table: %w", err)
 	}
 
-	writeCache := cache.NewFIFOCache[string, []byte](config.WriteCacheSize, cacheWeight)
+	writeCache := cache.NewFIFOCache[string, []byte](config.WriteCacheSize, cacheWeight, metrics.GetWriteCacheMetrics())
 	writeCache = cache.NewThreadSafeCache(writeCache)
 
-	readCache := cache.NewFIFOCache[string, []byte](config.ReadCacheSize, cacheWeight)
+	readCache := cache.NewFIFOCache[string, []byte](config.ReadCacheSize, cacheWeight, metrics.GetReadCacheMetrics())
 	readCache = cache.NewThreadSafeCache(readCache)
 
 	cachedTable := tablecache.NewCachedTable(table, writeCache, readCache)

--- a/litt/littdb_config.go
+++ b/litt/littdb_config.go
@@ -85,10 +85,17 @@ type Config struct {
 	// seeded by the current time.
 	SaltShaker *rand.Rand
 
-	// The size of the cache for tables that have not had their cache size set. The default is 0 (no cache).
+	// The size of the cache for tables that have not had their write cache size set. A write cache is used
+	// to store recently written values for fast access. The default is 0 (no cache).
 	// Cache size is in bytes, and includes the size of both the key and the value. Cache size can be set
 	// individually on each table by calling Table.SetCacheSize().
-	CacheSize uint64
+	WriteCacheSize uint64
+
+	// The size of the cache for tables that have not had their read cache size set. A read cache is used
+	// to store recently read values for fast access. The default is 0 (no cache).
+	// Cache size is in bytes, and includes the size of both the key and the value. Cache size can be set
+	// individually on each table by calling Table.SetCacheSize().
+	ReadCacheSize uint64
 
 	// The time source used by the database. This can be substituted for an artificial time source
 	// for testing purposes. The default is time.Now.

--- a/litt/littdb_config.go
+++ b/litt/littdb_config.go
@@ -88,13 +88,13 @@ type Config struct {
 	// The size of the cache for tables that have not had their write cache size set. A write cache is used
 	// to store recently written values for fast access. The default is 0 (no cache).
 	// Cache size is in bytes, and includes the size of both the key and the value. Cache size can be set
-	// individually on each table by calling Table.SetCacheSize().
+	// individually on each table by calling Table.SetWriteCacheSize().
 	WriteCacheSize uint64
 
 	// The size of the cache for tables that have not had their read cache size set. A read cache is used
 	// to store recently read values for fast access. The default is 0 (no cache).
 	// Cache size is in bytes, and includes the size of both the key and the value. Cache size can be set
-	// individually on each table by calling Table.SetCacheSize().
+	// individually on each table by calling Table.SetReadCacheSize().
 	ReadCacheSize uint64
 
 	// The time source used by the database. This can be substituted for an artificial time source

--- a/litt/memtable/mem_table.go
+++ b/litt/memtable/mem_table.go
@@ -173,8 +173,11 @@ func (m *memTable) Close() error {
 	return nil
 }
 
-func (m *memTable) SetCacheSize(size uint64) error {
-	// The memory table doesn't have a cache... it's already one giant cache.
+func (m *memTable) SetWriteCacheSize(size uint64) error {
+	return nil
+}
+
+func (m *memTable) SetReadCacheSize(size uint64) error {
 	return nil
 }
 

--- a/litt/table.go
+++ b/litt/table.go
@@ -51,7 +51,7 @@ type Table interface {
 	// method.
 	Get(key []byte) (value []byte, exists bool, err error)
 
-	// CacheAwareGet is identical go Get, except that it permits the caller to determine whether the value
+	// CacheAwareGet is identical to Get, except that it permits the caller to determine whether the value
 	// should still be read if it is not present in the cache. If read, it also returns whether the value
 	// was present in the cache. Note that the 'exists' return value is always accurate even if onlyReadFromCache
 	// is true. If onlyReadFromCache is true and the value exists but is not in the cache, the returned values are

--- a/litt/table.go
+++ b/litt/table.go
@@ -49,12 +49,19 @@ type Table interface {
 	// For the sake of performance, the returned data is NOT safe to mutate. If you need to modify the data,
 	// make a copy of it first. It is also not safe to modify the key byte slice after it is passed to this
 	// method.
-	Get(key []byte) ([]byte, bool, error)
+	Get(key []byte) (value []byte, exists bool, err error)
+
+	// CacheAwareGet is identical go Get, except that it permits the caller to determine whether the value
+	// should still be read if it is not present in the cache. If read, it also returns whether the value
+	// was present in the cache. Note that the 'exists' return value is always accurate even if onlyReadFromCache
+	// is true. If onlyReadFromCache is true and the value exists but is not in the cache, the returned values are
+	// (nil, true, false, nil).
+	CacheAwareGet(key []byte, onlyReadFromCache bool) (value []byte, exists bool, hot bool, err error)
 
 	// Exists returns true if the key exists in the database, and false otherwise. This is faster than calling Get.
 	//
 	// It is not safe to modify the key byte slice after it is passed to this method.
-	Exists(key []byte) (bool, error)
+	Exists(key []byte) (exists bool, err error)
 
 	// Flush ensures that all data written to the database is crash durable on disk. When this method returns,
 	// all data written by Put() operations is guaranteed to be crash durable. Put() operations that overlap with calls

--- a/litt/table.go
+++ b/litt/table.go
@@ -95,15 +95,25 @@ type Table interface {
 	// writes that can be performed.
 	SetShardingFactor(shardingFactor uint32) error
 
-	// SetCacheSize sets the cache size, in bytes, for the table. For table implementations without a cache, this
-	// method does nothing. The cache is used to store recently inserted or accessed data. When reading from the table,
-	// if the requested data is present in the cache, the cache is used instead of reading from disk. Reading from the
+	// SetWriteCacheSize sets the write cache size, in bytes, for the table. For table implementations without a cache,
+	// this method does nothing. The cache is used to store recently written data. When reading from the table,
+	// if the requested data is present in this cache, the cache is used instead of reading from disk. Reading from the
 	// cache is significantly faster than reading from the disk.
 	//
 	// If the cache size is set to 0 (default), the cache is disabled. The size of each cache entry is equal to the sum
 	// of key length and the value length. Note that the actual in-memory footprint of the cache will be slightly
 	// larger than the cache size due to implementation overhead (e.g. pointers, slice headers, map entries, etc.).
-	SetCacheSize(size uint64) error
+	SetWriteCacheSize(size uint64) error
+
+	// SetReadCacheSize sets the read cache size, in bytes, for the table. For table implementations without a cache,
+	// this method does nothing. The cache is used to store recently read data. When reading from the table,
+	// if the requested data is present in this cache, the cache is used instead of reading from disk. Reading from the
+	// cache is significantly faster than reading from the disk.
+	//
+	// If the cache size is set to 0 (default), the cache is disabled. The size of each cache entry is equal to the sum
+	// of key length and the value length. Note that the actual in-memory footprint of the cache will be slightly
+	// larger than the cache size due to implementation overhead (e.g. pointers, slice headers, map entries, etc.).
+	SetReadCacheSize(size uint64) error
 }
 
 // ManagedTable is a Table that can perform garbage collection on its data. This type should not be directly used

--- a/litt/test/cache_test.go
+++ b/litt/test/cache_test.go
@@ -1,0 +1,3 @@
+package test
+
+// TODO

--- a/litt/test/cache_test.go
+++ b/litt/test/cache_test.go
@@ -1,3 +1,190 @@
 package test
 
-// TODO
+import (
+	"os"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/common/testutils/random"
+	"github.com/Layr-Labs/eigenda/litt"
+	"github.com/Layr-Labs/eigenda/litt/littbuilder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache(t *testing.T) {
+	rand := random.NewTestRandom()
+
+	directory := t.TempDir()
+
+	config, err := litt.DefaultConfig(directory)
+	require.NoError(t, err)
+
+	config.WriteCacheSize = rand.Uint64Range(1000, 2000)
+	config.ReadCacheSize = rand.Uint64Range(1000, 2000)
+	config.Fsync = false
+	config.DoubleWriteProtection = true
+
+	db, err := littbuilder.NewDB(config)
+	require.NoError(t, err)
+
+	table, err := db.GetTable("test_table")
+	require.NoError(t, err)
+
+	expectedValues := make(map[string][]byte)
+
+	var firstKey []byte
+	var firstValueSize uint64
+
+	keySize := uint64(32)
+	maxValueSize := uint64(50)
+
+	// Write some values to the table. Stop before any values are evicted from the write cache.
+	bytesWritten := uint64(0)
+	for bytesWritten < config.WriteCacheSize-keySize-maxValueSize {
+		nextValueSize := rand.Uint64Range(1, maxValueSize)
+		kvSize := keySize + nextValueSize
+
+		bytesWritten += kvSize
+
+		key := rand.PrintableBytes(int(keySize))
+		value := rand.PrintableBytes(int(nextValueSize))
+
+		if firstKey == nil {
+			firstKey = key
+			firstValueSize = nextValueSize
+		}
+
+		expectedValues[string(key)] = value
+		err = table.Put(key, value)
+		require.NoError(t, err)
+	}
+	err = table.Flush()
+	require.NoError(t, err)
+
+	// Read all values. All should be hot (i.e. in the read cache).
+	for expectedKey, expectedValue := range expectedValues {
+		// Only permit reading from the cache.
+		value, ok, hot, err := table.CacheAwareGet([]byte(expectedKey), true)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, hot)
+		require.Equal(t, expectedValue, value)
+
+		// Permit reading from disk. Since everything is in the cache, this should be functionally equivalent.
+		value, ok, hot, err = table.CacheAwareGet([]byte(expectedKey), false)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, hot)
+		require.Equal(t, expectedValue, value)
+	}
+
+	// Write another value that is large enough to evict the first value. This should cause the first value to be
+	// evicted from the write cache.
+	key := rand.PrintableBytes(int(keySize))
+	value := rand.PrintableBytes(int(maxValueSize))
+	bytesWritten += keySize + maxValueSize
+	expectedValues[string(key)] = value
+	err = table.Put(key, value)
+	require.NoError(t, err)
+
+	// Read the first value. It should not be hot. For the first request, do not allow a trip to the cache.
+	value, ok, hot, err := table.CacheAwareGet(firstKey, true)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, value)
+	require.False(t, hot)
+
+	// Try again, but allow a trip to the cache.
+	value, ok, hot, err = table.CacheAwareGet(firstKey, false)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, hot)
+	require.Equal(t, expectedValues[string(firstKey)], value)
+
+	// Reading again should now result in a cache hit.
+	value, ok, hot, err = table.CacheAwareGet(firstKey, true)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, hot)
+	require.Equal(t, expectedValues[string(firstKey)], value)
+
+	// Write enough values to push all previously written values out of the write cache.
+	for bytesWritten < 5000 {
+		nextValueSize := rand.Uint64Range(1, maxValueSize)
+		kvSize := keySize + nextValueSize
+
+		bytesWritten += kvSize
+
+		key := rand.PrintableBytes(int(keySize))
+		value := rand.PrintableBytes(int(nextValueSize))
+
+		if firstKey == nil {
+			firstKey = key
+		}
+
+		expectedValues[string(key)] = value
+		err = table.Put(key, value)
+		require.NoError(t, err)
+	}
+	err = table.Flush()
+	require.NoError(t, err)
+
+	// At this moment in time, the number of bytes in the cache should be less than the write cache size, plus that
+	// of the first key which will be in the read cache. Verify that fact.
+	maxCacheSize := config.WriteCacheSize + keySize + firstValueSize
+	hotBytes := uint64(0)
+	for key, expectedValue := range expectedValues {
+		value, ok, hot, err = table.CacheAwareGet([]byte(key), true)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		if hot {
+			require.Equal(t, expectedValue, value)
+			hotBytes += uint64(len(key)) + uint64(len(value))
+		} else {
+			require.Nil(t, value)
+		}
+	}
+	require.LessOrEqual(t, hotBytes, maxCacheSize)
+
+	// Read enough values to guarantee that the write cache is at full capacity.
+	for key, expectedValue := range expectedValues {
+		value, ok, hot, err = table.CacheAwareGet([]byte(key), false)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, expectedValue, value)
+
+		// Reading a cold value twice in a row should not cause it to become hot.
+		if !hot {
+			value, ok, hot, err = table.CacheAwareGet([]byte(key), false)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, expectedValue, value)
+			require.True(t, hot)
+		}
+	}
+
+	// Do a final scan of the values in the DB. The number of hot bytes should not exceed the sizes of the caches.
+	maxCacheSize = config.WriteCacheSize + config.ReadCacheSize
+	hotBytes = uint64(0)
+	for key, expectedValue := range expectedValues {
+		value, ok, hot, err = table.CacheAwareGet([]byte(key), true)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		if hot {
+			require.Equal(t, expectedValue, value)
+			hotBytes += uint64(len(key)) + uint64(len(value))
+		} else {
+			require.Nil(t, value)
+		}
+	}
+	require.LessOrEqual(t, hotBytes, maxCacheSize)
+
+	err = db.Destroy()
+	require.NoError(t, err)
+
+	// ensure that the test directory is empty
+	entries, err := os.ReadDir(directory)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}

--- a/litt/test/db_test.go
+++ b/litt/test/db_test.go
@@ -70,7 +70,7 @@ func buildMemKeyDiskDB(t *testing.T, path string) (litt.DB, error) {
 	config, err := litt.DefaultConfig(path)
 	require.NoError(t, err)
 	config.KeymapType = keymap.MemKeymapType
-	config.CacheSize = 1000
+	config.WriteCacheSize = 1000
 	config.TargetSegmentFileSize = 100
 	config.ShardingFactor = 4
 	config.Fsync = false // fsync is too slow for unit test workloads
@@ -83,7 +83,7 @@ func buildLevelDBDiskDB(t *testing.T, path string) (litt.DB, error) {
 	config, err := litt.DefaultConfig(path)
 	require.NoError(t, err)
 	config.KeymapType = keymap.UnsafeLevelDBKeymapType
-	config.CacheSize = 1000
+	config.WriteCacheSize = 1000
 	config.TargetSegmentFileSize = 100
 	config.ShardingFactor = 4
 	config.Fsync = false // fsync is too slow for unit test workloads

--- a/litt/test/table_test.go
+++ b/litt/test/table_test.go
@@ -224,11 +224,14 @@ func buildCachedMemTable(
 		return nil, err
 	}
 
-	c := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
+	writeCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
+		return uint64(len(k) + len(v))
+	})
+	readCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
 	})
 
-	return tablecache.NewCachedTable(baseTable, c), nil
+	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
 }
 
 func buildCachedMemKeyDiskTable(
@@ -241,11 +244,14 @@ func buildCachedMemKeyDiskTable(
 		return nil, err
 	}
 
-	c := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
+	writeCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
+		return uint64(len(k) + len(v))
+	})
+	readCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
 	})
 
-	return tablecache.NewCachedTable(baseTable, c), nil
+	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
 }
 
 func buildCachedLevelDBKeyDiskTable(
@@ -258,11 +264,14 @@ func buildCachedLevelDBKeyDiskTable(
 		return nil, err
 	}
 
-	c := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
+	writeCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
+		return uint64(len(k) + len(v))
+	})
+	readCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
 	})
 
-	return tablecache.NewCachedTable(baseTable, c), nil
+	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
 }
 
 func randomTableOperationsTest(t *testing.T, tableBuilder *tableBuilder) {

--- a/litt/test/table_test.go
+++ b/litt/test/table_test.go
@@ -226,10 +226,10 @@ func buildCachedMemTable(
 
 	writeCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
-	})
+	}, nil)
 	readCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
-	})
+	}, nil)
 
 	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
 }
@@ -246,10 +246,10 @@ func buildCachedMemKeyDiskTable(
 
 	writeCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
-	})
+	}, nil)
 	readCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
-	})
+	}, nil)
 
 	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
 }
@@ -266,10 +266,10 @@ func buildCachedLevelDBKeyDiskTable(
 
 	writeCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
-	})
+	}, nil)
 	readCache := cache.NewFIFOCache[string, []byte](500, func(k string, v []byte) uint64 {
 		return uint64(len(k) + len(v))
-	})
+	}, nil)
 
 	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
 }

--- a/node/config.go
+++ b/node/config.go
@@ -124,6 +124,22 @@ type Config struct {
 
 	// The size of the cache for storing recently read chunks in littDB, in gigabytes.
 	LittDBReadCacheSizeGB float64
+
+	// The rate limit for the number of bytes served by the GetChunks API if the data is in the cache.
+	// Unit is in megabytes per second.
+	GetChunksHotCacheReadLimitMB float64
+
+	// The burst limit for the number of bytes served by the GetChunks API if the data is in the cache.
+	// Unit is in megabytes.
+	GetChunksHotBurstLimitMB float64
+
+	// The rate limit for the number of bytes served by the GetChunks API if the data is not in the cache.
+	// Unit is in megabytes per second.
+	GetChunksColdCacheReadLimitMB float64
+
+	// The burst limit for the number of bytes served by the GetChunks API if the data is not in the cache.
+	// Unit is in megabytes.
+	GetChunksColdBurstLimitMB float64
 }
 
 // NewConfig parses the Config from the provided flags or environment variables and
@@ -349,5 +365,9 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		LittDBWriteCacheSizeGB:              ctx.GlobalFloat64(flags.LittDBWriteCacheSizeGBFlag.Name),
 		LittDBReadCacheSizeGB:               ctx.GlobalFloat64(flags.LittDBReadCacheSizeGBFlag.Name),
 		DownloadPoolSize:                    ctx.GlobalInt(flags.DownloadPoolSizeFlag.Name),
+		GetChunksHotCacheReadLimitMB:        ctx.GlobalFloat64(flags.GetChunksHotCacheReadLimitMBFlag.Name),
+		GetChunksHotBurstLimitMB:            ctx.GlobalFloat64(flags.GetChunksHotBurstLimitMBFlag.Name),
+		GetChunksColdCacheReadLimitMB:       ctx.GlobalFloat64(flags.GetChunksColdCacheReadLimitMBFlag.Name),
+		GetChunksColdBurstLimitMB:           ctx.GlobalFloat64(flags.GetChunksColdBurstLimitMBFlag.Name),
 	}, nil
 }

--- a/node/config.go
+++ b/node/config.go
@@ -119,8 +119,11 @@ type Config struct {
 	// A special test only setting. If true, then littDB will throw an error if the same data is written twice.
 	LittDBDoubleWriteProtection bool
 
-	// The size of the cache for storing chunks in littDB, in gigabytes.
-	LittDBChunkCacheSizeGB float64
+	// The size of the cache for storing recently written chunks in littDB, in gigabytes.
+	LittDBWriteCacheSizeGB float64
+
+	// The size of the cache for storing recently read chunks in littDB, in gigabytes.
+	LittDBReadCacheSizeGB float64
 }
 
 // NewConfig parses the Config from the provided flags or environment variables and
@@ -343,7 +346,8 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		StoreChunksRequestMaxPastAge:        ctx.GlobalDuration(flags.StoreChunksRequestMaxPastAgeFlag.Name),
 		StoreChunksRequestMaxFutureAge:      ctx.GlobalDuration(flags.StoreChunksRequestMaxFutureAgeFlag.Name),
 		LittDBEnabled:                       ctx.GlobalBool(flags.LittDBEnabledFlag.Name),
-		LittDBChunkCacheSizeGB:              ctx.GlobalFloat64(flags.LittDBCacheSizeGBFlag.Name),
+		LittDBWriteCacheSizeGB:              ctx.GlobalFloat64(flags.LittDBWriteCacheSizeGBFlag.Name),
+		LittDBReadCacheSizeGB:               ctx.GlobalFloat64(flags.LittDBReadCacheSizeGBFlag.Name),
 		DownloadPoolSize:                    ctx.GlobalInt(flags.DownloadPoolSizeFlag.Name),
 	}, nil
 }

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -418,7 +418,7 @@ var (
 	}
 	LittDBReadCacheSizeGBFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "litt-db-read-cache-size-gb"),
-		Usage:    "The size of the LittDB write cache in gigabytes.",
+		Usage:    "The size of the LittDB read cache in gigabytes.",
 		Required: false,
 		Value:    1 * units.GiB,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_READ_CACHE_SIZE_GB"),
@@ -432,26 +432,26 @@ var (
 	}
 	GetChunksHotCacheReadLimitMBFlag = cli.Float64Flag{
 		Name:     common.PrefixFlag(FlagPrefix, "get-chunks-hot-cache-read-limit-mb"),
-		Usage:    "The size of the hot cache read limit in megabytes / second.",
+		Usage:    "The rate limit for GetChunks() calls that hit the cache, unit is MB/s.",
 		Required: false,
 		Value:    1024,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "GET_CHUNKS_HOT_CACHE_READ_LIMIT_MB"),
 	}
 	GetChunksHotBurstLimitMBFlag = cli.Float64Flag{
 		Name:     common.PrefixFlag(FlagPrefix, "get-chunks-hot-burst-limit-mb"),
-		Usage:    "The size of the hot burst limit in megabytes.",
+		Usage:    "The burst limit for GetChunks() calls that hit the cache, unit is MB.",
 		Required: false,
 		Value:    1024,
 	}
 	GetChunksColdCacheReadLimitMBFlag = cli.Float64Flag{
 		Name:     common.PrefixFlag(FlagPrefix, "get-chunks-cold-cache-read-limit-mb"),
-		Usage:    "The size of the cold cache read limit in megabytes / second.",
+		Usage:    "The rate limit for GetChunks() calls that miss the cache, unit is MB/s.",
 		Required: false,
 		Value:    32,
 	}
 	GetChunksColdBurstLimitMBFlag = cli.Float64Flag{
 		Name:     common.PrefixFlag(FlagPrefix, "get-chunks-cold-burst-limit-MB"),
-		Usage:    "The size of the cold burst limit in megabytes.",
+		Usage:    "The burst limit for GetChunks() calls that miss the cache, unit is MB.",
 		Required: false,
 		Value:    32,
 	}

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -409,12 +409,19 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_ENABLED"),
 	}
-	LittDBCacheSizeGBFlag = cli.IntFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "litt-db-cache-size-gb"),
-		Usage:    "The size of the LittDB cache in gigabytes.",
+	LittDBWriteCacheSizeGBFlag = cli.IntFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "litt-db-write-cache-size-gb"),
+		Usage:    "The size of the LittDB write cache in gigabytes.",
 		Required: false,
 		Value:    16 * units.GiB,
-		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_CACHE_SIZE_GB"),
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_WRITE_CACHE_SIZE_GB"),
+	}
+	LittDBReadCacheSizeGBFlag = cli.IntFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "litt-db-read-cache-size-gb"),
+		Usage:    "The size of the LittDB write cache in gigabytes.",
+		Required: false,
+		Value:    1 * units.GiB,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_READ_CACHE_SIZE_GB"),
 	}
 	DownloadPoolSizeFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "download-pool-size"),
@@ -549,6 +556,8 @@ var optionalFlags = []cli.Flag{
 	LevelDBEnableSyncWritesV2Flag,
 	LittDBEnabledFlag,
 	DownloadPoolSizeFlag,
+	LittDBWriteCacheSizeGBFlag,
+	LittDBReadCacheSizeGBFlag,
 }
 
 func init() {

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -430,6 +430,31 @@ var (
 		Value:    16,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "DOWNLOAD_POOL_SIZE"),
 	}
+	GetChunksHotCacheReadLimitMBFlag = cli.Float64Flag{
+		Name:     common.PrefixFlag(FlagPrefix, "get-chunks-hot-cache-read-limit-mb"),
+		Usage:    "The size of the hot cache read limit in megabytes / second.",
+		Required: false,
+		Value:    1024,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "GET_CHUNKS_HOT_CACHE_READ_LIMIT_MB"),
+	}
+	GetChunksHotBurstLimitMBFlag = cli.Float64Flag{
+		Name:     common.PrefixFlag(FlagPrefix, "get-chunks-hot-burst-limit-mb"),
+		Usage:    "The size of the hot burst limit in megabytes.",
+		Required: false,
+		Value:    1024,
+	}
+	GetChunksColdCacheReadLimitMBFlag = cli.Float64Flag{
+		Name:     common.PrefixFlag(FlagPrefix, "get-chunks-cold-cache-read-limit-mb"),
+		Usage:    "The size of the cold cache read limit in megabytes / second.",
+		Required: false,
+		Value:    32,
+	}
+	GetChunksColdBurstLimitMBFlag = cli.Float64Flag{
+		Name:     common.PrefixFlag(FlagPrefix, "get-chunks-cold-burst-limit-MB"),
+		Usage:    "The size of the cold burst limit in megabytes.",
+		Required: false,
+		Value:    32,
+	}
 
 	/////////////////////////////////////////////////////////////////////////////
 	// TEST FLAGS SECTION
@@ -558,6 +583,10 @@ var optionalFlags = []cli.Flag{
 	DownloadPoolSizeFlag,
 	LittDBWriteCacheSizeGBFlag,
 	LittDBReadCacheSizeGBFlag,
+	GetChunksHotCacheReadLimitMBFlag,
+	GetChunksHotBurstLimitMBFlag,
+	GetChunksColdCacheReadLimitMBFlag,
+	GetChunksColdBurstLimitMBFlag,
 }
 
 func init() {

--- a/node/validator_store.go
+++ b/node/validator_store.go
@@ -270,7 +270,12 @@ func NewValidatorStore(
 			return nil, fmt.Errorf("failed to get chunks table: %w", err)
 		}
 
-		err = chunkTable.SetCacheSize(uint64(config.LittDBChunkCacheSizeGB * units.GiB))
+		err = chunkTable.SetWriteCacheSize(uint64(config.LittDBWriteCacheSizeGB * units.GiB))
+		if err != nil {
+			return nil, fmt.Errorf("failed to set cache size for chunks table: %w", err)
+		}
+
+		err = chunkTable.SetReadCacheSize(uint64(config.LittDBReadCacheSizeGB * units.GiB))
 		if err != nil {
 			return nil, fmt.Errorf("failed to set cache size for chunks table: %w", err)
 		}

--- a/node/validator_store.go
+++ b/node/validator_store.go
@@ -279,12 +279,12 @@ func NewValidatorStore(
 
 		err = chunkTable.SetWriteCacheSize(uint64(config.LittDBWriteCacheSizeGB * units.GiB))
 		if err != nil {
-			return nil, fmt.Errorf("failed to set cache size for chunks table: %w", err)
+			return nil, fmt.Errorf("failed to set write cache size for chunks table: %w", err)
 		}
 
 		err = chunkTable.SetReadCacheSize(uint64(config.LittDBReadCacheSizeGB * units.GiB))
 		if err != nil {
-			return nil, fmt.Errorf("failed to set cache size for chunks table: %w", err)
+			return nil, fmt.Errorf("failed to set read cache size for chunks table: %w", err)
 		}
 
 		// A prior implementation stored data here. Delete it if it exists.

--- a/node/validator_store_test.go
+++ b/node/validator_store_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/testutils/random"
 	"github.com/Layr-Labs/eigenda/litt/util"
+	"github.com/docker/go-units"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,7 +73,11 @@ func TestRandomInsertions(t *testing.T) {
 	})
 	t.Run("littDB", func(t *testing.T) {
 		config := &Config{
-			LittDBEnabled: true,
+			LittDBEnabled:                 true,
+			GetChunksHotCacheReadLimitMB:  units.GiB,
+			GetChunksHotBurstLimitMB:      units.GiB,
+			GetChunksColdCacheReadLimitMB: units.GiB,
+			GetChunksColdBurstLimitMB:     units.GiB,
 		}
 		randomInsertionsTest(t, config)
 	})
@@ -150,7 +155,11 @@ func TestRestart(t *testing.T) {
 	})
 	t.Run("littDB", func(t *testing.T) {
 		config := &Config{
-			LittDBEnabled: true,
+			LittDBEnabled:                 true,
+			GetChunksHotCacheReadLimitMB:  units.GiB,
+			GetChunksHotBurstLimitMB:      units.GiB,
+			GetChunksColdCacheReadLimitMB: units.GiB,
+			GetChunksColdBurstLimitMB:     units.GiB,
 		}
 		restartTest(t, config)
 	})
@@ -261,9 +270,13 @@ func TestDoubleInsertionLittDB(t *testing.T) {
 	require.NoError(t, err)
 
 	config := &Config{
-		LittDBEnabled:               true,
-		DbPath:                      testDir,
-		LittDBDoubleWriteProtection: true, // causes littDB to throw if data is written twice
+		LittDBEnabled:                 true,
+		DbPath:                        testDir,
+		LittDBDoubleWriteProtection:   true, // causes littDB to throw if data is written twice
+		GetChunksHotCacheReadLimitMB:  units.GiB,
+		GetChunksHotBurstLimitMB:      units.GiB,
+		GetChunksColdCacheReadLimitMB: units.GiB,
+		GetChunksColdBurstLimitMB:     units.GiB,
 	}
 
 	store, err := NewValidatorStore(context.Background(), logger, config, time.Now, 2*time.Hour, nil)
@@ -350,9 +363,13 @@ func TestMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	config := &Config{
-		LittDBEnabled:             false,
-		ExpirationPollIntervalSec: 1,
-		DbPath:                    testDir,
+		LittDBEnabled:                 false,
+		ExpirationPollIntervalSec:     1,
+		DbPath:                        testDir,
+		GetChunksHotCacheReadLimitMB:  units.GiB,
+		GetChunksHotBurstLimitMB:      units.GiB,
+		GetChunksColdCacheReadLimitMB: units.GiB,
+		GetChunksColdBurstLimitMB:     units.GiB,
 	}
 
 	ttl := 2 * time.Hour

--- a/relay/blob_provider.go
+++ b/relay/blob_provider.go
@@ -46,7 +46,7 @@ func newBlobProvider(
 	}
 
 	cacheAccessor, err := cache.NewCacheAccessor[v2.BlobKey, []byte](
-		cache2.NewFIFOCache[v2.BlobKey, []byte](blobCacheSize, computeBlobCacheWeight),
+		cache2.NewFIFOCache[v2.BlobKey, []byte](blobCacheSize, computeBlobCacheWeight, nil),
 		maxIOConcurrency,
 		server.fetchBlob,
 		metrics)

--- a/relay/cache/cache_accessor_test.go
+++ b/relay/cache/cache_accessor_test.go
@@ -35,7 +35,7 @@ func TestRandomOperationsSingleThread(t *testing.T) {
 	}
 	cacheSize := rand.Intn(dataSize) + 1
 
-	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil)
+	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil, nil)
 	ca, err := NewCacheAccessor[int, *string](cache, 0, accessor, nil)
 	require.NoError(t, err)
 
@@ -83,7 +83,7 @@ func TestCacheMisses(t *testing.T) {
 		return &str, nil
 	}
 
-	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil)
+	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil, nil)
 	ca, err := NewCacheAccessor[int, *string](cache, 0, accessor, nil)
 	require.NoError(t, err)
 
@@ -147,7 +147,7 @@ func ParallelAccessTest(t *testing.T, sleepEnabled bool) {
 	}
 	cacheSize := rand.Intn(dataSize) + 1
 
-	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil)
+	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil, nil)
 	ca, err := NewCacheAccessor[int, *string](cache, 0, accessor, nil)
 	require.NoError(t, err)
 
@@ -217,7 +217,7 @@ func TestParallelAccessWithError(t *testing.T) {
 	}
 	cacheSize := 100
 
-	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil)
+	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil, nil)
 	ca, err := NewCacheAccessor[int, *string](cache, 0, accessor, nil)
 	require.NoError(t, err)
 
@@ -291,7 +291,7 @@ func TestConcurrencyLimiter(t *testing.T) {
 
 	cacheSize := 100
 
-	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil)
+	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil, nil)
 	ca, err := NewCacheAccessor[int, *string](cache, maxConcurrency, accessor, nil)
 	require.NoError(t, err)
 
@@ -346,7 +346,7 @@ func TestOriginalRequesterTimesOut(t *testing.T) {
 	}
 	cacheSize := rand.Intn(dataSize) + 1
 
-	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil)
+	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil, nil)
 	ca, err := NewCacheAccessor[int, *string](cache, 0, accessor, nil)
 	require.NoError(t, err)
 
@@ -435,7 +435,7 @@ func TestSecondaryRequesterTimesOut(t *testing.T) {
 	}
 	cacheSize := rand.Intn(dataSize) + 1
 
-	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil)
+	cache := cache2.NewFIFOCache[int, *string](uint64(cacheSize), nil, nil)
 	ca, err := NewCacheAccessor[int, *string](cache, 0, accessor, nil)
 	require.NoError(t, err)
 

--- a/relay/chunk_provider.go
+++ b/relay/chunk_provider.go
@@ -66,7 +66,10 @@ func newChunkProvider(
 
 	var err error
 	server.frameCache, err = cache.NewCacheAccessor[blobKeyWithMetadata, *core.ChunksData](
-		cachecommon.NewFIFOCache[blobKeyWithMetadata, *core.ChunksData](cacheSize, server.computeFramesCacheWeight),
+		cachecommon.NewFIFOCache[blobKeyWithMetadata, *core.ChunksData](
+			cacheSize,
+			server.computeFramesCacheWeight,
+			nil),
 		maxIOConcurrency,
 		server.fetchFrames,
 		metrics)

--- a/relay/metadata_provider.go
+++ b/relay/metadata_provider.go
@@ -78,7 +78,7 @@ func newMetadataProvider(
 	server.blobParamsMap.Store(blobParamsMap)
 
 	metadataCache, err := cache.NewCacheAccessor[v2.BlobKey, *blobMetadata](
-		cache2.NewFIFOCache[v2.BlobKey, *blobMetadata](uint64(metadataCacheSize), nil),
+		cache2.NewFIFOCache[v2.BlobKey, *blobMetadata](uint64(metadataCacheSize), nil, nil),
 		maxIOConcurrency,
 		server.fetchMetadata,
 		metrics)


### PR DESCRIPTION
## Why are these changes needed?

Add a read and write cache to littDB, and support operations that are cache aware. Add cache aware throttling to the `GetChunks()` validator RPC.