### PR TITLE
refactor: onchain state interface

### DIFF
--- a/core/meterer/meterer_test.go
+++ b/core/meterer/meterer_test.go
@@ -177,16 +177,40 @@ func teardown() {
 
 func TestMetererReservations(t *testing.T) {
 	ctx := context.Background()
-	paymentChainState.On("GetReservationWindow", testifymock.Anything).Return(uint64(5), nil)
-	paymentChainState.On("GetOnDemandGlobalSymbolsPerSecond", testifymock.Anything).Return(uint64(1009), nil)
-	paymentChainState.On("GetOnDemandGlobalRatePeriodInterval", testifymock.Anything).Return(uint64(1), nil)
-	paymentChainState.On("GetMinNumSymbols", testifymock.Anything).Return(uint64(3), nil)
+	
+	// Create mock payment vault params
+	mockParams := &meterer.PaymentVaultParams{
+		QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+			0: {
+				OnDemandSymbolsPerSecond: 1009,
+				OnDemandPricePerSymbol:   2,
+			},
+			1: {
+				OnDemandSymbolsPerSecond: 1009,
+				OnDemandPricePerSymbol:   2,
+			},
+		},
+		QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+			0: {
+				MinNumSymbols:              3,
+				ReservationRateLimitWindow: 5,
+				OnDemandRateLimitWindow:    1,
+			},
+			1: {
+				MinNumSymbols:              3,
+				ReservationRateLimitWindow: 5,
+				OnDemandRateLimitWindow:    1,
+			},
+		},
+		OnDemandQuorumNumbers: []core.QuorumID{0, 1},
+	}
+	paymentChainState.On("GetPaymentGlobalParams").Return(mockParams, nil)
 
 	now := time.Now()
 	quoromNumbers := []uint8{0, 1}
 	reservationPeriods := make([]uint64, len(quoromNumbers))
 	for i, quorumNumber := range quoromNumbers {
-		reservationPeriods[i] = meterer.GetReservationPeriodByNanosecond(now.UnixNano(), mt.ChainPaymentState.GetReservationWindow(core.QuorumID(quorumNumber)))
+		reservationPeriods[i] = meterer.GetReservationPeriodByNanosecond(now.UnixNano(), mockParams.QuorumProtocolConfigs[core.QuorumID(quorumNumber)].ReservationRateLimitWindow)
 	}
 
 	// Update mocks for GetReservedPaymentByAccountAndQuorums
