### PR TITLE
fix: better error log when relay cannot find blob in s3

### DIFF
--- a/disperser/common/v2/blobstore/s3_blob_store.go
+++ b/disperser/common/v2/blobstore/s3_blob_store.go
@@ -2,6 +2,7 @@ package blobstore
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Layr-Labs/eigenda/common/aws/s3"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
@@ -48,8 +49,7 @@ func (b *BlobStore) GetBlob(ctx context.Context, key corev2.BlobKey) ([]byte, er
 	}
 
 	if err != nil {
-		b.logger.Errorf("failed to download blob from bucket %s: %v", b.bucketName, err)
-		return nil, err
+		return nil, fmt.Errorf("failed to download blob from bucket %s: %v", b.bucketName, err)
 	}
 	return data, nil
 }

--- a/relay/blob_provider.go
+++ b/relay/blob_provider.go
@@ -70,10 +70,7 @@ func (s *blobProvider) GetBlob(ctx context.Context, blobKey v2.BlobKey) ([]byte,
 	data, err := s.blobCache.Get(ctx, blobKey)
 
 	if err != nil {
-		// It should not be possible for external users to force an error here since we won't
-		// even call this method if the blob key is invalid (so it's ok to have a noisy log here).
-		s.logger.Errorf("Failed to fetch blob: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("error calling blobCache.Get: %v", err)
 	}
 
 	return data, nil
@@ -86,8 +83,7 @@ func (s *blobProvider) fetchBlob(blobKey v2.BlobKey) ([]byte, error) {
 
 	data, err := s.blobStore.GetBlob(ctx, blobKey)
 	if err != nil {
-		s.logger.Errorf("Failed to fetch blob: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("error calling blobStore.GetBlob: %v", err)
 	}
 
 	return data, nil


### PR DESCRIPTION
## Why are these changes needed?

More elegant logging when a relay can't find a blob in S3.
