### PR TITLE
fix: Verify v2 cert instead of reflexively passing

### DIFF
--- a/api/clients/v2/coretypes/eigenda_cert.go
+++ b/api/clients/v2/coretypes/eigenda_cert.go
@@ -388,64 +388,60 @@ func (c *EigenDACertV2) Version() CertificateVersion {
 	return VersionTwoCert
 }
 
-// ConvertV2CertToV3 converts an EigenDACertV2 to an EigenDACertV3
-func ConvertV2CertToV3(certV2 *EigenDACertV2) (*EigenDACertV3, error) {
-	if certV2 == nil {
-		return nil, fmt.Errorf("input V2 certificate cannot be nil")
-	}
-
+// ToV3 converts an EigenDACertV2 to an EigenDACertV3
+func (c *EigenDACertV2) ToV3() (*EigenDACertV3, error) {
 	// Convert BlobInclusionInfo from V2 to V3 format
 	v3BlobInclusionInfo := certTypesBinding.EigenDATypesV2BlobInclusionInfo{
 		BlobCertificate: certTypesBinding.EigenDATypesV2BlobCertificate{
 			BlobHeader: certTypesBinding.EigenDATypesV2BlobHeaderV2{
-				Version:       certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.Version,
-				QuorumNumbers: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.QuorumNumbers,
+				Version:       c.BlobInclusionInfo.BlobCertificate.BlobHeader.Version,
+				QuorumNumbers: c.BlobInclusionInfo.BlobCertificate.BlobHeader.QuorumNumbers,
 				Commitment: certTypesBinding.EigenDATypesV2BlobCommitment{
 					Commitment: certTypesBinding.BN254G1Point{
-						X: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.Commitment.X,
-						Y: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.Commitment.Y,
+						X: c.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.Commitment.X,
+						Y: c.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.Commitment.Y,
 					},
 					LengthCommitment: certTypesBinding.BN254G2Point{
-						X: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.LengthCommitment.X,
-						Y: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.LengthCommitment.Y,
+						X: c.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.LengthCommitment.X,
+						Y: c.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.LengthCommitment.Y,
 					},
 					LengthProof: certTypesBinding.BN254G2Point{
-						X: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.LengthProof.X,
-						Y: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.LengthProof.Y,
+						X: c.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.LengthProof.X,
+						Y: c.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.LengthProof.Y,
 					},
-					Length: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.Length,
+					Length: c.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.Length,
 				},
-				PaymentHeaderHash: certV2.BlobInclusionInfo.BlobCertificate.BlobHeader.PaymentHeaderHash,
+				PaymentHeaderHash: c.BlobInclusionInfo.BlobCertificate.BlobHeader.PaymentHeaderHash,
 			},
-			Signature: certV2.BlobInclusionInfo.BlobCertificate.Signature,
-			RelayKeys: convertUint32SliceToRelayKeys(certV2.BlobInclusionInfo.BlobCertificate.RelayKeys),
+			Signature: c.BlobInclusionInfo.BlobCertificate.Signature,
+			RelayKeys: convertUint32SliceToRelayKeys(c.BlobInclusionInfo.BlobCertificate.RelayKeys),
 		},
-		BlobIndex:      certV2.BlobInclusionInfo.BlobIndex,
-		InclusionProof: certV2.BlobInclusionInfo.InclusionProof,
+		BlobIndex:      c.BlobInclusionInfo.BlobIndex,
+		InclusionProof: c.BlobInclusionInfo.InclusionProof,
 	}
 
 	// Convert BatchHeader from V2 to V3 format
 	v3BatchHeader := certTypesBinding.EigenDATypesV2BatchHeaderV2{
-		BatchRoot:            certV2.BatchHeader.BatchRoot,
-		ReferenceBlockNumber: certV2.BatchHeader.ReferenceBlockNumber,
+		BatchRoot:            c.BatchHeader.BatchRoot,
+		ReferenceBlockNumber: c.BatchHeader.ReferenceBlockNumber,
 	}
 
 	// Convert NonSignerStakesAndSignature from V2 to V3 format
 	v3NonSignerStakesAndSignature := certTypesBinding.EigenDATypesV1NonSignerStakesAndSignature{
-		NonSignerQuorumBitmapIndices: certV2.NonSignerStakesAndSignature.NonSignerQuorumBitmapIndices,
-		NonSignerPubkeys:             convertV2PubkeysToV3(certV2.NonSignerStakesAndSignature.NonSignerPubkeys),
-		QuorumApks:                   convertV2PubkeysToV3(certV2.NonSignerStakesAndSignature.QuorumApks),
+		NonSignerQuorumBitmapIndices: c.NonSignerStakesAndSignature.NonSignerQuorumBitmapIndices,
+		NonSignerPubkeys:             convertV2PubkeysToV3(c.NonSignerStakesAndSignature.NonSignerPubkeys),
+		QuorumApks:                   convertV2PubkeysToV3(c.NonSignerStakesAndSignature.QuorumApks),
 		ApkG2: certTypesBinding.BN254G2Point{
-			X: certV2.NonSignerStakesAndSignature.ApkG2.X,
-			Y: certV2.NonSignerStakesAndSignature.ApkG2.Y,
+			X: c.NonSignerStakesAndSignature.ApkG2.X,
+			Y: c.NonSignerStakesAndSignature.ApkG2.Y,
 		},
 		Sigma: certTypesBinding.BN254G1Point{
-			X: certV2.NonSignerStakesAndSignature.Sigma.X,
-			Y: certV2.NonSignerStakesAndSignature.Sigma.Y,
+			X: c.NonSignerStakesAndSignature.Sigma.X,
+			Y: c.NonSignerStakesAndSignature.Sigma.Y,
 		},
-		QuorumApkIndices:      certV2.NonSignerStakesAndSignature.QuorumApkIndices,
-		TotalStakeIndices:     certV2.NonSignerStakesAndSignature.TotalStakeIndices,
-		NonSignerStakeIndices: certV2.NonSignerStakesAndSignature.NonSignerStakeIndices,
+		QuorumApkIndices:      c.NonSignerStakesAndSignature.QuorumApkIndices,
+		TotalStakeIndices:     c.NonSignerStakesAndSignature.TotalStakeIndices,
+		NonSignerStakeIndices: c.NonSignerStakesAndSignature.NonSignerStakeIndices,
 	}
 
 	// Create the V3 certificate
@@ -453,7 +449,7 @@ func ConvertV2CertToV3(certV2 *EigenDACertV2) (*EigenDACertV3, error) {
 		BlobInclusionInfo:           v3BlobInclusionInfo,
 		BatchHeader:                 v3BatchHeader,
 		NonSignerStakesAndSignature: v3NonSignerStakesAndSignature,
-		SignedQuorumNumbers:         certV2.SignedQuorumNumbers,
+		SignedQuorumNumbers:         c.SignedQuorumNumbers,
 	}
 
 	return certV3, nil

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -71,7 +71,7 @@ func (cv *CertVerifier) CheckDACert(
 			return &CertVerifierInputError{Msg: fmt.Sprintf("expected cert to be of type EigenDACertV2, got %T", cert)}
 		}
 
-		certV3, err = coretypes.ConvertV2CertToV3(certV2)
+		certV3, err = certV2.ToV3()
 		if err != nil {
 			return &CertVerifierInternalError{Msg: "convert V2 cert to V3", Err: err}
 		}

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -55,39 +55,44 @@ func (cv *CertVerifier) CheckDACert(
 	// 1 - switch on the certificate version to determine which underlying type to decode into
 	//     and which contract to call
 
-	var certVerifierCaller *certVerifierBinding.ContractEigenDACertVerifier
-	var certBytes []byte
+	// EigenDACertV3 is the only version that is supported by the CheckDACert function
+	var certV3 *coretypes.EigenDACertV3
 	var err error
 	switch cert.Version() {
 	case coretypes.VersionThreeCert:
-		certV3, ok := cert.(*coretypes.EigenDACertV3)
+		var ok bool
+		certV3, ok = cert.(*coretypes.EigenDACertV3)
 		if !ok {
 			return &CertVerifierInputError{Msg: fmt.Sprintf("expected cert to be of type EigenDACertV3, got %T", cert)}
 		}
-
-		// TODO: Determine adequate future proofing strategy for EigenDACertVerifierRouter to be compliant
-		//       with future reference timestamp change which deprecates the reference block number
-		//       used for quorum stake check-pointing.
-		certVerifierCaller, err = cv.getVerifierCallerFromBlockNumber(ctx, certV3.ReferenceBlockNumber())
-		if err != nil {
-			return &CertVerifierInternalError{Msg: "get verifier caller", Err: err}
-		}
-
-		certBytes, err = certV3.Serialize(coretypes.CertSerializationABI)
-		if err != nil {
-			return &CertVerifierInternalError{Msg: "serialize cert", Err: err}
-		}
 	case coretypes.VersionTwoCert:
-		_, ok := cert.(*coretypes.EigenDACertV2)
+		certV2, ok := cert.(*coretypes.EigenDACertV2)
 		if !ok {
 			return &CertVerifierInputError{Msg: fmt.Sprintf("expected cert to be of type EigenDACertV2, got %T", cert)}
 		}
-		return nil // noop verification. only used on V2 testnets and no mainnets
+
+		certV3, err = coretypes.ConvertV2CertToV3(certV2)
+		if err != nil {
+			return &CertVerifierInternalError{Msg: "convert V2 cert to V3", Err: err}
+		}
 	default:
 		return &CertVerifierInputError{Msg: fmt.Sprintf("unsupported cert version: %d", cert.Version())}
 	}
 
 	// 2 - Call the contract method CheckDACert to verify the certificate
+	// TODO: Determine adequate future proofing strategy for EigenDACertVerifierRouter to be compliant
+	//       with future reference timestamp change which deprecates the reference block number
+	//       used for quorum stake check-pointing.
+	certVerifierCaller, err := cv.getVerifierCallerFromBlockNumber(ctx, certV3.ReferenceBlockNumber())
+	if err != nil {
+		return &CertVerifierInternalError{Msg: "get verifier caller", Err: err}
+	}
+
+	certBytes, err := certV3.Serialize(coretypes.CertSerializationABI)
+	if err != nil {
+		return &CertVerifierInternalError{Msg: "serialize cert", Err: err}
+	}
+
 	// TODO: determine if there's any merit in passing call options to impose better determinism and
 	// safety on the operation
 	result, err := certVerifierCaller.CheckDACert(

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 go = "1.21"
 
 # Tooling Dependencies
-"go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "1.60.3"
+golangci-lint = "1.60.3"
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "v1.14.0"
 # Belive yarn is needed for foundry deps (see contracts/remappings.txt) and subgraph stuff.
 # TODO: document exactly why these are needed.


### PR DESCRIPTION
Since v2 cert and v3 cert are identical, except for field ordering, we can easily (though verbosely) convert from v2->v3. This allows us to provide correct verification results for v2 certs, rather than reflexively treating them as valid.

Closes DAINT-550 ([link](https://linear.app/eigenlabs/issue/DAINT-550/golang-client-fix-that-v2-certs-are-verified-using-v3certverifier))