@@ -217,11 +241,12 @@ func TestMetererReservations(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid quorum for reservation: quorum number mismatch")
 
 	// small bin overflow for empty bin (using one quorum for protocol parameters for now)
-	header = createPaymentHeader(now.UnixNano()-int64(mt.ChainPaymentState.GetReservationWindow(meterer.OnDemandQuorumID))*1e9, big.NewInt(0), accountID2)
+	reservationWindow := mockParams.QuorumProtocolConfigs[meterer.OnDemandQuorumID].ReservationRateLimitWindow
+	header = createPaymentHeader(now.UnixNano()-int64(reservationWindow)*1e9, big.NewInt(0), accountID2)
 	_, err = mt.MeterRequest(ctx, *header, 10, quoromNumbers, now)
 	assert.NoError(t, err)
 	// overwhelming bin overflow for empty bins
-	header = createPaymentHeader(now.UnixNano()-int64(mt.ChainPaymentState.GetReservationWindow(meterer.OnDemandQuorumID))*1e9, big.NewInt(0), accountID2)
+	header = createPaymentHeader(now.UnixNano()-int64(reservationWindow)*1e9, big.NewInt(0), accountID2)
 	_, err = mt.MeterRequest(ctx, *header, 1000, quoromNumbers, now)
 	assert.ErrorContains(t, err, "overflow usage exceeds bin limit")
 
@@ -241,7 +266,7 @@ func TestMetererReservations(t *testing.T) {
 	assert.ErrorContains(t, err, "reservation not active")
 
 	// test invalid reservation period
-	header = createPaymentHeader(now.UnixNano()-2*int64(mt.ChainPaymentState.GetReservationWindow(meterer.OnDemandQuorumID))*1e9, big.NewInt(0), accountID1)
+	header = createPaymentHeader(now.UnixNano()-2*int64(reservationWindow)*1e9, big.NewInt(0), accountID1)
 	_, err = mt.MeterRequest(ctx, *header, 2000, quoromNumbers, now)
 	assert.ErrorContains(t, err, "invalid reservation period for reservation")
 
@@ -253,7 +278,7 @@ func TestMetererReservations(t *testing.T) {
 		accountAndQuorums = append(accountAndQuorums, fmt.Sprintf("%s:%d", accountID2.Hex(), quorum))
 	}
 	for i := 0; i < 9; i++ {
-		reservationPeriod := meterer.GetReservationPeriodByNanosecond(now.UnixNano(), mt.ChainPaymentState.GetReservationWindow(meterer.OnDemandQuorumID))
+		reservationPeriod := meterer.GetReservationPeriodByNanosecond(now.UnixNano(), reservationWindow)
 		header = createPaymentHeader(now.UnixNano(), big.NewInt(0), accountID2)
 		symbolsCharged, err := mt.MeterRequest(ctx, *header, symbolLength, quoromNumbers, now)
 		assert.NoError(t, err)
@@ -327,10 +352,25 @@ func TestMetererReservations(t *testing.T) {
 func TestMetererOnDemand(t *testing.T) {
 	ctx := context.Background()
 	quorumNumbers := []uint8{0, 1}
-	paymentChainState.On("GetPricePerSymbol", testifymock.Anything, testifymock.Anything).Return(uint64(2), nil)
-	paymentChainState.On("GetMinNumSymbols", testifymock.Anything, testifymock.Anything).Return(uint64(3), nil)
-	paymentChainState.On("GetOnDemandGlobalSymbolsPerSecond", testifymock.Anything).Return(uint64(1009), nil)
-	paymentChainState.On("GetOnDemandGlobalRatePeriodInterval", testifymock.Anything).Return(uint64(1), nil)
+	
+	// Create mock payment vault params for on-demand test
+	mockParams := &meterer.PaymentVaultParams{
+		QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+			meterer.OnDemandQuorumID: {
+				OnDemandSymbolsPerSecond: 1009,
+				OnDemandPricePerSymbol:   2,
+			},
+		},
+		QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+			meterer.OnDemandQuorumID: {
+				MinNumSymbols:           3,
+				OnDemandRateLimitWindow: 1,
+			},
+		},
+		OnDemandQuorumNumbers: []core.QuorumID{0, 1},
+	}
+	paymentChainState.On("GetPaymentGlobalParams").Return(mockParams, nil)
+	
 	now := time.Now()
 
 	paymentChainState.On("GetOnDemandPaymentByAccount", testifymock.Anything, testifymock.MatchedBy(func(account gethcommon.Address) bool {
@@ -340,7 +380,6 @@ func TestMetererOnDemand(t *testing.T) {
 		return account == accountID2
 	})).Return(account2OnDemandPayments, nil)
 	paymentChainState.On("GetOnDemandPaymentByAccount", testifymock.Anything, testifymock.Anything).Return(&core.OnDemandPayment{}, fmt.Errorf("payment not found"))
-	paymentChainState.On("GetOnDemandQuorumNumbers", testifymock.Anything).Return(quorumNumbers, nil)
 
 	// test unregistered account
 	unregisteredUser, err := crypto.GenerateKey()
@@ -371,9 +410,11 @@ func TestMetererOnDemand(t *testing.T) {
 
 	// test duplicated cumulative payments
 	symbolLength := uint64(100)
-	symbolsCharged := meterer.SymbolsCharged(symbolLength, mt.ChainPaymentState.GetMinNumSymbols(meterer.OnDemandQuorumID))
-	priceCharged := meterer.PaymentCharged(symbolsCharged, mt.ChainPaymentState.GetPricePerSymbol(meterer.OnDemandQuorumID))
-	assert.Equal(t, big.NewInt(int64(102*mt.ChainPaymentState.GetPricePerSymbol(meterer.OnDemandQuorumID))), priceCharged)
+	minSymbols := mockParams.QuorumProtocolConfigs[meterer.OnDemandQuorumID].MinNumSymbols
+	pricePerSymbol := mockParams.QuorumPaymentConfigs[meterer.OnDemandQuorumID].OnDemandPricePerSymbol
+	symbolsCharged := meterer.SymbolsCharged(symbolLength, minSymbols)
+	priceCharged := meterer.PaymentCharged(symbolsCharged, pricePerSymbol)
+	assert.Equal(t, big.NewInt(int64(102*pricePerSymbol)), priceCharged)
 	header = createPaymentHeader(now.UnixNano(), priceCharged, accountID2)
 	symbolsCharged, err = mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
 	assert.NoError(t, err)
@@ -399,16 +440,16 @@ func TestMetererOnDemand(t *testing.T) {
 	// test insufficient increment in cumulative payment
 	previousCumulativePayment := priceCharged.Mul(priceCharged, big.NewInt(9))
 	symbolLength = uint64(2)
-	symbolsCharged = meterer.SymbolsCharged(symbolLength, mt.ChainPaymentState.GetMinNumSymbols(meterer.OnDemandQuorumID))
-	priceCharged = meterer.PaymentCharged(symbolsCharged, mt.ChainPaymentState.GetPricePerSymbol(meterer.OnDemandQuorumID))
+	symbolsCharged = meterer.SymbolsCharged(symbolLength, minSymbols)
+	priceCharged = meterer.PaymentCharged(symbolsCharged, pricePerSymbol)
 	header = createPaymentHeader(now.UnixNano(), big.NewInt(0).Add(previousCumulativePayment, big.NewInt(0).Sub(priceCharged, big.NewInt(1))), accountID2)
 	_, err = mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
 	assert.ErrorContains(t, err, "insufficient cumulative payment increment")
 	previousCumulativePayment = big.NewInt(0).Add(previousCumulativePayment, priceCharged)
 
 	// test cannot insert cumulative payment in out of order
-	symbolsCharged = meterer.SymbolsCharged(uint64(50), mt.ChainPaymentState.GetMinNumSymbols(meterer.OnDemandQuorumID))
-	header = createPaymentHeader(now.UnixNano(), meterer.PaymentCharged(symbolsCharged, mt.ChainPaymentState.GetPricePerSymbol(meterer.OnDemandQuorumID)), accountID2)
+	symbolsCharged = meterer.SymbolsCharged(uint64(50), minSymbols)
+	header = createPaymentHeader(now.UnixNano(), meterer.PaymentCharged(symbolsCharged, pricePerSymbol), accountID2)
 	_, err = mt.MeterRequest(ctx, *header, 50, quorumNumbers, now)
 	assert.ErrorContains(t, err, "insufficient cumulative payment increment")
 
@@ -420,13 +461,13 @@ func TestMetererOnDemand(t *testing.T) {
 	assert.Equal(t, 1, len(result))
 
 	// with rollback of invalid payments, users cannot cheat by inserting an invalid cumulative payment
-	symbolsCharged = meterer.SymbolsCharged(uint64(30), mt.ChainPaymentState.GetMinNumSymbols(meterer.OnDemandQuorumID))
-	header = createPaymentHeader(now.UnixNano(), meterer.PaymentCharged(symbolsCharged, mt.ChainPaymentState.GetPricePerSymbol(meterer.OnDemandQuorumID)), accountID2)
+	symbolsCharged = meterer.SymbolsCharged(uint64(30), minSymbols)
+	header = createPaymentHeader(now.UnixNano(), meterer.PaymentCharged(symbolsCharged, pricePerSymbol), accountID2)
 	_, err = mt.MeterRequest(ctx, *header, 30, quorumNumbers, now)
 	assert.ErrorContains(t, err, "insufficient cumulative payment increment")
 
 	// test failed global rate limit (previously payment recorded: 2, global limit: 1009)
-	header = createPaymentHeader(now.UnixNano(), big.NewInt(0).Add(previousCumulativePayment, meterer.PaymentCharged(1010, mt.ChainPaymentState.GetPricePerSymbol(meterer.OnDemandQuorumID))), accountID1)
+	header = createPaymentHeader(now.UnixNano(), big.NewInt(0).Add(previousCumulativePayment, meterer.PaymentCharged(1010, pricePerSymbol)), accountID1)
 	_, err = mt.MeterRequest(ctx, *header, 1010, quorumNumbers, now)
 	assert.ErrorContains(t, err, "failed global rate limiting")
 	// Correct rollback

--- a/core/meterer/onchain_state.go
+++ b/core/meterer/onchain_state.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"sync"
 	"sync/atomic"
 
+	disperser_rpc "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/eth"
 	"github.com/Layr-Labs/eigensdk-go/logging"
@@ -19,23 +19,32 @@ import (
 
 // OnchainPaymentState is an interface for getting information about the current chain state for payments.
 type OnchainPayment interface {
+	// Core state refresh and access methods
 	RefreshOnchainPaymentState(ctx context.Context) error
 	GetReservedPaymentByAccountAndQuorums(ctx context.Context, accountID gethcommon.Address, quorumNumbers []core.QuorumID) (map[core.QuorumID]*core.ReservedPayment, error)
 	GetOnDemandPaymentByAccount(ctx context.Context, accountID gethcommon.Address) (*core.OnDemandPayment, error)
+	GetQuorumNumbers(ctx context.Context) ([]core.QuorumID, error)
+
+	// Quorum config getters
 	GetQuorumPaymentConfig(quorumID core.QuorumID) (*core.PaymentQuorumConfig, error)
 	GetQuorumProtocolConfig(quorumID core.QuorumID) (*core.PaymentQuorumProtocolConfig, error)
-	GetOnDemandQuorumNumbers(ctx context.Context) ([]uint8, error)
-	GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) uint64
-	GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) uint64
-	GetMinNumSymbols(quorumID core.QuorumID) uint64
-	GetPricePerSymbol(quorumID core.QuorumID) uint64
-	GetReservationWindow(quorumID core.QuorumID) uint64
-	// Return all the quorum numbers tracked by QuorumPaymentConfigs
-	GetQuorumNumbers(ctx context.Context) ([]uint8, error)
+	GetQuorumPaymentConfigs() map[core.QuorumID]*core.PaymentQuorumConfig
+	GetQuorumProtocolConfigs() map[core.QuorumID]*core.PaymentQuorumProtocolConfig
+
+	// On-demand specific getters
+	GetOnDemandQuorumNumbers(ctx context.Context) ([]core.QuorumID, error)
+	GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) (uint64, error)
+	GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) (uint64, error)
+
+	// Payment parameter getters
+	GetMinNumSymbols(quorumID core.QuorumID) (uint64, error)
+	GetPricePerSymbol(quorumID core.QuorumID) (uint64, error)
+	GetReservationWindow(quorumID core.QuorumID) (uint64, error)
 }
 
 var _ OnchainPayment = (*OnchainPaymentState)(nil)
 
+// OnchainPaymentState manages the state of on-chain payments including reservations and on-demand payments
 type OnchainPaymentState struct {
 	tx     *eth.Reader
 	logger logging.Logger
@@ -49,12 +58,14 @@ type OnchainPaymentState struct {
 	PaymentVaultParams atomic.Pointer[PaymentVaultParams]
 }
 
+// PaymentVaultParams contains all configuration parameters for the payment vault
 type PaymentVaultParams struct {
 	QuorumPaymentConfigs  map[core.QuorumID]*core.PaymentQuorumConfig
 	QuorumProtocolConfigs map[core.QuorumID]*core.PaymentQuorumProtocolConfig
-	OnDemandQuorumNumbers []uint8
+	OnDemandQuorumNumbers []core.QuorumID
 }
 
+// NewOnchainPaymentState creates a new OnchainPaymentState instance and initializes it with current chain state
 func NewOnchainPaymentState(ctx context.Context, tx *eth.Reader, logger logging.Logger) (*OnchainPaymentState, error) {
 	state := OnchainPaymentState{
 		tx:                 tx,
@@ -64,16 +75,15 @@ func NewOnchainPaymentState(ctx context.Context, tx *eth.Reader, logger logging.
 		PaymentVaultParams: atomic.Pointer[PaymentVaultParams]{},
 	}
 
-	paymentVaultParams, err := state.GetPaymentVaultParams(ctx)
+	err := state.RefreshOnchainPaymentState(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize payment state: %w", err)
 	}
-
-	state.PaymentVaultParams.Store(paymentVaultParams)
 
 	return &state, nil
 }
 
+// NewOnchainPaymentStateEmpty creates a new OnchainPaymentState instance without initializing chain state
 func NewOnchainPaymentStateEmpty(ctx context.Context, tx *eth.Reader, logger logging.Logger) (*OnchainPaymentState, error) {
 	state := OnchainPaymentState{
 		tx:                 tx,
@@ -86,84 +96,15 @@ func NewOnchainPaymentStateEmpty(ctx context.Context, tx *eth.Reader, logger log
 	return &state, nil
 }
 
-func (pcs *OnchainPaymentState) GetPaymentVaultParams(ctx context.Context) (*PaymentVaultParams, error) {
-	blockNumber, err := pcs.tx.GetCurrentBlockNumber(ctx)
-	if err != nil {
-		return nil, err
-	}
-	requiredQuorumNumbers, err := pcs.tx.GetRequiredQuorumNumbers(ctx, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	quorumCount, err := pcs.tx.GetQuorumCount(ctx, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	quorumNumbers := make([]uint8, quorumCount)
-	for i := range quorumNumbers {
-		quorumNumbers[i] = uint8(i)
-	}
-
-	// TODO(hopeyen): the construction of quorum configs will be updated with payment vault interface updates
-	globalSymbolsPerSecond, err := pcs.tx.GetOnDemandGlobalSymbolsPerSecond(ctx, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	globalRatePeriodInterval, err := pcs.tx.GetOnDemandGlobalRatePeriodInterval(ctx, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	minNumSymbols, err := pcs.tx.GetMinNumSymbols(ctx, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	pricePerSymbol, err := pcs.tx.GetPricePerSymbol(ctx, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	reservationWindow, err := pcs.tx.GetReservationWindow(ctx, blockNumber)
-	if err != nil {
-		return nil, err
-	}
-	quorumPaymentConfigs := make(map[core.QuorumID]*core.PaymentQuorumConfig)
-	quorumProtocolConfigs := make(map[core.QuorumID]*core.PaymentQuorumProtocolConfig)
-	quorumPaymentConfig := &core.PaymentQuorumConfig{
-		OnDemandSymbolsPerSecond: globalSymbolsPerSecond,
-		OnDemandPricePerSymbol:   pricePerSymbol,
-		// These two fields are not used in the offchain state
-		ReservationSymbolsPerSecond: uint64(0),
-	}
-	quorumProtocolConfig := &core.PaymentQuorumProtocolConfig{
-		MinNumSymbols:              minNumSymbols,
-		ReservationRateLimitWindow: reservationWindow,
-		OnDemandRateLimitWindow:    globalRatePeriodInterval,
-		// These two fields are not used in the offchain state
-		ReservationAdvanceWindow: uint64(0),
-		OnDemandEnabled:          false,
-	}
-	for _, quorumNumber := range quorumNumbers {
-		quorumPaymentConfigs[core.QuorumID(quorumNumber)] = quorumPaymentConfig
-		quorumProtocolConfigs[core.QuorumID(quorumNumber)] = quorumProtocolConfig
-	}
-	// OnDemand is initially only enabled on Quorum 0
-	quorumProtocolConfigs[OnDemandQuorumID].OnDemandEnabled = true
-
-	return &PaymentVaultParams{
-		OnDemandQuorumNumbers: requiredQuorumNumbers,
-		QuorumPaymentConfigs:  quorumPaymentConfigs,
-		QuorumProtocolConfigs: quorumProtocolConfigs,
-	}, nil
-}
-
-// RefreshOnchainPaymentState returns the current onchain payment state
+// RefreshOnchainPaymentState updates the payment state with current chain data
 func (pcs *OnchainPaymentState) RefreshOnchainPaymentState(ctx context.Context) error {
 	paymentVaultParams, err := pcs.GetPaymentVaultParams(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get payment vault params: %w", err)
 	}
-	// These parameters should be rarely updated, but we refresh them anyway
 	pcs.PaymentVaultParams.Store(paymentVaultParams)
 
+	// Refresh reserved and on-demand payments
 	var refreshErr error
 	if reservedPaymentsErr := pcs.refreshReservedPayments(ctx); reservedPaymentsErr != nil {
 		pcs.logger.Error("failed to refresh reserved payments", "error", reservedPaymentsErr)
@@ -175,7 +116,337 @@ func (pcs *OnchainPaymentState) RefreshOnchainPaymentState(ctx context.Context) 
 		refreshErr = errors.Join(refreshErr, ondemandPaymentsErr)
 	}
 
-	return refreshErr
+	if refreshErr != nil {
+		return fmt.Errorf("failed to refresh payment state: %w", refreshErr)
+	}
+
+	return nil
+}
+
+// GetPaymentVaultParams retrieves the current payment vault parameters from the chain
+func (pcs *OnchainPaymentState) GetPaymentVaultParams(ctx context.Context) (*PaymentVaultParams, error) {
+	blockNumber, err := pcs.tx.GetCurrentBlockNumber(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current block number: %w", err)
+	}
+
+	requiredQuorumNumbers, err := pcs.tx.GetRequiredQuorumNumbers(ctx, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get required quorum numbers: %w", err)
+	}
+
+	quorumCount, err := pcs.tx.GetQuorumCount(ctx, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get quorum count: %w", err)
+	}
+
+	quorumNumbers := make([]uint8, quorumCount)
+	for i := range quorumNumbers {
+		quorumNumbers[i] = uint8(i)
+	}
+
+	// Get global parameters
+	globalSymbolsPerSecond, err := pcs.tx.GetOnDemandGlobalSymbolsPerSecond(ctx, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get global symbols per second: %w", err)
+	}
+
+	globalRatePeriodInterval, err := pcs.tx.GetOnDemandGlobalRatePeriodInterval(ctx, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get global rate period interval: %w", err)
+	}
+
+	minNumSymbols, err := pcs.tx.GetMinNumSymbols(ctx, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get min num symbols: %w", err)
+	}
+
+	pricePerSymbol, err := pcs.tx.GetPricePerSymbol(ctx, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get price per symbol: %w", err)
+	}
+
+	reservationWindow, err := pcs.tx.GetReservationWindow(ctx, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reservation window: %w", err)
+	}
+
+	// Initialize config maps
+	quorumPaymentConfigs := make(map[core.QuorumID]*core.PaymentQuorumConfig)
+	quorumProtocolConfigs := make(map[core.QuorumID]*core.PaymentQuorumProtocolConfig)
+
+	// Populate configs for each quorum
+	for _, quorumNumber := range quorumNumbers {
+		quorumPaymentConfigs[quorumNumber] = &core.PaymentQuorumConfig{
+			OnDemandSymbolsPerSecond:    globalSymbolsPerSecond,
+			OnDemandPricePerSymbol:      pricePerSymbol,
+			ReservationSymbolsPerSecond: 0, // placeholder
+		}
+
+		quorumProtocolConfigs[quorumNumber] = &core.PaymentQuorumProtocolConfig{
+			ReservationRateLimitWindow: reservationWindow,
+			OnDemandRateLimitWindow:    globalRatePeriodInterval,
+			MinNumSymbols:              minNumSymbols,
+			OnDemandEnabled:            false, // placeholder
+			ReservationAdvanceWindow:   0,     // placeholder
+		}
+	}
+
+	// Enable on-demand for Quorum 0
+	quorumProtocolConfigs[OnDemandQuorumID].OnDemandEnabled = true
+
+	return &PaymentVaultParams{
+		OnDemandQuorumNumbers: requiredQuorumNumbers,
+		QuorumPaymentConfigs:  quorumPaymentConfigs,
+		QuorumProtocolConfigs: quorumProtocolConfigs,
+	}, nil
+}
+
+// GetReservedPaymentByAccountAndQuorums retrieves reserved payments for an account across specified quorums
+func (pcs *OnchainPaymentState) GetReservedPaymentByAccountAndQuorums(ctx context.Context, accountID gethcommon.Address, quorumNumbers []core.QuorumID) (map[core.QuorumID]*core.ReservedPayment, error) {
+	pcs.ReservationsLock.RLock()
+	if quorumReservations, ok := pcs.ReservedPayments[accountID]; ok {
+		// Check if all quorums are present
+		allFound := true
+		for _, quorumNumber := range quorumNumbers {
+			if _, ok := quorumReservations[quorumNumber]; !ok {
+				allFound = false
+				break
+			}
+		}
+		if allFound {
+			pcs.ReservationsLock.RUnlock()
+			return quorumReservations, nil
+		}
+	}
+	pcs.ReservationsLock.RUnlock()
+
+	// pulls the chain state
+	res, err := pcs.tx.GetReservedPaymentByAccount(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reserved payment: %w", err)
+	}
+
+	pcs.ReservationsLock.Lock()
+	defer pcs.ReservationsLock.Unlock()
+
+	// Initialize map if needed
+	if _, ok := pcs.ReservedPayments[accountID]; !ok {
+		pcs.ReservedPayments[accountID] = make(map[core.QuorumID]*core.ReservedPayment)
+	}
+
+	// Update cache with new data
+	for _, quorumNumber := range quorumNumbers {
+		if reservation, ok := res[quorumNumber]; ok {
+			pcs.ReservedPayments[accountID][quorumNumber] = reservation
+		}
+	}
+
+	return res, nil
+}
+
+// GetOnDemandPaymentByAccount retrieves on-demand payment information for an account
+func (pcs *OnchainPaymentState) GetOnDemandPaymentByAccount(ctx context.Context, accountID gethcommon.Address) (*core.OnDemandPayment, error) {
+	pcs.OnDemandLocks.RLock()
+	if payment, ok := pcs.OnDemandPayments[accountID]; ok {
+		pcs.OnDemandLocks.RUnlock()
+		return payment, nil
+	}
+	pcs.OnDemandLocks.RUnlock()
+
+	// pulls the chain state
+	res, err := pcs.tx.GetOnDemandPaymentByAccount(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get on-demand payment: %w", err)
+	}
+
+	pcs.OnDemandLocks.Lock()
+	pcs.OnDemandPayments[accountID] = res
+	pcs.OnDemandLocks.Unlock()
+
+	return res, nil
+}
+
+// GetQuorumPaymentConfig retrieves payment configuration for a specific quorum
+func (pcs *OnchainPaymentState) GetQuorumPaymentConfig(quorumID core.QuorumID) (*core.PaymentQuorumConfig, error) {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return nil, fmt.Errorf("payment vault params not initialized")
+	}
+	return params.GetQuorumPaymentConfig(quorumID)
+}
+
+// GetQuorumProtocolConfig retrieves protocol configuration for a specific quorum
+func (pcs *OnchainPaymentState) GetQuorumProtocolConfig(quorumID core.QuorumID) (*core.PaymentQuorumProtocolConfig, error) {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return nil, fmt.Errorf("payment vault params not initialized")
+	}
+	return params.GetQuorumProtocolConfig(quorumID)
+}
+
+// GetQuorumPaymentConfigs retrieves all quorum payment configurations
+func (pcs *OnchainPaymentState) GetQuorumPaymentConfigs() map[core.QuorumID]*core.PaymentQuorumConfig {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return nil
+	}
+	return params.QuorumPaymentConfigs
+}
+
+// GetQuorumProtocolConfigs retrieves all quorum protocol configurations
+func (pcs *OnchainPaymentState) GetQuorumProtocolConfigs() map[core.QuorumID]*core.PaymentQuorumProtocolConfig {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return nil
+	}
+	return params.QuorumProtocolConfigs
+}
+
+// GetOnDemandQuorumNumbers retrieves the list of quorums enabled for on-demand payments
+func (pcs *OnchainPaymentState) GetOnDemandQuorumNumbers(ctx context.Context) ([]uint8, error) {
+	blockNumber, err := pcs.tx.GetCurrentBlockNumber(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current block number: %w", err)
+	}
+
+	quorumNumbers, err := pcs.tx.GetRequiredQuorumNumbers(ctx, blockNumber)
+	if err != nil {
+		// Fallback to cached value if chain read fails
+		pcs.logger.Warn("failed to get required quorum numbers, using cached value", "error", err)
+		params := pcs.PaymentVaultParams.Load()
+		if params == nil {
+			return nil, fmt.Errorf("failed to get quorum numbers and no cached params available")
+		}
+		return params.OnDemandQuorumNumbers, nil
+	}
+	return quorumNumbers, nil
+}
+
+// GetOnDemandGlobalSymbolsPerSecond retrieves the global symbols per second rate for on-demand payments
+func (pcs *OnchainPaymentState) GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) (uint64, error) {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return 0, fmt.Errorf("payment vault params not initialized")
+	}
+	return params.GetOnDemandGlobalSymbolsPerSecond(quorumID)
+}
+
+// GetOnDemandGlobalRatePeriodInterval retrieves the rate period interval for on-demand payments
+func (pcs *OnchainPaymentState) GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) (uint64, error) {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return 0, fmt.Errorf("payment vault params not initialized")
+	}
+	return params.GetOnDemandGlobalRatePeriodInterval(quorumID)
+}
+
+// GetMinNumSymbols retrieves the minimum number of symbols required for a quorum
+func (pcs *OnchainPaymentState) GetMinNumSymbols(quorumID core.QuorumID) (uint64, error) {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return math.MaxUint64, fmt.Errorf("payment vault params not initialized")
+	}
+	return params.GetMinNumSymbols(quorumID)
+}
+
+// GetPricePerSymbol retrieves the price per symbol for a quorum
+func (pcs *OnchainPaymentState) GetPricePerSymbol(quorumID core.QuorumID) (uint64, error) {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return math.MaxUint64, fmt.Errorf("payment vault params not initialized")
+	}
+	return params.GetPricePerSymbol(quorumID)
+}
+
+// GetReservationWindow retrieves the reservation window duration for a quorum
+func (pcs *OnchainPaymentState) GetReservationWindow(quorumID core.QuorumID) (uint64, error) {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return 0, fmt.Errorf("payment vault params not initialized")
+	}
+	return params.GetReservationWindow(quorumID)
+}
+
+// GetQuorumNumbers retrieves all quorum numbers tracked by the payment system
+func (pcs *OnchainPaymentState) GetQuorumNumbers(ctx context.Context) ([]core.QuorumID, error) {
+	params := pcs.PaymentVaultParams.Load()
+	if params == nil {
+		return nil, fmt.Errorf("payment vault params not initialized")
+	}
+	return params.GetQuorumNumbers(), nil
+}
+
+// GetQuorumPaymentConfig retrieves payment configuration for a specific quorum
+func (pvp *PaymentVaultParams) GetQuorumPaymentConfig(quorumID core.QuorumID) (*core.PaymentQuorumConfig, error) {
+	config, ok := pvp.QuorumPaymentConfigs[quorumID]
+	if !ok {
+		return nil, fmt.Errorf("payment config not found for quorum %d", quorumID)
+	}
+	return config, nil
+}
+
+// GetQuorumProtocolConfig retrieves protocol configuration for a specific quorum
+func (pvp *PaymentVaultParams) GetQuorumProtocolConfig(quorumID core.QuorumID) (*core.PaymentQuorumProtocolConfig, error) {
+	config, ok := pvp.QuorumProtocolConfigs[quorumID]
+	if !ok {
+		return nil, fmt.Errorf("protocol config not found for quorum %d", quorumID)
+	}
+	return config, nil
+}
+
+// GetOnDemandGlobalSymbolsPerSecond retrieves the global symbols per second rate for on-demand payments
+func (pvp *PaymentVaultParams) GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) (uint64, error) {
+	config, err := pvp.GetQuorumPaymentConfig(quorumID)
+	if err != nil {
+		return 0, err
+	}
+	return config.OnDemandSymbolsPerSecond, nil
+}
+
+// GetOnDemandGlobalRatePeriodInterval retrieves the rate period interval for on-demand payments
+func (pvp *PaymentVaultParams) GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) (uint64, error) {
+	config, err := pvp.GetQuorumProtocolConfig(quorumID)
+	if err != nil {
+		return 0, err
+	}
+	return config.OnDemandRateLimitWindow, nil
+}
+
+// GetMinNumSymbols retrieves the minimum number of symbols required for a quorum
+func (pvp *PaymentVaultParams) GetMinNumSymbols(quorumID core.QuorumID) (uint64, error) {
+	config, err := pvp.GetQuorumProtocolConfig(quorumID)
+	if err != nil {
+		return 0, err
+	}
+	return config.MinNumSymbols, nil
+}
+
+// GetPricePerSymbol retrieves the price per symbol for a quorum
+func (pvp *PaymentVaultParams) GetPricePerSymbol(quorumID core.QuorumID) (uint64, error) {
+	config, err := pvp.GetQuorumPaymentConfig(quorumID)
+	if err != nil {
+		return 0, err
+	}
+	return config.OnDemandPricePerSymbol, nil
+}
+
+// GetReservationWindow retrieves the reservation window duration for a quorum
+func (pvp *PaymentVaultParams) GetReservationWindow(quorumID core.QuorumID) (uint64, error) {
+	config, err := pvp.GetQuorumProtocolConfig(quorumID)
+	if err != nil {
+		return 0, err
+	}
+	return config.ReservationRateLimitWindow, nil
+}
+
+// GetQuorumNumbers retrieves all quorum numbers tracked by the payment system
+func (pvp *PaymentVaultParams) GetQuorumNumbers() []core.QuorumID {
+	quorumNumbers := make([]core.QuorumID, 0, len(pvp.QuorumPaymentConfigs))
+	for quorumNumber := range pvp.QuorumPaymentConfigs {
+		quorumNumbers = append(quorumNumbers, core.QuorumID(quorumNumber))
+	}
+	return quorumNumbers
 }
 
 func (pcs *OnchainPaymentState) refreshReservedPayments(ctx context.Context) error {
@@ -246,190 +517,64 @@ func (pcs *OnchainPaymentState) refreshOnDemandPayments(ctx context.Context) err
 	return nil
 }
 
-// GetReservedPaymentByAccountAndQuorums returns a pointer to the active reservation for the given account ID; no writes will be made to the reservation
-func (pcs *OnchainPaymentState) GetReservedPaymentByAccountAndQuorums(ctx context.Context, accountID gethcommon.Address, quorumNumbers []core.QuorumID) (map[core.QuorumID]*core.ReservedPayment, error) {
-	pcs.ReservationsLock.RLock()
-	if quorumReservations, ok := (pcs.ReservedPayments)[accountID]; ok {
-		// Check if all the quorums are present; pull the chain state if not
-		allFound := true
-		for _, quorumNumber := range quorumNumbers {
-			if _, ok := quorumReservations[quorumNumber]; !ok {
-				allFound = false
-				break
-			}
-		}
-		if allFound {
-			pcs.ReservationsLock.RUnlock()
-			return quorumReservations, nil
-		}
+func (pvp *PaymentVaultParams) GetQuorumConfigs(quorumNumber core.QuorumID) (*core.PaymentQuorumConfig, *core.PaymentQuorumProtocolConfig, error) {
+	if pvp == nil {
+		return nil, nil, fmt.Errorf("payment vault params is nil")
 	}
-	pcs.ReservationsLock.RUnlock()
-
-	// pulls the chain state
-	// TODO(hopeyen): use specific quorum IDs from the chain when payment vault is updated
-	res, err := pcs.tx.GetReservedPaymentByAccount(ctx, accountID)
-	if err != nil {
-		return nil, err
-	}
-	pcs.ReservationsLock.Lock()
-	// Initialize the inner map for accountID if it doesn't exist
-	if _, ok := (pcs.ReservedPayments)[accountID]; !ok {
-		(pcs.ReservedPayments)[accountID] = make(map[core.QuorumID]*core.ReservedPayment)
-	}
-	for _, quorumNumber := range quorumNumbers {
-		if _, ok := res[quorumNumber]; ok {
-			(pcs.ReservedPayments)[accountID][quorumNumber] = res[quorumNumber]
-		}
-	}
-	pcs.ReservationsLock.Unlock()
-
-	return res, nil
-}
-
-// GetReservedPaymentByAccount returns a pointer to all quorums' reservation for the given account ID; no writes will be made to the reservation
-func (pcs *OnchainPaymentState) GetReservedPaymentByAccount(ctx context.Context, accountID gethcommon.Address) (map[core.QuorumID]*core.ReservedPayment, error) {
-	pcs.ReservationsLock.RLock()
-	if reservation, ok := (pcs.ReservedPayments)[accountID]; ok {
-		pcs.ReservationsLock.RUnlock()
-		return reservation, nil
-	}
-	pcs.ReservationsLock.RUnlock()
-
-	// pulls the chain state
-	res, err := pcs.tx.GetReservedPaymentByAccount(ctx, accountID)
-	if err != nil {
-		return nil, err
-	}
-
-	reservedPaymentsByQuorum := make(map[core.QuorumID]*core.ReservedPayment)
-	for quorumNumber, reservation := range res {
-		reservedPaymentsByQuorum[uint8(quorumNumber)] = reservation
-	}
-	pcs.ReservationsLock.Lock()
-	(pcs.ReservedPayments)[accountID] = reservedPaymentsByQuorum
-	pcs.ReservationsLock.Unlock()
-
-	return reservedPaymentsByQuorum, nil
-}
-
-// GetOnDemandPaymentByAccount returns a pointer to the on-demand payment for the given account ID; no writes will be made to the payment
-func (pcs *OnchainPaymentState) GetOnDemandPaymentByAccount(ctx context.Context, accountID gethcommon.Address) (*core.OnDemandPayment, error) {
-	pcs.OnDemandLocks.RLock()
-	if payment, ok := (pcs.OnDemandPayments)[accountID]; ok {
-		pcs.OnDemandLocks.RUnlock()
-		return payment, nil
-	}
-	pcs.OnDemandLocks.RUnlock()
-
-	// pulls the chain state
-	res, err := pcs.tx.GetOnDemandPaymentByAccount(ctx, accountID)
-	if err != nil {
-		return nil, err
-	}
-
-	pcs.OnDemandLocks.Lock()
-	(pcs.OnDemandPayments)[accountID] = res
-	pcs.OnDemandLocks.Unlock()
-	return res, nil
-}
-
-func (pcs *OnchainPaymentState) GetOnDemandQuorumNumbers(ctx context.Context) ([]uint8, error) {
-	blockNumber, err := pcs.tx.GetCurrentBlockNumber(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	quorumNumbers, err := pcs.tx.GetRequiredQuorumNumbers(ctx, blockNumber)
-	if err != nil {
-		// On demand required quorum is unlikely to change, so we are comfortable using the cached value
-		// in case the contract read fails
-		log.Println("Failed to get required quorum numbers, read from cache", "error", err)
-		params := pcs.PaymentVaultParams.Load()
-		if params == nil {
-			log.Println("Failed to get required quorum numbers and no cached params")
-			return nil, fmt.Errorf("failed to get required quorum numbers and no cached params")
-		}
-		// params.OnDemandQuorumNumbers could be empty if set by the protocol
-		return params.OnDemandQuorumNumbers, nil
-	}
-	return quorumNumbers, nil
-}
-
-// GetQuorumPaymentConfig safely retrieves a quorum payment config
-func (pcs *OnchainPaymentState) GetQuorumPaymentConfig(quorumID core.QuorumID) (*core.PaymentQuorumConfig, error) {
-	params := pcs.PaymentVaultParams.Load()
-	if params == nil {
-		pcs.logger.Error("PaymentVaultParams is nil")
-		return nil, fmt.Errorf("payment vault params is nil")
-	}
-	config, ok := params.QuorumPaymentConfigs[quorumID]
+	paymentQuorumConfig, ok := pvp.QuorumPaymentConfigs[quorumNumber]
 	if !ok {
-		pcs.logger.Error("Quorum payment config not found", "quorumID", quorumID)
-		return nil, fmt.Errorf("quorum payment config not found for quorum %d", quorumID)
+		return nil, nil, fmt.Errorf("payment quorum config not found for quorum %d", quorumNumber)
 	}
-	return config, nil
-}
-
-// GetQuorumProtocolConfig safely retrieves a quorum protocol config
-func (pcs *OnchainPaymentState) GetQuorumProtocolConfig(quorumID core.QuorumID) (*core.PaymentQuorumProtocolConfig, error) {
-	params := pcs.PaymentVaultParams.Load()
-	if params == nil {
-		pcs.logger.Error("PaymentVaultParams is nil")
-		return nil, fmt.Errorf("payment vault params is nil")
-	}
-	config, ok := params.QuorumProtocolConfigs[quorumID]
+	protocolConfig, ok := pvp.QuorumProtocolConfigs[quorumNumber]
 	if !ok {
-		pcs.logger.Error("Quorum protocol config not found", "quorumID", quorumID)
-		return nil, fmt.Errorf("quorum protocol config not found for quorum %d", quorumID)
+		return nil, nil, fmt.Errorf("payment quorum protocol config not found for quorum %d", quorumNumber)
 	}
-	return config, nil
+	return paymentQuorumConfig, protocolConfig, nil
 }
 
-func (pcs *OnchainPaymentState) GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) uint64 {
-	config, err := pcs.GetQuorumPaymentConfig(quorumID)
-	if err != nil {
-		return 0
+// PaymentVaultParamsFromProtobuf converts a protobuf payment vault params to a core payment vault params
+func PaymentVaultParamsFromProtobuf(vaultParams *disperser_rpc.PaymentVaultParams) (*PaymentVaultParams, error) {
+	if vaultParams == nil {
+		return nil, fmt.Errorf("payment vault params cannot be nil")
 	}
-	return config.OnDemandSymbolsPerSecond
-}
 
-func (pcs *OnchainPaymentState) GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) uint64 {
-	config, err := pcs.GetQuorumProtocolConfig(quorumID)
-	if err != nil {
-		return 0
+	if vaultParams.GetQuorumPaymentConfigs() == nil {
+		return nil, fmt.Errorf("payment quorum configs cannot be nil")
 	}
-	return config.OnDemandRateLimitWindow
-}
 
-func (pcs *OnchainPaymentState) GetMinNumSymbols(quorumID core.QuorumID) uint64 {
-	config, err := pcs.GetQuorumProtocolConfig(quorumID)
-	if err != nil {
-		return math.MaxUint64
+	if vaultParams.GetQuorumProtocolConfigs() == nil {
+		return nil, fmt.Errorf("payment quorum protocol configs cannot be nil")
 	}
-	return config.MinNumSymbols
-}
 
-func (pcs *OnchainPaymentState) GetPricePerSymbol(quorumID core.QuorumID) uint64 {
-	config, err := pcs.GetQuorumPaymentConfig(quorumID)
-	if err != nil {
-		return math.MaxUint64
-	}
-	return config.OnDemandPricePerSymbol
-}
+	// Convert protobuf configs to core types
+	quorumPaymentConfigs := make(map[core.QuorumID]*core.PaymentQuorumConfig)
+	quorumProtocolConfigs := make(map[core.QuorumID]*core.PaymentQuorumProtocolConfig)
 
-func (pcs *OnchainPaymentState) GetReservationWindow(quorumID core.QuorumID) uint64 {
-	config, err := pcs.GetQuorumProtocolConfig(quorumID)
-	if err != nil {
-		return 0
+	for quorumID, pbPaymentConfig := range vaultParams.GetQuorumPaymentConfigs() {
+		quorumPaymentConfigs[core.QuorumID(quorumID)] = &core.PaymentQuorumConfig{
+			ReservationSymbolsPerSecond: pbPaymentConfig.GetReservationSymbolsPerSecond(),
+			OnDemandSymbolsPerSecond:    pbPaymentConfig.GetOnDemandSymbolsPerSecond(),
+			OnDemandPricePerSymbol:      pbPaymentConfig.GetOnDemandPricePerSymbol(),
+		}
 	}
-	return config.ReservationRateLimitWindow
-}
 
-// return the key of QuorumPaymentConfigs
-func (pcs *OnchainPaymentState) GetQuorumNumbers(ctx context.Context) ([]uint8, error) {
-	quorumNumbers := make([]uint8, 0, len(pcs.PaymentVaultParams.Load().QuorumPaymentConfigs))
-	for quorumNumber := range pcs.PaymentVaultParams.Load().QuorumPaymentConfigs {
-		quorumNumbers = append(quorumNumbers, uint8(quorumNumber))
+	for quorumID, pbProtocolConfig := range vaultParams.GetQuorumProtocolConfigs() {
+		quorumProtocolConfigs[core.QuorumID(quorumID)] = &core.PaymentQuorumProtocolConfig{
+			MinNumSymbols:              pbProtocolConfig.GetMinNumSymbols(),
+			ReservationAdvanceWindow:   pbProtocolConfig.GetReservationAdvanceWindow(),
+			ReservationRateLimitWindow: pbProtocolConfig.GetReservationRateLimitWindow(),
+			OnDemandRateLimitWindow:    pbProtocolConfig.GetOnDemandRateLimitWindow(),
+			OnDemandEnabled:            pbProtocolConfig.GetOnDemandEnabled(),
+		}
 	}
-	return quorumNumbers, nil
+	// Convert uint32 slice to core.QuorumID slice
+	onDemandQuorumNumbers := make([]core.QuorumID, len(vaultParams.GetOnDemandQuorumNumbers()))
+	for i, num := range vaultParams.GetOnDemandQuorumNumbers() {
+		onDemandQuorumNumbers[i] = core.QuorumID(num)
+	}
+	return &PaymentVaultParams{
+		QuorumPaymentConfigs:  quorumPaymentConfigs,
+		QuorumProtocolConfigs: quorumProtocolConfigs,
+		OnDemandQuorumNumbers: onDemandQuorumNumbers,
+	}, nil
 }

--- a/core/meterer/onchain_state.go
+++ b/core/meterer/onchain_state.go
@@ -135,27 +135,23 @@ func (pcs *OnchainPaymentState) GetPaymentVaultParams(ctx context.Context) (*Pay
 		quorumNumbers[i] = uint8(i)
 	}
 
-	// Get global parameters
+	// TODO(hopeyen): the construction of quorum configs will be updated with payment vault interface updates
 	globalSymbolsPerSecond, err := pcs.tx.GetOnDemandGlobalSymbolsPerSecond(ctx, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get global symbols per second: %w", err)
 	}
-
 	globalRatePeriodInterval, err := pcs.tx.GetOnDemandGlobalRatePeriodInterval(ctx, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get global rate period interval: %w", err)
 	}
-
 	minNumSymbols, err := pcs.tx.GetMinNumSymbols(ctx, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get min num symbols: %w", err)
 	}
-
 	pricePerSymbol, err := pcs.tx.GetPricePerSymbol(ctx, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get price per symbol: %w", err)
 	}
-
 	reservationWindow, err := pcs.tx.GetReservationWindow(ctx, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get reservation window: %w", err)
@@ -295,24 +291,6 @@ func (pvp *PaymentVaultParams) GetQuorumProtocolConfig(quorumID core.QuorumID) (
 	return config, nil
 }
 
-// GetOnDemandGlobalSymbolsPerSecond retrieves the global symbols per second rate for on-demand payments
-func (pvp *PaymentVaultParams) GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) (uint64, error) {
-	config, err := pvp.GetQuorumPaymentConfig(quorumID)
-	if err != nil {
-		return 0, err
-	}
-	return config.OnDemandSymbolsPerSecond, nil
-}
-
-// GetOnDemandGlobalRatePeriodInterval retrieves the rate period interval for on-demand payments
-func (pvp *PaymentVaultParams) GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) (uint64, error) {
-	config, err := pvp.GetQuorumProtocolConfig(quorumID)
-	if err != nil {
-		return 0, err
-	}
-	return config.OnDemandRateLimitWindow, nil
-}
-
 // GetMinNumSymbols retrieves the minimum number of symbols required for a quorum
 func (pvp *PaymentVaultParams) GetMinNumSymbols(quorumID core.QuorumID) (uint64, error) {
 	config, err := pvp.GetQuorumProtocolConfig(quorumID)
@@ -415,21 +393,6 @@ func (pcs *OnchainPaymentState) refreshOnDemandPayments(ctx context.Context) err
 	}
 	pcs.OnDemandPayments = onDemandPayments
 	return nil
-}
-
-func (pvp *PaymentVaultParams) GetQuorumConfigs(quorumNumber core.QuorumID) (*core.PaymentQuorumConfig, *core.PaymentQuorumProtocolConfig, error) {
-	if pvp == nil {
-		return nil, nil, fmt.Errorf("payment vault params is nil")
-	}
-	paymentQuorumConfig, ok := pvp.QuorumPaymentConfigs[quorumNumber]
-	if !ok {
-		return nil, nil, fmt.Errorf("payment quorum config not found for quorum %d", quorumNumber)
-	}
-	protocolConfig, ok := pvp.QuorumProtocolConfigs[quorumNumber]
-	if !ok {
-		return nil, nil, fmt.Errorf("payment quorum protocol config not found for quorum %d", quorumNumber)
-	}
-	return paymentQuorumConfig, protocolConfig, nil
 }
 
 // PaymentVaultParamsFromProtobuf converts a protobuf payment vault params to a core payment vault params

--- a/core/meterer/onchain_state_test.go
+++ b/core/meterer/onchain_state_test.go
@@ -2,10 +2,10 @@ package meterer_test
 
 import (
 	"context"
-	"math"
 	"math/big"
 	"testing"
 
+	disperser_rpc "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	"github.com/Layr-Labs/eigenda/common/testutils"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/meterer"
@@ -20,21 +20,12 @@ var (
 		SymbolsPerSecond: 100,
 		StartTimestamp:   1000,
 		EndTimestamp:     2000,
-		QuorumSplits:     []byte{50, 50},
+		// QuorumSplits:     []byte{50, 50},
 	}
 	dummyOnDemandPayment = &core.OnDemandPayment{
 		CumulativePayment: big.NewInt(1000),
 	}
 )
-
-func TestRefreshOnchainPaymentState(t *testing.T) {
-	mockState := &mock.MockOnchainPaymentState{}
-	ctx := context.Background()
-	mockState.On("RefreshOnchainPaymentState", testifymock.Anything).Return(nil)
-
-	err := mockState.RefreshOnchainPaymentState(ctx)
-	assert.NoError(t, err)
-}
 
 func TestGetCurrentBlockNumber(t *testing.T) {
 	mockState := &mock.MockOnchainPaymentState{}
@@ -82,11 +73,26 @@ func TestOnchainPaymentStateNilAssignmentProtection(t *testing.T) {
 		stateWithNilParams, err := meterer.NewOnchainPaymentStateEmpty(context.Background(), nil, testutils.GetLogger())
 		assert.NoError(t, err)
 
-		assert.Equal(t, uint64(0), stateWithNilParams.GetOnDemandGlobalSymbolsPerSecond(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(0), stateWithNilParams.GetOnDemandGlobalRatePeriodInterval(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(math.MaxUint64), stateWithNilParams.GetMinNumSymbols(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(math.MaxUint64), stateWithNilParams.GetPricePerSymbol(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(0), stateWithNilParams.GetReservationWindow(meterer.OnDemandQuorumID))
+		// Test that nil PaymentVaultParams returns appropriate errors
+		_, err = stateWithNilParams.GetOnDemandGlobalSymbolsPerSecond(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment vault params not initialized")
+
+		_, err = stateWithNilParams.GetOnDemandGlobalRatePeriodInterval(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment vault params not initialized")
+
+		_, err = stateWithNilParams.GetMinNumSymbols(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment vault params not initialized")
+
+		_, err = stateWithNilParams.GetPricePerSymbol(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment vault params not initialized")
+
+		_, err = stateWithNilParams.GetReservationWindow(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment vault params not initialized")
 	})
 
 	t.Run("PaymentVaultParams_MissingQuorum", func(t *testing.T) {
@@ -98,11 +104,26 @@ func TestOnchainPaymentStateNilAssignmentProtection(t *testing.T) {
 		}
 		state.PaymentVaultParams.Store(params)
 
-		assert.Equal(t, uint64(0), state.GetOnDemandGlobalSymbolsPerSecond(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(0), state.GetOnDemandGlobalRatePeriodInterval(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(math.MaxUint64), state.GetMinNumSymbols(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(math.MaxUint64), state.GetPricePerSymbol(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(0), state.GetReservationWindow(meterer.OnDemandQuorumID))
+		// Test that missing quorum returns appropriate errors
+		_, err = state.GetOnDemandGlobalSymbolsPerSecond(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment config not found for quorum")
+
+		_, err = state.GetOnDemandGlobalRatePeriodInterval(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "protocol config not found for quorum")
+
+		_, err = state.GetMinNumSymbols(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "protocol config not found for quorum")
+
+		_, err = state.GetPricePerSymbol(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "payment config not found for quorum")
+
+		_, err = state.GetReservationWindow(meterer.OnDemandQuorumID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "protocol config not found for quorum")
 	})
 
 	t.Run("PaymentVaultParams_ValidConfig", func(t *testing.T) {
@@ -126,11 +147,21 @@ func TestOnchainPaymentStateNilAssignmentProtection(t *testing.T) {
 		}
 		state.PaymentVaultParams.Store(params)
 
-		assert.Equal(t, uint64(100), state.GetOnDemandGlobalSymbolsPerSecond(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(400), state.GetOnDemandGlobalRatePeriodInterval(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(300), state.GetMinNumSymbols(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(200), state.GetPricePerSymbol(meterer.OnDemandQuorumID))
-		assert.Equal(t, uint64(500), state.GetReservationWindow(meterer.OnDemandQuorumID))
+		globalSymbolsPerSecond, err := state.GetOnDemandGlobalSymbolsPerSecond(meterer.OnDemandQuorumID)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(100), globalSymbolsPerSecond)
+		globalPeriodInterval, err := state.GetOnDemandGlobalRatePeriodInterval(meterer.OnDemandQuorumID)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(400), globalPeriodInterval)
+		minNumSymbols, err := state.GetMinNumSymbols(meterer.OnDemandQuorumID)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(300), minNumSymbols)
+		pricePerSymbol, err := state.GetPricePerSymbol(meterer.OnDemandQuorumID)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(200), pricePerSymbol)
+		reservationWindow, err := state.GetReservationWindow(meterer.OnDemandQuorumID)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(500), reservationWindow)
 	})
 
 	t.Run("NilMapAssignment_Protection", func(t *testing.T) {
@@ -254,4 +285,458 @@ func TestNilAssignmentPanicScenario(t *testing.T) {
 		_, exists := state.ReservedPayments[account]
 		assert.False(t, exists)
 	})
+}
+
+func TestPaymentVaultParams_GetQuorumConfigs(t *testing.T) {
+	paymentVaultParams := &meterer.PaymentVaultParams{
+		QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+			0: {
+				ReservationSymbolsPerSecond: 1,
+				OnDemandSymbolsPerSecond:    2,
+				OnDemandPricePerSymbol:      3,
+			},
+			1: {
+				ReservationSymbolsPerSecond: 4,
+				OnDemandSymbolsPerSecond:    5,
+				OnDemandPricePerSymbol:      6,
+			},
+		},
+		QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+			0: {
+				MinNumSymbols:              7,
+				ReservationAdvanceWindow:   8,
+				ReservationRateLimitWindow: 9,
+				OnDemandRateLimitWindow:    10,
+				OnDemandEnabled:            true,
+			},
+			1: {
+				MinNumSymbols:              11,
+				ReservationAdvanceWindow:   12,
+				ReservationRateLimitWindow: 13,
+				OnDemandRateLimitWindow:    14,
+				OnDemandEnabled:            false,
+			},
+		},
+		OnDemandQuorumNumbers: []core.QuorumID{0, 1},
+	}
+
+	// Test with non-existent quorum
+	_, _, err := paymentVaultParams.GetQuorumConfigs(99)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "config not found")
+
+	paymentQuorumConfig, protocolConfig, err := paymentVaultParams.GetQuorumConfigs(0)
+	assert.NoError(t, err)
+	assert.NotNil(t, paymentQuorumConfig)
+	assert.NotNil(t, protocolConfig)
+	assert.Equal(t, uint64(7), protocolConfig.MinNumSymbols)
+	assert.Equal(t, uint64(3), paymentQuorumConfig.OnDemandPricePerSymbol)
+	assert.Equal(t, []core.QuorumID{0, 1}, paymentVaultParams.OnDemandQuorumNumbers)
+}
+
+func TestPaymentVaultParamsFromProtobuf(t *testing.T) {
+	tests := []struct {
+		name        string
+		vaultParams *disperser_rpc.PaymentVaultParams
+		expected    *meterer.PaymentVaultParams
+		expectedErr string
+	}{
+		{
+			name:        "nil vault params",
+			vaultParams: nil,
+			expectedErr: "payment vault params cannot be nil",
+		},
+		{
+			name: "nil quorum payment configs",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs:  nil,
+				QuorumProtocolConfigs: map[uint32]*disperser_rpc.PaymentQuorumProtocolConfig{},
+				OnDemandQuorumNumbers: []uint32{},
+			},
+			expectedErr: "payment quorum configs cannot be nil",
+		},
+		{
+			name: "nil quorum protocol configs",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs:  map[uint32]*disperser_rpc.PaymentQuorumConfig{},
+				QuorumProtocolConfigs: nil,
+				OnDemandQuorumNumbers: []uint32{},
+			},
+			expectedErr: "payment quorum protocol configs cannot be nil",
+		},
+		{
+			name: "empty configs",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs:  map[uint32]*disperser_rpc.PaymentQuorumConfig{},
+				QuorumProtocolConfigs: map[uint32]*disperser_rpc.PaymentQuorumProtocolConfig{},
+				OnDemandQuorumNumbers: []uint32{},
+			},
+			expected: &meterer.PaymentVaultParams{
+				QuorumPaymentConfigs:  map[core.QuorumID]*core.PaymentQuorumConfig{},
+				QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{},
+				OnDemandQuorumNumbers: []core.QuorumID{},
+			},
+		},
+		{
+			name: "single quorum config",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs: map[uint32]*disperser_rpc.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 100,
+						OnDemandSymbolsPerSecond:    200,
+						OnDemandPricePerSymbol:      300,
+					},
+				},
+				QuorumProtocolConfigs: map[uint32]*disperser_rpc.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              400,
+						ReservationAdvanceWindow:   500,
+						ReservationRateLimitWindow: 600,
+						OnDemandRateLimitWindow:    700,
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []uint32{0},
+			},
+			expected: &meterer.PaymentVaultParams{
+				QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 100,
+						OnDemandSymbolsPerSecond:    200,
+						OnDemandPricePerSymbol:      300,
+					},
+				},
+				QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              400,
+						ReservationAdvanceWindow:   500,
+						ReservationRateLimitWindow: 600,
+						OnDemandRateLimitWindow:    700,
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []core.QuorumID{0},
+			},
+		},
+		{
+			name: "multiple quorum configs",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs: map[uint32]*disperser_rpc.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 100,
+						OnDemandSymbolsPerSecond:    200,
+						OnDemandPricePerSymbol:      300,
+					},
+					1: {
+						ReservationSymbolsPerSecond: 1100,
+						OnDemandSymbolsPerSecond:    1200,
+						OnDemandPricePerSymbol:      1300,
+					},
+					255: {
+						ReservationSymbolsPerSecond: 25500,
+						OnDemandSymbolsPerSecond:    25600,
+						OnDemandPricePerSymbol:      25700,
+					},
+				},
+				QuorumProtocolConfigs: map[uint32]*disperser_rpc.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              400,
+						ReservationAdvanceWindow:   500,
+						ReservationRateLimitWindow: 600,
+						OnDemandRateLimitWindow:    700,
+						OnDemandEnabled:            true,
+					},
+					1: {
+						MinNumSymbols:              1400,
+						ReservationAdvanceWindow:   1500,
+						ReservationRateLimitWindow: 1600,
+						OnDemandRateLimitWindow:    1700,
+						OnDemandEnabled:            false,
+					},
+					255: {
+						MinNumSymbols:              25800,
+						ReservationAdvanceWindow:   25900,
+						ReservationRateLimitWindow: 26000,
+						OnDemandRateLimitWindow:    26100,
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []uint32{0, 1, 255},
+			},
+			expected: &meterer.PaymentVaultParams{
+				QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 100,
+						OnDemandSymbolsPerSecond:    200,
+						OnDemandPricePerSymbol:      300,
+					},
+					1: {
+						ReservationSymbolsPerSecond: 1100,
+						OnDemandSymbolsPerSecond:    1200,
+						OnDemandPricePerSymbol:      1300,
+					},
+					255: {
+						ReservationSymbolsPerSecond: 25500,
+						OnDemandSymbolsPerSecond:    25600,
+						OnDemandPricePerSymbol:      25700,
+					},
+				},
+				QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              400,
+						ReservationAdvanceWindow:   500,
+						ReservationRateLimitWindow: 600,
+						OnDemandRateLimitWindow:    700,
+						OnDemandEnabled:            true,
+					},
+					1: {
+						MinNumSymbols:              1400,
+						ReservationAdvanceWindow:   1500,
+						ReservationRateLimitWindow: 1600,
+						OnDemandRateLimitWindow:    1700,
+						OnDemandEnabled:            false,
+					},
+					255: {
+						MinNumSymbols:              25800,
+						ReservationAdvanceWindow:   25900,
+						ReservationRateLimitWindow: 26000,
+						OnDemandRateLimitWindow:    26100,
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []core.QuorumID{0, 1, 255},
+			},
+		},
+		{
+			name: "zero values",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs: map[uint32]*disperser_rpc.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 0,
+						OnDemandSymbolsPerSecond:    0,
+						OnDemandPricePerSymbol:      0,
+					},
+				},
+				QuorumProtocolConfigs: map[uint32]*disperser_rpc.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              0,
+						ReservationAdvanceWindow:   0,
+						ReservationRateLimitWindow: 0,
+						OnDemandRateLimitWindow:    0,
+						OnDemandEnabled:            false,
+					},
+				},
+				OnDemandQuorumNumbers: []uint32{0},
+			},
+			expected: &meterer.PaymentVaultParams{
+				QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 0,
+						OnDemandSymbolsPerSecond:    0,
+						OnDemandPricePerSymbol:      0,
+					},
+				},
+				QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              0,
+						ReservationAdvanceWindow:   0,
+						ReservationRateLimitWindow: 0,
+						OnDemandRateLimitWindow:    0,
+						OnDemandEnabled:            false,
+					},
+				},
+				OnDemandQuorumNumbers: []core.QuorumID{0},
+			},
+		},
+		{
+			name: "max values",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs: map[uint32]*disperser_rpc.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: ^uint64(0), // max uint64
+						OnDemandSymbolsPerSecond:    ^uint64(0),
+						OnDemandPricePerSymbol:      ^uint64(0),
+					},
+				},
+				QuorumProtocolConfigs: map[uint32]*disperser_rpc.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              ^uint64(0),
+						ReservationAdvanceWindow:   ^uint64(0),
+						ReservationRateLimitWindow: ^uint64(0),
+						OnDemandRateLimitWindow:    ^uint64(0),
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []uint32{0},
+			},
+			expected: &meterer.PaymentVaultParams{
+				QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: ^uint64(0),
+						OnDemandSymbolsPerSecond:    ^uint64(0),
+						OnDemandPricePerSymbol:      ^uint64(0),
+					},
+				},
+				QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              ^uint64(0),
+						ReservationAdvanceWindow:   ^uint64(0),
+						ReservationRateLimitWindow: ^uint64(0),
+						OnDemandRateLimitWindow:    ^uint64(0),
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []core.QuorumID{0},
+			},
+		},
+		{
+			name: "empty on-demand quorum numbers",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs: map[uint32]*disperser_rpc.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 100,
+						OnDemandSymbolsPerSecond:    200,
+						OnDemandPricePerSymbol:      300,
+					},
+				},
+				QuorumProtocolConfigs: map[uint32]*disperser_rpc.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              400,
+						ReservationAdvanceWindow:   500,
+						ReservationRateLimitWindow: 600,
+						OnDemandRateLimitWindow:    700,
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []uint32{},
+			},
+			expected: &meterer.PaymentVaultParams{
+				QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 100,
+						OnDemandSymbolsPerSecond:    200,
+						OnDemandPricePerSymbol:      300,
+					},
+				},
+				QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+					0: {
+						MinNumSymbols:              400,
+						ReservationAdvanceWindow:   500,
+						ReservationRateLimitWindow: 600,
+						OnDemandRateLimitWindow:    700,
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []core.QuorumID{},
+			},
+		},
+		{
+			name: "mismatched quorum configs",
+			vaultParams: &disperser_rpc.PaymentVaultParams{
+				QuorumPaymentConfigs: map[uint32]*disperser_rpc.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 100,
+						OnDemandSymbolsPerSecond:    200,
+						OnDemandPricePerSymbol:      300,
+					},
+					2: {
+						ReservationSymbolsPerSecond: 2100,
+						OnDemandSymbolsPerSecond:    2200,
+						OnDemandPricePerSymbol:      2300,
+					},
+				},
+				QuorumProtocolConfigs: map[uint32]*disperser_rpc.PaymentQuorumProtocolConfig{
+					1: {
+						MinNumSymbols:              1400,
+						ReservationAdvanceWindow:   1500,
+						ReservationRateLimitWindow: 1600,
+						OnDemandRateLimitWindow:    1700,
+						OnDemandEnabled:            false,
+					},
+					3: {
+						MinNumSymbols:              3400,
+						ReservationAdvanceWindow:   3500,
+						ReservationRateLimitWindow: 3600,
+						OnDemandRateLimitWindow:    3700,
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []uint32{0, 1, 2, 3},
+			},
+			expected: &meterer.PaymentVaultParams{
+				QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+					0: {
+						ReservationSymbolsPerSecond: 100,
+						OnDemandSymbolsPerSecond:    200,
+						OnDemandPricePerSymbol:      300,
+					},
+					2: {
+						ReservationSymbolsPerSecond: 2100,
+						OnDemandSymbolsPerSecond:    2200,
+						OnDemandPricePerSymbol:      2300,
+					},
+				},
+				QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+					1: {
+						MinNumSymbols:              1400,
+						ReservationAdvanceWindow:   1500,
+						ReservationRateLimitWindow: 1600,
+						OnDemandRateLimitWindow:    1700,
+						OnDemandEnabled:            false,
+					},
+					3: {
+						MinNumSymbols:              3400,
+						ReservationAdvanceWindow:   3500,
+						ReservationRateLimitWindow: 3600,
+						OnDemandRateLimitWindow:    3700,
+						OnDemandEnabled:            true,
+					},
+				},
+				OnDemandQuorumNumbers: []core.QuorumID{0, 1, 2, 3},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := meterer.PaymentVaultParamsFromProtobuf(tt.vaultParams)
+
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+
+				// Compare QuorumPaymentConfigs
+				assert.Equal(t, len(tt.expected.QuorumPaymentConfigs), len(result.QuorumPaymentConfigs))
+				for quorumID, expectedConfig := range tt.expected.QuorumPaymentConfigs {
+					actualConfig, exists := result.QuorumPaymentConfigs[quorumID]
+					assert.True(t, exists, "QuorumPaymentConfig for quorum %d should exist", quorumID)
+					assert.Equal(t, expectedConfig.ReservationSymbolsPerSecond, actualConfig.ReservationSymbolsPerSecond)
+					assert.Equal(t, expectedConfig.OnDemandSymbolsPerSecond, actualConfig.OnDemandSymbolsPerSecond)
+					assert.Equal(t, expectedConfig.OnDemandPricePerSymbol, actualConfig.OnDemandPricePerSymbol)
+				}
+
+				// Compare QuorumProtocolConfigs
+				assert.Equal(t, len(tt.expected.QuorumProtocolConfigs), len(result.QuorumProtocolConfigs))
+				for quorumID, expectedConfig := range tt.expected.QuorumProtocolConfigs {
+					actualConfig, exists := result.QuorumProtocolConfigs[quorumID]
+					assert.True(t, exists, "QuorumProtocolConfig for quorum %d should exist", quorumID)
+					assert.Equal(t, expectedConfig.MinNumSymbols, actualConfig.MinNumSymbols)
+					assert.Equal(t, expectedConfig.ReservationAdvanceWindow, actualConfig.ReservationAdvanceWindow)
+					assert.Equal(t, expectedConfig.ReservationRateLimitWindow, actualConfig.ReservationRateLimitWindow)
+					assert.Equal(t, expectedConfig.OnDemandRateLimitWindow, actualConfig.OnDemandRateLimitWindow)
+					assert.Equal(t, expectedConfig.OnDemandEnabled, actualConfig.OnDemandEnabled)
+				}
+
+				// Compare OnDemandQuorumNumbers
+				assert.Equal(t, len(tt.expected.OnDemandQuorumNumbers), len(result.OnDemandQuorumNumbers))
+				for i, expectedQuorum := range tt.expected.OnDemandQuorumNumbers {
+					assert.Equal(t, expectedQuorum, result.OnDemandQuorumNumbers[i])
+				}
+			}
+		})
+	}
 }

