### PR TITLE
feat: experimental WASM build target for relay

### DIFF
--- a/relay/Makefile
+++ b/relay/Makefile
@@ -9,10 +9,16 @@ build: clean
 	go mod tidy
 	go build -o ./bin/relay ./cmd
 
-build-wasm: clean
-	go mod tidy
-	GOOS=js GOARCH=wasm go build -o ./bin/relay.wasm ./cmd
-
 # Run the light node.
 run: build
 	./bin/relay
+
+build-wasm: clean
+	go mod tidy
+	GOOS=js GOARCH=wasm go build -o ./bin/relay.wasm ./cmd
+	@cp "$$(go env GOROOT)/misc/wasm/wasm_exec.js" ./bin/
+	@cp ./wasm/run_wasm.js ./bin/
+
+run-wasm:
+	node ./bin/run_wasm.js
+

--- a/relay/Makefile
+++ b/relay/Makefile
@@ -9,6 +9,10 @@ build: clean
 	go mod tidy
 	go build -o ./bin/relay ./cmd
 
+build-wasm: clean
+	go mod tidy
+	GOOS=js GOARCH=wasm go build -o ./bin/relay.wasm ./cmd
+
 # Run the light node.
 run: build
 	./bin/relay

--- a/relay/chunkstore/chunk_store_test.go
+++ b/relay/chunkstore/chunk_store_test.go
@@ -1,5 +1,6 @@
 //go:build !js
 // +build !js
+
 package chunkstore
 
 import (

--- a/relay/chunkstore/chunk_store_test.go
+++ b/relay/chunkstore/chunk_store_test.go
@@ -1,3 +1,5 @@
+//go:build !js
+// +build !js
 package chunkstore
 
 import (

--- a/relay/relay_test_utils.go
+++ b/relay/relay_test_utils.go
@@ -1,3 +1,5 @@
+//go:build !js
+// +build !js
 package relay
 
 import (

--- a/relay/relay_test_utils.go
+++ b/relay/relay_test_utils.go
@@ -1,5 +1,6 @@
 //go:build !js
 // +build !js
+
 package relay
 
 import (

--- a/relay/wasm/run_wasm.js
+++ b/relay/wasm/run_wasm.js
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const path = require("path");
+
+// Load wasm_exec.js from same dir as this script
+const goPath = path.resolve(__dirname, "wasm_exec.js");
+require(goPath); // defines global `Go`
+
+const go = new Go();
+
+// Inject environment variables
+go.env = {
+  ...process.env, // include your shell's env
+};
+
+go.argv = ["relay.wasm", ...process.argv.slice(2)];
+
+// Read relay.wasm from same dir as script
+const wasmPath = path.resolve(__dirname, "relay.wasm");
+
+(async () => {
+  const wasmBuffer = fs.readFileSync(wasmPath);
+  const { instance } = await WebAssembly.instantiate(wasmBuffer, go.importObject);
+  try {
+    await go.run(instance);
+  } catch (err) {
+    console.error("WASM runtime error:", err);
+  }
+})();

--- a/relay/wasm/run_wasm.js
+++ b/relay/wasm/run_wasm.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const path = require("path");
 
-// Load wasm_exec.js from same dir as this script
 const goPath = path.resolve(__dirname, "wasm_exec.js");
 require(goPath); // defines global `Go`
 
@@ -14,7 +13,6 @@ go.env = {
 
 go.argv = ["relay.wasm", ...process.argv.slice(2)];
 
-// Read relay.wasm from same dir as script
 const wasmPath = path.resolve(__dirname, "relay.wasm");
 
 (async () => {


### PR DESCRIPTION
## Why are these changes needed?
These changes allow us to compile the relay to WASM

Cloudflare Zero-Fee Egress would require hosting the relay as a [CloudFlare Worker](https://workers.cloudflare.com/) via WASM (go is not supported)

WASM is itself a sandbox and does not allow for OS-level or related system calls. This means Inabox/dockertest is not supported. See annotations to `chunkstore/chunk_store_test.go` and `relay_test_utils.go` to exclude them from WASM build target.

Running `relay.wasm` on terminal requires a nodejs wrapper defined under `wasm/run_wasm.js`. Hosted WASM services (ie on Cloudflare) would not require this as they provide their own WASM runtime.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
