### PR TITLE
fix: update dataapi v2 nodeInfo to call v2 validator API

### DIFF
--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -326,7 +326,7 @@ func (s *ServerV2) FetchOperatorsStake(c *gin.Context) {
 func (s *ServerV2) FetchOperatorsNodeInfo(c *gin.Context) {
 	handlerStart := time.Now()
 
-	report, err := s.operatorHandler.ScanOperatorsHostInfo(c.Request.Context())
+	report, err := s.operatorHandler.ScanOperatorsHostInfoV2(c.Request.Context())
 	if err != nil {
 		s.logger.Error("failed to scan operators host info", "error", err)
 		s.metrics.IncrementFailedRequestNum("FetchOperatorsNodeInfo")


### PR DESCRIPTION
mainnet-beta validators are running v2-only mode, but data-api-v2 node-info was still calling the v1 nodeInfo causing the request to fail
