### PR TITLE
refactor: pointsIO functions and docs

### DIFF
--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -45,14 +45,14 @@ func ReadG1PointSection(filepath string, from, to uint64, numWorker uint64) ([]b
 }
 
 // Convenience wrapper for reading all G1 points from the start of the file.
-// See [readPointSection] for details on the parameters.
+// n is the number of points to read, numWorker is the number of goroutines to use for parallel parsing.
 func ReadG1Points(filepath string, n uint64, numWorker uint64) ([]bn254.G1Affine, error) {
 	// ReadG1Points is just ReadG1PointSection starting from 0
 	return ReadG1PointSection(filepath, 0, n, numWorker)
 }
 
 // Convenience wrapper for reading all G1 points in uncompressed format.
-// This is just a wrapper around [readPointSection] with the uncompressed size.
+// n is the number of points to read, numWorker is the number of goroutines to use for parallel parsing.
 // We don't currently use uncompressed file formats; see [BenchmarkReadG2PointsCompressedVsUncompressed] for performance comparison.
 func ReadG1PointsUncompressed(filepath string, n uint64, numWorker uint64) ([]bn254.G1Affine, error) {
 	// ReadG1PointsUncompressed is just ReadG1PointSection starting from 0
@@ -77,7 +77,8 @@ func ReadG2Point(n uint64, srsOrder uint64, g2Path string) (bn254.G2Affine, erro
 	return g2point[0], nil
 }
 
-// Convenience wrapper around [readPointSection] for reading a section of G2 points.
+// Convenience wrapper around [readPointSection] for reading G2 points from the start of the file.
+// n is the number of points to read, numWorker is the number of goroutines to use for parallel parsing.
 func ReadG2Points(filepath string, n uint64, numWorker uint64) ([]bn254.G2Affine, error) {
 	result, err := ReadG2PointSection(filepath, 0, n, numWorker)
 	if err != nil {
@@ -88,7 +89,7 @@ func ReadG2Points(filepath string, n uint64, numWorker uint64) ([]bn254.G2Affine
 }
 
 // Convenience wrapper for reading all G2 points in uncompressed format.
-// This is just a wrapper around [readPointSection] with the uncompressed size.
+// n is the number of points to read, numWorker is the number of goroutines to use for parallel parsing.
 // We don't currently use uncompressed file formats; see [BenchmarkReadG2PointsCompressedVsUncompressed] for performance comparison.
 func ReadG2PointsUncompressed(filepath string, n uint64, numWorker uint64) ([]bn254.G2Affine, error) {
 	// ReadG2PointsUncompressed is just ReadG2PointSection starting from 0
@@ -101,7 +102,8 @@ func ReadG2PointsUncompressed(filepath string, n uint64, numWorker uint64) ([]bn
 }
 
 // Convenience wrapper for reading a section of G2 points.
-// See [readPointSection] for details on the parameters.
+// from and to specify the range of point indices to read (inclusive from, exclusive to).
+// numWorker specifies the number of goroutines to use for parallel parsing.
 func ReadG2PointSection(filepath string, from, to uint64, numWorker uint64) ([]bn254.G2Affine, error) {
 	return readPointSection[bn254.G2Affine](filepath, from, to, G2PointBytes, numWorker)
 }

--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -182,9 +182,9 @@ func readPointSection[T bn254.G1Affine | bn254.G2Affine](
 		numWorker = n
 	}
 
-	buf, err := readDesiredBytes(reader, n*pointSizeBytes)
+	buf, err := readBytes(reader, n*pointSizeBytes)
 	if err != nil {
-		return nil, fmt.Errorf("readDesiredBytes: %w", err)
+		return nil, fmt.Errorf("readBytes: %w", err)
 	}
 
 	points := make([]T, n)
@@ -231,9 +231,9 @@ func readPointSection[T bn254.G1Affine | bn254.G2Affine](
 	return points, nil
 }
 
-// readDesiredBytes reads exactly numBytesToRead bytes from the reader and returns
+// readBytes reads exactly numBytesToRead bytes from the reader and returns
 // the result.
-func readDesiredBytes(reader *bufio.Reader, numBytesToRead uint64) ([]byte, error) {
+func readBytes(reader *bufio.Reader, numBytesToRead uint64) ([]byte, error) {
 	buf := make([]byte, numBytesToRead)
 	_, err := io.ReadFull(reader, buf)
 	// Note that ReadFull() guarantees the bytes read is len(buf) IFF err is nil.

--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -227,7 +227,6 @@ func deserializePointsInRange[T bn254.G1Affine | bn254.G2Affine](
 				return
 			}
 		case *bn254.G2Affine:
-			// G2 points are stored as uncompressed points, so we can directly set bytes
 			if _, err := p.SetBytes(pointData); err != nil {
 				results <- fmt.Errorf("error setting G2 point bytes: %w", err)
 				return

--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -191,15 +191,15 @@ func readPointSection[T bn254.G1Affine | bn254.G2Affine](
 	results := make(chan error, numWorker)
 	pointsPerWorker := n / numWorker
 
-	for i := uint64(0); i < numWorker; i++ {
+	for i := uint64(0); i < numWorker; i++ { // i is the workerIndex
 		startPoint := i * pointsPerWorker
 		endPoint := startPoint + pointsPerWorker
 		if i == numWorker-1 {
-			endPoint = n
+			endPoint = n // The final worker reads the rest of the points
 		}
 
 		go func(startPoint, endPoint uint64) {
-			for j := startPoint; j < endPoint; j++ {
+			for j := startPoint; j < endPoint; j++ { // j is the pointIndex
 				pointData := buf[j*pointSizeBytes : (j+1)*pointSizeBytes]
 				switch p := any(&points[j]).(type) {
 				case *bn254.G1Affine:

--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -191,17 +191,17 @@ func readPointSection[T bn254.G1Affine | bn254.G2Affine](
 	results := make(chan error, numWorker)
 	pointsPerWorker := n / numWorker
 
-	for i := uint64(0); i < numWorker; i++ { // i is the workerIndex
-		startPoint := i * pointsPerWorker
+	for workerIndex := uint64(0); workerIndex < numWorker; workerIndex++ {
+		startPoint := workerIndex * pointsPerWorker
 		endPoint := startPoint + pointsPerWorker
-		if i == numWorker-1 {
-			endPoint = n // The final worker reads the rest of the points
+		if workerIndex == numWorker-1 {
+			endPoint = n
 		}
 
 		go func(startPoint, endPoint uint64) {
-			for j := startPoint; j < endPoint; j++ { // j is the pointIndex
-				pointData := buf[j*pointSizeBytes : (j+1)*pointSizeBytes]
-				switch p := any(&points[j]).(type) {
+			for pointIndex := startPoint; pointIndex < endPoint; pointIndex++ {
+				pointData := buf[pointIndex*pointSizeBytes : (pointIndex+1)*pointSizeBytes]
+				switch p := any(&points[pointIndex]).(type) {
 				case *bn254.G1Affine:
 					if _, err := p.SetBytes(pointData); err != nil {
 						results <- fmt.Errorf("error setting G1 point bytes: %w", err)

--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -173,7 +173,7 @@ func readPointSection[T bn254.G1Affine | bn254.G2Affine](
 	n := to - from
 	reader := bufio.NewReaderSize(file, int(n*pointSizeBytes))
 
-	_, err = file.Seek(int64(from)*int64(pointSizeBytes), 0)
+	_, err = file.Seek(int64(from)*int64(pointSizeBytes), io.SeekStart)
 	if err != nil {
 		return nil, err
 	}

--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -189,17 +189,17 @@ func readPointSection[T bn254.G1Affine | bn254.G2Affine](
 
 	points := make([]T, n)
 	results := make(chan error, numWorker)
-	size := n / numWorker
+	pointsPerWorker := n / numWorker
 
 	for i := uint64(0); i < numWorker; i++ {
-		start := i * size
-		end := start + size
+		startPoint := i * pointsPerWorker
+		endPoint := startPoint + pointsPerWorker
 		if i == numWorker-1 {
-			end = n
+			endPoint = n
 		}
 
-		go func(start, end uint64) {
-			for j := start; j < end; j++ {
+		go func(startPoint, endPoint uint64) {
+			for j := startPoint; j < endPoint; j++ {
 				pointData := buf[j*pointSizeBytes : (j+1)*pointSizeBytes]
 				switch p := any(&points[j]).(type) {
 				case *bn254.G1Affine:
@@ -219,7 +219,7 @@ func readPointSection[T bn254.G1Affine | bn254.G2Affine](
 				}
 			}
 			results <- nil
-		}(start, end)
+		}(startPoint, endPoint)
 	}
 
 	for w := uint64(0); w < numWorker; w++ {

--- a/encoding/kzg/pointsIO.go
+++ b/encoding/kzg/pointsIO.go
@@ -26,7 +26,7 @@ const (
 
 // Read the n-th G1 point from SRS.
 func ReadG1Point(n uint64, srsOrder uint64, g1Path string) (bn254.G1Affine, error) {
-	// Do we really need to check srsOrder here? Or can we just read the file and let the error propagate if n is out of bounds?
+	// TODO: Do we really need to check srsOrder here? Or can we just read the file and let the error propagate if n is out of bounds?
 	if n >= srsOrder {
 		return bn254.G1Affine{}, fmt.Errorf("requested power %v is larger than SRSOrder %v", n, srsOrder)
 	}

--- a/encoding/kzg/pointsIO_test.go
+++ b/encoding/kzg/pointsIO_test.go
@@ -1,0 +1,181 @@
+package kzg
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	G1PointsFilePath         = "../../resources/srs/g1.point"
+	G2PointsFilePath         = "../../resources/srs/g2.point"
+	G2TrailingPointsFilePath = "../../resources/srs/g2.trailing.point"
+)
+
+func TestDeserializePoints(t *testing.T) {
+	const testNumPoints = 10000
+
+	// Read G1 points
+	g1Points, err := ReadG1Points(G1PointsFilePath, testNumPoints, 1)
+	require.NoError(t, err)
+	require.Len(t, g1Points, int(testNumPoints))
+
+	// Read G2 points
+	g2Points, err := ReadG2Points(G2PointsFilePath, testNumPoints, 1)
+	require.NoError(t, err)
+	require.Len(t, g2Points, testNumPoints)
+
+	// Read G2 trailing points
+	g2TrailingPoints, err := ReadG2Points(G2TrailingPointsFilePath, testNumPoints, 1)
+	require.NoError(t, err)
+	require.Len(t, g2TrailingPoints, testNumPoints)
+}
+
+// Benchmark to test efficacy of parsing G1 and G2 points with different number of goroutines (workers).
+func BenchmarkNumWorkers(b *testing.B) {
+	workerCounts := []int{1, 2, 4, 8, 16, 32, runtime.GOMAXPROCS(0)}
+	const benchNumPoints = 10000
+
+	for _, numWorkers := range workerCounts {
+		b.Run(fmt.Sprintf("%d-Workers-G1", numWorkers), func(b *testing.B) {
+			for b.Loop() {
+				g1Points, err := ReadG1Points(G1PointsFilePath, benchNumPoints, uint64(numWorkers))
+				require.NoError(b, err)
+				require.Len(b, g1Points, benchNumPoints)
+			}
+		})
+	}
+
+	for _, numWorkers := range workerCounts {
+		b.Run(fmt.Sprintf("%d-Workers-G2", numWorkers), func(b *testing.B) {
+			for b.Loop() {
+				g2Points, err := ReadG2Points(G2PointsFilePath, benchNumPoints, uint64(numWorkers))
+				require.NoError(b, err)
+				require.Len(b, g2Points, benchNumPoints)
+			}
+		})
+	}
+}
+
+// ================== UNCOMPRESSED POINTS FILES  ==================
+// We currently store the points in compressed form for smaller file sizes.
+// We could store in uncompressed form (double size) for faster binary startup time.
+// See https://docs.gnark.consensys.io/HowTo/serialize#compression
+// The tests/benchmarks below can be used to compare the performance of reading compressed vs uncompressed points files.
+// Results when I ran them on my M1 MacBook Pro were 2x faster parsing at the cost of 2x larger file sizes:
+// - G2 points: 32 MiB Compressed (9.5s parsing) vs 64 MiB Uncompressed (4.9s parsing)
+
+const (
+	G1PointsUncompressedFilePath         = "../../resources/srs/g1_uncompressed.point"
+	G2PointsUncompressedFilePath         = "../../resources/srs/g2_uncompressed.point"
+	G2TrailingPointsUncompressedFilePath = "../../resources/srs/g2.trailing_uncompressed.point"
+)
+
+// BenchmarkReadG2Points benchmarks the time needed to parse compressed and uncompressed G2 points.
+// Reading ~16-64MiB files takes ms so doesn't matter much for the benchmark.
+func BenchmarkReadG2PointsCompressedVsUncompressed(b *testing.B) {
+	b.Skip("Meant to be run manually, run TestGenerateUncompressedPointFiles first to create uncompressed files")
+
+	numWorkers := uint64(runtime.GOMAXPROCS(0))
+	testNumPoints := uint64(16 << 20 / G1PointBytes)
+
+	b.Run("Compressed", func(b *testing.B) {
+		for b.Loop() {
+			_, err := ReadG2Points(G2PointsFilePath, testNumPoints, numWorkers)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("Uncompressed", func(b *testing.B) {
+		for b.Loop() {
+			_, err := ReadG2PointsUncompressed(G2PointsUncompressedFilePath, testNumPoints, numWorkers)
+			require.NoError(b, err)
+		}
+	})
+}
+
+// Used to create the uncompressed points files in the resources/srs directory.
+func TestGenerateUncompressedPointFiles(t *testing.T) {
+	t.Skip("run manually to create uncompressed srs point files")
+	numWorkers := uint64(runtime.GOMAXPROCS(0))
+
+	// 16MiB of compressed G1 points means 16 * 1024 * 1024 / G1PointBytes points
+	numPoints := uint64(16 << 20 / G1PointBytes)
+
+	g2Points, err := ReadG2Points(G2PointsFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+
+	err = createUncompressedFile(g2Points, G2PointsUncompressedFilePath)
+	require.NoError(t, err)
+
+	g2TrailingPoints, err := ReadG2Points(G2TrailingPointsFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+	err = createUncompressedFile(g2TrailingPoints, G2TrailingPointsUncompressedFilePath)
+	require.NoError(t, err)
+
+	g1Points, err := ReadG1Points(G1PointsFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+	err = createUncompressedFile(g1Points, G1PointsUncompressedFilePath)
+	require.NoError(t, err)
+}
+
+// TestUncompressedPointsFilesEquivalence tests that the uncompressed points files match the original points
+func TestUncompressedPointsFilesEquivalence(t *testing.T) {
+	t.Skip("run manually to verify uncompressed points files match original points")
+	numWorkers := uint64(runtime.GOMAXPROCS(0))
+	numPoints := uint64(16 << 20 / G1PointBytes)
+
+	g2Points, err := ReadG2Points(G2PointsFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+	g2PointsUncompressed, err := ReadG2PointsUncompressed(G2PointsUncompressedFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+
+	g2PointsTrailing, err := ReadG2Points(G2TrailingPointsFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+	g2PointsTrailingUncompressed, err := ReadG2PointsUncompressed(G2TrailingPointsUncompressedFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+
+	g1Points, err := ReadG1Points(G1PointsFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+	g1PointsUncompressed, err := ReadG1PointsUncompressed(G1PointsUncompressedFilePath, numPoints, numWorkers)
+	require.NoError(t, err)
+
+	// Verify points are equal
+	for i := range numPoints {
+		require.Equal(t, g2Points[i], g2PointsUncompressed[i], "G2 point mismatch at index %d", i)
+		require.Equal(t, g2PointsTrailing[i], g2PointsTrailingUncompressed[i], "G2 trailing point mismatch at index %d", i)
+		require.Equal(t, g1Points[i], g1PointsUncompressed[i], "G1 point mismatch at index %d", i)
+	}
+}
+
+// createUncompressedFile creates a file with uncompressed G2 points
+func createUncompressedFile[T bn254.G1Affine | bn254.G2Affine](points []T, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for _, point := range points {
+		// Uncompressed format using RawBytes
+		switch p := any(&point).(type) {
+		case *bn254.G1Affine:
+			data := p.RawBytes()
+			if _, err := file.Write(data[:]); err != nil {
+				return err
+			}
+		case *bn254.G2Affine:
+			data := p.RawBytes()
+			if _, err := file.Write(data[:]); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported point type: %T", p)
+		}
+	}
+	return nil
+}

--- a/encoding/kzg/pointsIO_test.go
+++ b/encoding/kzg/pointsIO_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/Layr-Labs/eigenda/core"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/stretchr/testify/require"
 )
@@ -158,7 +159,7 @@ func createUncompressedFile[T bn254.G1Affine | bn254.G2Affine](points []T, filen
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer core.CloseLogOnError(file, filename, nil)
 
 	for _, point := range points {
 		// Uncompressed format using RawBytes


### PR DESCRIPTION
## Why are these changes needed?

My initial goal was to see whether we could bring the parsing times lower (takes ~10sec to parse 32MiB G2 file), which makes for long startup times of some binaries like load-generator, proxy, etc.

Wrote this comment in the test file:
> We currently store the points in compressed form for smaller file sizes.
We could store in uncompressed form (double size) for faster binary startup time.
See https://docs.gnark.consensys.io/HowTo/serialize#compression
The tests/benchmarks below can be used to compare the performance of reading compressed vs uncompressed points files.
Results when I ran them on my M1 MacBook Pro were 2x faster parsing at the cost of 2x larger file sizes:
> - G2 points: 32 MiB Compressed (9.5s parsing) vs 64 MiB Uncompressed (4.9s parsing)

TLDR is that we could store our SRS files in uncompressed format, which takes 2x the space but allows for 2x faster parsing. Not sure this is worth the introduced complexity (we'd need to document better that customers can use whichever srs points they want, etc) right now so opted to leave the tests/benchmarks related to uncompressed files, but to not commit the uncompressed SRS files.

Otherwise just refactored the entire pointsIO file to now consist of a single main generic function, and a bunch of wrappers that just call it (still feel like we should delete most of them though...)

## Future Works

Another issue I find annoying is that our parsing functions don't make use of the passed in context, so it's impossible to ctrl-c the proxy while its parsing, so we're forced to wait 10sec before shutdown. But I'm tired already of refactoring this, so will likely do this in the future PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
