### PR TITLE
fix(dataapi): fix time query_param serialization/formatting bugs

### DIFF
--- a/disperser/dataapi/v2/batches.go
+++ b/disperser/dataapi/v2/batches.go
@@ -40,7 +40,7 @@ func ParseFeedParams(c *gin.Context, metrics *dataapi.Metrics, handlerName strin
 	// Parse before parameter
 	params.beforeTime = now
 	if c.Query("before") != "" {
-		beforeTime, err := time.Parse("2006-01-02T15:04:05Z", c.Query("before"))
+		beforeTime, err := parseQueryParamTime(c.Query("before"))
 		if err != nil {
 			metrics.IncrementInvalidArgRequestNum(handlerName)
 			return nil, fmt.Errorf("failed to parse `before` param: %w", err)
@@ -58,7 +58,7 @@ func ParseFeedParams(c *gin.Context, metrics *dataapi.Metrics, handlerName strin
 	// Parse after parameter
 	params.afterTime = params.beforeTime.Add(-time.Hour)
 	if c.Query("after") != "" {
-		afterTime, err := time.Parse("2006-01-02T15:04:05Z", c.Query("after"))
+		afterTime, err := parseQueryParamTime(c.Query("after"))
 		if err != nil {
 			metrics.IncrementInvalidArgRequestNum(handlerName)
 			return nil, fmt.Errorf("failed to parse `after` param: %w", err)

--- a/disperser/dataapi/v2/blobs.go
+++ b/disperser/dataapi/v2/blobs.go
@@ -52,7 +52,7 @@ func (s *ServerV2) FetchBlobFeed(c *gin.Context) {
 	// Handle before parameter
 	beforeTime := now
 	if c.Query("before") != "" {
-		beforeTime, err = time.Parse("2006-01-02T15:04:05Z", c.Query("before"))
+		beforeTime, err = parseQueryParamTime(c.Query("before"))
 		if err != nil {
 			s.metrics.IncrementInvalidArgRequestNum("FetchBlobFeed")
 			invalidParamsErrorResponse(c, fmt.Errorf("failed to parse `before` param: %w", err))
@@ -71,7 +71,7 @@ func (s *ServerV2) FetchBlobFeed(c *gin.Context) {
 	// Handle after parameter
 	afterTime := beforeTime.Add(-time.Hour)
 	if c.Query("after") != "" {
-		afterTime, err = time.Parse("2006-01-02T15:04:05Z", c.Query("after"))
+		afterTime, err = parseQueryParamTime(c.Query("after"))
 		if err != nil {
 			s.metrics.IncrementInvalidArgRequestNum("FetchBlobFeed")
 			invalidParamsErrorResponse(c, fmt.Errorf("failed to parse `after` param: %w", err))

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -105,6 +105,10 @@ var (
 	})
 )
 
+// TODO: we need to make sure that this is always aligned with the timeFormat that
+// the dataapi server uses to parse timestamps from the request.
+const timeFormat = time.RFC3339Nano
+
 type MockSubgraphClient struct {
 	mock.Mock
 }
@@ -431,8 +435,8 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 			{
 				name: "after >= before",
 				queryParams: map[string]string{
-					"after":  now.Add(-time.Minute).UTC().Format("2006-01-02T15:04:05.999999999Z"),
-					"before": now.Add(-time.Hour).UTC().Format("2006-01-02T15:04:05.999999999Z"),
+					"after":  serverv2.FormatQueryParamTime(now.Add(-time.Minute)),
+					"before": serverv2.FormatQueryParamTime(now.Add(-time.Hour)),
 				},
 				wantError: "must be earlier than `before` timestamp",
 			},
@@ -512,7 +516,7 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 		}
 
 		// Test 2: 2-hour window captures all test batches
-		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		afterTime := serverv2.FormatQueryParamTime(time.Now().Add(-2 * time.Hour))
 		reqUrl := fmt.Sprintf("%s?limit=-1&after=%s", baseUrl, afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.OperatorDispersalFeedResponse](t, w)
@@ -524,10 +528,8 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 		}
 
 		// Teste 3: custom end time
-		after := time.Unix(0, int64(dispersedAt[20])).UTC()
-		afterTime = after.Format("2006-01-02T15:04:05.999999999Z")
-		before := time.Unix(0, int64(dispersedAt[50])).UTC()
-		beforeTime := before.Format("2006-01-02T15:04:05.999999999Z")
+		afterTime = time.Unix(0, int64(dispersedAt[20])).UTC().Format(time.RFC3339Nano)
+		beforeTime := time.Unix(0, int64(dispersedAt[50])).UTC().Format(time.RFC3339Nano)
 		reqUrl = fmt.Sprintf("%s?before=%s&after=%s&limit=-1", baseUrl, beforeTime, afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.OperatorDispersalFeedResponse](t, w)
@@ -552,7 +554,7 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 		}
 
 		// Test 2: 2-hour window captures all test batches
-		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		afterTime := serverv2.FormatQueryParamTime(time.Now().Add(-2 * time.Hour))
 		reqUrl := fmt.Sprintf("%s?limit=-1&after=%s&direction=backward", baseUrl, afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.OperatorDispersalFeedResponse](t, w)
@@ -564,10 +566,8 @@ func TestFetchOperatorDispersalFeed(t *testing.T) {
 		}
 
 		// Teste 3: custom end time
-		after := time.Unix(0, int64(dispersedAt[20])).UTC()
-		afterTime = after.Format("2006-01-02T15:04:05.999999999Z")
-		before := time.Unix(0, int64(dispersedAt[50])).UTC()
-		beforeTime := before.Format("2006-01-02T15:04:05.999999999Z")
+		afterTime = serverv2.FormatQueryParamTime(time.Unix(0, int64(dispersedAt[20])))
+		beforeTime := serverv2.FormatQueryParamTime(time.Unix(0, int64(dispersedAt[50])))
 		reqUrl = fmt.Sprintf("%s?before=%s&after=%s&limit=-1&direction=backward", baseUrl, beforeTime, afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.OperatorDispersalFeedResponse](t, w)
@@ -713,8 +713,8 @@ func TestFetchBlobFeed(t *testing.T) {
 			{
 				name: "after >= before",
 				queryParams: map[string]string{
-					"after":  now.Add(-time.Minute).UTC().Format("2006-01-02T15:04:05.999999999Z"),
-					"before": now.Add(-time.Hour).UTC().Format("2006-01-02T15:04:05.999999999Z"),
+					"after":  now.Add(-time.Minute).UTC().Format(timeFormat),
+					"before": now.Add(-time.Hour).UTC().Format(timeFormat),
 				},
 				wantError: "must be earlier than `before` timestamp",
 			},
@@ -791,7 +791,7 @@ func TestFetchBlobFeed(t *testing.T) {
 
 		// Test 2: 2-hour window captures all test blobs
 		// Verifies correct ordering of timestamp-colliding blobs
-		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		afterTime := serverv2.FormatQueryParamTime(time.Now().Add(-2 * time.Hour))
 		reqUrl := fmt.Sprintf("/v2/blobs/feed?after=%s&limit=-1", afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BlobFeedResponse](t, w)
@@ -810,7 +810,7 @@ func TestFetchBlobFeed(t *testing.T) {
 		// Test 3: Custom end time with 1-hour window
 		// Retrieves keys[41] through keys[100]
 		tm := time.Unix(0, int64(requestedAt[100])+1).UTC()
-		endTime := tm.Format("2006-01-02T15:04:05.999999999Z")
+		endTime := tm.Format(timeFormat)
 		reqUrl = fmt.Sprintf("/v2/blobs/feed?before=%s&limit=-1", endTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BlobFeedResponse](t, w)
@@ -838,7 +838,7 @@ func TestFetchBlobFeed(t *testing.T) {
 
 		// Test 2: 2-hour window captures all test blobs
 		// Verifies correct ordering of timestamp-colliding blobs
-		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		afterTime := serverv2.FormatQueryParamTime(time.Now().Add(-2 * time.Hour))
 		reqUrl := fmt.Sprintf("/v2/blobs/feed?direction=backward&after=%s&limit=-1", afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BlobFeedResponse](t, w)
@@ -857,7 +857,7 @@ func TestFetchBlobFeed(t *testing.T) {
 		// Test 3: Custom end time with 1-hour window
 		// Retrieves keys[100] through keys[41]
 		tm := time.Unix(0, int64(requestedAt[100])+1).UTC()
-		endTime := tm.Format("2006-01-02T15:04:05.999999999Z")
+		endTime := tm.Format(timeFormat)
 		reqUrl = fmt.Sprintf("/v2/blobs/feed?direction=backward&before=%s&limit=-1", endTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BlobFeedResponse](t, w)
@@ -877,8 +877,7 @@ func TestFetchBlobFeed(t *testing.T) {
 		// Verifies:
 		// - Correct sequencing across pages
 		// - Proper token handling
-		tm := time.Unix(0, time.Now().UnixNano()).UTC()
-		endTime := tm.Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		endTime := serverv2.FormatQueryParamTime(time.Unix(0, time.Now().UnixNano()))
 		reqUrl := fmt.Sprintf("/v2/blobs/feed?before=%s&limit=20", endTime)
 		w := executeRequest(t, r, http.MethodGet, reqUrl)
 		response := decodeResponseBody[serverv2.BlobFeedResponse](t, w)
@@ -910,8 +909,7 @@ func TestFetchBlobFeed(t *testing.T) {
 		// Verifies:
 		// - Correct sequencing across pages
 		// - Proper token handling (cursor is exclusive)
-		tm := time.Unix(0, int64(requestedAt[80])).UTC()
-		endTime := tm.Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		endTime := serverv2.FormatQueryParamTime(time.Unix(0, int64(requestedAt[80])))
 		reqUrl := fmt.Sprintf("/v2/blobs/feed?direction=backward&after=%s&limit=20", endTime)
 		w := executeRequest(t, r, http.MethodGet, reqUrl)
 		response := decodeResponseBody[serverv2.BlobFeedResponse](t, w)
@@ -941,8 +939,7 @@ func TestFetchBlobFeed(t *testing.T) {
 		// - We have 3 blobs with identical timestamp (firstBlobTime): firstBlobKeys[0,1,2]
 		// - These are followed by sequential blobs: keys[3,4] with different timestamps
 		// - End time is set to requestedAt[5]
-		tm := time.Unix(0, int64(requestedAt[5])).UTC()
-		endTime := tm.Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		endTime := serverv2.FormatQueryParamTime(time.Unix(0, int64(requestedAt[5])))
 
 		// First page: fetch 2 blobs, which have same requestedAt timestamp
 		reqUrl := fmt.Sprintf("/v2/blobs/feed?before=%s&limit=2", endTime)
@@ -1517,8 +1514,8 @@ func TestFetchBatchFeed(t *testing.T) {
 			{
 				name: "after >= before",
 				queryParams: map[string]string{
-					"after":  now.Add(-time.Minute).UTC().Format("2006-01-02T15:04:05.999999999Z"),
-					"before": now.Add(-time.Hour).UTC().Format("2006-01-02T15:04:05.999999999Z"),
+					"after":  now.Add(-time.Minute).UTC().Format(timeFormat),
+					"before": now.Add(-time.Hour).UTC().Format(timeFormat),
 				},
 				wantError: "must be earlier than `before` timestamp",
 			},
@@ -1586,7 +1583,7 @@ func TestFetchBatchFeed(t *testing.T) {
 		}
 
 		// Test 2: 2-hour window captures all test batches
-		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		afterTime := serverv2.FormatQueryParamTime(time.Now().Add(-2 * time.Hour))
 		reqUrl := fmt.Sprintf("/v2/batches/feed?limit=-1&after=%s", afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BatchFeedResponse](t, w)
@@ -1600,7 +1597,7 @@ func TestFetchBatchFeed(t *testing.T) {
 		// Test 3: Custom end time with 1-hour window
 		// With 1h ending time at attestedAt[66], this retrieves batch[7] throught batch[65] (59 batches, as the `before` is exclusive)
 		tm := time.Unix(0, int64(attestedAt[66])).UTC()
-		beforeTime := tm.Format("2006-01-02T15:04:05.999999999Z")
+		beforeTime := tm.Format(timeFormat)
 		reqUrl = fmt.Sprintf("/v2/batches/feed?before=%s&limit=-1", beforeTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BatchFeedResponse](t, w)
@@ -1625,7 +1622,7 @@ func TestFetchBatchFeed(t *testing.T) {
 		}
 
 		// Test 2: 2-hour window captures all test batches
-		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		afterTime := serverv2.FormatQueryParamTime(time.Now().Add(-2 * time.Hour))
 		reqUrl := fmt.Sprintf("/v2/batches/feed?direction=backward&limit=-1&after=%s", afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BatchFeedResponse](t, w)
@@ -1640,7 +1637,7 @@ func TestFetchBatchFeed(t *testing.T) {
 		// With 1h ending time at attestedAt[66], this retrieves batch[65] throught batch[7] (59 batches,
 		// as the `before` is exclusive)
 		tm := time.Unix(0, int64(attestedAt[66])).UTC()
-		beforeTime := tm.Format("2006-01-02T15:04:05.999999999Z")
+		beforeTime := tm.Format(timeFormat)
 		reqUrl = fmt.Sprintf("/v2/batches/feed?direction=backward&before=%s&limit=-1", beforeTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.BatchFeedResponse](t, w)
@@ -2137,7 +2134,7 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		// +------------------+-------------------+------------------+--------------+
 
 		tm := time.Unix(0, int64(now)+1).UTC()
-		endTime := tm.Format("2006-01-02T15:04:05.999999999Z")
+		endTime := tm.Format(timeFormat)
 		reqUrl := fmt.Sprintf("/v2/operators/signing-info?end=%s&interval=1000", endTime)
 		w := executeRequest(t, r, http.MethodGet, reqUrl)
 		response := decodeResponseBody[serverv2.OperatorsSigningInfoResponse](t, w)
@@ -2404,7 +2401,7 @@ func TestFetchAccountBlobFeed(t *testing.T) {
 		}
 
 		// Test 2: 2-hour window captures all test blobs
-		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		afterTime := serverv2.FormatQueryParamTime(time.Now().Add(-2 * time.Hour))
 		reqUrl := fmt.Sprintf("%s?limit=-1&after=%s", baseUrl, afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.AccountBlobFeedResponse](t, w)
@@ -2416,9 +2413,9 @@ func TestFetchAccountBlobFeed(t *testing.T) {
 
 		// Teste 3: custom end time
 		after := time.Unix(0, int64(requestedAt[20])).UTC()
-		afterTime = after.Format("2006-01-02T15:04:05.999999999Z")
+		afterTime = after.Format(timeFormat)
 		before := time.Unix(0, int64(requestedAt[50])).UTC()
-		beforeTime := before.Format("2006-01-02T15:04:05.999999999Z")
+		beforeTime := before.Format(timeFormat)
 		reqUrl = fmt.Sprintf("%s?before=%s&after=%s&limit=-1", baseUrl, beforeTime, afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.AccountBlobFeedResponse](t, w)
@@ -2440,7 +2437,7 @@ func TestFetchAccountBlobFeed(t *testing.T) {
 		}
 
 		// Test 2: 2-hour window captures all test blobs
-		afterTime := time.Now().Add(-2 * time.Hour).Format("2006-01-02T15:04:05.999999999Z") // nano precision format
+		afterTime := serverv2.FormatQueryParamTime(time.Now().Add(-2 * time.Hour))
 		reqUrl := fmt.Sprintf("%s?limit=-1&after=%s&direction=backward", baseUrl, afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.AccountBlobFeedResponse](t, w)
@@ -2452,9 +2449,9 @@ func TestFetchAccountBlobFeed(t *testing.T) {
 
 		// Teste 3: custom end time
 		after := time.Unix(0, int64(requestedAt[20])).UTC()
-		afterTime = after.Format("2006-01-02T15:04:05.999999999Z")
+		afterTime = after.Format(timeFormat)
 		before := time.Unix(0, int64(requestedAt[50])).UTC()
-		beforeTime := before.Format("2006-01-02T15:04:05.999999999Z")
+		beforeTime := before.Format(timeFormat)
 		reqUrl = fmt.Sprintf("%s?before=%s&after=%s&limit=-1&direction=backward", baseUrl, beforeTime, afterTime)
 		w = executeRequest(t, r, http.MethodGet, reqUrl)
 		response = decodeResponseBody[serverv2.AccountBlobFeedResponse](t, w)

--- a/disperser/dataapi/v2/time.go
+++ b/disperser/dataapi/v2/time.go
@@ -1,0 +1,24 @@
+package v2
+
+import "time"
+
+const timeFormat = time.RFC3339Nano
+
+// Format a time in [timeFormat] format for use in query parameters.
+// This ensures that the server can parse the time correctly.
+// Used for blobs and batches queries.
+func FormatQueryParamTime(time time.Time) string {
+	// Note that we need to convert to UTC() such that it gets formatted to
+	// something like "2023-10-01T12:34:56.789Z" instead of "2023-10-01T12:34:56.789+00:00",
+	// because `+` gets converted to a space in query parameters,
+	// which is then not parsable as a RFC3339Nano time.
+	return time.UTC().Format(timeFormat)
+}
+
+// Parse the time string in RFC3339Nano [timeFormat] format.
+// This is used for parsing query parameters like "before" and "after",
+// for blobs and batches queries.
+// Meant to parse query params that are formatted with [FormatQueryParamTime].
+func parseQueryParamTime(timeStr string) (time.Time, error) {
+	return time.Parse(timeFormat, timeStr)
+}


### PR DESCRIPTION
Some weird handwritten format was being used before, which was not RFC3399Nano... and was causing bugs in the test (passing in CI only because ci is running in north america). I noticed the bug when trying to run the tests locally from Indonesia.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
