### PR TITLE
fix: auditor finding 5

### DIFF
--- a/node/grpc/server_v2.go
+++ b/node/grpc/server_v2.go
@@ -186,7 +186,12 @@ func (s *ServerV2) validateAndStoreChunks(
 	probe *common.SequenceProbe,
 ) error {
 
-	batchData := make([]*node.BundleToStore, 0, len(rawBundles))
+	bundleCount := 0
+	for _, bundles := range rawBundles {
+		bundleCount += len(bundles.Bundles)
+	}
+
+	batchData := make([]*node.BundleToStore, 0, bundleCount)
 	for _, bundles := range rawBundles {
 		blobKey, err := bundles.BlobCertificate.BlobHeader.BlobKey()
 		if err != nil {


### PR DESCRIPTION
## Why are these changes needed?

### Auditor Finding

Finding `#5` (Note): Under provisioned slice capacity for batchData
- The code allocates batchData with capacity len(rawBundles), but when running multiple operator quorums, each rawBundle may expand into multiple node.BundleToStore entries. Because actual entries can exceed len(rawBundles), Go automatically reslices—and reallocates—the underlying slice, degrading performance. [[Code](https://github.com/Layr-Labs/eigenda/blob/1b1b48777cf9da4a00ab0544584ff09060a03922/node/node_v2.go#L159-L165)] and [[Code](https://github.com/Layr-Labs/eigenda/blob/1b1b48777cf9da4a00ab0544584ff09060a03922/node/grpc/server_v2.go#L179-L189)]
- Recommendation: Compute the total expected number of BundleToStore elements up‐front (for example, by summing len(rb.Bundles) for each rb in rawBundles), then use that sum for make([]*node.BundleToStore, 0, total) to eliminate unnecessary reallocations.

### Response

Although the issue is minor, I agree with the auditor's assessment. This PR fixes the issue.
