### PR TITLE
chore: cherry-pick celo's PR from proxy repo

### DIFF
--- a/api/proxy/.golangci.yml
+++ b/api/proxy/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - unused # checks for unused constants, variables, functions and types
     ## disabled by default
     - asasalint # checks for pass []any as any in variadic func(...any)
-    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - asciicheck # checks that your code does not contain non-ASCII identifiers1
     - bidichk # checks for dangerous unicode character sequences
     - bodyclose # checks whether HTTP response body is closed successfully
     - cyclop # checks function and package cyclomatic complexity
@@ -195,7 +195,7 @@ linters:
           - unparam
 
       # Allow certain patterns to be ignored by lll (long lines)
-      - source: '".{120,}"' # Ignores double-quoted strings longer than 120 chars
+      - source: '".{100,}"' # Ignores double-quoted strings longer than 120 chars
         linters: [lll]
       - source: "// https?://" # This pattern matches comments containing URLs
         linters: [lll]

--- a/api/proxy/.golangci.yml
+++ b/api/proxy/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - unused # checks for unused constants, variables, functions and types
     ## disabled by default
     - asasalint # checks for pass []any as any in variadic func(...any)
-    - asciicheck # checks that your code does not contain non-ASCII identifiers1
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
     - bidichk # checks for dangerous unicode character sequences
     - bodyclose # checks whether HTTP response body is closed successfully
     - cyclop # checks function and package cyclomatic complexity
@@ -195,7 +195,9 @@ linters:
           - unparam
 
       # Allow certain patterns to be ignored by lll (long lines)
-      - source: '".{100,}"' # Ignores double-quoted strings longer than 120 chars
+      # This should probably be 120 to match our golines formatter, but there is a weird interaction which an external contributor hit.
+      # The bug was a string smaller than 120, but with key + string made the line bigger than 120, which invalidated the exclusion rule.
+      - source: '".{100,}"' # Ignores double-quoted strings longer than 100 chars
         linters: [lll]
       - source: "// https?://" # This pattern matches comments containing URLs
         linters: [lll]

--- a/api/proxy/docs/help_out.txt
+++ b/api/proxy/docs/help_out.txt
@@ -140,4 +140,5 @@ This check is optional and will be skipped when set to 0. (default: 0) [$EIGENDA
    --storage.concurrent-write-routines value                                  Number of threads spun-up for async secondary storage insertions. (<=0) denotes single threaded insertions where (>0) indicates decoupled writes. (default: 0) [$EIGENDA_PROXY_STORAGE_CONCURRENT_WRITE_THREADS]
    --storage.dispersal-backend value                                          Target EigenDA backend version for blob dispersal (e.g. V1 or V2). (default: "V1") [$EIGENDA_PROXY_STORAGE_DISPERSAL_BACKEND]
    --storage.fallback-targets value [ --storage.fallback-targets value ]      List of read fallback targets to rollover to if cert can't be read from EigenDA. [$EIGENDA_PROXY_STORAGE_FALLBACK_TARGETS]
+   --storage.write-on-cache-miss                                              While doing a GET, write to the secondary storage if the cert/blob is not found in the cache but is found in EigenDA. (default: false) [$EIGENDA_PROXY_STORAGE_WRITE_ON_CACHE_MISS]
 

--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -122,7 +122,7 @@ func BuildStoreManager(
 
 	fallbacks := buildSecondaries(config.StoreConfig.FallbackTargets, s3Store, redisStore)
 	caches := buildSecondaries(config.StoreConfig.CacheTargets, s3Store, redisStore)
-	secondary := secondary.NewSecondaryManager(log, metrics, caches, fallbacks)
+	secondary := secondary.NewSecondaryManager(log, metrics, caches, fallbacks, config.StoreConfig.WriteOnCacheMiss)
 
 	if secondary.Enabled() { // only spin-up go routines if secondary storage is enabled
 		log.Info("Starting secondary write loop(s)", "count", config.StoreConfig.AsyncPutWorkers)

--- a/api/proxy/store/cli.go
+++ b/api/proxy/store/cli.go
@@ -14,6 +14,7 @@ var (
 	FallbackTargetsFlagName  = withFlagPrefix("fallback-targets")
 	CacheTargetsFlagName     = withFlagPrefix("cache-targets")
 	ConcurrentWriteThreads   = withFlagPrefix("concurrent-write-routines")
+	WriteOnCacheMissFlagName = withFlagPrefix("write-on-cache-miss")
 )
 
 func withFlagPrefix(s string) string {
@@ -65,6 +66,13 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			EnvVars:  withEnvPrefix(envPrefix, "CONCURRENT_WRITE_THREADS"),
 			Category: category,
 		},
+		&cli.BoolFlag{
+			Name:     WriteOnCacheMissFlagName,
+			Usage:    "While doing a GET, write to the secondary storage if the cert/blob is not found in the cache but is found in EigenDA.",
+			Value:    false,
+			EnvVars:  withEnvPrefix(envPrefix, "WRITE_ON_CACHE_MISS"),
+			Category: category,
+		},
 	}
 }
 
@@ -94,5 +102,6 @@ func ReadConfig(ctx *cli.Context) (Config, error) {
 		AsyncPutWorkers:  ctx.Int(ConcurrentWriteThreads),
 		FallbackTargets:  ctx.StringSlice(FallbackTargetsFlagName),
 		CacheTargets:     ctx.StringSlice(CacheTargetsFlagName),
+		WriteOnCacheMiss: ctx.Bool(WriteOnCacheMissFlagName),
 	}, nil
 }

