### PR TITLE
chore(proxy-clients): new sub go module

### DIFF
--- a/api/proxy/README.md
+++ b/api/proxy/README.md
@@ -12,7 +12,7 @@ A basic REST proxy server to interact with the EigenDA network:
 [![push-image-ghcr](https://github.com/Layr-Labs/eigenda-proxy/actions/workflows/push-ghcr.yml/badge.svg)](https://github.com/Layr-Labs/eigenda-proxy/actions/workflows/push-ghcr.yml)
 
 
-[V1 Integration Guide](https://docs.eigenda.xyz/integrations-guides/dispersal/clients/eigenda-proxy) | [V2 Integration Spec](https://layr-labs.github.io/eigenda/integration.html) | [Clients Godoc Examples](https://pkg.go.dev/github.com/Layr-Labs/eigenda-proxy/clients/standard_client) | [EigenDA Repo](https://github.com/Layr-Labs/eigenda)
+[V1 Integration Guide](https://docs.eigenda.xyz/integrations-guides/dispersal/clients/eigenda-proxy) | [V2 Integration Spec](https://layr-labs.github.io/eigenda/integration.html) | [Clients Godoc Examples](https://pkg.go.dev/github.com/Layr-Labs/eigenda/api/proxy/clients/standard_client) | [EigenDA Repo](https://github.com/Layr-Labs/eigenda)
 
 ## Overview
 

--- a/api/proxy/clients/go.mod
+++ b/api/proxy/clients/go.mod
@@ -5,7 +5,7 @@
 // 1. [omitted]
 // 2. if you have a repository with a complex set of dependencies, but you have a client API with a smaller set of dependencies.
 //    In some cases, it might make sense to have an api or clientapi or similar directory with its own go.mod, or to separate out that clientapi into its own repository.
-module github.com/Layr-Labs/eigenda-proxy/clients
+module github.com/Layr-Labs/eigenda/api/proxy/clients
 
 go 1.22
 
@@ -62,13 +62,4 @@ require (
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-// See https://go.dev/ref/mod#go-mod-file-retract for more information about the retract directive.
-retract (
-	// We published a `clients/v1.0.1` tag by mistake, which got picked up by pkg.go.dev, and now
-	// the latest version of the docs (pointed to in our README) leads to https://pkg.go.dev/github.com/Layr-Labs/eigenda-proxy/clients@v1.0.1/standard_client.
-	// This directive retracts that version, such that the docs (and go commands) no longer point to this version (at this point v0.2.0 is the latest).
-	// Once we reach semver v1.0.1, we can possibly remove this retract directive (??), or just skip this number and go to v1.0.2.
-    v1.0.1
 )

--- a/api/proxy/clients/standard_client/example_memstore_test.go
+++ b/api/proxy/clients/standard_client/example_memstore_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Layr-Labs/eigenda-proxy/clients/standard_client"
+	"github.com/Layr-Labs/eigenda/api/proxy/clients/standard_client"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )

--- a/api/proxy/test/benchmark/benchmark_test.go
+++ b/api/proxy/test/benchmark/benchmark_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Layr-Labs/eigenda-proxy/clients/standard_client"
+	"github.com/Layr-Labs/eigenda/api/proxy/clients/standard_client"
 	"github.com/Layr-Labs/eigenda/api/proxy/common"
 	"github.com/Layr-Labs/eigenda/api/proxy/test/testutils"
 )

--- a/api/proxy/test/e2e/safety_checks_test.go
+++ b/api/proxy/test/e2e/safety_checks_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Layr-Labs/eigenda-proxy/clients/standard_client"
+	"github.com/Layr-Labs/eigenda/api/proxy/clients/standard_client"
 	"github.com/Layr-Labs/eigenda/api/proxy/common"
 	"github.com/Layr-Labs/eigenda/api/proxy/test/testutils"
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"

--- a/api/proxy/test/e2e/server_test.go
+++ b/api/proxy/test/e2e/server_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Layr-Labs/eigenda-proxy/clients/memconfig_client"
-	"github.com/Layr-Labs/eigenda-proxy/clients/standard_client"
+	"github.com/Layr-Labs/eigenda/api/proxy/clients/memconfig_client"
+	"github.com/Layr-Labs/eigenda/api/proxy/clients/standard_client"
 	"github.com/Layr-Labs/eigenda/api/proxy/common"
 	"github.com/Layr-Labs/eigenda/api/proxy/common/types/commitments"
 	"github.com/Layr-Labs/eigenda/api/proxy/metrics"

--- a/api/proxy/test/fuzz/server_fuzz_test.go
+++ b/api/proxy/test/fuzz/server_fuzz_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Layr-Labs/eigenda-proxy/clients/standard_client"
+	"github.com/Layr-Labs/eigenda/api/proxy/clients/standard_client"
 	"github.com/Layr-Labs/eigenda/api/proxy/common"
 	"github.com/Layr-Labs/eigenda/api/proxy/test/testutils"
 	"github.com/Layr-Labs/eigensdk-go/logging"

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,6 @@ go 1.24
 // See https://tip.golang.org/doc/devel/release#go1.24.0
 toolchain go1.24.4
 
-// We need to keep eigenda-proxy clients separate because they are imported from modules that are not on go1.24 yet.
-replace github.com/Layr-Labs/eigenda-proxy/clients => ./api/proxy/clients
-
 // Pointing to latest eigenda-develop commit that contains https://github.com/Layr-Labs/optimism/pull/49
 // TODO: update to a proper version once we make the next release.
 replace github.com/ethereum-optimism/optimism => github.com/Layr-Labs/optimism v1.13.1-0.20250616152614-59132dd56ae5
@@ -23,7 +20,7 @@ replace github.com/ethereum-optimism/optimism => github.com/Layr-Labs/optimism v
 replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2-rc.5
 
 require (
-	github.com/Layr-Labs/eigenda-proxy/clients v1.0.1
+	github.com/Layr-Labs/eigenda/api/proxy/clients v1.0.1
 	github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28
 	github.com/Layr-Labs/eigensdk-go/signer v0.0.0-20250118004418-2a25f31b3b28
 	github.com/avast/retry-go/v4 v4.6.0


### PR DESCRIPTION
Closes DAINT-644.

We were still using the eigenda-proxy/clients package. Now moving this package over to monorepo.

This is also a good chance to cleanup the weird godoc behavior that won't listen to our retract directive in go.mod to remove the 1.0.1 version.

So with this new package our client docs will at least point to the most up-to-date examples.

TODO: publish this new module as v0.2.1 so that it lands on pkg.dev (using same version as the current one for the eigenda-proxy/clients pkg)

TODO: will need to update our eigencloud docs to point to this new module.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
