### PR TITLE
chore: add basic CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Clients
+# See https://github.com/orgs/Layr-Labs/teams/eigenda-intg
+/api/clients @Layr-Labs/eigenda-intg
+
+# Contracts
+/contracts @pakim249CAL
+
+# Security docs
+/docs/audits @anupsv


### PR DESCRIPTION
Want to force any client changes to be reviewed by at least one member of the integration team, to keep us in the loop.

Also added @pakim249CAL  as owner of contracts, and @anupsv  as owner of docs/audits.

We should probably define some smaller teams like devops/infra, etc. and assign these teams to specifc parts of the codebase.

## TODO

@anupsv @joshconverse can you guys turn on required review from CODEOWNERS on this repo please?
<img width="527" alt="image" src="https://github.com/user-attachments/assets/699881d2-ee50-4f62-a5b8-24aecaaceead" />

Actually it looks like there's an issue with the team... perhaps its not publicly visible? or not attached to this repo? or doesn't have write access? Can you guys look into this?
![image](https://github.com/user-attachments/assets/e9ee7ba1-d327-478a-be62-5d20a799ebbc)

