### PR TITLE
fix: disperser client deadlock

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -208,6 +208,7 @@ func (c *disperserClient) DisperseBlobWithProbe(
 
 	err = c.initOncePopulateAccountant(ctx)
 	if err != nil {
+		c.accountantLock.Unlock()
 		return nil, [32]byte{}, api.NewErrorFailover(err)
 	}
 


### PR DESCRIPTION
## Why are these changes needed?

disperser client was not unlocking the accountantLock in one error path, which was causing proxy to deadlock when retrying.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
