### PR TITLE
fix: traffic generator now able to send high traffic

### DIFF
--- a/common/units.go
+++ b/common/units.go
@@ -1,4 +1,4 @@
-package util
+package common
 
 import "fmt"
 

--- a/common/variable_ticker.go
+++ b/common/variable_ticker.go
@@ -14,6 +14,8 @@ import (
 const MinimumFrequency = float64(time.Second/math.MaxInt64) * 2.0
 
 // Any frequency above this value will be interpreted as a frequency of MaximumFrequency Hz. Needed to avoid overflow.
+// The time.Second constant holds the number of nanoseconds in a second, which means that the ticker can never tick
+// more than once per nanosecond.
 const MaximumFrequency = float64(time.Second)
 
 // the period between debug logs about the ticker's frequency and acceleration.

--- a/litt/benchmark/benchmark_metrics.go
+++ b/litt/benchmark/benchmark_metrics.go
@@ -5,8 +5,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/litt/benchmark/config"
-	"github.com/Layr-Labs/eigenda/litt/util"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 )
 
@@ -197,19 +197,19 @@ func (m *metrics) logMetrics() {
 		"    Flush Count:            %s\n"+
 		"    Average Flush Latency:  %s\n"+
 		"    Longest Flush Duration: %s",
-		util.PrettyPrintTime(elapsedTimeNanoseconds),
-		util.PrettyPrintBytes(writeThroughput),
-		util.PrettyPrintBytes(bytesWritten),
-		util.CommaOMatic(writeCount),
-		util.PrettyPrintTime(averageWriteLatency),
-		util.PrettyPrintTime(m.longestWriteDuration.Load()),
-		util.PrettyPrintBytes(readThroughput),
-		util.PrettyPrintBytes(m.bytesRead.Load()),
-		util.CommaOMatic(readCount),
-		util.PrettyPrintTime(averageReadLatency),
-		util.PrettyPrintTime(m.longestReadDuration.Load()),
-		util.CommaOMatic(flushCount),
-		util.PrettyPrintTime(averageFlushLatency),
-		util.PrettyPrintTime(m.longestFlushDuration.Load()))
+		common.PrettyPrintTime(elapsedTimeNanoseconds),
+		common.PrettyPrintBytes(writeThroughput),
+		common.PrettyPrintBytes(bytesWritten),
+		common.CommaOMatic(writeCount),
+		common.PrettyPrintTime(averageWriteLatency),
+		common.PrettyPrintTime(m.longestWriteDuration.Load()),
+		common.PrettyPrintBytes(readThroughput),
+		common.PrettyPrintBytes(m.bytesRead.Load()),
+		common.CommaOMatic(readCount),
+		common.PrettyPrintTime(averageReadLatency),
+		common.PrettyPrintTime(m.longestReadDuration.Load()),
+		common.CommaOMatic(flushCount),
+		common.PrettyPrintTime(averageFlushLatency),
+		common.PrettyPrintTime(m.longestFlushDuration.Load()))
 
 }

--- a/litt/littbuilder/db_impl.go
+++ b/litt/littbuilder/db_impl.go
@@ -9,9 +9,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/litt"
 	"github.com/Layr-Labs/eigenda/litt/metrics"
-	"github.com/Layr-Labs/eigenda/litt/util"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 )
 
@@ -188,7 +188,7 @@ func (d *db) GetTable(name string) (litt.Table, error) {
 		}
 		d.logger.Infof(
 			"Table '%s' initialized, table contains %d key-value pairs and has a size of %s.",
-			name, table.KeyCount(), util.PrettyPrintBytes(table.Size()))
+			name, table.KeyCount(), common.PrettyPrintBytes(table.Size()))
 
 		d.tables[name] = table
 	}

