### PR TITLE
docs(mdbook): recency window check should use <= not <

### DIFF
--- a/docs/spec/src/integration/spec/6-secure-integration.md
+++ b/docs/spec/src/integration/spec/6-secure-integration.md
@@ -22,7 +22,7 @@ Looking at the timing diagram above, we need the EigenDA availability period to 
 
 Rollups must thus enforce that
 ```
-cert.L1InclusionBlock - cert.RBN < RecencyWindowSize
+certL1InclusionBlock - cert.RBN <= RecencyWindowSize
 ```
 
 This has a second security implication. A malicious EigenDA disperser could have chosen a reference block number (RBN) that is very old, where the stake of operators was very different from the current one, due to operators withdrawing stake for example.


### PR DESCRIPTION
If we take extreme case RecencyWindowSize=1, then equation certL1InclusionBlock - cert.RBN < 1 means that inclusionblock=RBN, but that is impossible (RBN has to be in the past before validators can sign). 
So this weird contradiction makes it obvious that we should use <= for clean (inclusive) semantic.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
