### PR TITLE
feat: utility for generating important payload size thresholds.

### DIFF
--- a/api/clients/v2/coretypes/blob.go
+++ b/api/clients/v2/coretypes/blob.go
@@ -81,6 +81,11 @@ func (b *Blob) BlobLengthSymbols() uint32 {
 	return b.blobLengthSymbols
 }
 
+// BlobLengthBytes returns the length of the blob, in bytes
+func (b *Blob) BlobLengthBytes() uint32 {
+	return b.blobLengthSymbols * 32
+}
+
 // toEncodedPayload creates an encodedPayload from the blob
 //
 // The payloadForm indicates how payloads are interpreted. The way that payloads are interpreted dictates what

--- a/encoding/utils.go
+++ b/encoding/utils.go
@@ -30,6 +30,12 @@ func RoundUpDivide[T constraints.Integer](a, b T) T {
 	return (a + b - 1) / b
 }
 
+// IsPowerOf2 checks if a number is a power of 2
+func IsPowerOf2[T constraints.Integer](d T) bool {
+	return d != 0 && (d&(d-1)) == 0
+}
+
+// NextPowerOf2 returns the next power of 2 greater than or equal to d
 func NextPowerOf2[T constraints.Integer](d T) T {
 	nextPower := math.Ceil(math.Log2(float64(d)))
 	return T(math.Pow(2.0, nextPower))

--- a/tools/sizing/README.md
+++ b/tools/sizing/README.md
@@ -1,0 +1,49 @@
+# How To Choose Good Payload Sizes
+
+Choosing a good payload size is important for optimizing EigenDA usage costs. If you have the ability to control
+the size of your payload and you choose unoptimally, you may end up paying twice as much for your traffic.
+
+## Definitions
+
+A `payload` is defined as the raw, unencoded data that is sent to EigenDA. From a logical point of view, this is what
+an EigenDA customer wants to store and later be able to have that data be highly available.
+
+A `blob` is a `payload` that has been encoded and packaged in a way that is suitable for sending to EigenDA. When a
+`payload` is converted to a blob, the `blob` is always larger than the original `payload`. `Blobs` must always have
+a length equal to a power of 2. If a `blob` would otherwise not be a power of 2, it is padded with zeros until its
+length is a power of 2.
+
+When EigenDA determines the cost of dispersing data, it uses the size of the `blob` as the basis for the cost, NOT
+the size of the `payload`. If two `payloads` of different sizes are converted to a `blob` of the same size, they will
+have the same cost. Since a `blob` size might be rounded up to the next power of 2, sometimes adding a single byte
+to a `payload` can double the size of the resulting `blob`, and therefore double the cost of dispersing that data.
+
+## Choosing Payload Sizes
+
+The table below shows the `blob` size that various `payload` sizes will be converted to. Having a payload that exactly
+matches a size in the `Maximum Payload Size` column means that the dispersal is maximally efficient from a cost
+perspective. Going one byte over that size will double the cost of dispersing that data, as it pushes the `blob`
+size to the next power of 2. If possible, aim to size your `payloads` to be as close to the `Maximum Payload Size` as
+possible but without exceeding it.
+
+In the table below, all bounds are inclusive.
+
+| Minimum Payload Size | Maximum Payload Size | Blob Size       | Blob Size |
+|:---------------------|:---------------------|:----------------|:----------|
+| 0 bytes              | 126945 bytes         | 131072 bytes    | 128 kb    |
+| 126946 bytes         | 253921 bytes         | 262144 bytes    | 256 kb    |
+| 253922 bytes         | 507873 bytes         | 524288 bytes    | 512 kb    |
+| 507874 bytes         | 1015777 bytes        | 1048576 bytes   | 1 mb      |
+| 1015778 bytes        | 2031585 bytes        | 2097152 bytes   | 2 mb      |
+| 2031586 bytes        | 4063201 bytes        | 4194304 bytes   | 4 mb      |
+| 4063202 bytes        | 8126433 bytes        | 8388608 bytes   | 8 mb      |
+| 8126434 bytes        | 16252897 bytes       | 16777216 bytes  | 16 mb     |
+
+## Minimum Blob SIze
+
+The minimum `blob` size is 128kb. Sending extremely small `payloads` will always result in a blob of at least 128kb.
+
+## Maximum Blob Size
+
+The maximum `blob` size is 16mb. Sending extremely large `payloads` may result in a dispersal error if it cannot 
+fit into a 16mb `blob`.

--- a/tools/sizing/size_finder.go
+++ b/tools/sizing/size_finder.go
@@ -1,0 +1,103 @@
+package sizing
+
+import (
+	"fmt"
+
+	"github.com/Layr-Labs/eigenda/encoding"
+)
+
+// next_power_of_2(len(payload)*32/31)
+
+// BlobHeaderSize is the size of the header data on a blob, in bytes.
+const BlobHeaderSize = uint64(31)
+
+// PayloadSizeToBlobSize takes a payload size in bytes and returns the corresponding blob size in bytes.
+// The blob size is the size used for determining payments and throttling by EigenDA. Two payloads of
+// differing length that have the same blob size cost the same and use the same amount of bandwidth.
+func PayloadSizeToBlobSize(payloadSize uint64) uint64 {
+	return encoding.NextPowerOf2(payloadSize*32/31 + BlobHeaderSize)
+}
+
+// BlobSizeToMaxPayloadSize takes a given a blob size and determines the maximum payload size
+// that yields that blob size.
+func BlobSizeToMaxPayloadSize(blobSize uint64) (uint64, error) {
+	if !encoding.IsPowerOf2(blobSize) {
+		return 0, fmt.Errorf("blob size %d is not a power of 2", blobSize)
+	}
+
+	return (blobSize - BlobHeaderSize) * 31 / 32, nil
+}
+
+// BlobSizeToMinPayloadSize takes a given a blob size and determines the minimum payload size
+// that yields that blob size.
+func BlobSizeToMinPayloadSize(blobSize uint64) (uint64, error) {
+	if !encoding.IsPowerOf2(blobSize) {
+		return 0, fmt.Errorf("blob size %d is not a power of 2", blobSize)
+	}
+
+	return (blobSize/2 - BlobHeaderSize + 1) * 31 / 32, nil
+}
+
+// FindLegalBlobSizes finds a list of blob sizes that are legal for EigenDA. A legal blob size is
+// a blob size that is a power of 2 and is between the minimum and maximum blob sizes (inclusive).
+func FindLegalBlobSizes(minBlobSize uint64, maxBlobSize uint64) ([]uint64, error) {
+	if minBlobSize > maxBlobSize {
+		return nil, fmt.Errorf("min blob size %d is greater than max blob size %d", minBlobSize, maxBlobSize)
+	}
+	if !encoding.IsPowerOf2(minBlobSize) {
+		return nil, fmt.Errorf("min blob size %d is not a power of 2", minBlobSize)
+	}
+	if !encoding.IsPowerOf2(maxBlobSize) {
+		return nil, fmt.Errorf("max blob size %d is not a power of 2", maxBlobSize)
+	}
+
+	sizes := make([]uint64, 0)
+
+	for i := minBlobSize; i <= maxBlobSize; i *= 2 {
+		sizes = append(sizes, i)
+	}
+
+	return sizes, nil
+}
+
+// FindMaxPayloadSizes finds a list of payload sizes that are as large as possible for a given blob size.
+// Increasing the size of a maximum payload by a single byte will result in a blob that is the next tier larger.
+func FindMaxPayloadSizes(minBlobSize uint64, maxBlobSize uint64) ([]uint64, error) {
+	legalBlobSizes, err := FindLegalBlobSizes(minBlobSize, maxBlobSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find legal blob sizes: %w", err)
+	}
+
+	sizes := make([]uint64, 0, len(legalBlobSizes))
+
+	for _, blobSize := range legalBlobSizes {
+		maxPayloadSize, err := BlobSizeToMaxPayloadSize(blobSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get maximum payload size for blob size %d: %w", blobSize, err)
+		}
+		sizes = append(sizes, maxPayloadSize)
+	}
+
+	return sizes, nil
+}
+
+// FindMinPayloadSizes finds a list of payload sizes that are the minimum possible payload size for a given blob size.
+// Decreasing the size of a minimum payload by a single byte will result in a blob that is the next tier smaller.
+func FindMinPayloadSizes(minBlobSize uint64, maxBlobSize uint64) ([]uint64, error) {
+	legalBlobSizes, err := FindLegalBlobSizes(minBlobSize, maxBlobSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find legal blob sizes: %w", err)
+	}
+
+	sizes := make([]uint64, 0, len(legalBlobSizes))
+
+	for _, blobSize := range legalBlobSizes {
+		minPayloadSize, err := BlobSizeToMinPayloadSize(blobSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get minimum payload size for blob size %d: %w", blobSize, err)
+		}
+		sizes = append(sizes, minPayloadSize)
+	}
+
+	return sizes, nil
+}

--- a/tools/sizing/size_finder_test.go
+++ b/tools/sizing/size_finder_test.go
@@ -1,0 +1,176 @@
+package sizing
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/api/clients/v2"
+	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
+	"github.com/docker/go-units"
+	"github.com/stretchr/testify/require"
+)
+
+const minBlobSize = uint64(128 * units.KiB)
+const maxBlobSize = uint64(16 * units.MiB)
+
+var defaultPayloadForm = clients.GetDefaultPayloadClientConfig().PayloadPolynomialForm
+
+// Derive the real size of a blob for a given payload by creating a payload and converting it to a blob.
+func deriveRealBlobSize(t *testing.T, payloadSize uint64) uint64 {
+
+	rawBytes := make([]byte, payloadSize)
+	payload := coretypes.NewPayload(rawBytes)
+	blob, err := payload.ToBlob(defaultPayloadForm)
+	require.NoError(t, err)
+
+	return uint64(blob.BlobLengthBytes())
+}
+
+// This function generates a table containing optimum blob sizes. It is intended to be run manually.
+func TestGenerateOptimumSizeTable(t *testing.T) {
+
+	// Uncomment this to generate an optimum size table.
+	t.Skip() // Do not merge with this line uncommented.
+
+	minBlobSize := uint64(128 * units.KiB)
+	maxBlobSize := uint64(16 * units.MiB)
+
+	blobSizes, err := FindLegalBlobSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	minPayloadSizes, err := FindMinPayloadSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	maxPayloadSizes, err := FindMaxPayloadSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	columns := []string{
+		"Minimum Payload Size",
+		"Maximum Payload Size",
+		"Blob Size      ",
+		"Blob Size",
+	}
+
+	sb := strings.Builder{}
+
+	// Write header
+	for _, col := range columns {
+		sb.WriteString(fmt.Sprintf("| %s ", col))
+	}
+	sb.WriteString("|\n")
+
+	// Write separator
+	for _, col := range columns {
+		sb.WriteString("|:")
+		sb.WriteString(strings.Repeat("-", len(col)+1))
+	}
+	sb.WriteString("|\n")
+
+	for i := 0; i < len(blobSizes); i++ {
+		minSize := 0
+		if i > 0 {
+			minSize = int(minPayloadSizes[i])
+		}
+		maxSize := maxPayloadSizes[i]
+		blobSize := blobSizes[i]
+
+		niceUnit := "kb"
+		niceQuantity := int(float64(blobSize) / float64(units.KiB))
+		if niceQuantity >= 1024 {
+			niceUnit = "mb"
+			niceQuantity = int(float64(blobSize) / float64(units.MiB))
+		}
+
+		str := fmt.Sprintf("%d bytes", minSize)
+		str = fmt.Sprintf("| %-*s ", len(columns[0]), str) // Pad to column width
+		sb.WriteString(str)
+
+		str = fmt.Sprintf("%d bytes", maxSize)
+		str = fmt.Sprintf("| %-*s ", len(columns[1]), str) // Pad to column width
+		sb.WriteString(str)
+
+		str = fmt.Sprintf("%d bytes", blobSize)
+		str = fmt.Sprintf("| %-*s ", len(columns[2]), str) // Pad to column width
+		sb.WriteString(str)
+
+		str = fmt.Sprintf("%d %s", niceQuantity, niceUnit)
+		str = fmt.Sprintf("| %-*s ", len(columns[3]), str) // Pad to column width
+		sb.WriteString(str)
+
+		sb.WriteString("|\n")
+	}
+
+	fmt.Printf(sb.String())
+}
+
+func TestMinPayloadSizes(t *testing.T) {
+	legalBlobSizes, err := FindLegalBlobSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	minPayloadSizes, err := FindMinPayloadSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	require.Equal(t, len(legalBlobSizes), len(minPayloadSizes))
+
+	for i := 0; i < len(legalBlobSizes); i++ {
+		blobSize := legalBlobSizes[i]
+		minPayloadSize := minPayloadSizes[i]
+
+		realBlobSize := deriveRealBlobSize(t, minPayloadSize)
+		require.Equal(t, blobSize, realBlobSize)
+
+		// Subtracting 1 byte from the minimum payload size should result in a blob that is the next tier smaller.
+		if i > 0 {
+			previousTier := legalBlobSizes[i-1]
+			realBlobSize = deriveRealBlobSize(t, minPayloadSize-1)
+			require.Equal(t, previousTier, realBlobSize)
+		}
+	}
+}
+
+func TestMaxPayloadSizes(t *testing.T) {
+	legalBlobSizes, err := FindLegalBlobSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	maxPayloadSizes, err := FindMaxPayloadSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	require.Equal(t, len(legalBlobSizes), len(maxPayloadSizes))
+
+	for i := 0; i < len(legalBlobSizes); i++ {
+		blobSize := legalBlobSizes[i]
+		maxPayloadSize := maxPayloadSizes[i]
+
+		realBlobSize := deriveRealBlobSize(t, maxPayloadSize)
+		require.Equal(t, blobSize, realBlobSize)
+
+		// Adding 1 byte to the maximum payload size should result in a blob that is the next tier larger.
+		if i < len(legalBlobSizes)-1 {
+			nextTier := legalBlobSizes[i+1]
+			realBlobSize = deriveRealBlobSize(t, maxPayloadSize+1)
+			require.Equal(t, nextTier, realBlobSize)
+		}
+	}
+}
+
+func TestMinAgreesWithMax(t *testing.T) {
+	legalBlobSizes, err := FindLegalBlobSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	minPayloadSizes, err := FindMinPayloadSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	maxPayloadSizes, err := FindMaxPayloadSizes(minBlobSize, maxBlobSize)
+	require.NoError(t, err)
+
+	// Each minimum payload size should be exactly one larger than the maximum payload size of the previous tier.
+	for i := 0; i < len(legalBlobSizes); i++ {
+		if i > 0 {
+			minPayloadSize := minPayloadSizes[i]
+			maxPayloadSize := maxPayloadSizes[i-1]
+
+			require.Equal(t, minPayloadSize, maxPayloadSize+1)
+		}
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?

Added code that generates the following table:

| Minimum Payload Size | Maximum Payload Size | Blob Size       | Blob Size |
|:---------------------|:---------------------|:----------------|:----------|
| 0 bytes              | 126945 bytes         | 131072 bytes    | 128 kb    |
| 126946 bytes         | 253921 bytes         | 262144 bytes    | 256 kb    |
| 253922 bytes         | 507873 bytes         | 524288 bytes    | 512 kb    |
| 507874 bytes         | 1015777 bytes        | 1048576 bytes   | 1 mb      |
| 1015778 bytes        | 2031585 bytes        | 2097152 bytes   | 2 mb      |
| 2031586 bytes        | 4063201 bytes        | 4194304 bytes   | 4 mb      |
| 4063202 bytes        | 8126433 bytes        | 8388608 bytes   | 8 mb      |
| 8126434 bytes        | 16252897 bytes       | 16777216 bytes  | 16 mb     |