### PR TITLE
fix: Make LittDBStoragePathsFlag not required

### DIFF
--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -423,7 +423,7 @@ var (
 	}
 	LittDBStoragePathsFlag = cli.StringSliceFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "litt-db-storage-paths"),
-		Usage:    "Comma separated list of paths to store the LittDB data files. At least one path must be provided.",
+		Usage:    "Comma separated list of paths to store the LittDB data files. If not provided, falls back to NODE_DB_PATH with '/chunk_v2_litt' suffix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_STORAGE_PATHS"),
 	}

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -424,7 +424,7 @@ var (
 	LittDBStoragePathsFlag = cli.StringSliceFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "litt-db-storage-paths"),
 		Usage:    "Comma separated list of paths to store the LittDB data files. At least one path must be provided.",
-		Required: true,
+		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_STORAGE_PATHS"),
 	}
 	DownloadPoolSizeFlag = cli.IntFlag{


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
