### PR TITLE
refactor: unify dynamo column

### DIFF
--- a/core/meterer/dynamodb_metering_store.go
+++ b/core/meterer/dynamodb_metering_store.go
@@ -74,8 +74,8 @@ func (s *DynamoDBMeteringStore) IncrementBinUsages(ctx context.Context, accountI
 	for i, quorumNumber := range quorumNumbers {
 		accountIDAndQuorum := accountID.Hex() + ":" + strconv.FormatUint(uint64(quorumNumber), 10)
 		key := map[string]types.AttributeValue{
-			"AccountIDAndQuorum": &types.AttributeValueMemberS{Value: accountIDAndQuorum},
-			"ReservationPeriod":  &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriods[quorumNumber], 10)},
+			"AccountID":         &types.AttributeValueMemberS{Value: accountIDAndQuorum},
+			"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriods[quorumNumber], 10)},
 		}
 		ops[i] = commondynamodb.TransactAddOp{
 			Key:   key,
@@ -93,8 +93,8 @@ func (s *DynamoDBMeteringStore) IncrementBinUsages(ctx context.Context, accountI
 	for _, quorumNumber := range quorumNumbers {
 		accountIDAndQuorum := accountID.Hex() + ":" + strconv.FormatUint(uint64(quorumNumber), 10)
 		key := map[string]types.AttributeValue{
-			"AccountIDAndQuorum": &types.AttributeValueMemberS{Value: accountIDAndQuorum},
-			"ReservationPeriod":  &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriods[quorumNumber], 10)},
+			"AccountID":         &types.AttributeValueMemberS{Value: accountIDAndQuorum},
+			"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriods[quorumNumber], 10)},
 		}
 		item, getErr := s.dynamoClient.GetItem(ctx, s.reservationTableName, key)
 		if getErr != nil {
@@ -366,8 +366,8 @@ func (s *DynamoDBMeteringStore) DecrementBinUsages(ctx context.Context, accountI
 	for i, quorumNumber := range quorumNumbers {
 		accountIDAndQuorum := accountID.Hex() + ":" + strconv.FormatUint(uint64(quorumNumber), 10)
 		key := map[string]types.AttributeValue{
-			"AccountIDAndQuorum": &types.AttributeValueMemberS{Value: accountIDAndQuorum},
-			"ReservationPeriod":  &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriods[quorumNumber], 10)},
+			"AccountID":         &types.AttributeValueMemberS{Value: accountIDAndQuorum},
+			"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriods[quorumNumber], 10)},
 		}
 		ops[i] = commondynamodb.TransactAddOp{
 			Key:   key,

--- a/core/meterer/dynamodb_metering_store_test.go
+++ b/core/meterer/dynamodb_metering_store_test.go
@@ -105,7 +105,8 @@ func TestIncrementBinUsages_EdgeCases(t *testing.T) {
 		quorum := core.QuorumID(1)
 		periods := map[core.QuorumID]uint64{quorum: reservationPeriod}
 		// First increment
-		_, _ = tc.store.IncrementBinUsages(tc.ctx, accountID, []core.QuorumID{quorum}, periods, map[core.QuorumID]uint64{quorum: size})
+		_, err := tc.store.IncrementBinUsages(tc.ctx, accountID, []core.QuorumID{quorum}, periods, map[core.QuorumID]uint64{quorum: size})
+		assert.NoError(t, err)
 		// Second increment
 		binUsages, err := tc.store.IncrementBinUsages(tc.ctx, accountID, []core.QuorumID{quorum}, periods, map[core.QuorumID]uint64{quorum: size})
 		assert.NoError(t, err)

--- a/core/meterer/meterer_test.go
+++ b/core/meterer/meterer_test.go
@@ -256,13 +256,13 @@ func TestMetererReservations(t *testing.T) {
 		assert.NoError(t, err)
 		for _, accountAndQuorum := range accountAndQuorums {
 			item, err := dynamoClient.GetItem(ctx, reservationTableName, commondynamodb.Key{
-				"AccountIDAndQuorum": &types.AttributeValueMemberS{Value: accountAndQuorum},
-				"ReservationPeriod":  &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriod, 10)},
+				"AccountID":         &types.AttributeValueMemberS{Value: accountAndQuorum},
+				"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.FormatUint(reservationPeriod, 10)},
 			})
 			assert.NotNil(t, item)
 			assert.NoError(t, err)
 			assert.Equal(t, uint64(requiredLength), symbolsCharged)
-			assert.Equal(t, accountAndQuorum, item["AccountIDAndQuorum"].(*types.AttributeValueMemberS).Value)
+			assert.Equal(t, accountAndQuorum, item["AccountID"].(*types.AttributeValueMemberS).Value)
 			assert.Equal(t, strconv.Itoa(int(reservationPeriod)), item["ReservationPeriod"].(*types.AttributeValueMemberN).Value)
 			assert.Equal(t, strconv.Itoa((i+1)*int(requiredLength)), item["BinUsage"].(*types.AttributeValueMemberN).Value)
 		}
@@ -275,11 +275,11 @@ func TestMetererReservations(t *testing.T) {
 	overflowedReservationPeriod := reservationPeriod + 2
 	accountAndQuorum := fmt.Sprintf("%s:%d", accountID2.Hex(), quoromNumbers[0])
 	item, err := dynamoClient.GetItem(ctx, reservationTableName, commondynamodb.Key{
-		"AccountIDAndQuorum": &types.AttributeValueMemberS{Value: accountAndQuorum},
-		"ReservationPeriod":  &types.AttributeValueMemberN{Value: strconv.Itoa(int(overflowedReservationPeriod))},
+		"AccountID":         &types.AttributeValueMemberS{Value: accountAndQuorum},
+		"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.Itoa(int(overflowedReservationPeriod))},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, accountAndQuorum, item["AccountIDAndQuorum"].(*types.AttributeValueMemberS).Value)
+	assert.Equal(t, accountAndQuorum, item["AccountID"].(*types.AttributeValueMemberS).Value)
 	assert.Equal(t, strconv.Itoa(int(overflowedReservationPeriod)), item["ReservationPeriod"].(*types.AttributeValueMemberN).Value)
 	// 25 rounded up to the nearest multiple of minNumSymbols - (200-21*9) = 16
 	assert.Equal(t, strconv.Itoa(int(16)), item["BinUsage"].(*types.AttributeValueMemberN).Value)
@@ -294,8 +294,8 @@ func TestMetererReservations(t *testing.T) {
 	// First, reset the bin data for quorum 1
 	accountAndQuorum1 := fmt.Sprintf("%s_%d", accountID2.Hex(), uint8(1))
 	err = dynamoClient.DeleteItem(ctx, reservationTableName, commondynamodb.Key{
-		"AccountIDAndQuorum": &types.AttributeValueMemberS{Value: accountAndQuorum1},
-		"ReservationPeriod":  &types.AttributeValueMemberN{Value: strconv.Itoa(int(reservationPeriod))},
+		"AccountID":         &types.AttributeValueMemberS{Value: accountAndQuorum1},
+		"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.Itoa(int(reservationPeriod))},
 	})
 	assert.NoError(t, err)
 
@@ -306,8 +306,8 @@ func TestMetererReservations(t *testing.T) {
 
 	// Verify quorum 1 was not updated (because the operation should be atomic)
 	item, err = dynamoClient.GetItem(ctx, reservationTableName, commondynamodb.Key{
-		"AccountIDAndQuorum": &types.AttributeValueMemberS{Value: accountAndQuorum1},
-		"ReservationPeriod":  &types.AttributeValueMemberN{Value: strconv.Itoa(int(reservationPeriod))},
+		"AccountID":         &types.AttributeValueMemberS{Value: accountAndQuorum1},
+		"ReservationPeriod": &types.AttributeValueMemberN{Value: strconv.Itoa(int(reservationPeriod))},
 	})
 	assert.NoError(t, err)
 	// The item should not exist or have zero usage since the batched update failed

--- a/core/meterer/util.go
+++ b/core/meterer/util.go
@@ -15,7 +15,7 @@ func CreateReservationTable(clientConfig commonaws.ClientConfig, tableName strin
 	_, err := test_utils.CreateTable(ctx, clientConfig, tableName, &dynamodb.CreateTableInput{
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
-				AttributeName: aws.String("AccountIDAndQuorum"),
+				AttributeName: aws.String("AccountID"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
@@ -25,7 +25,7 @@ func CreateReservationTable(clientConfig commonaws.ClientConfig, tableName strin
 		},
 		KeySchema: []types.KeySchemaElement{
 			{
-				AttributeName: aws.String("AccountIDAndQuorum"),
+				AttributeName: aws.String("AccountID"),
 				KeyType:       types.KeyTypeHash,
 			},
 			{


### PR DESCRIPTION
## Why are these changes needed?

Use generic "AccountID" instead of "AccountIDAndQuorum" for reservations table. 

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
