### PR TITLE
fix: littdb read metrics

### DIFF
--- a/litt/cache/cached_table.go
+++ b/litt/cache/cached_table.go
@@ -134,26 +134,26 @@ func (c *cachedTable) CacheAwareGet(
 	if exists {
 		// The value was recently written
 		hot = true
-		return value, exists, hot, nil
+		return value, exists, hot, err
 	} else {
 		value, exists = c.readCache.Get(stringKey)
 		if exists {
 			// The value was recently read
 			hot = true
-			return value, exists, hot, nil
+			return value, exists, hot, err
 		}
 	}
 
 	value, exists, hot, err = c.base.CacheAwareGet(key, onlyReadFromCache)
 	if err != nil {
-		return nil, false, false, err
+		return value, exists, hot, err
 	}
 
 	if exists && value != nil {
 		c.readCache.Put(stringKey, value)
 	}
 
-	return value, exists, hot, nil
+	return value, exists, hot, err
 }
 
 func (c *cachedTable) Exists(key []byte) (exists bool, err error) {

--- a/litt/disktable/disk_table.go
+++ b/litt/disktable/disk_table.go
@@ -540,23 +540,10 @@ func (d *DiskTable) Get(key []byte) (value []byte, exists bool, err error) {
 			"Cannot process Get() request, DB is in panicked state due to error: %w", err)
 	}
 
-	var cacheHit bool
-	var dataSize uint64
-	if d.metrics != nil {
-		start := d.clock()
-		defer func() {
-			end := d.clock()
-			delta := end.Sub(start)
-			d.metrics.ReportReadOperation(d.name, delta, dataSize, cacheHit)
-		}()
-	}
-
 	// First, check if the key is in the unflushed data map.
 	// If so, return it from there.
 	if value, ok := d.unflushedDataCache.Load(util.UnsafeBytesToString(key)); ok {
 		bytes := value.([]byte)
-		cacheHit = true
-		dataSize = uint64(len(bytes))
 		return bytes, true, nil
 	}
 
@@ -582,8 +569,6 @@ func (d *DiskTable) Get(key []byte) (value []byte, exists bool, err error) {
 		return nil, false, fmt.Errorf("failed to read data: %w", err)
 	}
 
-	dataSize = uint64(len(data))
-
 	return data, true, nil
 }
 
@@ -597,25 +582,12 @@ func (d *DiskTable) CacheAwareGet(
 			"Cannot process CacheAwareGet() request, DB is in panicked state due to error: %w", err)
 	}
 
-	var cacheHit bool
-	var dataSize uint64
-	if d.metrics != nil {
-		start := d.clock()
-		defer func() {
-			end := d.clock()
-			delta := end.Sub(start)
-			d.metrics.ReportReadOperation(d.name, delta, dataSize, cacheHit)
-		}()
-	}
-
 	// First, check if the key is in the unflushed data map. If so, return it from there.
 	// Performance wise, this has equivalent semantics to reading the value from
 	// a cache, so we'd might as well count it as a cache hit.
 	var rawValue any
 	if rawValue, exists = d.unflushedDataCache.Load(util.UnsafeBytesToString(key)); exists {
 		value = rawValue.([]byte)
-		cacheHit = true
-		dataSize = uint64(len(value))
 		return value, true, true, nil
 	}
 
@@ -648,8 +620,6 @@ func (d *DiskTable) CacheAwareGet(
 	if err != nil {
 		return nil, false, false, fmt.Errorf("failed to read data: %w", err)
 	}
-
-	dataSize = uint64(len(value))
 
 	return value, true, false, nil
 }

--- a/litt/littbuilder/build_utils.go
+++ b/litt/littbuilder/build_utils.go
@@ -224,7 +224,7 @@ func buildTable(
 	readCache := cache.NewFIFOCache[string, []byte](config.ReadCacheSize, cacheWeight, metrics.GetReadCacheMetrics())
 	readCache = cache.NewThreadSafeCache(readCache)
 
-	cachedTable := tablecache.NewCachedTable(table, writeCache, readCache)
+	cachedTable := tablecache.NewCachedTable(table, writeCache, readCache, metrics)
 
 	return cachedTable, nil
 }

--- a/litt/test/table_test.go
+++ b/litt/test/table_test.go
@@ -231,7 +231,7 @@ func buildCachedMemTable(
 		return uint64(len(k) + len(v))
 	}, nil)
 
-	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
+	return tablecache.NewCachedTable(baseTable, writeCache, readCache, nil), nil
 }
 
 func buildCachedMemKeyDiskTable(
@@ -251,7 +251,7 @@ func buildCachedMemKeyDiskTable(
 		return uint64(len(k) + len(v))
 	}, nil)
 
-	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
+	return tablecache.NewCachedTable(baseTable, writeCache, readCache, nil), nil
 }
 
 func buildCachedLevelDBKeyDiskTable(
@@ -271,7 +271,7 @@ func buildCachedLevelDBKeyDiskTable(
 		return uint64(len(k) + len(v))
 	}, nil)
 
-	return tablecache.NewCachedTable(baseTable, writeCache, readCache), nil
+	return tablecache.NewCachedTable(baseTable, writeCache, readCache, nil), nil
 }
 
 func randomTableOperationsTest(t *testing.T, tableBuilder *tableBuilder) {


### PR DESCRIPTION
## Why are these changes needed?

Fix broken LittDB read metrics. Currently, the DB doesn't report reads that only hit the cache.
