### PR TITLE
fix: Update disperser client to take in logger vs initializing default one for ntp clock

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -14,6 +14,7 @@ import (
 	dispv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/encoding/rs"
+	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/docker/go-units"
 	"google.golang.org/grpc"
 )
@@ -84,7 +85,7 @@ var _ DisperserClient = &disperserClient{}
 //
 //	// Subsequent calls will use the existing connection
 //	status2, blobKey2, err := client.DisperseBlob(ctx, data, blobHeader)
-func NewDisperserClient(config *DisperserClientConfig, signer corev2.BlobRequestSigner, prover encoding.Prover, accountant *Accountant) (*disperserClient, error) {
+func NewDisperserClient(logger logging.Logger, config *DisperserClientConfig, signer corev2.BlobRequestSigner, prover encoding.Prover, accountant *Accountant) (*disperserClient, error) {
 	if config == nil {
 		return nil, api.NewErrorInvalidArg("config must be provided")
 	}
@@ -107,14 +108,7 @@ func NewDisperserClient(config *DisperserClientConfig, signer corev2.BlobRequest
 	}
 
 	// Initialize NTP synced clock
-	loggerConfig := common.DefaultLoggerConfig()
-	logger, err := common.NewLogger(loggerConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create logger: %w", err)
-	}
-	logger = logger.With("component", "DisperserClient")
-
-	ntpClock, err := core.NewNTPSyncedClock(context.Background(), config.NtpServer, config.NtpSyncInterval, logger)
+	ntpClock, err := core.NewNTPSyncedClock(context.Background(), config.NtpServer, config.NtpSyncInterval, logger.With("component", "DisperserClient"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create NTP clock: %w", err)
 	}

--- a/api/clients/v2/examples/client_construction.go
+++ b/api/clients/v2/examples/client_construction.go
@@ -47,7 +47,7 @@ func createPayloadDisperser(privateKey string) (*payloaddispersal.PayloadDispers
 		return nil, fmt.Errorf("create kzg prover: %v", err)
 	}
 
-	disperserClient, err := createDisperserClient(privateKey, kzgProver)
+	disperserClient, err := createDisperserClient(logger, privateKey, kzgProver)
 	if err != nil {
 		return nil, fmt.Errorf("create disperser client: %w", err)
 	}
@@ -195,7 +195,7 @@ func createRelayClient(
 		relayUrlProvider)
 }
 
-func createDisperserClient(privateKey string, kzgProver *prover.Prover) (clients.DisperserClient, error) {
+func createDisperserClient(logger logging.Logger, privateKey string, kzgProver *prover.Prover) (clients.DisperserClient, error) {
 	signer, err := auth.NewLocalBlobRequestSigner(privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("create blob request signer: %w", err)
@@ -208,6 +208,7 @@ func createDisperserClient(privateKey string, kzgProver *prover.Prover) (clients
 	}
 
 	return clients.NewDisperserClient(
+		logger,
 		disperserClientConfig,
 		signer,
 		kzgProver,

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -248,7 +248,7 @@ func setupPayloadDisperserWithRouter() error {
 		Port:     "32005",
 	}
 
-	disperserClient, err := clientsv2.NewDisperserClient(disperserClientConfig, signer, nil, nil)
+	disperserClient, err := clientsv2.NewDisperserClient(logger, disperserClientConfig, signer, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -140,7 +140,7 @@ func NewTestClient(
 		UseSecureGrpcFlag: true,
 	}
 
-	disperserClient, err := clients.NewDisperserClient(disperserConfig, signer, kzgProver, nil)
+	disperserClient, err := clients.NewDisperserClient(logger, disperserConfig, signer, kzgProver, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create disperser client: %w", err)
 	}

--- a/test/v2/correctness/correctness_test.go
+++ b/test/v2/correctness/correctness_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/relay"
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
 	auth "github.com/Layr-Labs/eigenda/core/auth/v2"
 	"github.com/Layr-Labs/eigenda/encoding"
@@ -443,6 +444,10 @@ func dispersalWithInvalidSignatureTest(t *testing.T, environment string) {
 
 	c := client.GetTestClient(t, environment)
 
+	loggerConfig := common.DefaultLoggerConfig()
+	logger, err := common.NewLogger(loggerConfig)
+	require.NoError(t, err)
+
 	// Create a dispersal client with a random key
 	signer, err := auth.NewLocalBlobRequestSigner(fmt.Sprintf("%x", rand.Bytes(32)))
 	require.NoError(t, err)
@@ -456,7 +461,7 @@ func dispersalWithInvalidSignatureTest(t *testing.T, environment string) {
 		Port:              fmt.Sprintf("%d", c.GetConfig().DisperserPort),
 		UseSecureGrpcFlag: true,
 	}
-	disperserClient, err := clients.NewDisperserClient(disperserConfig, signer, nil, nil)
+	disperserClient, err := clients.NewDisperserClient(logger, disperserConfig, signer, nil, nil)
 	require.NoError(t, err)
 
 	payloadBytes := rand.VariableBytes(units.KiB, 2*units.KiB)


### PR DESCRIPTION
Currently debug logs are always being presented in proxy for NTP clock synchronization updates. This should instead use a preconfigured logger passed through via dependency injection

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
