### PR TITLE
feat: adds account index to blobmetadatastore-v2

### DIFF
--- a/disperser/apiserver/disperse_blob_v2.go
+++ b/disperser/apiserver/disperse_blob_v2.go
@@ -34,6 +34,13 @@ func (s *DispersalServerV2) DisperseBlob(ctx context.Context, req *pb.DisperseBl
 		return nil, api.NewErrorInvalidArg(fmt.Sprintf("failed to validate the request: %v", err))
 	}
 
+	// Update AccountIndex after successful validation
+	accountID := blobHeader.PaymentMetadata.AccountID
+	timestamp := uint64(time.Now().Unix())
+	if err := s.blobMetadataStore.UpdateAccountIndex(ctx, accountID, timestamp); err != nil {
+		s.logger.Warn("failed to update account index", "accountID", accountID.Hex(), "error", err)
+	}
+
 	if err := s.checkBlobExistence(ctx, blobHeader); err != nil {
 		return nil, err
 	}

--- a/disperser/apiserver/disperse_blob_v2.go
+++ b/disperser/apiserver/disperse_blob_v2.go
@@ -60,7 +60,12 @@ func (s *DispersalServerV2) DisperseBlob(ctx context.Context, req *pb.DisperseBl
 	go func() {
 		accountID := blobHeader.PaymentMetadata.AccountID
 		timestamp := uint64(time.Now().Unix())
-		if err := s.blobMetadataStore.UpdateAccount(context.Background(), accountID, timestamp); err != nil {
+
+		// Use a timeout context for the async database operation
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := s.blobMetadataStore.UpdateAccount(ctx, accountID, timestamp); err != nil {
 			s.logger.Warn("failed to update account", "accountID", accountID.Hex(), "error", err)
 		}
 	}()

--- a/disperser/apiserver/disperse_blob_v2.go
+++ b/disperser/apiserver/disperse_blob_v2.go
@@ -56,12 +56,12 @@ func (s *DispersalServerV2) DisperseBlob(ctx context.Context, req *pb.DisperseBl
 	}
 	s.logger.Debug("stored blob", "blobKey", blobKey.Hex())
 
-	// Update AccountIndex asynchronously after successful blob storage
+	// Update Account asynchronously after successful blob storage
 	go func() {
 		accountID := blobHeader.PaymentMetadata.AccountID
 		timestamp := uint64(time.Now().Unix())
-		if err := s.blobMetadataStore.UpdateAccountIndex(context.Background(), accountID, timestamp); err != nil {
-			s.logger.Warn("failed to update account index", "accountID", accountID.Hex(), "error", err)
+		if err := s.blobMetadataStore.UpdateAccount(context.Background(), accountID, timestamp); err != nil {
+			s.logger.Warn("failed to update account", "accountID", accountID.Hex(), "error", err)
 		}
 	}()
 

--- a/disperser/common/v2/blob.go
+++ b/disperser/common/v2/blob.go
@@ -100,7 +100,7 @@ type BlobAttestationInfo struct {
 	Attestation   *corev2.Attestation
 }
 
-// Account represents account information from the AccountIndex
+// Account represents account information from the Account table
 type Account struct {
 	Address   gethcommon.Address `json:"address"`
 	UpdatedAt uint64             `json:"updated_at"` // unix timestamp in seconds

--- a/disperser/common/v2/blob.go
+++ b/disperser/common/v2/blob.go
@@ -6,6 +6,7 @@ import (
 	pb "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/encoding"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 type BlobStatus uint
@@ -97,4 +98,10 @@ type BlobMetadata struct {
 type BlobAttestationInfo struct {
 	InclusionInfo *corev2.BlobInclusionInfo
 	Attestation   *corev2.Attestation
+}
+
+// Account represents account information from the AccountIndex
+type Account struct {
+	Address   gethcommon.Address `json:"address"`
+	UpdatedAt uint64             `json:"updated_at"` // unix timestamp in seconds
 }

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -480,11 +480,11 @@ func (s *BlobMetadataStore) GetBlobMetadataByAccountID(
 	return blobs, nil
 }
 
-// UpdateAccountIndex updates the AccountIndex partition to track account activity.
+// UpdateAccount updates the Account partition to track account activity.
 // This method performs an upsert operation, creating or updating an entry for the given account
 // with the current timestamp.
-func (s *BlobMetadataStore) UpdateAccountIndex(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error {
-	s.logger.Debug("updating account index", "accountID", accountID.Hex(), "timestamp", timestamp)
+func (s *BlobMetadataStore) UpdateAccount(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error {
+	s.logger.Debug("updating account", "accountID", accountID.Hex(), "timestamp", timestamp)
 
 	item := commondynamodb.Item{
 		"PK":          &types.AttributeValueMemberS{Value: accountPK},
@@ -496,7 +496,7 @@ func (s *BlobMetadataStore) UpdateAccountIndex(ctx context.Context, accountID ge
 
 	err := s.dynamoDBClient.PutItem(ctx, s.tableName, item)
 	if err != nil {
-		return fmt.Errorf("failed to update account index for accountID %s: %w", accountID.Hex(), err)
+		return fmt.Errorf("failed to update account for accountID %s: %w", accountID.Hex(), err)
 	}
 
 	return nil
@@ -511,7 +511,7 @@ func (s *BlobMetadataStore) GetAccounts(ctx context.Context, lookbackSeconds uin
 	cutoffTime := now - lookbackSeconds
 
 	// Query the AccountUpdatedAtIndex GSI with time filter
-	// All account records have AccountType = "Account" which allows us to query
+	// All account records have AccountType = "AccountIndex" which allows us to query
 	// all accounts after the cutoff time efficiently
 	items, err := s.dynamoDBClient.QueryIndex(
 		ctx,
@@ -524,7 +524,7 @@ func (s *BlobMetadataStore) GetAccounts(ctx context.Context, lookbackSeconds uin
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query account activity index: %w", err)
+		return nil, fmt.Errorf("failed to query accounts: %w", err)
 	}
 
 	// Convert to Account structs

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -2205,25 +2205,25 @@ func TestCheckBlobExists(t *testing.T) {
 	require.False(t, exists, "Random blob key should not exist")
 }
 
-func TestBlobMetadataStoreUpdateAccountIndex(t *testing.T) {
+func TestBlobMetadataStoreUpdateAccount(t *testing.T) {
 	ctx := context.Background()
 
 	// Test account
 	accountID := gethcommon.HexToAddress("0x1234567890123456789012345678901234567890")
 	timestamp := uint64(time.Now().Unix())
 
-	// Test updating account index - should not return an error
-	err := blobMetadataStore.UpdateAccountIndex(ctx, accountID, timestamp)
+	// Test updating account - should not return an error
+	err := blobMetadataStore.UpdateAccount(ctx, accountID, timestamp)
 	require.NoError(t, err)
 
 	// Test updating the same account with a new timestamp - should not return an error
 	newTimestamp := timestamp + 100
-	err = blobMetadataStore.UpdateAccountIndex(ctx, accountID, newTimestamp)
+	err = blobMetadataStore.UpdateAccount(ctx, accountID, newTimestamp)
 	require.NoError(t, err)
 
 	// Test with different account
 	accountID2 := gethcommon.HexToAddress("0x9876543210987654321098765432109876543210")
-	err = blobMetadataStore.UpdateAccountIndex(ctx, accountID2, timestamp)
+	err = blobMetadataStore.UpdateAccount(ctx, accountID2, timestamp)
 	require.NoError(t, err)
 }
 

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -2226,3 +2226,20 @@ func TestBlobMetadataStoreUpdateAccountIndex(t *testing.T) {
 	err = blobMetadataStore.UpdateAccountIndex(ctx, accountID2, timestamp)
 	require.NoError(t, err)
 }
+
+func TestBlobMetadataStoreGetAccounts(t *testing.T) {
+	ctx := context.Background()
+
+	// Test with 1-hour lookback
+	lookbackSeconds := uint64(3600) // 1 hour
+
+	// Should not return an error even if no results
+	accounts, err := blobMetadataStore.GetAccounts(ctx, lookbackSeconds)
+	require.NoError(t, err)
+	assert.NotNil(t, accounts)
+
+	// Test with different lookback periods
+	accounts24h, err := blobMetadataStore.GetAccounts(ctx, 24*3600) // 24 hours
+	require.NoError(t, err)
+	assert.NotNil(t, accounts24h)
+}

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -2204,3 +2204,25 @@ func TestCheckBlobExists(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists, "Random blob key should not exist")
 }
+
+func TestBlobMetadataStoreUpdateAccountIndex(t *testing.T) {
+	ctx := context.Background()
+
+	// Test account
+	accountID := gethcommon.HexToAddress("0x1234567890123456789012345678901234567890")
+	timestamp := uint64(time.Now().Unix())
+
+	// Test updating account index - should not return an error
+	err := blobMetadataStore.UpdateAccountIndex(ctx, accountID, timestamp)
+	require.NoError(t, err)
+
+	// Test updating the same account with a new timestamp - should not return an error
+	newTimestamp := timestamp + 100
+	err = blobMetadataStore.UpdateAccountIndex(ctx, accountID, newTimestamp)
+	require.NoError(t, err)
+
+	// Test with different account
+	accountID2 := gethcommon.HexToAddress("0x9876543210987654321098765432109876543210")
+	err = blobMetadataStore.UpdateAccountIndex(ctx, accountID2, timestamp)
+	require.NoError(t, err)
+}

--- a/disperser/common/v2/blobstore/instrumented_metadata_store.go
+++ b/disperser/common/v2/blobstore/instrumented_metadata_store.go
@@ -205,11 +205,11 @@ func (m *InstrumentedMetadataStore) GetBlobMetadataByAccountID(
 	return metadata, err
 }
 
-func (m *InstrumentedMetadataStore) UpdateAccountIndex(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error {
-	defer m.trackInFlight("UpdateAccountIndex")()
+func (m *InstrumentedMetadataStore) UpdateAccount(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error {
+	defer m.trackInFlight("UpdateAccount")()
 	startTime := time.Now()
-	err := m.metadataStore.UpdateAccountIndex(ctx, accountID, timestamp)
-	m.recordMetrics("UpdateAccountIndex", startTime, err)
+	err := m.metadataStore.UpdateAccount(ctx, accountID, timestamp)
+	m.recordMetrics("UpdateAccount", startTime, err)
 	return err
 }
 

--- a/disperser/common/v2/blobstore/instrumented_metadata_store.go
+++ b/disperser/common/v2/blobstore/instrumented_metadata_store.go
@@ -213,6 +213,14 @@ func (m *InstrumentedMetadataStore) UpdateAccountIndex(ctx context.Context, acco
 	return err
 }
 
+func (m *InstrumentedMetadataStore) GetAccounts(ctx context.Context, lookbackSeconds uint64) ([]*v2.Account, error) {
+	defer m.trackInFlight("GetAccounts")()
+	startTime := time.Now()
+	accounts, err := m.metadataStore.GetAccounts(ctx, lookbackSeconds)
+	m.recordMetrics("GetAccounts", startTime, err)
+	return accounts, err
+}
+
 func (m *InstrumentedMetadataStore) GetBlobMetadataByStatus(ctx context.Context, status v2.BlobStatus, lastUpdatedAt uint64) ([]*v2.BlobMetadata, error) {
 	defer m.trackInFlight("GetBlobMetadataByStatus")()
 	start := time.Now()

--- a/disperser/common/v2/blobstore/instrumented_metadata_store.go
+++ b/disperser/common/v2/blobstore/instrumented_metadata_store.go
@@ -205,6 +205,14 @@ func (m *InstrumentedMetadataStore) GetBlobMetadataByAccountID(
 	return metadata, err
 }
 
+func (m *InstrumentedMetadataStore) UpdateAccountIndex(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error {
+	defer m.trackInFlight("UpdateAccountIndex")()
+	startTime := time.Now()
+	err := m.metadataStore.UpdateAccountIndex(ctx, accountID, timestamp)
+	m.recordMetrics("UpdateAccountIndex", startTime, err)
+	return err
+}
+
 func (m *InstrumentedMetadataStore) GetBlobMetadataByStatus(ctx context.Context, status v2.BlobStatus, lastUpdatedAt uint64) ([]*v2.BlobMetadata, error) {
 	defer m.trackInFlight("GetBlobMetadataByStatus")()
 	start := time.Now()

--- a/disperser/common/v2/blobstore/metadata_store.go
+++ b/disperser/common/v2/blobstore/metadata_store.go
@@ -133,6 +133,10 @@ type MetadataStore interface {
 	// Combined Operations
 	// These methods provide convenient access to related data in a single call
 	GetSignedBatch(ctx context.Context, batchHeaderHash [32]byte) (*corev2.BatchHeader, *corev2.Attestation, error)
+
+	// Account Index Operations
+	// These methods manage account activity tracking
+	UpdateAccountIndex(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error
 }
 
 // Equal returns true if the cursor is equal to the given <requestedAt, blobKey>

--- a/disperser/common/v2/blobstore/metadata_store.go
+++ b/disperser/common/v2/blobstore/metadata_store.go
@@ -135,8 +135,9 @@ type MetadataStore interface {
 	GetSignedBatch(ctx context.Context, batchHeaderHash [32]byte) (*corev2.BatchHeader, *corev2.Attestation, error)
 
 	// Account Index Operations
-	// These methods manage account activity tracking
+	// These methods manage account tracking
 	UpdateAccountIndex(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error
+	GetAccounts(ctx context.Context, lookbackSeconds uint64) ([]*v2.Account, error)
 }
 
 // Equal returns true if the cursor is equal to the given <requestedAt, blobKey>

--- a/disperser/common/v2/blobstore/metadata_store.go
+++ b/disperser/common/v2/blobstore/metadata_store.go
@@ -134,9 +134,9 @@ type MetadataStore interface {
 	// These methods provide convenient access to related data in a single call
 	GetSignedBatch(ctx context.Context, batchHeaderHash [32]byte) (*corev2.BatchHeader, *corev2.Attestation, error)
 
-	// Account Index Operations
+	// Account Operations
 	// These methods manage account tracking
-	UpdateAccountIndex(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error
+	UpdateAccount(ctx context.Context, accountID gethcommon.Address, timestamp uint64) error
 	GetAccounts(ctx context.Context, lookbackSeconds uint64) ([]*v2.Account, error)
 }
 

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -15,6 +15,45 @@ const docTemplateV2 = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/accounts": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Accounts"
+                ],
+                "summary": "Fetch accounts within a time window (sorted by latest timestamp)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of hours to look back [default: 24; max: 24000 (1000 days)]",
+                        "name": "lookback_hours",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.AccountFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/accounts/{account_id}/blobs": {
             "get": {
                 "produces": [
@@ -1220,6 +1259,29 @@ const docTemplateV2 = `{
                     "items": {
                         "$ref": "#/definitions/v2.BlobInfo"
                     }
+                }
+            }
+        },
+        "v2.AccountFeedResponse": {
+            "type": "object",
+            "properties": {
+                "accounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AccountResponse"
+                    }
+                }
+            }
+        },
+        "v2.AccountResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "dispersed_at": {
+                    "description": "RFC3339 format",
+                    "type": "string"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -12,6 +12,45 @@
     },
     "basePath": "/api/v2",
     "paths": {
+        "/accounts": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Accounts"
+                ],
+                "summary": "Fetch accounts within a time window (sorted by latest timestamp)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of hours to look back [default: 24; max: 24000 (1000 days)]",
+                        "name": "lookback_hours",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2.AccountFeedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "error: Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "error: Server error",
+                        "schema": {
+                            "$ref": "#/definitions/v2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/accounts/{account_id}/blobs": {
             "get": {
                 "produces": [
@@ -1217,6 +1256,29 @@
                     "items": {
                         "$ref": "#/definitions/v2.BlobInfo"
                     }
+                }
+            }
+        },
+        "v2.AccountFeedResponse": {
+            "type": "object",
+            "properties": {
+                "accounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/v2.AccountResponse"
+                    }
+                }
+            }
+        },
+        "v2.AccountResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "dispersed_at": {
+                    "description": "RFC3339 format",
+                    "type": "string"
                 }
             }
         },

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -241,6 +241,21 @@ definitions:
           $ref: '#/definitions/v2.BlobInfo'
         type: array
     type: object
+  v2.AccountFeedResponse:
+    properties:
+      accounts:
+        items:
+          $ref: '#/definitions/v2.AccountResponse'
+        type: array
+    type: object
+  v2.AccountResponse:
+    properties:
+      address:
+        type: string
+      dispersed_at:
+        description: RFC3339 format
+        type: string
+    type: object
   v2.AttestationInfo:
     properties:
       attestation:
@@ -560,6 +575,32 @@ info:
   title: EigenDA Data Access API V2
   version: "2.0"
 paths:
+  /accounts:
+    get:
+      parameters:
+      - description: 'Number of hours to look back [default: 24; max: 24000 (1000
+          days)]'
+        in: query
+        name: lookback_hours
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2.AccountFeedResponse'
+        "400":
+          description: 'error: Bad request'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+        "500":
+          description: 'error: Server error'
+          schema:
+            $ref: '#/definitions/v2.ErrorResponse'
+      summary: Fetch accounts within a time window (sorted by latest timestamp)
+      tags:
+      - Accounts
   /accounts/{account_id}/blobs:
     get:
       parameters:

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -61,14 +61,14 @@ const (
 	maxOperatorsStakeAge    = 300 // not expect the stake changes frequently
 	maxOperatorPortCheckAge = 60  // not expect validator port changes frequently, but it's consequential to have right port
 
-	// Live content
+	// Live content - used to set max-age (seconds) in cache-control header
 	maxMetricAge        = 5
 	maxThroughputAge    = 5
 	maxBlobFeedAge      = 5
 	maxBatchFeedAge     = 5
 	maxDispersalFeedAge = 5
 	maxSigningInfoAge   = 5
-	maxAccountAge       = 300 // 5 minutes
+	maxAccountAge       = 5
 )
 
 type (

--- a/disperser/dataapi/v2/types.go
+++ b/disperser/dataapi/v2/types.go
@@ -235,3 +235,16 @@ func createBlobMetadata(bm *disperserv2.BlobMetadata) *BlobMetadata {
 		ExpiryUnixSec: bm.Expiry,
 	}
 }
+
+// Account types
+type (
+	AccountResponse struct {
+		AccountID      string `json:"account_id"`
+		Address        string `json:"address"`
+		LastActivityAt string `json:"last_activity_at"` // RFC3339 format
+	}
+
+	AccountFeedResponse struct {
+		Accounts []AccountResponse `json:"accounts"`
+	}
+)

--- a/disperser/dataapi/v2/types.go
+++ b/disperser/dataapi/v2/types.go
@@ -239,9 +239,8 @@ func createBlobMetadata(bm *disperserv2.BlobMetadata) *BlobMetadata {
 // Account types
 type (
 	AccountResponse struct {
-		AccountID      string `json:"account_id"`
-		Address        string `json:"address"`
-		LastActivityAt string `json:"last_activity_at"` // RFC3339 format
+		Address     string `json:"address"`
+		DispersedAt string `json:"dispersed_at"` // RFC3339 format
 	}
 
 	AccountFeedResponse struct {


### PR DESCRIPTION
Blob explorer is building an Accounts page and needs an endpoint that provides a list of accounts that have recently dispersed blobs over a given look back interval (ie 24h, 7d, 14d). This change adds an Account partition to blobmetadatastore and AccountUpdatedAtIndex GSI that orders the partition by timestamp of last dispersal.

Flow
- Accounts are upserted with (address, updated_at) after blob has been stored by disperser.
- The account update is async so as to not add latency to dispersal response.
- Dataapi returns a list of `[](address, dispersed_at)`