### PR TITLE
fix: roperly call .End() on validator client probe

### DIFF
--- a/api/clients/v2/validator/validator_client.go
+++ b/api/clients/v2/validator/validator_client.go
@@ -78,6 +78,7 @@ func (c *validatorClient) GetBlob(
 ) ([]byte, error) {
 
 	probe := c.metrics.newGetBlobProbe()
+	defer probe.End()
 
 	probe.SetStage("verify_commitment")
 	commitmentBatch := []encoding.BlobCommitments{blobCommitments}


### PR DESCRIPTION
## Why are these changes needed?

Fix a metrics bug.
