### PR TITLE
chore: add TODO for LittDB audit finding 4

### DIFF
--- a/litt/disktable/disk_table.go
+++ b/litt/disktable/disk_table.go
@@ -302,12 +302,14 @@ func (d *DiskTable) reloadKeymap(
 	lowestSegmentIndex uint32,
 	highestSegmentIndex uint32) error {
 
-	// TODO(cody.littley): there is currently a race condition that may cause key files and value files to
-	//  be inconsistent. This is not a problem as long as the keymap is not reloaded, since this inconsistency
-	//  only hurts us when we are reloading the keymap. This needs to be fixed, but is not urgent since reloading
-	//  the keymap is not a feature currently used in production.
-	d.logger.Errorf("there is currently a race condition in this method, " +
-		"changing keymap type should not be used until fixed")
+	if len(segments) > 0 {
+		// TODO(cody.littley): there is currently a race condition that may cause key files and value files to
+		//  be inconsistent. This is not a problem as long as the keymap is not reloaded, since this inconsistency
+		//  only hurts us when we are reloading the keymap. This needs to be fixed, but is not urgent since reloading
+		//  the keymap is not a feature currently used in production.
+		d.logger.Errorf("there is currently a race condition in this method, " +
+			"changing keymap type should not be used until fixed")
+	}
 
 	start := d.clock()
 	defer func() {


### PR DESCRIPTION
## Why are these changes needed?

### Auditor Comment

Finding `#4`: Flush order race between shardControlLoop and keyFileControlLoop (I don’t have an idea for the better name :()
- The shardControlLoop and keyFileControlLoop  invoke Flush() independently. If the process crashes after the key file is persisted (flushed) but before all shard files are flushed, on restart the reloadKeymap function treats every discovered key as valid—despite missing shard data—because it applies the rule “once we find a valid pair, all subsequent entries are assumed good”. This could be happened when the last key’s shard file was flushed but rest of them are not.
- This can make “dangling” keys on the keymap that pass existence checks yet lack backing shard content, breaking data consistency. — It passes Exists check anyway, so we cannot put the value with the same key again.
- [[Code](https://github.com/Layr-Labs/eigenda/blob/1b1b48777cf9da4a00ab0544584ff09060a03922/litt/disktable/disk_table.go#L330-L351)] and [[Code](https://github.com/Layr-Labs/eigenda/blob/1b1b48777cf9da4a00ab0544584ff09060a03922/litt/disktable/segment/segment.go#L419-L457)]
- Recommendation:
    - Enforce ordering: Always flush shards first, then the key file.
        - I don’t think this could 100% fix the issue, because the OS/Golang automatically flushes in some circumstances (i.e., if the buffer fills up)
    - Validation on Reload: During reloadKeymap, verify that each key’s corresponding shard file is intact before marking it as present in the in‐memory key map. Failing validation should trigger a rebuild or a rollback of that key entry.

### Response

I agree that there is a consistency issue here. However, due to timing constraints, I suggest we delay fixing this issue. This bug only manifests if we reload the keymap, which we will only do if we are changing the type of the keymap on an existing database, or if using the in memory keymap implementation which reloads each time the DB is restarted. In our current production code, we do not intend to support the in memory keymap, nor do we intend to support keymap migration (at least initially).

I added an error log that triggers if we call into the code that may experience an inconsistency.

We will need to fix this bug before we support the following features:
- keymap migration
- in-memory keymap in production
- keymap disaster recovery (e.g. if levelDB has a bug and dies)
- incremental backups (these will only copy segment files and will rebuild the keymap)