### PR TITLE
fix: Add permissions for claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,4 +64,6 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          max_turns: "10"
+          timeout_minutes: "5"
 


### PR DESCRIPTION
- Adds permissions to Claude github action, to limit invocation to authorized users
