### PR TITLE
Fix broken link to encoding module specification in amortized-proving.md

### DIFF
--- a/docs/spec/src/protocol/architecture/amortized-proving.md
+++ b/docs/spec/src/protocol/architecture/amortized-proving.md
@@ -9,7 +9,7 @@ We will also highlight the additional constraints on the Encoding interface whic
 
 ## Deriving the polynomial coefficients and commitment
 
-As described in the [Encoding Module Specification](../spec/protocol-modules/storage/encoding.md), given a blob of data, we convert the blob to a polynomial $p(X) = \sum_{i=0}^{m-1} c_iX^i$ by simply slicing the data into a string of symbols, and interpreting this list of symbols as the tuple $(c_i)_{i=0}^{m-1}$.
+As described in the [Encoding Module Specification](./encoding.md), given a blob of data, we convert the blob to a polynomial $p(X) = \sum_{i=0}^{m-1} c_iX^i$ by simply slicing the data into a string of symbols, and interpreting this list of symbols as the tuple $(c_i)_{i=0}^{m-1}$.
 
 In the case of the KZG-FFT encoder, the polynomial lives on the field associated with the BN254 elliptic curve, which as order [TODO: fill in order].
 


### PR DESCRIPTION
Replaced the outdated relative link to the encoding module specification in amortized-proving.md with the correct path (./encoding.md). This resolves a documentation error where the previous link pointed to a non-existent file, ensuring that readers can now access the intended encoding module documentation without issues. No other content was changed.