### PR TITLE
fix: node shouldnt require eigenda directory flag

### DIFF
--- a/api/proxy/.env.exampleV1.holesky
+++ b/api/proxy/.env.exampleV1.holesky
@@ -3,7 +3,7 @@
 # Hex-encoded signer private key. In V1, this key should not be associated with an Ethereum address holding any funds.
 EIGENDA_PROXY_EIGENDA_SIGNER_PRIVATE_KEY_HEX=
 
-# JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigenlayer.xyz/eigenda/networks/
+# JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigencloud.xyz/products/eigenda/networks/mainnet
 EIGENDA_PROXY_EIGENDA_ETH_RPC=https://ethereum-holesky-rpc.publicnode.com
 
 # RPC URL of the EigenDA disperser service. Mainnet is `disperser.eigenda.xyz:443`).

--- a/api/proxy/.env.exampleV1.sepolia
+++ b/api/proxy/.env.exampleV1.sepolia
@@ -3,7 +3,7 @@
 # Hex-encoded signer private key. In V1, this key should not be associated with an Ethereum address holding any funds.
 EIGENDA_PROXY_EIGENDA_SIGNER_PRIVATE_KEY_HEX=
 
-# JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigenlayer.xyz/eigenda/networks/
+# JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigencloud.xyz/products/eigenda/networks/mainnet
 EIGENDA_PROXY_EIGENDA_ETH_RPC=https://ethereum-sepolia.rpc.subquery.network/public
 
 # RPC URL of the EigenDA disperser service. Mainnet is `disperser.eigenda.xyz:443`).

--- a/api/proxy/store/generated_key/eigenda/verify/deprecated_flags.go
+++ b/api/proxy/store/generated_key/eigenda/verify/deprecated_flags.go
@@ -36,7 +36,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
 			Name:    DeprecatedEthRPCFlagName,
-			Usage:   "JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigenlayer.xyz/eigenda/networks/",
+			Usage:   "JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigencloud.xyz/products/eigenda/networks/mainnet",
 			EnvVars: []string{withDeprecatedEnvPrefix(envPrefix, "ETH_RPC")},
 			Action: func(_ *cli.Context, _ string) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",

--- a/node/node.go
+++ b/node/node.go
@@ -52,8 +52,8 @@ const (
 var (
 	// eigenDAUIMap is a mapping for ChainID to the EigenDA UI url.
 	eigenDAUIMap = map[string]string{
-		"17000": "https://holesky.eigenlayer.xyz/avs/eigenda",
-		"1":     "https://app.eigenlayer.xyz/avs/eigenda",
+		"1":     "https://app.eigenlayer.xyz/avs/0x870679e138bcdf293b7ff14dd44b70fc97e12fc0",
+		"17000": "https://holesky.eigenlayer.xyz/avs/0xd4a7e1bd8015057293f0d0a557088c286942e84b/operator-set/4294967295",
 	}
 )
 
@@ -102,12 +102,6 @@ func NewNode(
 	client *geth.InstrumentedEthClient,
 	logger logging.Logger,
 ) (*Node, error) {
-	// Setup metrics
-	// sdkClients, err := buildSdkClients(config, logger)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	nodeLogger := logger.With("component", "Node")
 
 	socketAddr := fmt.Sprintf(":%d", config.MetricsPort)
@@ -127,7 +121,7 @@ func NewNode(
 	// Create Transactor
 	tx, err := eth.NewWriter(logger, client, config.EigenDADirectory, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create writer: %w", err)
 	}
 
 	// Create ChainState Client
@@ -155,7 +149,7 @@ func NewNode(
 	config.EncoderConfig.LoadG2Points = false
 	v, err := verifier.NewVerifier(&config.EncoderConfig, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create verifier: %w", err)
 	}
 	asgn := &core.StdAssignmentCoordinator{}
 	validator := core.NewShardValidator(v, asgn, cst, config.ID)
@@ -415,7 +409,7 @@ func (n *Node) Start(ctx context.Context) error {
 		eigenDAUrl, ok := eigenDAUIMap[n.ChainID.String()]
 		if ok {
 			n.Logger.Infof("The node has successfully started. Note: if it's not opted in on %s, "+
-				"then please follow the EigenDA operator guide section in docs.eigenlayer.xyz to register", eigenDAUrl)
+				"then please follow the EigenDA operator guide section in https://docs.eigencloud.xyz/products/eigenda/operator-guides/run-a-node/registration to register", eigenDAUrl)
 		} else {
 			n.Logger.Infof("The node has started but the network with chainID %s is not supported yet",
 				n.ChainID.String())


### PR DESCRIPTION
## Why are these changes needed?

Preprod Validator was seeing 2025/07/16 22:21:34 application failed: failed to create address directory reader: address directory must be a valid hex address:
When using the old config. EigenDADirectory was added, but should be backward compatible and just seamlessly fallback to using the provided EigenDAServiceManager passed in as argument when Directory is not present.

We will later deprecate and remove the other flags but for now we want the flags to be backwards compatible.

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
