### PR TITLE
ci: add merge_group trigger to all workflows

### DIFF
--- a/.github/workflows/buf-proto.yaml
+++ b/.github/workflows/buf-proto.yaml
@@ -20,6 +20,7 @@ on:
     paths:
       - "api/proto/**"
       - "api/buf.yaml"
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql-scanning.yaml
+++ b/.github/workflows/codeql-scanning.yaml
@@ -25,6 +25,7 @@ on:
       - "relay/**"
       - ".github/codeql/**"
       - ".github/workflows/codeql-scanning.yaml"
+  merge_group:
   schedule:
     - cron: "0 9 * * *"
 

--- a/.github/workflows/compile-protobufs.yaml
+++ b/.github/workflows/compile-protobufs.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
 
 jobs:
   golangci:

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 env:
   MISE_VERSION: 2024.12.14

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
 
 env:
   MISE_VERSION: 2024.12.14

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -3,6 +3,7 @@ name: PR Title Linting
 on:
   pull_request:
     types: [opened, edited, synchronize]
+  merge_group:
 
 jobs:
   lint-pr-title:

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -10,6 +10,7 @@ on:
       - master
     paths:
       - 'subgraphs/**'
+  merge_group:
 
 jobs:
   test-subgraphs:

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
     types: [opened, reopened, synchronize]
+  merge_group:
 
 env:
   FOUNDRY_PROFILE: ci

--- a/.github/workflows/test-proxy.yml
+++ b/.github/workflows/test-proxy.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "api/proxy/**"
       - ".github/workflows/per-pr-proxy.yml"
+  merge_group:
 
 env:
   MISE_VERSION: 2024.12.14

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 env:
   MISE_VERSION: 2024.12.14


### PR DESCRIPTION
This enables enabling the merge queue. Previously any PR that landed in the merge queue was stuck there because the required workflows were never starting because they were missing this merge_group trigger.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
