### PR TITLE
ci: fix flaky v1 live test

### DIFF
--- a/.github/workflows/live-network-tests.yaml
+++ b/.github/workflows/live-network-tests.yaml
@@ -46,7 +46,7 @@ jobs:
 
           PAYLOAD=$(jq -n \
             --arg channel "#da-live-tests" \
-            --arg text "${MENTION}Live Network Tests completed, status: ${STATUS_EMOJI} ${{ job.status }}" \
+            --arg text "${MENTION}Live V2 Network Tests completed, status: ${STATUS_EMOJI} ${{ job.status }}" \
             --arg title "logs" \
             --arg title_link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --arg color "$COLOR" \
@@ -101,7 +101,7 @@ jobs:
 
           PAYLOAD=$(jq -n \
             --arg channel "#da-live-tests" \
-            --arg text "${MENTION}Live Network Tests completed, status: ${STATUS_EMOJI} ${{ job.status }}" \
+            --arg text "${MENTION}Live V1 Network Tests completed, status: ${STATUS_EMOJI} ${{ job.status }}" \
             --arg title "logs" \
             --arg title_link "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --arg color "$COLOR" \

--- a/api/clients/eigenda_client_e2e_live_test.go
+++ b/api/clients/eigenda_client_e2e_live_test.go
@@ -41,6 +41,7 @@ func TestClientUsingTestnet(t *testing.T) {
 
 	t.Run("PutBlobWaitForConfirmationDepth0AndGetBlob", func(t *testing.T) {
 		t.Parallel()
+		confDepth := uint64(0)
 
 		client, err := NewEigenDAClient(testutils.GetLogger(), EigenDAClientConfig{
 			RPC: testRPC,
@@ -52,7 +53,7 @@ func TestClientUsingTestnet(t *testing.T) {
 			CustomQuorumIDs:          []uint{},
 			SignerPrivateKeyHex:      testSignerPrivateKeyHex,
 			WaitForFinalization:      false,
-			WaitForConfirmationDepth: 0,
+			WaitForConfirmationDepth: confDepth,
 			SvcManagerAddr:           testSvcManagerAddr,
 			EthRpcUrl:                testEthRpcUrl,
 		})
@@ -73,18 +74,18 @@ func TestClientUsingTestnet(t *testing.T) {
 		confDepth := uint64(3)
 
 		client, err := NewEigenDAClient(testutils.GetLogger(), EigenDAClientConfig{
-			RPC: "disperser-holesky.eigenda.xyz:443",
+			RPC: testRPC,
 			// Should need way less than 20 minutes, but we set it to 20 minutes to be safe
 			// In worst case we had 10 min batching interval + some time for the tx to land onchain,
 			// plus wait for 3 blocks of confirmation.
-			StatusQueryTimeout:       20 * time.Minute,
-			StatusQueryRetryInterval: 5 * time.Second,
+			StatusQueryTimeout:       testStatusQueryTimeout,
+			StatusQueryRetryInterval: testStatusQueryRetryInterval,
 			CustomQuorumIDs:          []uint{},
-			SignerPrivateKeyHex:      "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1",
+			SignerPrivateKeyHex:      testSignerPrivateKeyHex,
 			WaitForFinalization:      false,
 			WaitForConfirmationDepth: confDepth,
-			SvcManagerAddr:           "0xD4A7E1Bd8015057293f0D0A557088c286942e84b",
-			EthRpcUrl:                "https://1rpc.io/holesky",
+			SvcManagerAddr:           testSvcManagerAddr,
+			EthRpcUrl:                testEthRpcUrl,
 		})
 		data := "hello world!"
 		assert.NoError(t, err)


### PR DESCRIPTION
## Why are these changes needed?

Forgot when I refactored last time to update the 2nd test to use the shared global vars to configure the client.
This switches the 2nd test to stop using 1rpc holesky endpoint, which has been very flaky and causing ci flakes, such as https://github.com/Layr-Labs/eigenda/actions/runs/16402747848

Also updated the slack msg to differentiate v1 and v2 tests, since they were being updated on slack with the same msg since they both were using the same msg:
<img width="379" height="220" alt="image" src="https://github.com/user-attachments/assets/0e7f01d9-8365-49ec-a13b-562d689160ff" />