--- a/test/v2/load/load_generator.go
+++ b/test/v2/load/load_generator.go
@@ -185,8 +185,7 @@ func (l *LoadGenerator) run() {
 	//	panic(fmt.Errorf("failed to set target frequency: %w", err))
 	//}
 
-	period := time.Duration(1.0/l.submissionFrequency) * time.Second
-	l.client.GetLogger().Infof("period between blob submissions: %s", period) // TODO
+	period := time.Duration(1.0 / l.submissionFrequency * float64(time.Second))
 	ticker := time.NewTicker(period)
 	defer ticker.Stop()
 

--- a/test/v2/load/load_generator.go
+++ b/test/v2/load/load_generator.go
@@ -186,6 +186,7 @@ func (l *LoadGenerator) run() {
 	//}
 
 	period := time.Duration(1.0/l.submissionFrequency) * time.Second
+	l.client.GetLogger().Infof("period between blob submissions: %s", period) // TODO
 	ticker := time.NewTicker(period)
 	defer ticker.Stop()
 

--- a/test/v2/load/load_generator.go
+++ b/test/v2/load/load_generator.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
-	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/pprof"
 	"github.com/Layr-Labs/eigenda/common/testutils/random"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
@@ -191,7 +190,7 @@ func (l *LoadGenerator) run() {
 	defer ticker.Stop()
 
 	for l.alive.Load() {
-		<-ticker.Tick()
+		<-ticker.C
 
 		l.lifecycleLimiter <- struct{}{}
 		go func() {

--- a/test/v2/load/load_generator.go
+++ b/test/v2/load/load_generator.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Layr-Labs/eigenda/common/pprof"
 	"github.com/Layr-Labs/eigenda/common/testutils/random"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/Layr-Labs/eigenda/encoding"
+	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
 	"github.com/Layr-Labs/eigenda/litt/util"
 	"github.com/Layr-Labs/eigenda/test/v2/client"
 	"github.com/docker/go-units"
@@ -48,6 +50,8 @@ type LoadGenerator struct {
 	randPool *sync.Pool
 	// The time when the load generator started.
 	startTime time.Time
+	// The size of the payload that will result in an encoded blob of the target size.
+	payloadSize uint32
 }
 
 // ReadConfigFile loads a LoadGeneratorConfig from a file.
@@ -73,12 +77,25 @@ func ReadConfigFile(filePath string) (*LoadGeneratorConfig, error) {
 // NewLoadGenerator creates a new LoadGenerator.
 func NewLoadGenerator(
 	config *LoadGeneratorConfig,
-	client *client.TestClient) *LoadGenerator {
+	client *client.TestClient) (*LoadGenerator, error) {
 
 	bytesPerSecond := config.MBPerSecond * units.MiB
-	averageBlobSize := config.AverageBlobSizeMB * units.MiB
 
-	submissionFrequency := bytesPerSecond / averageBlobSize
+	// The size of the blob we want to send.
+	targetBlobSize := uint64(config.BlobSizeMB * units.MiB)
+	// The target blob size must be a power of 2.
+	targetBlobSize = encoding.NextPowerOf2(targetBlobSize)
+
+	// The size of the payload necessary to create a blob of the target size.
+	payloadSize, err := codec.BlobSizeToMaxPayloadSize(uint32(targetBlobSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute payload size for target blob size %d: %w", targetBlobSize, err)
+	}
+
+	submissionFrequency := bytesPerSecond / float64(targetBlobSize)
+
+	client.GetLogger().Infof("Target blob size: %s bytes, submission frequency: %f hz",
+		util.PrettyPrintBytes(targetBlobSize), submissionFrequency)
 
 	submissionLimiter := make(chan struct{}, config.SubmissionParallelism)
 	relayReadLimiter := make(chan struct{}, config.RelayReadParallelism)
@@ -123,7 +140,8 @@ func NewLoadGenerator(
 		randPool:             randPool,
 		metrics:              metrics,
 		startTime:            time.Now(),
-	}
+		payloadSize:          payloadSize,
+	}, nil
 }
 
 // Start starts the load generator. If block is true, this function will block until Stop() or
@@ -214,12 +232,7 @@ func (l *LoadGenerator) disperseBlob(rand *random.TestRandom) (
 	eigenDACert coretypes.EigenDACert,
 	err error) {
 
-	payloadSize := int(rand.BoundedGaussian(
-		l.config.AverageBlobSizeMB*units.MiB,
-		l.config.BlobSizeStdDev*units.MiB,
-		1.0,
-		float64(l.client.GetConfig().MaxBlobSize+1)))
-	payload = rand.Bytes(payloadSize)
+	payload = rand.Bytes(int(l.payloadSize))
 
 	timeout := time.Duration(l.config.DispersalTimeout) * time.Second
 	ctx, cancel := context.WithTimeout(l.ctx, timeout)
@@ -283,7 +296,7 @@ func (l *LoadGenerator) readBlobFromRelays(
 		l.metrics.endOperation("relay_read")
 	}()
 
-	blobLengthSymbols := uint32(eigenDACert.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.Length)
+	blobLengthSymbols := eigenDACert.BlobInclusionInfo.BlobCertificate.BlobHeader.Commitment.Length
 	relayKeys := eigenDACert.RelayKeys()
 	readStartIndex := rand.Int32Range(0, int32(len(relayKeys)))
 

--- a/test/v2/load/load_generator.go
+++ b/test/v2/load/load_generator.go
@@ -165,25 +165,30 @@ func (l *LoadGenerator) Stop() {
 // run runs the load generator.
 func (l *LoadGenerator) run() {
 
+	// TODO
 	// Start with frequency 0.
-	ticker, err := common.NewVariableTickerWithFrequency(l.ctx, 0)
-	if err != nil {
-		// Not possible, error is only returned with invalid arguments, and 0hz is a valid frequency.
-		panic(fmt.Errorf("failed to create variable ticker: %w", err))
-	}
+	//ticker, err := common.NewVariableTickerWithFrequency(l.ctx, 0)
+	//if err != nil {
+	//	// Not possible, error is only returned with invalid arguments, and 0hz is a valid frequency.
+	//	panic(fmt.Errorf("failed to create variable ticker: %w", err))
+	//}
+	//
+	//defer ticker.Close()
+	//// Set acceleration prior to setting target frequency, since acceleration 0 allows "infinite" acceleration.
+	//err = ticker.SetAcceleration(l.config.FrequencyAcceleration)
+	//if err != nil {
+	//	// load generator configuration error, no way to recover
+	//	panic(fmt.Errorf("failed to set acceleration: %w", err))
+	//}
+	//err = ticker.SetTargetFrequency(l.submissionFrequency)
+	//if err != nil {
+	//	// load generator configuration error, no way to recover
+	//	panic(fmt.Errorf("failed to set target frequency: %w", err))
+	//}
 
-	defer ticker.Close()
-	// Set acceleration prior to setting target frequency, since acceleration 0 allows "infinite" acceleration.
-	err = ticker.SetAcceleration(l.config.FrequencyAcceleration)
-	if err != nil {
-		// load generator configuration error, no way to recover
-		panic(fmt.Errorf("failed to set acceleration: %w", err))
-	}
-	err = ticker.SetTargetFrequency(l.submissionFrequency)
-	if err != nil {
-		// load generator configuration error, no way to recover
-		panic(fmt.Errorf("failed to set target frequency: %w", err))
-	}
+	period := time.Duration(1.0/l.submissionFrequency) * time.Second
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
 
 	for l.alive.Load() {
 		<-ticker.Tick()

--- a/test/v2/load/load_generator_config.go
+++ b/test/v2/load/load_generator_config.go
@@ -4,10 +4,8 @@ package load
 type LoadGeneratorConfig struct {
 	// The desired number of megabytes bytes per second to write.
 	MBPerSecond float64
-	// The average size of the blobs to write, in megabytes.
-	AverageBlobSizeMB float64
-	// The standard deviation of the blob size, in megabytes.
-	BlobSizeStdDev float64
+	// The size of the blobs to write, in megabytes.
+	BlobSizeMB float64
 	// By default, this utility reads each blob back from each relay once. The number of
 	// reads per relay is multiplied by this factor. For example, If this is set to 3,
 	// then each blob is read back from each relay 3 times. If less than 1, then this value
@@ -48,8 +46,7 @@ type LoadGeneratorConfig struct {
 func DefaultLoadGeneratorConfig() *LoadGeneratorConfig {
 	return &LoadGeneratorConfig{
 		MBPerSecond:                   0.5,
-		AverageBlobSizeMB:             1.0,
-		BlobSizeStdDev:                0.0,
+		BlobSizeMB:                    2.0,
 		RelayReadAmplification:        1.0,
 		ValidatorReadAmplification:    1.0,
 		ValidatorVerificationFraction: 0.01,

--- a/test/v2/load/main/load_main.go
+++ b/test/v2/load/main/load_main.go
@@ -42,7 +42,10 @@ func main() {
 		panic(fmt.Errorf("failed to read config file %s: %w", loadFile, err))
 	}
 
-	generator := load.NewLoadGenerator(config, c)
+	generator, err := load.NewLoadGenerator(config, c)
+	if err != nil {
+		panic(fmt.Errorf("failed to create load generator: %w", err))
+	}
 
 	signals := make(chan os.Signal)
 	go func() {


### PR DESCRIPTION
## Why are these changes needed?

There was a bug in the traffic generator setup where the maximum submission rate was capped at 1hz. This PR fixes that, as well as adding some debug logs that will assist with understanding ramp up time.

```
2025-07-10 10:56:27.133	
Jul 10 15:56:27.133 DBG common/variable_ticker.go:181 Current ticker frequency: 0.000 Hz, target frequency: 4 Hz. Acceleration is 0.0025 Hz/s, it will take 26.67 minutes to reach the target frequency.
```
