### PR TITLE
fix: properly set LittDB sharding factor for validators

### DIFF
--- a/node/validator_store.go
+++ b/node/validator_store.go
@@ -108,7 +108,7 @@ func NewValidatorStore(
 	logger.Info(stringBuilder.String())
 
 	littConfig, err := litt.DefaultConfig(config.LittDBStoragePaths...)
-	littConfig.ShardingFactor = 1
+	littConfig.ShardingFactor = uint32(len(config.LittDBStoragePaths))
 	littConfig.MetricsEnabled = true
 	littConfig.MetricsRegistry = registry
 	littConfig.MetricsNamespace = littDBMetricsPrefix


### PR DESCRIPTION
## Why are these changes needed?

Set the sharding factor on validators to be equal to the number of drives.
