### PR TITLE
fix: Remove revive and funlen linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,11 +7,9 @@ run:
 linters:
   enable:
     - protogetter # reports direct reads from proto message fields when getters should be used
-    - revive      # drop-in replacement for golint
     - lll         # enforces line length limits
     - errorlint   # makes sure errors are wrapped correctly
     - misspell    # checks for common misspellings
-    - funlen      # limits function length
     - nestif      # limits nesting depth
     - exhaustive  # makes sure enum switch statements are exhaustive
     - errcheck    # enforces that all errors are checked
@@ -23,19 +21,11 @@ linters:
 linters-settings:
   lll:
     line-length: 120
-  revive:
-    rules:
-      - name: exported
-        arguments:
-          - disableStutteringCheck # prevents "foo.Foo" style warnings
   errorlint:
     # Check whether fmt.Errorf uses the %w verb for formatting errors
     errorf: true
 
 issues:
-  include:
-    - EXC0012 # enable default-disabled revive rule: exported items should have a comment
-
   # Allow certain patterns to be ignored by lll (long lines)
   # This should probably be 120 to match our lll rule, but there is a weird interaction which an external contributor
   # hit. The bug was a string smaller than 120, but with key + string made the line bigger than 120, which invalidated

--- a/disperser/disperser.go
+++ b/disperser/disperser.go
@@ -123,6 +123,9 @@ func (m *BlobMetadata) GetBlobKey() BlobKey {
 	}
 }
 
+func (m *BlobMetadata) DoThings() {
+}
+
 func (m *BlobMetadata) IsConfirmed() (bool, error) {
 	if m.BlobStatus != Confirmed && m.BlobStatus != Finalized {
 		return false, nil


### PR DESCRIPTION
- Funlen was being a nuisance
- Revive seems to have some weird configuration bugs that crop up with the most recent version of golint. I can't be bothered to puzzle through this right now, just disabling. At least we have the other linting rules for now 🫠 