### PR TITLE
fix: disperser_client v2 nil ptr bug

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -452,7 +452,7 @@ func convertLegacyPaymentStateToNew(legacyReply *disperser_rpc.GetPaymentStateRe
 		}
 
 		// Apply the global params to all quorums, both on-demand and reservation.
-		onDemandQuorums := legacyReply.PaymentGlobalParams.OnDemandQuorumNumbers
+		onDemandQuorums := legacyReply.GetPaymentGlobalParams().OnDemandQuorumNumbers
 		if len(onDemandQuorums) == 0 {
 			// Disperser v0.9.0 has a bug where it does not return on-demand quorums: https://github.com/Layr-Labs/eigenda/pull/1699
 			// Until we upgrade all dispersers, we will assume that on-demand quorums are 0 and 1.


### PR DESCRIPTION
Bug found by @cody-littley. We really need the correctness_tests running in CI to prevent these kinds of bugs.

legacyReply.Reservation can be nil, which causes a panic when it is dereferenced. I can reproduce this by running TestDispersalWithInvalidSignature() in correctness_test.go.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
