### PR TITLE
docs: better proto BlobHeader.version documentation

### DIFF
--- a/api/proto/common/v2/common_v2.proto
+++ b/api/proto/common/v2/common_v2.proto
@@ -7,22 +7,38 @@ option go_package = "github.com/Layr-Labs/eigenda/api/grpc/common/v2";
 
 // BlobHeader contains the information describing a blob and the way it is to be dispersed.
 message BlobHeader {
-  // The blob version. Blob versions are pushed onchain by EigenDA governance in an append only fashion and store the
-  // maximum number of operators, number of chunks, and coding rate for a blob. On blob verification, these values
-  // are checked against supplied or default security thresholds to validate the security assumptions of the
-  // blob's availability.
-  uint32 version = 1;
-  // quorum_numbers is the list of quorum numbers that the blob is part of.
-  // Each quorum will store the data, hence adding quorum numbers adds redundancy, making the blob more likely to be retrievable. Each quorum requires separate payment.
+  // The BlobParams version to use when encoding the blob into chunks to be dispersed to operators.
   //
-  // On-demand dispersal is currently limited to using a subset of the following quorums:
+  // BlobParams versions are pushed onchain to the EigenDAThresholdRegistry by EigenDA governance in an append only fashion
+  // and store the maximum number of operators, number of chunks, and coding rate for a blob.
+  //
+  // A user can choose any of the onchain defined VersionedBlobParams, and must make sure to choose SecurityThresholds in its CertVerifier contract
+  // that along with the chosen VersionedBlobParams satisfy the checkSecurityParams function: https://github.com/Layr-Labs/eigenda/blob/3e670ff3dbd3a0a3f63b51e40544f528ac923b78/contracts/src/periphery/cert/libraries/EigenDACertVerificationLib.sol#L188
+  // This function is called internally by the CertVerifier's checkDACert function.
+  //
+  // If a version that is not available on the ThresholdRegistry is chosen, the disperser will return an error.
+  //
+  // EigenDA maintained:
+  //   VersionedBlobParams definition: https://github.com/Layr-Labs/eigenda/blob/3e670ff3dbd3a0a3f63b51e40544f528ac923b78/contracts/src/core/libraries/v1/EigenDATypesV1.sol#L7
+  //   IEigenDAThresholdRegistry (stores the BlobParams): https://github.com/Layr-Labs/eigenda/blob/3e670ff3dbd3a0a3f63b51e40544f528ac923b78/contracts/src/core/interfaces/IEigenDAThresholdRegistry.sol
+  //   EigenDAServiceManager address (implements IEigenDAThresholdRegistry): https://docs.eigenda.xyz/networks/mainnet#contract-addresses
+  // Rollup maintained:
+  //   SecurityThresholds interface: https://github.com/Layr-Labs/eigenda/blob/3e670ff3dbd3a0a3f63b51e40544f528ac923b78/contracts/src/periphery/cert/interfaces/IEigenDACertVerifier.sol#L23
+  //   checkDACert interface: https://github.com/Layr-Labs/eigenda/blob/3e670ff3dbd3a0a3f63b51e40544f528ac923b78/contracts/src/periphery/cert/interfaces/IEigenDACertVerifierBase.sol#L8
+  uint32 version = 1;
+  // quorum_numbers is the list of quorum numbers that the blob shall be dispersed to.
+  // Each quorum will store the data independently, meaning that additional quorum numbers increase redundancy, making the blob more likely to be retrievable.
+  // Each quorum requires separate payment.
+  //
+  // On-demand bandwidth dispersals do not currently support custom quorums and hence are limited to dispersing to one or two of the following quorums only:
   // - 0: ETH
   // - 1: EIGEN
   //
-  // Reserved-bandwidth dispersal is free to use multiple quorums, however those must be reserved ahead of time. The quorum_numbers specified here must be a subset of the ones allowed by the on-chain reservation.
-  // Check the allowed quorum numbers by looking up reservation struct: https://github.com/Layr-Labs/eigenda/blob/1430d56258b4e814b388e497320fd76354bfb478/contracts/src/interfaces/IPaymentVault.sol#L10
+  // Reserved-bandwidth dispersal do support custom quorums, as long as they are reserved onchain ahead of time. The quorum_numbers specified here must be a subset of the ones allowed by the on-chain reservation.
+  // Users can check their reserved quorum numbers on the IPaymentVault's reservation struct: https://github.com/Layr-Labs/eigenda/blob/1430d56258b4e814b388e497320fd76354bfb478/contracts/src/interfaces/IPaymentVault.sol#L10
   repeated uint32 quorum_numbers = 2;
-  // commitment is the KZG commitment to the blob
+  // commitment is the KZG commitment to the blob.
+  // This commitment can either be constructed locally, or obtained by using the disperser's GetBlobCommitment RPC (see disperser_v2.proto).
   common.BlobCommitment commitment = 3;
   // payment_header contains payment information for the blob
   PaymentHeader payment_header = 4;


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Writing docs for custom quorums and the CertVerifier's security model, and realized we haven't documented properly the assumptions behind the BlobParams version.

Also slightly improved other fields of the BlobHeader.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
