### PR TITLE
Fix broken links in LittDB documentation

### DIFF
--- a/litt/README.md
+++ b/litt/README.md
@@ -13,8 +13,8 @@
     - [Configuration Options](#configuration-options)
     - [CLI](#littdb-cli)
 - [Definitions](#definitions)
-- [Architecture](docsrchitecture.md)
-- [Filesystem Layout](docsilesystem_layout.md)
+- [Architecture](docs/architecture.md)
+- [Filesystem Layout](docs/filesystem_layout.md)
 
 # What is LittDB?
 


### PR DESCRIPTION


---


This pull request corrects two broken internal links in `litt/README.md`:
- Fixed typos in references to the architecture and filesystem layout documentation.
- Ensured all documentation links point to existing files.

---