--- a/core/mock/payment_state.go
+++ b/core/mock/payment_state.go
@@ -25,7 +25,7 @@ func (m *MockOnchainPaymentState) GetCurrentBlockNumber(ctx context.Context) (ui
 }
 
 func (m *MockOnchainPaymentState) RefreshOnchainPaymentState(ctx context.Context) error {
-	args := m.Called()
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 
@@ -80,29 +80,49 @@ func (m *MockOnchainPaymentState) GetOnDemandQuorumNumbers(ctx context.Context) 
 	return value, args.Error(1)
 }
 
-func (m *MockOnchainPaymentState) GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) uint64 {
+func (m *MockOnchainPaymentState) GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) (uint64, error) {
 	args := m.Called(quorumID)
-	return args.Get(0).(uint64)
+	var value uint64
+	if args.Get(0) != nil {
+		value = args.Get(0).(uint64)
+	}
+	return value, args.Error(1)
 }
 
-func (m *MockOnchainPaymentState) GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) uint64 {
+func (m *MockOnchainPaymentState) GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) (uint64, error) {
 	args := m.Called(quorumID)
-	return args.Get(0).(uint64)
+	var value uint64
+	if args.Get(0) != nil {
+		value = args.Get(0).(uint64)
+	}
+	return value, args.Error(1)
 }
 
