### PR TITLE
fix: allow liveness checks on private IPs (ie preprod)

### DIFF
--- a/disperser/dataapi/queried_operators_handlers.go
+++ b/disperser/dataapi/queried_operators_handlers.go
@@ -222,7 +222,7 @@ func checkIsOnlineAndProcessOperator(operatorStatus OperatorOnlineStatus, operat
 	operatorOnlineStatusresultsChan <- metadata
 }
 
-// Check that the socketString is not private/unspecified
+// Check that the socketString is invalid or unspecified (private IPs are allowed)
 func ValidOperatorIP(address string, logger logging.Logger) bool {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
@@ -239,7 +239,7 @@ func ValidOperatorIP(address string, logger logging.Logger) bool {
 		logger.Error("IP address is nil", "host", host, "ips", ips)
 		return false
 	}
-	isValid := !ipAddr.IsPrivate() && !ipAddr.IsUnspecified()
+	isValid := !ipAddr.IsUnspecified()
 	logger.Debug("Operator IP validation", "address", address, "host", host, "ips", ips, "ipAddr", ipAddr, "isValid", isValid)
 
 	return isValid

--- a/disperser/dataapi/server_test.go
+++ b/disperser/dataapi/server_test.go
@@ -502,7 +502,7 @@ func TestFetchUnsignedBatchesHandler(t *testing.T) {
 func TestPortCheckIpValidation(t *testing.T) {
 	assert.Equal(t, false, dataapi.ValidOperatorIP("", mockLogger))
 	assert.Equal(t, false, dataapi.ValidOperatorIP("0.0.0.0:32005", mockLogger))
-	assert.Equal(t, false, dataapi.ValidOperatorIP("10.0.0.1:32005", mockLogger))
+	assert.Equal(t, true, dataapi.ValidOperatorIP("10.0.0.1:32005", mockLogger))
 	assert.Equal(t, false, dataapi.ValidOperatorIP("::ffff:192.0.2.1:32005", mockLogger))
 	assert.Equal(t, false, dataapi.ValidOperatorIP("google.com", mockLogger))
 	assert.Equal(t, true, dataapi.ValidOperatorIP("localhost:32005", mockLogger))


### PR DESCRIPTION
Preprod operators are failing liveness checks because they are registered with private IPs which we currently block from scans.

When we originally added liveness checks, we were only doing a port scan and had concerns that liveness could be used to enumerate internal resources. Current liveness now does a full grpc reflection to validate ports map to the correct dispersal/retrieval service which will prevent any enumeration attacks.