--- a/api/proxy/store/config.go
+++ b/api/proxy/store/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	AsyncPutWorkers int
 	FallbackTargets []string
 	CacheTargets    []string
+
+	WriteOnCacheMiss bool
 }
 
 // checkTargets ... verifies that a backend target slice is constructed correctly

--- a/api/proxy/test/testutils/setup.go
+++ b/api/proxy/test/testutils/setup.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	"golang.org/x/exp/rand"
 
 	miniotc "github.com/testcontainers/testcontainers-go/modules/minio"
 	redistc "github.com/testcontainers/testcontainers-go/modules/redis"
@@ -172,6 +171,7 @@ type TestConfig struct {
 	Expiration       time.Duration
 	MaxBlobLength    string
 	WriteThreadCount int
+	WriteOnCacheMiss bool
 	// at most one of the below options should be true
 	UseKeccak256ModeS3 bool
 	UseS3Caching       bool
@@ -205,6 +205,7 @@ func NewTestConfig(
 		UseRedisCaching:    false,
 		UseS3Fallback:      false,
 		WriteThreadCount:   0,
+		WriteOnCacheMiss:   false,
 	}
 }
 
@@ -300,6 +301,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 			AsyncPutWorkers:  testCfg.WriteThreadCount,
 			BackendsToEnable: testCfg.BackendsToEnable,
 			DispersalBackend: testCfg.DispersalBackend,
+			WriteOnCacheMiss: testCfg.WriteOnCacheMiss,
 		},
 		ClientConfigV1: common.ClientConfigV1{
 			EdaClientCfg: clients.EigenDAClientConfig{
@@ -426,15 +428,4 @@ func createS3Bucket(bucketName string) {
 	} else {
 		log.Info(fmt.Sprintf("Successfully created %s\n", bucketName))
 	}
-}
-func RandStr(n int) string {
-	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
-	}
-	return string(b)
-}
-func RandBytes(n int) []byte {
-	return []byte(RandStr(n))
 }

--- a/api/proxy/test/testutils/utils.go
+++ b/api/proxy/test/testutils/utils.go
@@ -1,0 +1,84 @@
+package testutils
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"golang.org/x/exp/rand"
+)
+
+func RandStr(n int) string {
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func RandBytes(n int) []byte {
+	return []byte(RandStr(n))
+}
+
+// Panics if the bucket does not exist
+func RemoveBlobInfoFromBucket(bucketName string, blobInfo []byte) error {
+	// Initialize minio client object.
+	endpoint := minioEndpoint
+	accessKeyID := minioAdmin
+	secretAccessKey := minioAdmin
+	useSSL := false
+	minioClient, err := minio.New(
+		endpoint, &minio.Options{
+			Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
+			Secure: useSSL,
+		})
+	// Panic, the bucket should already exist
+	if err != nil {
+		panic(err)
+	}
+	key := crypto.Keccak256(blobInfo[1:])
+	objectName := hex.EncodeToString(key)
+	ctx := context.Background()
+	err = minioClient.RemoveObject(ctx, bucketName, objectName, minio.RemoveObjectOptions{})
+	if err != nil {
+		return err
+	}
+	log.Info(fmt.Sprintf("Successfully removed %s from %s\n", objectName, bucketName))
+
+	return nil
+}
+
+// Panics if the bucket does not exist
+func ExistsBlobInfotInBucket(bucketName string, blobInfo []byte) (bool, error) {
+	// Initialize minio client object.
+	endpoint := minioEndpoint
+	accessKeyID := minioAdmin
+	secretAccessKey := minioAdmin
+	useSSL := false
+	minioClient, err := minio.New(
+		endpoint, &minio.Options{
+			Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
+			Secure: useSSL,
+		})
+	// Panic, the bucket should already exist
+	if err != nil {
+		panic(err)
+	}
+	key := crypto.Keccak256(blobInfo[1:])
+	objectName := hex.EncodeToString(key)
+	ctx := context.Background()
+	_, err = minioClient.StatObject(ctx, bucketName, objectName, minio.StatObjectOptions{})
+	if err != nil {
+		errResponse := minio.ToErrorResponse(err)
+		if errResponse.Code == "NoSuchKey" {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
Pulls in latest PR on proxy repo: https://github.com/Layr-Labs/eigenda-proxy/pull/422

I think I made a mistake and squash merged https://github.com/Layr-Labs/eigenda/pull/1611, because subtree pull was giving me this error (same when trying with --squash): 
```
$ git subtree pull --prefix=api/proxy https://github.com/Layr-Labs/eigenda-proxy.git main --squash
From https://github.com/Layr-Labs/eigenda-proxy
 * branch              main       -> FETCH_HEAD
fatal: can't squash-merge: 'api/proxy' was never added.
```

But TIL that git is smart when cherry-picking and has a [directory-rename feature](https://git-scm.com/docs/directory-rename-detection/2.22.0), so the changes were automatically applied to the files under api/proxy, except for 2 small weirdness:
- golangci.lint file was conflicting with root golangci file.. so had to fix conflict by hand
- the new testutil/utils.go file behaved very weirdly.. was saying there was a conflict even though it was just getting added and we didn't already have that file... not super sure but just commited it "with conflicts" and everything was fine.