### PR TITLE
fix: reduce controller health check info noise

### DIFF
--- a/common/healthcheck/heartbeat.go
+++ b/common/healthcheck/heartbeat.go
@@ -31,8 +31,6 @@ func HeartbeatMonitor(filePath string, maxStallDuration time.Duration, livenessC
 				return nil
 			}
 
-			logger.Info("Received heartbeat", "component", hb.Component, "timestamp", hb.Timestamp)
-
 			// Update the last heartbeat for this component
 			lastHeartbeats[hb.Component] = hb.Timestamp
 
@@ -43,8 +41,6 @@ func HeartbeatMonitor(filePath string, maxStallDuration time.Duration, livenessC
 			}
 			if err := os.WriteFile(filePath, []byte(summary), 0666); err != nil {
 				logger.Error("Failed to update heartbeat file", "error", err)
-			} else {
-				logger.Info("Wrote heartbeat file", "path", filePath)
 			}
 
 			stallTicker.Reset(maxStallDuration)
@@ -79,7 +75,6 @@ func SignalHeartbeat(component string, livenessChan chan<- HeartbeatMessage, log
 	}
 	select {
 	case livenessChan <- hb:
-		logger.Info("Heartbeat signal sent", "component", component)
 	default:
 		logger.Warn("Heartbeat signal skipped, no receiver on the channel", "component", component)
 	}

--- a/disperser/cmd/controller/main.go
+++ b/disperser/cmd/controller/main.go
@@ -249,8 +249,6 @@ func RunController(ctx *cli.Context) error {
 		)
 		if err != nil {
 			logger.Warn("Heartbeat monitor exited with error", "err", err)
-		} else {
-			logger.Info("Heartbeat monitor stopped cleanly")
 		}
 	}()
 


### PR DESCRIPTION
## Why are these changes needed?

-Removed the info log sent by controller health check

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(
