### PR TITLE
refactor: quorum specific metrics for metered bytes

### DIFF
--- a/core/meterer/meterer.go
+++ b/core/meterer/meterer.go
@@ -76,41 +76,36 @@ func (m *Meterer) Start(ctx context.Context) {
 
 // MeterRequest validates a blob header and adds it to the meterer's state
 // TODO: return error if there's a rejection (with reasoning) or internal error (should be very rare)
-func (m *Meterer) MeterRequest(ctx context.Context, header core.PaymentMetadata, numSymbols uint64, quorumNumbers []uint8, receivedAt time.Time) (uint64, error) {
+func (m *Meterer) MeterRequest(ctx context.Context, header core.PaymentMetadata, numSymbols uint64, quorumNumbers []uint8, receivedAt time.Time) (map[core.QuorumID]uint64, error) {
 	m.logger.Info("Validating incoming request's payment metadata", "paymentMetadata", header, "numSymbols", numSymbols, "quorumNumbers", quorumNumbers)
 
 	params, err := m.ChainPaymentState.GetPaymentGlobalParams()
 	if err != nil {
-		return 0, fmt.Errorf("failed to get payment global params: %w", err)
+		return nil, fmt.Errorf("failed to get payment global params: %w", err)
 	}
-	// Validate against the payment method
+
+	// Validate against the payment method; if it's not on-demand, it's a reservation request
 	if !IsOnDemandPayment(&header) {
 		reservations, err := m.ChainPaymentState.GetReservedPaymentByAccountAndQuorums(ctx, header.AccountID, quorumNumbers)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get active reservation by account: %w", err)
+			return nil, fmt.Errorf("failed to get active reservation by account: %w", err)
 		}
-		if err := m.serveReservationRequest(ctx, params, header, reservations, numSymbols, quorumNumbers, receivedAt); err != nil {
-			return 0, fmt.Errorf("invalid reservation request: %w", err)
-		}
-	} else {
-		onDemandPayment, err := m.ChainPaymentState.GetOnDemandPaymentByAccount(ctx, header.AccountID)
+		usage, err := m.serveReservationRequest(ctx, params, header, reservations, numSymbols, quorumNumbers, receivedAt)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get on-demand payment by account: %w", err)
+			return nil, fmt.Errorf("invalid reservation request: %w", err)
 		}
-		if err := m.serveOnDemandRequest(ctx, params, header, onDemandPayment, numSymbols, quorumNumbers, receivedAt); err != nil {
-			return 0, fmt.Errorf("invalid on-demand request: %w", err)
-		}
+		return usage, nil
 	}
 
-	// TODO(hopeyen): each quorum can have different min num symbols; the returned symbolsCharged is only for used for metrics.
-	// for now we simply return the charge for quorum 0, as quorums are likely to share the same min num symbols
-	// we can make this more granular by adding metrics to the meterer later on
-	_, protocolConfig, err := params.GetQuorumConfigs(OnDemandQuorumID)
+	onDemandPayment, err := m.ChainPaymentState.GetOnDemandPaymentByAccount(ctx, header.AccountID)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get on-demand quorum config: %w", err)
+		return nil, fmt.Errorf("failed to get on-demand payment by account: %w", err)
 	}
-	symbolsCharged := SymbolsCharged(numSymbols, protocolConfig.MinNumSymbols)
-	return symbolsCharged, nil
+	usage, err := m.serveOnDemandRequest(ctx, params, header, onDemandPayment, numSymbols, quorumNumbers, receivedAt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid on-demand request: %w", err)
+	}
+	return usage, nil
 }
 
 // serveReservationRequest handles the rate limiting logic for incoming requests
