### PR TITLE
fix: Initialize connection with validator in background goroutine

### DIFF
--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -216,6 +216,8 @@ func (d *Dispatcher) HandleBatch(
 		validatorProbe.SetStage("pool_submission")
 
 		d.pool.Submit(func() {
+			defer validatorProbe.End()
+
 			validatorProbe.SetStage("get_client")
 
 			host, _, _, v2DispersalPort, _, err := core.ParseOperatorSocket(op.Socket)
@@ -251,7 +253,6 @@ func (d *Dispatcher) HandleBatch(
 				return
 			}
 
-			defer validatorProbe.End()
 			validatorProbe.SetStage("put_dispersal_request")
 
 			req := &corev2.DispersalRequest{

--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -212,8 +212,10 @@ func (d *Dispatcher) HandleBatch(
 		opID := opID
 		op := op
 
+		validatorProbe := d.metrics.newSendToValidatorProbe()
+		validatorProbe.SetStage("pool_submission")
+
 		d.pool.Submit(func() {
-			validatorProbe := d.metrics.newSendToValidatorProbe()
 			validatorProbe.SetStage("get_client")
 
 			host, _, _, v2DispersalPort, _, err := core.ParseOperatorSocket(op.Socket)
@@ -248,8 +250,6 @@ func (d *Dispatcher) HandleBatch(
 				}
 				return
 			}
-
-			validatorProbe.SetStage("pool_submission")
 
 			defer validatorProbe.End()
 			validatorProbe.SetStage("put_dispersal_request")


### PR DESCRIPTION
## Why are these changes needed?
Do not initialize grpc connections on the main batch creation goroutine. In extreme cases, grpc connections can take several seconds to set up.
