### PR TITLE
upgrade actions/checkout to v4 & golangci-lint-action to v8

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -22,10 +22,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checkout wiki
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{github.repository}}.wiki
         token: ${{ github.token }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,10 +18,10 @@ jobs:
       - run: go version
 
       - name: Checkout EigenDA
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v1.60
           args: --timeout 3m --verbose --out-format=colored-line-number

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -73,7 +73,7 @@ jobs:
     name: Verify bindings are updated
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Why are these changes needed?
They ensure we stay on actively-maintained, more secure and faster CI tooling:

* **actions/checkout\@v4** brings performance optimizations, better LFS/sparse-checkout support, and up-to-date security patches.
* **golangci-lint-action\@v8** gives you the latest linter features, smarter caching, and automatic non-breaking fixes.

Also i think that we can update [`actions/setup-go@v3`](https://github.com/Layr-Labs/eigenda/blob/master/.github/workflows/golangci-lint.yml#L15) to [`actions/setup-go@v4`](https://github.com/Layr-Labs/eigenda/blob/master/.github/actions/test-coverage/action.yml#L35) as we have it here. 

Feel free to givea feedback, please! 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
