### PR TITLE
Fix proxy cert version logging for POST requests

### DIFF
--- a/api/proxy/server/handlers_cert.go
+++ b/api/proxy/server/handlers_cert.go
@@ -199,6 +199,8 @@ func (svr *Server) handlePostShared(
 	default:
 		return fmt.Errorf("unknown dispersal backend: %v", svr.sm.GetDispersalBackend())
 	}
+	// Set cert version in request context for logging middleware
+	middleware.SetCertVersion(r, string(certVersion))
 	versionedCert := certs.NewVersionedCert(serializedCert, certVersion)
 
 	responseCommit, err := commitments.EncodeCommitment(versionedCert, mode)


### PR DESCRIPTION
## Description

This PR fixes the issue where the proxy was logging 'unknown' cert_version when completing HTTP request handlers for POST requests.

## Root Cause

The issue was in the  function in . While the cert version was being determined and logged in the handler itself, it was never being set in the request context for the logging middleware to use.

## The Fix

Added the following line in the  function after the cert version is determined but before the  is created:



## Why This Fix Works

1. **Consistency**: The fix follows the same pattern used in the GET handler () which already correctly sets the cert version in the request context.

2. **Timing**: The fix is placed after the cert version is determined from the dispersal backend but before it's used to create the , ensuring the logging middleware has access to the correct cert version.

3. **Scope**: The fix affects all POST handlers that use the  function, which includes:
   -  (standard commitment mode)
   -  (optimism generic commitment mode)

4. **No Impact on Keccak Handlers**: The  handler doesn't need this fix because it doesn't have a cert version concept.

## Result

After this fix, POST requests will no longer log  in the middleware. Instead, they will log the actual cert version (e.g.,  for V2 certs), matching the behavior already present in GET requests.

## Related Issue

Fixes #1720