### PR TITLE
Updated to remove references to experimental APIs

### DIFF
--- a/api/proto/README.md
+++ b/api/proto/README.md
@@ -1,43 +1,9 @@
-# A note about experimental/WIP APIs
+# v1 and v2 APIs
 
-There are a number of APIs that are currently under active development. These APIs can be fully ignored.
-All such APIs will have comments in the form
+With the [EigenDA v2 release](https://docs.eigencloud.xyz/products/eigenda/releases/blazar), a number 
+of APIs have been updated for the v2 release, and new APIs added. Use the v2 APIs. 
 
-```
-/////////////////////////////////////////////////////////////////////////////////////
-// Experimental: the following definitions are experimental and subject to change. //
-/////////////////////////////////////////////////////////////////////////////////////
-```
+The v1 APIs will be deprecated at a future date. A long deprecation period will occur and be actively communicated.
 
-The majority of the WIP APIs are for a project we are calling internally `EigenDA v2 Architecture`.
-More on that below.
-
-## Q: Which APIs are currently experimental?
-
-The following APIs are currently experimental:
-- `disperser/v2/*`
-- `node/v2/*`
-- `relay/*`
-
-## Q: are APIs not marked with "Experimental" stable?
-
-Yes. We are commited to maintaining backwards compatibility for all APIs that are not marked as experimental,
-and any breaking changes will be made only after a long deprecation period and active communication with
-all stakeholders. Furthermore, breaking API changes are expected to be rare.
-
-## Q: Should I use experimental APIs?
-
-No. No experimental APIs are currently deployed to any public environments. In general, assume
-that experimental APIs are not functional absent messaging from the EigenDA team declaring otherwise.
-
-## Q: Are experimental APIs stable?
-
-No, although they will become more and more stable as they reach maturity.
-
-## Q: What is "v2"?
-
-The EigenDA v2 Architecture is a fundamental redesign of the protocol. The v2 Architecture improves robustness,
-efficiency, and paves the way for upcoming features such as permissionless disperser instances
-and data availability sampling.
-
-We intend on publishing a more detailed roadmap and design overview in the near future, stay tuned!
+For an overview of the APIs, refer to the [EigenDA documentation](https://docs.eigencloud.xyz/products/eigenda/core-concepts/overview). For low level details, refer to the `.proto` files 
+in this directory.


### PR DESCRIPTION
## Why are these changes needed?

API readme out of date - referenced v2 APIs as experimental not current. 
