### PR TITLE
fix: apiserver empty OnDemandQuorumNumbers bug

### DIFF
--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -353,6 +353,7 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 		MinNumSymbols:          minNumSymbols,
 		PricePerSymbol:         pricePerSymbol,
 		ReservationWindow:      reservationWindow,
+		OnDemandQuorumNumbers:  []uint32{0, 1},
 	}
 
 	// build reply

--- a/disperser/apiserver/server_v2.go
+++ b/disperser/apiserver/server_v2.go
@@ -300,6 +300,15 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 	minNumSymbols := s.meterer.ChainPaymentState.GetMinNumSymbols()
 	pricePerSymbol := s.meterer.ChainPaymentState.GetPricePerSymbol()
 	reservationWindow := s.meterer.ChainPaymentState.GetReservationWindow()
+	onDemandQuorumNumbers, err := s.meterer.ChainPaymentState.GetOnDemandQuorumNumbers(ctx)
+	if err != nil {
+		s.logger.Warn("failed to get on-demand quorum numbers, use default", "err", err, "defaultRequiredQuorums", []uint8{0, 1})
+		onDemandQuorumNumbers = []uint8{0, 1} // default to 0 and 1 if not available
+	}
+	onDemandQuorumNumbersUint32 := make([]uint32, len(onDemandQuorumNumbers))
+	for i, v := range onDemandQuorumNumbers {
+		onDemandQuorumNumbersUint32[i] = uint32(v)
+	}
 
 	// off-chain account specific payment state
 	now := time.Now().Unix()
@@ -353,7 +362,7 @@ func (s *DispersalServerV2) GetPaymentState(ctx context.Context, req *pb.GetPaym
 		MinNumSymbols:          minNumSymbols,
 		PricePerSymbol:         pricePerSymbol,
 		ReservationWindow:      reservationWindow,
-		OnDemandQuorumNumbers:  []uint32{0, 1},
+		OnDemandQuorumNumbers:  onDemandQuorumNumbersUint32,
 	}
 
 	// build reply


### PR DESCRIPTION
DO NOT MERGE. This is purely opened to show the diff between hotpatch.1 and hotpatch.2.
If we want to deploy this, then `release/0.9.0-hotpatch.2` should be tagged and deployed as a hotfix.
But I think this might not be needed after we merge https://github.com/Layr-Labs/eigenda/pull/1700

## Why are these changes needed?

Hotfix to release/0.9.0 disperser's apiserver, which is affecting sepolia disperser, and I'm guessing holesky and mainnet.
See https://eigenlabs.slack.com/archives/C06JZQHN5R7/p1751361561231669 for more details.

Not sure what we want to do with this. Could deploy this as-is. Or could cherry-pick on top of next release we plan to deploy (0.9.1/0.9.2) which also contains the bug.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
