### PR TITLE
fix: auditor finding 6

### DIFF
--- a/node/node_v2.go
+++ b/node/node_v2.go
@@ -157,6 +157,10 @@ func (n *Node) DownloadBundles(
 			// TODO (cody-littley) this is flaky, and will fail if any relay fails. We should retry failures
 			return nil, nil, fmt.Errorf("failed to get chunks from relays: %v", resp.err)
 		}
+		if len(resp.bundles) != len(resp.metadata) {
+			return nil, nil, fmt.Errorf("number of bundles and metadata do not match (%d != %d)",
+				len(resp.bundles), len(resp.metadata))
+		}
 		for i, bundle := range resp.bundles {
 			metadata := resp.metadata[i]
 			blobShards[metadata.blobShardIndex].Bundles[metadata.quorum], err = new(core.Bundle).Deserialize(bundle)


### PR DESCRIPTION
## Why are these changes needed?

### Auditor Request

- if len(resp.bundles) > len(resp.metadata), indexing resp.metadata[i] will panic. This could be happened when the malicious relays return more bundles than the validator requested. [[Code](https://github.com/Layr-Labs/eigenda/blob/1b1b48777cf9da4a00ab0544584ff09060a03922/node/node_v2.go#L159-L160)]
- Recommendation: Later validation stages will catch blob inconsistencies, so before iterating, assert that len(resp.bundles) == len(resp.metadata). If they differ, return an error.

```
        for i, bundle := range resp.bundles {
            metadata := resp.metadata[i]
```

### Auditor Response

I've fixed the issue by adding a check that fails the operation if there is a size mismatch.