### PR TITLE
fix(proxy-release): make proxy release containing arm build

### DIFF
--- a/.github/workflows/test-proxy.yml
+++ b/.github/workflows/test-proxy.yml
@@ -200,7 +200,7 @@ jobs:
           -e EIGENDA_PROXY_ADDR=0.0.0.0 \
           -e EIGENDA_PROXY_PORT=6666 \
           -e EIGENDA_PROXY_MEMSTORE_ENABLED=true \
-          ghcr.io/layr-labs/eigenda-proxy:dev
+          ghcr.io/layr-labs/eigenda-proxy:latest
         working-directory: api/proxy
       - name: Wait for rpc to come up
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ docker-release-build:
 	BUILD_TAG=${SEMVER} SEMVER=${SEMVER} GITDATE=${GITDATE} GIT_SHA=${GITSHA} GIT_SHORT_SHA=${GITCOMMIT} \
 	docker buildx bake node-group-release ${PUSH_FLAG}
 	BUILD_TAG=${SEMVER} SEMVER=${SEMVER} GITDATE=${GITDATE} GIT_SHA=${GITSHA} GIT_SHORT_SHA=${GITCOMMIT} \
-	docker buildx bake proxy ${PUSH_FLAG}
+	docker buildx bake proxy-release ${PUSH_FLAG}
 
 semver:
 	echo "${SEMVER}"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -294,7 +294,7 @@ target "proxy" {
   target     = "proxy"
   # We push to layr-labs/ directly instead of layr-labs/eigenda/ for historical reasons,
   # since proxy was previously in its own repo: https://github.com/Layr-Labs/eigenda-proxy
-  tags       = ["${REGISTRY}/layr-labs/eigenda-proxy:${BUILD_TAG}"]
+  tags       = ["${REGISTRY}/layr-labs/eigenda-proxy-init:${BUILD_TAG}"]
 }
 
 target "proxy-internal" {
@@ -348,4 +348,9 @@ target "node-release" {
 target "nodeplugin-release" {
   inherits = ["nodeplugin", "_release"]
   tags     = ["${REGISTRY}/${REPO}/opr-nodeplugin:${BUILD_TAG}"]
+}
+
+target "proxy-release" {
+  inherits = ["proxy", "_release"]
+  tags     = ["${REGISTRY}/eigenda-proxy:${BUILD_TAG}"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -352,5 +352,7 @@ target "nodeplugin-release" {
 
 target "proxy-release" {
   inherits = ["proxy", "_release"]
+  # We push to layr-labs/ directly instead of layr-labs/eigenda/ for historical reasons,
+  # since proxy was previously in its own repo: https://github.com/Layr-Labs/eigenda-proxy
   tags     = ["${REGISTRY}/eigenda-proxy:${BUILD_TAG}"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -73,7 +73,7 @@ group "ci-release" {
     "controller",
     "relay",
     "blobapi",
-    "proxy",
+    "proxy-release",
   ]
 }
 
@@ -294,7 +294,7 @@ target "proxy" {
   target     = "proxy"
   # We push to layr-labs/ directly instead of layr-labs/eigenda/ for historical reasons,
   # since proxy was previously in its own repo: https://github.com/Layr-Labs/eigenda-proxy
-  tags       = ["${REGISTRY}/layr-labs/eigenda-proxy-init:${BUILD_TAG}"]
+  tags       = ["${REGISTRY}/layr-labs/proxy:${BUILD_TAG}"]
 }
 
 target "proxy-internal" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -73,7 +73,7 @@ group "ci-release" {
     "controller",
     "relay",
     "blobapi",
-    "proxy-release",
+    "proxy",
   ]
 }
 


### PR DESCRIPTION
## Why are these changes needed?

Eigenda-proxy is relied by Kurtosis DevNet, which is often run by developers on their local machine. 

but Kurtosis Config cannot specify the platform. So we have to prepare the ARM image.

If someone uses a MacBook with ARM chips, they will very likely be unable to pull the Docker image and break their testing. 

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