-func (m *MockOnchainPaymentState) GetMinNumSymbols(quorumID core.QuorumID) uint64 {
+func (m *MockOnchainPaymentState) GetMinNumSymbols(quorumID core.QuorumID) (uint64, error) {
 	args := m.Called(quorumID)
-	return args.Get(0).(uint64)
+	var value uint64
+	if args.Get(0) != nil {
+		value = args.Get(0).(uint64)
+	}
+	return value, args.Error(1)
 }
 
-func (m *MockOnchainPaymentState) GetPricePerSymbol(quorumID core.QuorumID) uint64 {
+func (m *MockOnchainPaymentState) GetPricePerSymbol(quorumID core.QuorumID) (uint64, error) {
 	args := m.Called(quorumID)
-	return args.Get(0).(uint64)
+	var value uint64
+	if args.Get(0) != nil {
+		value = args.Get(0).(uint64)
+	}
+	return value, args.Error(1)
 }
 
-func (m *MockOnchainPaymentState) GetReservationWindow(quorumID core.QuorumID) uint64 {
+func (m *MockOnchainPaymentState) GetReservationWindow(quorumID core.QuorumID) (uint64, error) {
 	args := m.Called(quorumID)
-	return args.Get(0).(uint64)
+	var value uint64
+	if args.Get(0) != nil {
+		value = args.Get(0).(uint64)
+	}
+	return value, args.Error(1)
 }
 
 func (m *MockOnchainPaymentState) GetQuorumNumbers(ctx context.Context) ([]uint8, error) {
@@ -122,4 +142,14 @@ func (m *MockOnchainPaymentState) GetQuorumPaymentConfig(quorumID core.QuorumID)
 func (m *MockOnchainPaymentState) GetQuorumProtocolConfig(quorumID core.QuorumID) (*core.PaymentQuorumProtocolConfig, error) {
 	args := m.Called(quorumID)
 	return args.Get(0).(*core.PaymentQuorumProtocolConfig), args.Error(1)
+}
+
+func (m *MockOnchainPaymentState) GetQuorumPaymentConfigs() map[core.QuorumID]*core.PaymentQuorumConfig {
+	args := m.Called()
+	return args.Get(0).(map[core.QuorumID]*core.PaymentQuorumConfig)
+}
+
+func (m *MockOnchainPaymentState) GetQuorumProtocolConfigs() map[core.QuorumID]*core.PaymentQuorumProtocolConfig {
+	args := m.Called()
+	return args.Get(0).(map[core.QuorumID]*core.PaymentQuorumProtocolConfig)
 }

--- a/core/mock/payment_state.go
+++ b/core/mock/payment_state.go
@@ -15,36 +15,9 @@ type MockOnchainPaymentState struct {
 
 var _ meterer.OnchainPayment = (*MockOnchainPaymentState)(nil)
 
-func (m *MockOnchainPaymentState) GetCurrentBlockNumber(ctx context.Context) (uint32, error) {
-	args := m.Called()
-	var value uint32
-	if args.Get(0) != nil {
-		value = args.Get(0).(uint32)
-	}
-	return value, args.Error(1)
-}
-
 func (m *MockOnchainPaymentState) RefreshOnchainPaymentState(ctx context.Context) error {
 	args := m.Called(ctx)
 	return args.Error(0)
-}
-
-func (m *MockOnchainPaymentState) GetReservedPaymentByAccount(ctx context.Context, accountID gethcommon.Address) (map[core.QuorumID]*core.ReservedPayment, error) {
-	args := m.Called(ctx, accountID)
-	var value map[core.QuorumID]*core.ReservedPayment
-	if args.Get(0) != nil {
-		value = args.Get(0).(map[core.QuorumID]*core.ReservedPayment)
-	}
-	return value, args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetReservedPaymentByAccountAndQuorum(ctx context.Context, accountID gethcommon.Address, quorumId uint8) (*core.ReservedPayment, error) {
-	args := m.Called(ctx, accountID, quorumId)
-	var value *core.ReservedPayment
-	if args.Get(0) != nil {
-		value = args.Get(0).(*core.ReservedPayment)
-	}
-	return value, args.Error(1)
 }
 
 func (m *MockOnchainPaymentState) GetReservedPaymentByAccountAndQuorums(ctx context.Context, accountID gethcommon.Address, quorumNumbers []core.QuorumID) (map[core.QuorumID]*core.ReservedPayment, error) {
@@ -71,85 +44,20 @@ func (m *MockOnchainPaymentState) GetOnDemandPaymentByAccount(ctx context.Contex
 	return value, args.Error(1)
 }
 
-func (m *MockOnchainPaymentState) GetOnDemandQuorumNumbers(ctx context.Context) ([]uint8, error) {
+func (m *MockOnchainPaymentState) GetQuorumNumbers(ctx context.Context) ([]core.QuorumID, error) {
+	args := m.Called(ctx)
+	var value []core.QuorumID
+	if args.Get(0) != nil {
+		value = args.Get(0).([]core.QuorumID)
+	}
+	return value, args.Error(1)
+}
+
+func (m *MockOnchainPaymentState) GetPaymentGlobalParams() (*meterer.PaymentVaultParams, error) {
 	args := m.Called()
-	var value []uint8
+	var value *meterer.PaymentVaultParams
 	if args.Get(0) != nil {
-		value = args.Get(0).([]uint8)
+		value = args.Get(0).(*meterer.PaymentVaultParams)
 	}
 	return value, args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetOnDemandGlobalSymbolsPerSecond(quorumID core.QuorumID) (uint64, error) {
-	args := m.Called(quorumID)
-	var value uint64
-	if args.Get(0) != nil {
-		value = args.Get(0).(uint64)
-	}
-	return value, args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetOnDemandGlobalRatePeriodInterval(quorumID core.QuorumID) (uint64, error) {
-	args := m.Called(quorumID)
-	var value uint64
-	if args.Get(0) != nil {
-		value = args.Get(0).(uint64)
-	}
-	return value, args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetMinNumSymbols(quorumID core.QuorumID) (uint64, error) {
-	args := m.Called(quorumID)
-	var value uint64
-	if args.Get(0) != nil {
-		value = args.Get(0).(uint64)
-	}
-	return value, args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetPricePerSymbol(quorumID core.QuorumID) (uint64, error) {
-	args := m.Called(quorumID)
-	var value uint64
-	if args.Get(0) != nil {
-		value = args.Get(0).(uint64)
-	}
-	return value, args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetReservationWindow(quorumID core.QuorumID) (uint64, error) {
-	args := m.Called(quorumID)
-	var value uint64
-	if args.Get(0) != nil {
-		value = args.Get(0).(uint64)
-	}
-	return value, args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetQuorumNumbers(ctx context.Context) ([]uint8, error) {
-	args := m.Called()
-	var value []uint8
-	if args.Get(0) != nil {
-		value = args.Get(0).([]uint8)
-	}
-	return value, args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetQuorumPaymentConfig(quorumID core.QuorumID) (*core.PaymentQuorumConfig, error) {
-	args := m.Called(quorumID)
-	return args.Get(0).(*core.PaymentQuorumConfig), args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetQuorumProtocolConfig(quorumID core.QuorumID) (*core.PaymentQuorumProtocolConfig, error) {
-	args := m.Called(quorumID)
-	return args.Get(0).(*core.PaymentQuorumProtocolConfig), args.Error(1)
-}
-
-func (m *MockOnchainPaymentState) GetQuorumPaymentConfigs() map[core.QuorumID]*core.PaymentQuorumConfig {
-	args := m.Called()
-	return args.Get(0).(map[core.QuorumID]*core.PaymentQuorumConfig)
-}
-
-func (m *MockOnchainPaymentState) GetQuorumProtocolConfigs() map[core.QuorumID]*core.PaymentQuorumProtocolConfig {
-	args := m.Called()
-	return args.Get(0).(map[core.QuorumID]*core.PaymentQuorumProtocolConfig)
 }

--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -752,21 +752,43 @@ func newTestServer(transactor core.Writer, testName string) *apiserver.Dispersal
 		panic("failed to make initial query to the on-chain state")
 	}
 
-	mockState.On("GetPricePerSymbol").Return(uint32(encoding.BYTES_PER_SYMBOL), nil)
-	mockState.On("GetMinNumSymbols").Return(uint32(1), nil)
-	mockState.On("GetOnDemandGlobalSymbolsPerSecond").Return(uint64(4096), nil)
-	mockState.On("GetRequiredQuorumNumbers").Return([]uint8{0, 1}, nil)
-	mockState.On("GetOnDemandQuorumNumbers").Return([]uint8{0, 1}, nil)
-	mockState.On("GetReservationWindow").Return(uint32(1), nil)
+	// Setup mock payment vault params for server test  
+	serverTestMockParams := &meterer.PaymentVaultParams{
+		QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+			0: {
+				OnDemandSymbolsPerSecond: 4096,
+				OnDemandPricePerSymbol:   uint64(encoding.BYTES_PER_SYMBOL),
+			},
+			1: {
+				OnDemandSymbolsPerSecond: 4096,
+				OnDemandPricePerSymbol:   uint64(encoding.BYTES_PER_SYMBOL),
+			},
+		},
+		QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+			0: {
+				MinNumSymbols:              1,
+				ReservationRateLimitWindow: 1,
+			},
+			1: {
+				MinNumSymbols:              1,
+				ReservationRateLimitWindow: 1,
+			},
+		},
+		OnDemandQuorumNumbers: []core.QuorumID{0, 1},
+	}
+	mockState.On("GetPaymentGlobalParams").Return(serverTestMockParams, nil)
+	mockState.On("GetQuorumNumbers", tmock.Anything).Return([]core.QuorumID{0, 1}, nil)
 	mockState.On("GetOnDemandPaymentByAccount", tmock.Anything, tmock.Anything).Return(&core.OnDemandPayment{
 		CumulativePayment: big.NewInt(3000),
 	}, nil)
-	mockState.On("GetReservedPaymentByAccount", tmock.Anything, tmock.Anything).Return(&core.ReservedPayment{
-		SymbolsPerSecond: 2048,
-		StartTimestamp:   0,
-		EndTimestamp:     math.MaxUint32,
-		QuorumNumbers:    []uint8{0, 1},
-		QuorumSplits:     []byte{50, 50},
+	mockState.On("GetReservedPaymentByAccountAndQuorums", tmock.Anything, tmock.Anything, tmock.Anything).Return(map[core.QuorumID]*core.ReservedPayment{
+		0: &core.ReservedPayment{
+			SymbolsPerSecond: 2048,
+			StartTimestamp:   0,
+			EndTimestamp:     math.MaxUint32,
+			QuorumNumbers:    []uint8{0, 1},
+			QuorumSplits:     []byte{50, 50},
+		},
 	}, nil)
 	// append test name to each table name for an unique store
 	table_names := []string{"reservations_server_" + testName, "ondemand_server_" + testName, "global_server_" + testName}

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -304,19 +304,19 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 		s.logger.Error("failed to get payment global params", "err", err)
 		return nil, api.NewErrorInternal("failed to get payment parameters")
 	}
-	
+
 	paymentConfig, err := params.GetQuorumPaymentConfig(core.QuorumID(0))
 	if err != nil {
 		s.logger.Error("failed to get payment config for quorum 0", "err", err)
 		return nil, api.NewErrorInternal("failed to get payment configuration")
 	}
-	
+
 	protocolConfig, err := params.GetQuorumProtocolConfig(core.QuorumID(0))
 	if err != nil {
 		s.logger.Error("failed to get protocol config for quorum 0", "err", err)
 		return nil, api.NewErrorInternal("failed to get protocol configuration")
 	}
-	
+
 	globalSymbolsPerSecond := paymentConfig.OnDemandSymbolsPerSecond
 	minNumSymbols := protocolConfig.MinNumSymbols
 	pricePerSymbol := paymentConfig.OnDemandPricePerSymbol

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -299,10 +299,28 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 		return nil, api.NewErrorInvalidArg(fmt.Sprintf("authentication failed: %s", err.Error()))
 	}
 	// on-chain global payment parameters
-	globalSymbolsPerSecond := s.meterer.ChainPaymentState.GetOnDemandGlobalSymbolsPerSecond(core.QuorumID(0))
-	minNumSymbols := s.meterer.ChainPaymentState.GetMinNumSymbols(core.QuorumID(0))
-	pricePerSymbol := s.meterer.ChainPaymentState.GetPricePerSymbol(core.QuorumID(0))
-	reservationWindow := s.meterer.ChainPaymentState.GetReservationWindow(core.QuorumID(0))
+	params, err := s.meterer.ChainPaymentState.GetPaymentGlobalParams()
+	if err != nil {
+		s.logger.Error("failed to get payment global params", "err", err)
+		return nil, api.NewErrorInternal("failed to get payment parameters")
+	}
+	
+	paymentConfig, err := params.GetQuorumPaymentConfig(core.QuorumID(0))
+	if err != nil {
+		s.logger.Error("failed to get payment config for quorum 0", "err", err)
+		return nil, api.NewErrorInternal("failed to get payment configuration")
+	}
+	
+	protocolConfig, err := params.GetQuorumProtocolConfig(core.QuorumID(0))
+	if err != nil {
+		s.logger.Error("failed to get protocol config for quorum 0", "err", err)
+		return nil, api.NewErrorInternal("failed to get protocol configuration")
+	}
+	
+	globalSymbolsPerSecond := paymentConfig.OnDemandSymbolsPerSecond
+	minNumSymbols := protocolConfig.MinNumSymbols
+	pricePerSymbol := paymentConfig.OnDemandPricePerSymbol
+	reservationWindow := protocolConfig.ReservationRateLimitWindow
 
 	// off-chain account specific payment state
 	now := time.Now().Unix()
@@ -311,7 +329,12 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 	// TODO(hopeyen): remove this in a subsequent PR. The logic here is complicated and only temporary
 	periods := make([]uint64, len(quorumIds))
 	for i, quorumId := range quorumIds {
-		periods[i] = meterer.GetReservationPeriod(now, s.meterer.ChainPaymentState.GetReservationWindow(quorumId))
+		quorumProtocolConfig, err := params.GetQuorumProtocolConfig(quorumId)
+		if err != nil {
+			s.logger.Error("failed to get protocol config for quorum", "quorumId", quorumId, "err", err)
+			return nil, api.NewErrorInternal("failed to get quorum protocol configuration")
+		}
+		periods[i] = meterer.GetReservationPeriod(now, quorumProtocolConfig.ReservationRateLimitWindow)
 	}
 	records, err := s.meterer.MeteringStore.GetPeriodRecords(ctx, accountID, quorumIds, periods, 3)
 	if err != nil {

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -305,16 +305,10 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 		return nil, api.NewErrorInternal("failed to get payment parameters")
 	}
 
-	paymentConfig, err := params.GetQuorumPaymentConfig(core.QuorumID(0))
+	paymentConfig, protocolConfig, err := params.GetQuorumConfigs(core.QuorumID(0))
 	if err != nil {
 		s.logger.Error("failed to get payment config for quorum 0", "err", err)
 		return nil, api.NewErrorInternal("failed to get payment configuration")
-	}
-
-	protocolConfig, err := params.GetQuorumProtocolConfig(core.QuorumID(0))
-	if err != nil {
-		s.logger.Error("failed to get protocol config for quorum 0", "err", err)
-		return nil, api.NewErrorInternal("failed to get protocol configuration")
 	}
 
 	globalSymbolsPerSecond := paymentConfig.OnDemandSymbolsPerSecond
@@ -329,7 +323,7 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 	// TODO(hopeyen): remove this in a subsequent PR. The logic here is complicated and only temporary
 	periods := make([]uint64, len(quorumIds))
 	for i, quorumId := range quorumIds {
-		quorumProtocolConfig, err := params.GetQuorumProtocolConfig(quorumId)
+		_, quorumProtocolConfig, err := params.GetQuorumConfigs(quorumId)
 		if err != nil {
 			s.logger.Error("failed to get protocol config for quorum", "quorumId", quorumId, "err", err)
 			return nil, api.NewErrorInternal("failed to get quorum protocol configuration")

--- a/disperser/apiserver/server_v2_test.go
+++ b/disperser/apiserver/server_v2_test.go
@@ -516,16 +516,40 @@ func newTestServerV2(t *testing.T) *testComponents {
 	// append test name to each table name for an unique store
 	mockState := &mock.MockOnchainPaymentState{}
 	mockState.On("RefreshOnchainPaymentState", tmock.Anything).Return(nil).Maybe()
-	mockState.On("GetReservationWindow", tmock.Anything).Return(uint64(1), nil)
-	mockState.On("GetPricePerSymbol", tmock.Anything).Return(uint64(2), nil)
-	mockState.On("GetOnDemandGlobalSymbolsPerSecond", tmock.Anything).Return(uint64(1009), nil)
-	mockState.On("GetOnDemandGlobalRatePeriodInterval", tmock.Anything).Return(uint64(1), nil)
-	mockState.On("GetMinNumSymbols", tmock.Anything).Return(uint64(3), nil)
+	// Setup mock payment vault params for server v2 test
+	serverV2MockParams := &meterer.PaymentVaultParams{
+		QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+			0: {
+				OnDemandSymbolsPerSecond: 1009,
+				OnDemandPricePerSymbol:   2,
+			},
+			1: {
+				OnDemandSymbolsPerSecond: 1009,
+				OnDemandPricePerSymbol:   2,
+			},
+		},
+		QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+			0: {
+				MinNumSymbols:              3,
+				ReservationRateLimitWindow: 1,
+				OnDemandRateLimitWindow:    1,
+			},
+			1: {
+				MinNumSymbols:              3,
+				ReservationRateLimitWindow: 1,
+				OnDemandRateLimitWindow:    1,
+			},
+		},
+		OnDemandQuorumNumbers: []core.QuorumID{0, 1},
+	}
+	mockState.On("GetPaymentGlobalParams").Return(serverV2MockParams, nil)
 
 	now := uint64(time.Now().Unix())
-	mockState.On("GetReservedPaymentByAccount", tmock.Anything, tmock.Anything).Return(&core.ReservedPayment{SymbolsPerSecond: 100, StartTimestamp: now + 1200, EndTimestamp: now + 1800, QuorumSplits: []byte{50, 50}, QuorumNumbers: []uint8{0, 1}}, nil)
+	mockState.On("GetReservedPaymentByAccountAndQuorums", tmock.Anything, tmock.Anything, tmock.Anything).Return(map[core.QuorumID]*core.ReservedPayment{
+		0: &core.ReservedPayment{SymbolsPerSecond: 100, StartTimestamp: now + 1200, EndTimestamp: now + 1800, QuorumSplits: []byte{50, 50}, QuorumNumbers: []uint8{0, 1}},
+		1: &core.ReservedPayment{SymbolsPerSecond: 100, StartTimestamp: now + 1200, EndTimestamp: now + 1800, QuorumSplits: []byte{50, 50}, QuorumNumbers: []uint8{0, 1}},
+	}, nil)
 	mockState.On("GetOnDemandPaymentByAccount", tmock.Anything, tmock.Anything).Return(&core.OnDemandPayment{CumulativePayment: big.NewInt(3864)}, nil)
-	mockState.On("GetOnDemandQuorumNumbers", tmock.Anything).Return([]uint8{0, 1}, nil)
 
 	if err := mockState.RefreshOnchainPaymentState(context.Background()); err != nil {
 		panic("failed to make initial query to the on-chain state")

--- a/node/node_v2_test.go
+++ b/node/node_v2_test.go
@@ -154,7 +154,6 @@ func TestRefreshOnchainStateFailure(t *testing.T) {
 	c.tx.On("GetRelayURLs", mock.Anything).Return(nil, assert.AnError)
 	c.tx.On("GetCurrentBlockNumber", mock.Anything).Return(uint32(10), nil)
 	c.tx.On("GetQuorumCount", mock.Anything).Return(uint8(2), nil)
-	c.tx.On("GetMinNumSymbols", mock.Anything).Return(uint64(4096), nil)
 
 	err := c.node.RefreshOnchainState(newCtx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
@@ -233,7 +232,6 @@ func TestRefreshOnchainStateSuccess(t *testing.T) {
 	}, nil)
 	c.tx.On("GetCurrentBlockNumber", mock.Anything).Return(uint32(10), nil)
 	c.tx.On("GetQuorumCount", mock.Anything).Return(uint8(2), nil)
-	c.tx.On("GetMinNumSymbols", mock.Anything).Return(uint64(4096), nil)
 
 	err = c.node.RefreshOnchainState(newCtx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -227,20 +227,43 @@ func mustMakeDisperser(t *testing.T, cst core.IndexedChainState, store disperser
 	mockState := &coremock.MockOnchainPaymentState{}
 	reservationLimit := uint64(1024)
 	paymentLimit := big.NewInt(512)
-	mockState.On("GetReservedPaymentByAccount", mock.Anything, mock.MatchedBy(func(account gethcommon.Address) bool {
+	mockState.On("GetReservedPaymentByAccountAndQuorums", mock.Anything, mock.MatchedBy(func(account gethcommon.Address) bool {
 		return account == publicKey
-	})).Return(&core.ReservedPayment{SymbolsPerSecond: reservationLimit, StartTimestamp: 0, EndTimestamp: math.MaxUint32, QuorumSplits: []byte{50, 50}, QuorumNumbers: []uint8{0, 1}}, nil)
-	mockState.On("GetReservedPaymentByAccount", mock.Anything, mock.Anything).Return(&core.ReservedPayment{}, errors.New("reservation not found"))
+	}), mock.Anything).Return(map[core.QuorumID]*core.ReservedPayment{
+		0: &core.ReservedPayment{SymbolsPerSecond: reservationLimit, StartTimestamp: 0, EndTimestamp: math.MaxUint32, QuorumSplits: []byte{50, 50}, QuorumNumbers: []uint8{0, 1}},
+		1: &core.ReservedPayment{SymbolsPerSecond: reservationLimit, StartTimestamp: 0, EndTimestamp: math.MaxUint32, QuorumSplits: []byte{50, 50}, QuorumNumbers: []uint8{0, 1}},
+	}, nil)
+	mockState.On("GetReservedPaymentByAccountAndQuorums", mock.Anything, mock.Anything, mock.Anything).Return(map[core.QuorumID]*core.ReservedPayment{}, errors.New("reservation not found"))
 
 	mockState.On("GetOnDemandPaymentByAccount", mock.Anything, mock.MatchedBy(func(account gethcommon.Address) bool {
 		return account == publicKey
 	})).Return(&core.OnDemandPayment{CumulativePayment: paymentLimit}, nil)
 	mockState.On("GetOnDemandPaymentByAccount", mock.Anything, mock.Anything).Return(&core.OnDemandPayment{}, errors.New("payment not found"))
-	mockState.On("GetOnDemandQuorumNumbers", mock.Anything).Return([]uint8{0, 1}, nil)
-	mockState.On("GetOnDemandGlobalSymbolsPerSecond", mock.Anything).Return(uint64(1024), nil)
-	mockState.On("GetPricePerSymbol", mock.Anything).Return(uint32(1), nil)
-	mockState.On("GetMinNumSymbols", mock.Anything).Return(uint32(128), nil)
-	mockState.On("GetReservationWindow", mock.Anything).Return(uint32(60), nil)
+	// Setup mock payment vault params for integration test
+	integrationMockParams := &meterer.PaymentVaultParams{
+		QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+			0: {
+				OnDemandSymbolsPerSecond: 1024,
+				OnDemandPricePerSymbol:   1,
+			},
+			1: {
+				OnDemandSymbolsPerSecond: 1024,
+				OnDemandPricePerSymbol:   1,
+			},
+		},
+		QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+			0: {
+				MinNumSymbols:              128,
+				ReservationRateLimitWindow: 60,
+			},
+			1: {
+				MinNumSymbols:              128,
+				ReservationRateLimitWindow: 60,
+			},
+		},
+		OnDemandQuorumNumbers: []core.QuorumID{0, 1},
+	}
+	mockState.On("GetPaymentGlobalParams").Return(integrationMockParams, nil)
 	mockState.On("RefreshOnchainPaymentState", mock.Anything).Return(nil).Maybe()
 
 	deployLocalStack = !(os.Getenv("DEPLOY_LOCALSTACK") == "false")


### PR DESCRIPTION
## Why are these changes needed?

Part of https://github.com/Layr-Labs/eigenda/pull/1619

- Simplifies the `OnchainPayment` interface (16 methods -> 5 methods)
- Single call + structured access that provides atomic access to related configuration and makes error handling more explicit and consistent

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
