### PR TITLE
disable release buildx image attestations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,9 @@ integration-tests-dataapi:
 
 docker-release-build:
 	BUILD_TAG=${SEMVER} SEMVER=${SEMVER} GITDATE=${GITDATE} GIT_SHA=${GITSHA} GIT_SHORT_SHA=${GITCOMMIT} \
-	docker buildx bake node-group-release ${PUSH_FLAG}
+	docker buildx bake node-group-release ${PUSH_FLAG} --provenance=false --sbom=false
 	BUILD_TAG=${SEMVER} SEMVER=${SEMVER} GITDATE=${GITDATE} GIT_SHA=${GITSHA} GIT_SHORT_SHA=${GITCOMMIT} \
-	docker buildx bake proxy ${PUSH_FLAG}
+	docker buildx bake proxy ${PUSH_FLAG} --provenance=false --sbom=false
 
 semver:
 	echo "${SEMVER}"


### PR DESCRIPTION
these show up as [unknown/unknown](https://github.com/Layr-Labs/eigenda/pkgs/container/eigenda%2Fopr-node) GCR image types

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
