### PR TITLE
chore: proxy turn on metrics server by default

### DIFF
--- a/api/proxy/.env.example
+++ b/api/proxy/.env.example
@@ -83,8 +83,3 @@ EIGENDA_PROXY_EIGENDA_CONFIRMATION_DEPTH=6
 # you only actually need to read the amount of SRS data that corresponds to the size of the largest blob that will be
 # sent, decreasing this value is a crude sort of optimization.
 EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH=1MiB
-
-# === Metrics Configuration ===
-
-# Enable the metrics server, which is disabled by default.
-EIGENDA_PROXY_METRICS_ENABLED=true

--- a/api/proxy/docs/help_out.txt
+++ b/api/proxy/docs/help_out.txt
@@ -107,7 +107,7 @@ This check is optional and will be skipped when set to 0. (default: 0) [$EIGENDA
    Metrics
 
    --metrics.addr value  Metrics listening address (default: "0.0.0.0") [$EIGENDA_PROXY_METRICS_ADDR]
-   --metrics.enabled     Enable the metrics server (default: false) [$EIGENDA_PROXY_METRICS_ENABLED]
+   --metrics.enabled     Enable the metrics server. On by default, so use --metrics.enabled=false to disable. (default: true) [$EIGENDA_PROXY_METRICS_ENABLED]
    --metrics.port value  Metrics listening port (default: 7300) [$EIGENDA_PROXY_METRICS_PORT]
 
    Proxy Server

--- a/api/proxy/metrics/cli.go
+++ b/api/proxy/metrics/cli.go
@@ -35,8 +35,9 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
 			Name:     EnabledFlagName,
-			Usage:    "Enable the metrics server",
+			Usage:    "Enable the metrics server. On by default, so use --metrics.enabled=false to disable.",
 			Category: category,
+			Value:    true,
 			EnvVars:  withEnvPrefix(envPrefix, "ENABLED"),
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
Closes DAINT-650.

This simplifies the .env.example config file, and makes one less configuration to search for for new users.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
