### PR TITLE
chore: bump to go1.24

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -14,9 +14,6 @@ inputs:
   amend:
     description: Amend wiki, avoiding spurious commits.
     default: false
-  go-version:
-    description: The Go version to download (if necessary) and use.
-    default: "1.21"
 
 runs:
   using: "composite"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG SEMVER=""
 ARG GITCOMMIT=""
 ARG GITDATE=""
 
-FROM golang:1.21.13-alpine3.20 AS base-builder
+FROM golang:1.24.4-alpine3.22 AS base-builder
 RUN apk add --no-cache make musl-dev linux-headers gcc git jq bash
 
 # Common build stage

--- a/common/memory/Dockerfile.memtest
+++ b/common/memory/Dockerfile.memtest
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /app
 

--- a/disperser/cmd/encoder/icicle.Dockerfile
+++ b/disperser/cmd/encoder/icicle.Dockerfile
@@ -1,6 +1,9 @@
 FROM nvidia/cuda:12.2.2-devel-ubuntu22.04 AS builder
 
 # Install Go
+# TODO: this probably won't work given that we've updated go.mod to use go 1.24.
+# However `docker buildx bake encoder-icicle` is failing on current master (0a61560a77)
+# so I'm a bit confused about the state of this Dockerfile...
 ENV GOLANG_VERSION=1.21.13
 ENV GOLANG_SHA256=502fc16d5910562461e6a6631fb6377de2322aad7304bf2bcd23500ba9dab4a7
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,13 @@
 module github.com/Layr-Labs/eigenda
 
-go 1.21.13
+// We currently do not make use of any go1.24 features, but want to
+// use weak pointers for littdb, which is why we have this minimum version.
+go 1.24
+
+// We pin the compiler version to ensure determinism across local machines and CI.
+// This should be updated periodically when new minor releases are made.
+// See https://tip.golang.org/doc/devel/release#go1.24.0
+toolchain go1.24.4
 
 require (
 	github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,11 @@
 [tools]
-# Core Dependencies
-go = "1.21"
+
+# The exact version here doesn't matter because the `go` command is forward compatible,
+# meaning that it will automatically download a golang version (as a module) to match the
+# go and toolchain versions specified in the go.mod file.
+# See https://go.dev/blog/toolchain for more details.
+# We still want *some* go version here so that the `go` command is available though.
+go = "1.24"
 
 # Tooling Dependencies
 golangci-lint = "1.60.3"


### PR DESCRIPTION
## Why are these changes needed?

Just a little bumpidibump, nothing interesting happening here.

Most of the reasoning for this bump is laid out in comments in the code itself, except for one reason which precipitated this PR. I'm trying to merge eigenda-proxy into the monorepo in #1611, and proxy is on go 1.22, so our go version needs to get bumped to allow merging of both go.mod files.

## Notes

Is there anything we need to update in https://github.com/Layr-Labs/eigenda-devops before (?) we merge this? cc @dmanc @pschork 
