### PR TITLE
fix: payment state api doesn't fail at zero valued reservations/ondemand

### DIFF
--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -902,7 +902,7 @@ func (t *Reader) GetOnDemandPaymentByAccount(ctx context.Context, accountID geth
 	}
 
 	if onDemandDeposit.Cmp(big.NewInt(0)) == 0 {
-		return nil, errors.New("on-demand deposit does not exist for given account")
+		return nil, ErrPaymentDoesNotExist
 	}
 
 	return &core.OnDemandPayment{

--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -901,8 +901,8 @@ func (t *Reader) GetOnDemandPaymentByAccount(ctx context.Context, accountID geth
 		return nil, err
 	}
 
-	if onDemandDeposit.Cmp(big.NewInt(0)) == 0 {
-		return nil, ErrPaymentDoesNotExist
+	if err := CheckOnDemandPayment(onDemandDeposit); err != nil {
+		return nil, err
 	}
 
 	return &core.OnDemandPayment{

--- a/core/eth/utils.go
+++ b/core/eth/utils.go
@@ -1,11 +1,11 @@
 package eth
 
 import (
-	"fmt"
 	"math/big"
 	"slices"
 
 	"github.com/Layr-Labs/eigenda/core"
+	"github.com/pingcap/errors"
 
 	eigendasrvmg "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDAServiceManager"
 	paymentvault "github.com/Layr-Labs/eigenda/contracts/bindings/PaymentVault"
@@ -15,6 +15,9 @@ import (
 
 var (
 	maxNumberOfQuorums = 192
+
+	// ErrPaymentDoesNotExist is returned when a payment/deposit does not exist (is zero)
+	ErrPaymentDoesNotExist = errors.New("payment does not exist")
 )
 
 type BN254G1Point struct {
@@ -136,10 +139,10 @@ func isZeroValuedReservation(reservation paymentvault.IPaymentVaultReservation) 
 }
 
 // ConvertToReservedPayments converts a upstream binding data structure to local definition.
-// Returns an error if the input reservation is zero-valued.
+// Returns core.ErrPaymentDoesNotExist if the input reservation is zero-valued.
 func ConvertToReservedPayments(reservation paymentvault.IPaymentVaultReservation) (map[core.QuorumID]*core.ReservedPayment, error) {
 	if isZeroValuedReservation(reservation) {
-		return nil, fmt.Errorf("reservation is not a valid active reservation")
+		return nil, ErrPaymentDoesNotExist
 	}
 
 	reservedPayments := make(map[core.QuorumID]*core.ReservedPayment)

--- a/core/eth/utils.go
+++ b/core/eth/utils.go
@@ -16,7 +16,7 @@ import (
 var (
 	maxNumberOfQuorums = 192
 
-	// ErrPaymentDoesNotExist is returned when a payment/deposit does not exist (is zero)
+	// ErrPaymentDoesNotExist is returned when a reservation/deposit does not exist (is zero)
 	ErrPaymentDoesNotExist = errors.New("payment does not exist")
 )
 

--- a/core/eth/utils.go
+++ b/core/eth/utils.go
@@ -138,6 +138,13 @@ func isZeroValuedReservation(reservation paymentvault.IPaymentVaultReservation) 
 		reservation.EndTimestamp == 0
 }
 
+func CheckOnDemandPayment(payment *big.Int) error {
+	if payment.Cmp(big.NewInt(0)) == 0 {
+		return ErrPaymentDoesNotExist
+	}
+	return nil
+}
+
 // ConvertToReservedPayments converts a upstream binding data structure to local definition.
 // Returns core.ErrPaymentDoesNotExist if the input reservation is zero-valued.
 func ConvertToReservedPayments(reservation paymentvault.IPaymentVaultReservation) (map[core.QuorumID]*core.ReservedPayment, error) {

--- a/core/meterer/onchain_state.go
+++ b/core/meterer/onchain_state.go
@@ -15,8 +15,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
-// PaymentAccounts (For reservations and on-demand payments)
-
 // OnchainPaymentState is an interface for getting information about the current chain state for payments.
 type OnchainPayment interface {
 	// State management

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	"github.com/Layr-Labs/eigenda/common/healthcheck"
 	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/core/eth"
 	"github.com/Layr-Labs/eigenda/core/meterer"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/disperser"
@@ -431,10 +432,12 @@ func (s *DispersalServerV2) GetPaymentStateForAllQuorums(ctx context.Context, re
 	periodRecords := make(map[uint32]*pb.PeriodRecords)
 	quorumIds := s.onchainState.Load().getAllQuorumIds()
 	reservations, err := s.meterer.ChainPaymentState.GetReservedPaymentByAccountAndQuorums(ctx, accountID, quorumIds)
-	if err != nil {
-		s.logger.Error("failed to get onchain reservation", "err", err, "accountID", accountID)
-		return nil, api.NewErrorInternal("failed to get onchain reservation")
+	// Return no reservations if none exists, when user only has ondemand payments
+	if err != nil && !errors.Is(err, eth.ErrPaymentDoesNotExist) {
+		s.logger.Error("failed to get reservation", "err", err, "accountID", accountID)
+		return nil, api.NewErrorInternal("failed to get reservation")
 	}
+
 	reservationQuorumIds := []core.QuorumID{}
 	reservationCurrentPeriods := []uint64{}
 	if len(reservations) > 0 {
@@ -483,8 +486,12 @@ func (s *DispersalServerV2) GetPaymentStateForAllQuorums(ctx context.Context, re
 	var onchainCumulativePaymentBytes []byte
 	onDemandPayment, err := s.meterer.ChainPaymentState.GetOnDemandPaymentByAccount(ctx, accountID)
 	if err != nil {
-		s.logger.Error("failed to get ondemand payment", "err", err, "accountID", accountID)
-		return nil, api.NewErrorInternal("failed to get ondemand payment")
+		if !errors.Is(err, eth.ErrPaymentDoesNotExist) {
+			s.logger.Error("failed to get ondemand payment", "err", err, "accountID", accountID)
+			return nil, api.NewErrorInternal("failed to get ondemand payment")
+		}
+		// Return empty bytes if the ondemand payment does not exist, when user only has reserved payments
+		onchainCumulativePaymentBytes = []byte{}
 	} else {
 		onchainCumulativePaymentBytes = onDemandPayment.CumulativePayment.Bytes()
 	}


### PR DESCRIPTION
## Why are these changes needed?

Added an error type of `ErrPaymentDoesNotExist`

If a reservation has zero on all the fields or ondemand account has zero balance, we treat that payment as it doesn't exist. 
Within [4f0684f](https://github.com/Layr-Labs/eigenda/pull/1664/commits/4f0684f5fa0c64845783072493357cd04b049a95), we updated the behavior from allow zero values as fallback to all fields, to returning error when there's an error from the onchain payment state.
It is too strict for users who are not using on-demand, because ondemand being zero was considered an error by the eth reader. We update to make eth reader return a specific error type, and allow this error to use zero value when constructing payment states.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
