### PR TITLE
fix: disperser_client v2 should use default onDemandQuorums

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -454,7 +454,10 @@ func convertLegacyPaymentStateToNew(legacyReply *disperser_rpc.GetPaymentStateRe
 		// Apply the global params to all quorums, both on-demand and reservation.
 		onDemandQuorums := legacyReply.PaymentGlobalParams.OnDemandQuorumNumbers
 		if len(onDemandQuorums) == 0 {
-			onDemandQuorums = []uint32{0, 1} // Default to quorums 0 and 1 if not specified
+			// Disperser v0.9.0 has a bug where it does not return on-demand quorums: https://github.com/Layr-Labs/eigenda/pull/1699
+			// Until we upgrade all dispersers, we will assume that on-demand quorums are 0 and 1.
+			// TODO: this should instead return an error once we have upgraded all dispersers.
+			onDemandQuorums = []uint32{0, 1}
 		}
 		reservationQuorums := legacyReply.Reservation.QuorumNumbers
 		// There may be overlapping quorums but it doesn't matter since we will apply the same global params to all of them.


### PR DESCRIPTION
Right now it was erroring when onDemandQuorums were not set, and our 0.9.0 release which is deployed on sepolia/holesky-testnet/mainnet has a bug where the onDemandQuorums are not returned.

This is an alternative to #1699, which is easier to rollout.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
