### PR TITLE
feat: littDB CLI benchmark command

### DIFF
--- a/litt/cli/benchmark.go
+++ b/litt/cli/benchmark.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"log"
+
+	"github.com/Layr-Labs/eigenda/litt/benchmark"
+	"github.com/urfave/cli/v2"
+)
+
+// A launcher for the benchmark.
+func benchmarkCommand(ctx *cli.Context) error {
+	if ctx.NArg() != 1 {
+		return cli.Exit("benchmark command requires exactly one argument: <config-path>", 1)
+	}
+
+	configPath := ctx.Args().Get(0)
+
+	// Create the benchmark engine
+	engine, err := benchmark.NewBenchmarkEngine(configPath)
+	if err != nil {
+		log.Fatalf("Failed to create benchmark engine: %v", err)
+	}
+
+	// Run the benchmark
+	engine.Logger().Infof("Configuration loaded from %s", configPath)
+	engine.Logger().Info("Press Ctrl+C to stop the benchmark")
+
+	err = engine.Run()
+	if err != nil {
+		return err
+	} else {
+		engine.Logger().Info("Benchmark Terminated")
+	}
+
+	return nil
+}

--- a/litt/cli/litt_cli.go
+++ b/litt/cli/litt_cli.go
@@ -88,7 +88,7 @@ func buildCLIParser(logger logging.Logger) *cli.App {
 				Usage:     "Run a LittDB benchmark.",
 				ArgsUsage: "<path/to/benchmark/config.json>",
 				Args:      true,
-				Action:    nil, // benchmarkCommand, // TODO this will be added in a follow up PR
+				Action:    benchmarkCommand,
 			},
 			{
 				Name:  "prune",


### PR DESCRIPTION
## Why are these changes needed?

Adds a command for running the littDB benchmark.

Usage:

```
cd litt
make build
litt benchmark ./benchmark/config/basic-config.json
```

Press `ctrl-c` to exit the benchmark.

Benchmark files are written to `~/benchmark`. Do `rm -r ~/benchmark` to clean up after the benchmark.
