### PR TITLE
docs(mdbook): add book link in readme

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,6 +1,6 @@
 # EigenDA Spec
 
-Built using [mdBook](https://rust-lang.github.io/mdBook/index.html).
+Built using [mdBook](https://rust-lang.github.io/mdBook/index.html) and published as a github pages site at [https://layr-labs.github.io/eigenda/](https://layr-labs.github.io/eigenda/).
 
 Meant to contain technical overviews, spec, and low-level implementation details related to EigenDA, as opposed to the [docs](https://docs.eigenda.xyz/) site which is meant to contain more introductory and high-level material.
 


### PR DESCRIPTION
This makes it easier to discover the website (bowen didn't even know the readmes got published as a github pages site until recently).

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
