### PR TITLE
ci: always run all workflows (no paths:) to enable merge_queue

### DIFF
--- a/.github/workflows/buf-proto.yaml
+++ b/.github/workflows/buf-proto.yaml
@@ -12,14 +12,9 @@
 name: Buf Proto
 on:
   push:
-    paths:
-      - "api/proto/**"
-      - "api/buf.yaml"
+    branches:
+      - master
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths:
-      - "api/proto/**"
-      - "api/buf.yaml"
   merge_group:
 
 permissions:

--- a/.github/workflows/compile-protobufs.yaml
+++ b/.github/workflows/compile-protobufs.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   merge_group:
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   merge_group:
 
 env:

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -3,7 +3,10 @@ name: PR Title Linting
 on:
   pull_request:
     types: [opened, edited, synchronize]
-  merge_group:
+  # This workflow is currently not required on github because it doesn't work
+  # for merge_group events, because of its use of '.pull_request.title' below.
+  # TODO: update this workflow to work with merge_group events.
+  # merge_group:
 
 jobs:
   lint-pr-title:
@@ -14,7 +17,7 @@ jobs:
         run: |
           PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
           echo "PR title: $PR_TITLE"
-          
+
           # Define the valid pattern (supports conventional commit format with breaking changes)
           if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|test|style|ci|perf)(\([a-z0-9-]+\))?(!)?:\ .* ]]; then
             echo "❌ Invalid PR title: '$PR_TITLE'"
@@ -28,5 +31,5 @@ jobs:
             echo "- docs: update README with new instructions"
             exit 1
           fi
-          
+
           echo "✅ PR title is valid"

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+    # TODO: these tests can't be required to pass in order to merge,
+    # because they only run on these paths so would block PRs that don't change subgraphs.
+    # Do we want to change this and always run this workflow and mark is as required?
     paths:
       - 'subgraphs/**'
   pull_request:

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, reopened, synchronize]
   merge_group:
 
 env:

--- a/.github/workflows/test-proxy.yml
+++ b/.github/workflows/test-proxy.yml
@@ -2,14 +2,9 @@ name: test-proxy # this name appears in the badge on the README
 
 on:
   push:
-    branches: ["master"]
-    paths:
-      - "api/proxy/**"
-      - ".github/workflows/per-pr-proxy.yml"
+    branches: 
+      - master
   pull_request:
-    paths:
-      - "api/proxy/**"
-      - ".github/workflows/per-pr-proxy.yml"
   merge_group:
 
 env:


### PR DESCRIPTION
Main issue is that required workflows can't have `paths:` because then they block any PR which doesn't change those paths, since they don't run and hence block the merge queue.

So opted to remove all `paths:` conditionals in our workflows.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
