### PR TITLE
feat: grpc logging interceptor in v2 apiserver

### DIFF
--- a/disperser/apiserver/metrics_v2.go
+++ b/disperser/apiserver/metrics_v2.go
@@ -14,14 +14,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"google.golang.org/grpc"
 )
 
 const namespace = "eigenda_disperser_api"
 
 // metricsV2 encapsulates the metrics for the v2 API server.
 type metricsV2 struct {
-	grpcServerOption grpc.ServerOption
+	grpcMetrics *grpcprom.ServerMetrics
 
 	getBlobCommitmentLatency        *prometheus.SummaryVec
 	getPaymentStateLatency          *prometheus.SummaryVec
@@ -43,10 +42,6 @@ func newAPIServerV2Metrics(registry *prometheus.Registry, metricsConfig disperse
 	registry.MustRegister(grpcMetrics)
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(collectors.NewGoCollector())
-
-	grpcServerOption := grpc.UnaryInterceptor(
-		grpcMetrics.UnaryServerInterceptor(),
-	)
 
 	objectives := map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
 
@@ -129,7 +124,7 @@ func newAPIServerV2Metrics(registry *prometheus.Registry, metricsConfig disperse
 	)
 
 	return &metricsV2{
-		grpcServerOption:                grpcServerOption,
+		grpcMetrics:                     grpcMetrics,
 		getBlobCommitmentLatency:        getBlobCommitmentLatency,
 		getPaymentStateLatency:          getPaymentStateLatency,
 		disperseBlobLatency:             disperseBlobLatency,

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -12,6 +12,7 @@ import (
 	pbcommon "github.com/Layr-Labs/eigenda/api/grpc/common"
 	pbv1 "github.com/Layr-Labs/eigenda/api/grpc/disperser"
 	pb "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/healthcheck"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/meterer"
@@ -21,6 +22,7 @@ import (
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	grpclogging "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -145,8 +147,14 @@ func (s *DispersalServerV2) Start(ctx context.Context) error {
 	}
 
 	opt := grpc.MaxRecvMsgSize(1024 * 1024 * 300) // 300 MiB
-
-	gs := grpc.NewServer(opt, s.metrics.grpcServerOption)
+	loggingOpts := []grpclogging.Option{
+		grpclogging.WithLogOnEvents(grpclogging.StartCall, grpclogging.FinishCall),
+	}
+	gs := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			grpclogging.UnaryServerInterceptor(common.InterceptorLogger(s.logger), loggingOpts...),
+			s.metrics.grpcMetrics.UnaryServerInterceptor(),
+		), opt)
 	reflection.Register(gs)
 	pb.RegisterDisperserServer(gs, s)
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/gin-contrib/logger v0.2.6
 	github.com/gin-gonic/gin v1.9.1
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ingonyama-zk/icicle/v3 v3.4.0
 	github.com/jedib0t/go-pretty/v6 v6.5.9
@@ -114,7 +115,6 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect


### PR DESCRIPTION
## Why are these changes needed?
This PR adds logging from v2 apiserver request/responses
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