@@ -122,17 +117,18 @@ func (m *Meterer) serveReservationRequest(
 	numSymbols uint64,
 	quorumNumbers []uint8,
 	receivedAt time.Time,
-) error {
+) (map[core.QuorumID]uint64, error) {
 	m.logger.Debug("Recording and validating reservation usage", "header", header, "reservation", reservations)
 	if err := ValidateReservations(reservations, globalParams.QuorumProtocolConfigs, quorumNumbers, header.Timestamp, receivedAt.UnixNano()); err != nil {
-		return fmt.Errorf("invalid reservation: %w", err)
+		return nil, fmt.Errorf("invalid reservation: %w", err)
 	}
 
 	// Make atomic batched updates over all reservations identified by the same account and quorum
-	if err := m.incrementBinUsage(ctx, header, reservations, globalParams, numSymbols); err != nil {
-		return fmt.Errorf("failed to increment bin usages: %w", err)
+	usage, err := m.incrementBinUsage(ctx, header, reservations, globalParams, numSymbols)
+	if err != nil {
+		return nil, fmt.Errorf("failed to increment bin usages: %w", err)
 	}
-	return nil
+	return usage, nil
 }
 
 // incrementBinUsage increments the bin usage atomically and checks for overflow
@@ -141,7 +137,7 @@ func (m *Meterer) incrementBinUsage(
 	reservations map[core.QuorumID]*core.ReservedPayment,
 	globalParams *PaymentVaultParams,
 	numSymbols uint64,
-) error {
+) (map[core.QuorumID]uint64, error) {
 	charges := make(map[core.QuorumID]uint64)
 	quorumNumbers := make([]core.QuorumID, 0, len(reservations))
 	reservationWindows := make(map[core.QuorumID]uint64, len(reservations))
@@ -149,7 +145,7 @@ func (m *Meterer) incrementBinUsage(
 	for quorumID := range reservations {
 		_, protocolConfig, err := globalParams.GetQuorumConfigs(quorumID)
 		if err != nil {
-			return fmt.Errorf("failed to get quorum config for quorum %d: %w", quorumID, err)
+			return nil, fmt.Errorf("failed to get quorum config for quorum %d: %w", quorumID, err)
 		}
 		charges[quorumID] = SymbolsCharged(numSymbols, protocolConfig.MinNumSymbols)
 		quorumNumbers = append(quorumNumbers, quorumID)
@@ -158,13 +154,9 @@ func (m *Meterer) incrementBinUsage(
 	}
 	// Batch increment all quorums for the current quorums' reservation period
 	// For each quorum, increment by its specific symbolsCharged value
-	updatedUsages := make(map[core.QuorumID]uint64)
 	usage, err := m.MeteringStore.IncrementBinUsages(ctx, header.AccountID, quorumNumbers, requestReservationPeriods, charges)
 	if err != nil {
-		return err
-	}
-	for _, quorumID := range quorumNumbers {
-		updatedUsages[quorumID] = usage[quorumID]
+		return nil, err
 	}
 	overflowAmounts := make(map[core.QuorumID]uint64)
 	overflowPeriods := make(map[core.QuorumID]uint64)
@@ -173,16 +165,16 @@ func (m *Meterer) incrementBinUsage(
 		reservationWindow := reservationWindows[quorumID]
 		requestReservationPeriod := requestReservationPeriods[quorumID]
 		usageLimit := GetReservationBinLimit(reservation, reservationWindow)
-		newUsage, ok := updatedUsages[quorumID]
+		newUsage, ok := usage[quorumID]
 		if !ok {
-			return fmt.Errorf("failed to get updated usage for quorum %d", quorumID)
+			return nil, fmt.Errorf("failed to get updated usage for quorum %d", quorumID)
 		}
 		prevUsage := newUsage - charges[quorumID]
 		if newUsage <= usageLimit {
 			continue
 		} else if prevUsage >= usageLimit {
 			// Bin was already filled before this increment
-			return fmt.Errorf("bin has already been filled for quorum %d", quorumID)
+			return nil, fmt.Errorf("bin has already been filled for quorum %d", quorumID)
 		}
 		overflowPeriod := GetOverflowPeriod(requestReservationPeriod, reservationWindow)
 		if charges[quorumID] <= usageLimit && overflowPeriod <= GetReservationPeriod(int64(reservation.EndTimestamp), reservationWindow) {
@@ -190,11 +182,11 @@ func (m *Meterer) incrementBinUsage(
 			overflowAmounts[quorumID] = newUsage - usageLimit
 			overflowPeriods[quorumID] = overflowPeriod
 		} else {
-			return fmt.Errorf("overflow usage exceeds bin limit for quorum %d", quorumID)
+			return nil, fmt.Errorf("overflow usage exceeds bin limit for quorum %d", quorumID)
 		}
 	}
 	if len(overflowAmounts) != len(overflowPeriods) {
-		return fmt.Errorf("overflow amount and period mismatch")
+		return nil, fmt.Errorf("overflow amount and period mismatch")
 	}
 	// Batch increment overflow bins for all overflown reservation candidates
 	if len(overflowAmounts) > 0 {
@@ -208,55 +200,60 @@ func (m *Meterer) incrementBinUsage(
 			// Rollback the increments for the current periods
 			rollbackErr := m.MeteringStore.DecrementBinUsages(ctx, header.AccountID, quorumNumbers, requestReservationPeriods, charges)
 			if rollbackErr != nil {
-				return fmt.Errorf("failed to increment overflow bins: %w; rollback also failed: %v", err, rollbackErr)
+				return nil, fmt.Errorf("failed to increment overflow bins: %w; rollback also failed: %v", err, rollbackErr)
 			}
-			return fmt.Errorf("failed to increment overflow bins: %w; successfully rolled back increments", err)
+			return nil, fmt.Errorf("failed to increment overflow bins: %w; successfully rolled back increments", err)
 		}
 	}
 
-	return nil
+	return charges, nil
 }
 
 // serveOnDemandRequest handles the rate limiting logic for incoming requests
 // On-demand requests doesn't have additional quorum settings and should only be
 // allowed by ETH and EIGEN quorums
-func (m *Meterer) serveOnDemandRequest(ctx context.Context, globalParams *PaymentVaultParams, header core.PaymentMetadata, onDemandPayment *core.OnDemandPayment, symbolsCharged uint64, headerQuorums []uint8, receivedAt time.Time) error {
+func (m *Meterer) serveOnDemandRequest(ctx context.Context, globalParams *PaymentVaultParams, header core.PaymentMetadata, onDemandPayment *core.OnDemandPayment, numSymbols uint64, headerQuorums []uint8, receivedAt time.Time) (map[core.QuorumID]uint64, error) {
 	m.logger.Debug("Recording and validating on-demand usage", "header", header, "onDemandPayment", onDemandPayment)
 
 	if err := ValidateQuorum(headerQuorums, globalParams.OnDemandQuorumNumbers); err != nil {
-		return fmt.Errorf("invalid quorum for On-Demand Request: %w", err)
+		return nil, fmt.Errorf("invalid quorum for On-Demand Request: %w", err)
 	}
 
 	// Verify that the claimed cumulative payment doesn't exceed the on-chain deposit
 	if header.CumulativePayment.Cmp(onDemandPayment.CumulativePayment) > 0 {
-		return fmt.Errorf("request claims a cumulative payment greater than the on-chain deposit")
+		return nil, fmt.Errorf("request claims a cumulative payment greater than the on-chain deposit")
 	}
 
 	paymentConfig, protocolConfig, err := globalParams.GetQuorumConfigs(OnDemandQuorumID)
 	if err != nil {
-		return fmt.Errorf("failed to get payment config for on-demand quorum: %w", err)
+		return nil, fmt.Errorf("failed to get payment config for on-demand quorum: %w", err)
 	}
 
-	symbolsCharged = SymbolsCharged(symbolsCharged, protocolConfig.MinNumSymbols)
+	symbolsCharged := SymbolsCharged(numSymbols, protocolConfig.MinNumSymbols)
 	paymentCharged := PaymentCharged(symbolsCharged, paymentConfig.OnDemandPricePerSymbol)
 	oldPayment, err := m.MeteringStore.AddOnDemandPayment(ctx, header, paymentCharged)
 	if err != nil {
-		return fmt.Errorf("failed to update cumulative payment: %w", err)
+		return nil, fmt.Errorf("failed to update cumulative payment: %w", err)
 	}
 
 	// Update bin usage atomically and check against bin capacity
-	if err := m.incrementGlobalBinUsage(ctx, globalParams, uint64(symbolsCharged), receivedAt); err != nil {
+	if err := m.incrementGlobalBinUsage(ctx, globalParams, symbolsCharged, receivedAt); err != nil {
 		// If global bin usage update fails, roll back the payment to its previous value
 		// The rollback will only happen if the current payment value still matches what we just wrote
 		// This ensures we don't accidentally roll back a newer payment that might have been processed
 		dbErr := m.MeteringStore.RollbackOnDemandPayment(ctx, header.AccountID, header.CumulativePayment, oldPayment)
 		if dbErr != nil {
-			return dbErr
+			return nil, dbErr
 		}
-		return fmt.Errorf("failed global rate limiting: %w", err)
+		return nil, fmt.Errorf("failed global rate limiting: %w", err)
 	}
 
-	return nil
+	// charges is applied to the header quorums
+	charges := make(map[core.QuorumID]uint64, len(headerQuorums))
+	for _, quorumID := range headerQuorums {
+		charges[core.QuorumID(quorumID)] = symbolsCharged
+	}
+	return charges, nil
 }
 
 // IncrementGlobalBinUsage increments the bin usage atomically and checks for overflow

--- a/core/meterer/meterer_test.go
+++ b/core/meterer/meterer_test.go
@@ -152,7 +152,7 @@ func setup(_ *testing.M) {
 		panic("failed to create metering store")
 	}
 
-	paymentChainState.On("RefreshOnchainPaymentState", testifymock.Anything).Return(nil).Maybe()
+	paymentChainState.On("RefreshOnchainPaymentState", testifymock.Anything).Return(nil)
 
 	// add some default sensible configs
 	mt = meterer.NewMeterer(
@@ -586,6 +586,9 @@ func TestMetererDifferentQuorumConfigurations(t *testing.T) {
 
 	// Clear existing mocks to avoid conflicts
 	paymentChainState.ExpectedCalls = nil
+
+	// Re-setup the required mock for RefreshOnchainPaymentState
+	paymentChainState.On("RefreshOnchainPaymentState", testifymock.Anything).Return(nil)
 
 	// Create mock payment vault params with different MinNumSymbols for each quorum
 	mockParams := &meterer.PaymentVaultParams{

--- a/core/meterer/meterer_test.go
+++ b/core/meterer/meterer_test.go
@@ -275,8 +275,10 @@ func TestMetererReservations(t *testing.T) {
 	for i := 0; i < 9; i++ {
 		reservationPeriod := meterer.GetReservationPeriodByNanosecond(now.UnixNano(), reservationWindow)
 		header = createPaymentHeader(now.UnixNano(), big.NewInt(0), accountID2)
-		symbolsCharged, err := mt.MeterRequest(ctx, *header, symbolLength, quoromNumbers, now)
+		symbolsChargedMap, err := mt.MeterRequest(ctx, *header, symbolLength, quoromNumbers, now)
 		assert.NoError(t, err)
+		// Get symbols charged for quorum 0 (all quorums should have the same charge in this test)
+		symbolsCharged := symbolsChargedMap[core.QuorumID(quoromNumbers[0])]
 		for _, accountAndQuorum := range accountAndQuorums {
 			item, err := dynamoClient.GetItem(ctx, reservationTableName, commondynamodb.Key{
 				"AccountID":         &types.AttributeValueMemberS{Value: accountAndQuorum},
@@ -292,8 +294,10 @@ func TestMetererReservations(t *testing.T) {
 	}
 	// first over flow is allowed
 	header = createPaymentHeader(now.UnixNano(), big.NewInt(0), accountID2)
-	symbolsCharged, err := mt.MeterRequest(ctx, *header, 25, quoromNumbers, now)
+	symbolsChargedMap, err := mt.MeterRequest(ctx, *header, 25, quoromNumbers, now)
 	assert.NoError(t, err)
+	// Get symbols charged for quorum 0 (all quorums should have the same charge in this test)
+	symbolsCharged := symbolsChargedMap[core.QuorumID(quoromNumbers[0])]
 	assert.Equal(t, uint64(27), symbolsCharged)
 
 	for _, accountAndQuorum := range accountAndQuorums {
@@ -414,9 +418,11 @@ func TestMetererOnDemand(t *testing.T) {
 	priceCharged := meterer.PaymentCharged(symbolsCharged, pricePerSymbol)
 	assert.Equal(t, big.NewInt(int64(102*pricePerSymbol)), priceCharged)
 	header = createPaymentHeader(now.UnixNano(), priceCharged, accountID2)
-	symbolsCharged, err = mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
+	symbolsChargedMap, err := mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(102), symbolsCharged)
+	// Get symbols charged for quorum 0 (all quorums should have the same charge in this test)
+	actualSymbolsCharged := symbolsChargedMap[core.QuorumID(quorumNumbers[0])]
+	assert.Equal(t, uint64(102), actualSymbolsCharged)
 	header = createPaymentHeader(now.UnixNano(), priceCharged, accountID2)
 	_, err = mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
 	// Doesn't check for exact payment, checks for increment
@@ -425,9 +431,11 @@ func TestMetererOnDemand(t *testing.T) {
 	// test valid payments
 	for i := 1; i < 9; i++ {
 		header = createPaymentHeader(now.UnixNano(), new(big.Int).Mul(priceCharged, big.NewInt(int64(i+1))), accountID2)
-		symbolsCharged, err = mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
+		symbolsChargedMap, err := mt.MeterRequest(ctx, *header, symbolLength, quorumNumbers, now)
 		assert.NoError(t, err)
-		assert.Equal(t, uint64(102), symbolsCharged)
+		// Get symbols charged for quorum 0 (all quorums should have the same charge in this test)
+		actualSymbolsCharged := symbolsChargedMap[core.QuorumID(quorumNumbers[0])]
+		assert.Equal(t, uint64(102), actualSymbolsCharged)
 	}
 
 	// test cumulative payment on-chain constraint
@@ -570,6 +578,153 @@ func TestMeterer_symbolsCharged(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestMetererDifferentQuorumConfigurations(t *testing.T) {
+	ctx := context.Background()
+
+	// Clear existing mocks to avoid conflicts
+	paymentChainState.ExpectedCalls = nil
+
+	// Create mock payment vault params with different MinNumSymbols for each quorum
+	mockParams := &meterer.PaymentVaultParams{
+		QuorumPaymentConfigs: map[core.QuorumID]*core.PaymentQuorumConfig{
+			0: {
+				OnDemandSymbolsPerSecond: 1000,
+				OnDemandPricePerSymbol:   1,
+			},
+			1: {
+				OnDemandSymbolsPerSecond: 1000,
+				OnDemandPricePerSymbol:   1,
+			},
+			2: {
+				OnDemandSymbolsPerSecond: 1000,
+				OnDemandPricePerSymbol:   1,
+			},
+		},
+		QuorumProtocolConfigs: map[core.QuorumID]*core.PaymentQuorumProtocolConfig{
+			0: {
+				MinNumSymbols:              10, // Quorum 0: min 10 symbols
+				ReservationRateLimitWindow: 5,
+				OnDemandRateLimitWindow:    1,
+			},
+			1: {
+				MinNumSymbols:              25, // Quorum 1: min 25 symbols  
+				ReservationRateLimitWindow: 5,
+				OnDemandRateLimitWindow:    1,
+			},
+			2: {
+				MinNumSymbols:              50, // Quorum 2: min 50 symbols
+				ReservationRateLimitWindow: 5,
+				OnDemandRateLimitWindow:    1,
+			},
+		},
+		OnDemandQuorumNumbers: []core.QuorumID{0, 1, 2},
+	}
+	paymentChainState.On("GetPaymentGlobalParams").Return(mockParams, nil)
+
+	now := time.Now()
+	quorumNumbers := []uint8{0, 1, 2}
+
+	// Create reservations for all three quorums
+	testReservations := &core.ReservedPayment{
+		SymbolsPerSecond: 100,
+		StartTimestamp:   uint64(now.Add(-2 * time.Minute).Unix()),
+		EndTimestamp:     uint64(now.Add(3 * time.Minute).Unix()),
+		QuorumSplits:     []byte{33, 33, 34},
+		QuorumNumbers:    quorumNumbers,
+	}
+
+	paymentChainState.On("GetReservedPaymentByAccountAndQuorums", testifymock.Anything, accountID1, testifymock.Anything).Return(
+		map[core.QuorumID]*core.ReservedPayment{
+			0: testReservations,
+			1: testReservations,
+			2: testReservations,
+		},
+	)
+
+	tests := []struct {
+		name           string
+		numSymbols     uint64
+		expectedCharge map[core.QuorumID]uint64
+	}{
+		{
+			name:       "Small request - all quorums use their minimum",
+			numSymbols: 5, // Less than all minimums
+			expectedCharge: map[core.QuorumID]uint64{
+				0: 10, // Uses quorum 0's min: 10
+				1: 25, // Uses quorum 1's min: 25
+				2: 50, // Uses quorum 2's min: 50
+			},
+		},
+		{
+			name:       "Medium request - some use minimum, some use actual",
+			numSymbols: 30, // Between quorum 1 and 2 minimums
+			expectedCharge: map[core.QuorumID]uint64{
+				0: 30, // 30 rounded up to multiple of 10 = 30
+				1: 50, // 30 rounded up to multiple of 25 = 50
+				2: 50, // Uses minimum: 30 < 50 (min)
+			},
+		},
+		{
+			name:       "Large request - all use actual size",
+			numSymbols: 100, // Greater than all minimums
+			expectedCharge: map[core.QuorumID]uint64{
+				0: 100, // Uses actual: 100 > 10 (min)
+				1: 100, // Uses actual: 100 > 25 (min)
+				2: 100, // Uses actual: 100 > 50 (min)
+			},
+		},
+		{
+			name:       "Edge case - exactly equals one minimum",
+			numSymbols: 25, // Exactly equals quorum 1's minimum
+			expectedCharge: map[core.QuorumID]uint64{
+				0: 30, // 25 rounded up to multiple of 10 = 30
+				1: 25, // 25 equals minimum, so uses 25
+				2: 50, // Uses minimum: 25 < 50 (min)
+			},
+		},
+		{
+			name:       "Rounding behavior test",
+			numSymbols: 33, // Test rounding to multiples
+			expectedCharge: map[core.QuorumID]uint64{
+				0: 40, // 33 rounded up to multiple of 10 = 40
+				1: 50, // 33 rounded up to multiple of 25 = 50
+				2: 50, // Uses minimum: 33 < 50 (min)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := createPaymentHeader(now.UnixNano(), big.NewInt(0), accountID1)
+			symbolsChargedMap, err := mt.MeterRequest(ctx, *header, tt.numSymbols, quorumNumbers, now)
+			
+			assert.NoError(t, err)
+			assert.Equal(t, len(tt.expectedCharge), len(symbolsChargedMap), "Should have charges for all quorums")
+			
+			for quorumID, expectedCharge := range tt.expectedCharge {
+				actualCharge, exists := symbolsChargedMap[quorumID]
+				assert.True(t, exists, "Should have charge for quorum %d", quorumID)
+				assert.Equal(t, expectedCharge, actualCharge, 
+					"Quorum %d should charge %d symbols for %d input symbols (min: %d)", 
+					quorumID, expectedCharge, tt.numSymbols, mockParams.QuorumProtocolConfigs[quorumID].MinNumSymbols)
+			}
+			
+			// Verify the charging logic matches the SymbolsCharged function for each quorum
+			for quorumID, expectedCharge := range tt.expectedCharge {
+				minSymbols := mockParams.QuorumProtocolConfigs[quorumID].MinNumSymbols
+				computedCharge := meterer.SymbolsCharged(tt.numSymbols, minSymbols)
+				assert.Equal(t, expectedCharge, computedCharge,
+					"Expected charge should match SymbolsCharged(%d, %d) for quorum %d",
+					tt.numSymbols, minSymbols, quorumID)
+			}
+		})
+	}
+
+	// Restore original mock state by clearing all expected calls
+	// Note: Other tests may need to re-setup their mocks if they run after this test
+	paymentChainState.ExpectedCalls = nil
 }
 
 func createPaymentHeader(timestamp int64, cumulativePayment *big.Int, accountID gethcommon.Address) *core.PaymentMetadata {

--- a/disperser/apiserver/disperse_blob_v2.go
+++ b/disperser/apiserver/disperse_blob_v2.go
@@ -125,11 +125,11 @@ func (s *DispersalServerV2) checkPaymentMeter(ctx context.Context, req *pb.Dispe
 		CumulativePayment: cumulativePayment,
 	}
 
-	symbolsCharged, err := s.meterer.MeterRequest(ctx, paymentHeader, uint64(blobLength), blobHeader.QuorumNumbers, receivedAt)
+	symbolsCharges, err := s.meterer.MeterRequest(ctx, paymentHeader, uint64(blobLength), blobHeader.QuorumNumbers, receivedAt)
 	if err != nil {
 		return api.NewErrorResourceExhausted(err.Error())
 	}
-	s.metrics.reportDisperseMeteredBytes(int(symbolsCharged) * encoding.BYTES_PER_SYMBOL)
+	s.metrics.reportDisperseMeteredBytes(blobHeader.QuorumNumbers, symbolsCharges)
 
 	return nil
 }


### PR DESCRIPTION
## Why are these changes needed?

make quorum number as a label, and record metered bytes charged to each quorum for every request
also added a unit test on having different quorum configurations

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
