### PR TITLE
fix: NODE_HOSTNAME value ignored and overwritten (#1628)

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -735,9 +735,14 @@ func (n *Node) checkCurrentNodeIp(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
+			hostname := n.Config.Hostname
+			if hostname == "" || isLocalhost(hostname) {
+				hostname = ""
+			}
 			newSocketAddr, err := SocketAddress(
 				ctx,
 				n.PubIPProvider,
+				hostname,
 				n.Config.DispersalPort,
 				n.Config.RetrievalPort,
 				n.Config.V2DispersalPort,

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -135,16 +135,17 @@ func pluginOps(ctx *cli.Context) {
 		return
 	}
 
-	_, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort, err := core.ParseOperatorSocket(config.Socket)
+	hostname, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort, err := core.ParseOperatorSocket(config.Socket)
 	if err != nil {
 		log.Printf("Error: failed to parse operator socket: %v", err)
 		return
 	}
 
 	socket := config.Socket
-	if isLocalhost(socket) {
+	// Use public IP provider if hostname is empty or contains localhost
+	if hostname == "" || node.isLocalhost(hostname) {
 		pubIPProvider := pubip.ProviderOrDefault(logger, config.PubIPProvider)
-		socket, err = node.SocketAddress(context.Background(), pubIPProvider, dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
+		socket, err = node.SocketAddress(context.Background(), pubIPProvider, "", dispersalPort, retrievalPort, v2DispersalPort, v2RetrievalPort)
 		if err != nil {
 			log.Printf("Error: failed to get socket address from ip provider: %v", err)
 			return
@@ -197,8 +198,4 @@ func pluginOps(ctx *cli.Context) {
 	default:
 		log.Fatalf("Fatal: unsupported operation: %s", config.Operation)
 	}
-}
-
-func isLocalhost(socket string) bool {
-	return strings.Contains(socket, "localhost") || strings.Contains(socket, "127.0.0.1") || strings.Contains(socket, "0.0.0.0")
 }


### PR DESCRIPTION
* if NODE_HOSTNAME is set and it's not localhost, make operator socket with the given host name
* if NODE_HOSTNAME is empty or is localhost, get the public ip as before
* moved the `isLocalhost()` function to utils.go

## Why are these changes needed?

As described in (#1628) the get public ip of the machine doesn't work well with a proxy when the value of the hostname is ignored.


## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
