### PR TITLE
feat: LittDB table info command

### DIFF
--- a/litt/cli/litt_cli.go
+++ b/litt/cli/litt_cli.go
@@ -63,7 +63,7 @@ func buildCLIParser(logger logging.Logger) *cli.App {
 						Required: true,
 					},
 				},
-				Action: nil, // tableInfoCommand, // TODO this will be added in a follow up PR
+				Action: tableInfoCommand,
 			},
 			{
 				Name:  "rebase",

--- a/litt/cli/table_info.go
+++ b/litt/cli/table_info.go
@@ -26,7 +26,7 @@ type TableInfo struct {
 	IsSnapshot bool
 	// The time when the oldest segment was sealed.
 	OldestSegmentSealTime time.Time
-	// The time when the newest segment was sealed. This is used to determine the age of the oldest segment.
+	// The time when the newest segment was sealed.
 	NewestSegmentSealTime time.Time
 	// The index of the oldest segment in the table.
 	LowestSegmentIndex uint32
@@ -124,7 +124,7 @@ func tableInfo(logger logging.Logger, tableName string, paths []string, fsync bo
 		segmentPaths,
 		false,
 		time.Now(),
-		true,
+		false,
 		fsync)
 
 	if err != nil {

--- a/litt/cli/table_info.go
+++ b/litt/cli/table_info.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/litt"
+	"github.com/Layr-Labs/eigenda/litt/disktable"
+	"github.com/Layr-Labs/eigenda/litt/disktable/segment"
+	"github.com/Layr-Labs/eigenda/litt/littbuilder"
+	"github.com/Layr-Labs/eigenda/litt/util"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/urfave/cli/v2"
+)
+
+// TableInfo contains high level information about a table in LittDB.
+type TableInfo struct {
+	// The number of key-value pairs in the table.
+	KeyCount uint64
+	// The size of the table in bytes.
+	Size uint64
+	// If true, the table at the specified path is a snapshot of another table.
+	IsSnapshot bool
+	// The time when the oldest segment was sealed.
+	OldestSegmentSealTime time.Time
+	// The time when the newest segment was sealed. This is used to determine the age of the oldest segment.
+	NewestSegmentSealTime time.Time
+	// The index of the oldest segment in the table.
+	LowestSegmentIndex uint32
+	// The index of the newest segment in the table.
+	HighestSegmentIndex uint32
+	// The type of the keymap used by the table. If "", then this table doesn't have a keymap (i.e. it will rebuild
+	// a keymap the next time it is loaded).
+	KeymapType string
+}
+
+// tableInfoCommand is the CLI command handler for the "table-info" command.
+func tableInfoCommand(ctx *cli.Context) error {
+	if ctx.NArg() != 1 {
+		return fmt.Errorf(
+			"table-info command requires exactly at least one argument: <table-name>")
+	}
+
+	logger, err := common.NewLogger(common.DefaultConsoleLoggerConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create logger: %w", err)
+	}
+
+	tableName := ctx.Args().Get(0)
+
+	sources := ctx.StringSlice("src")
+	if len(sources) == 0 {
+		return fmt.Errorf("no sources provided")
+	}
+	for i, src := range sources {
+		var err error
+		sources[i], err = util.SanitizePath(src)
+		if err != nil {
+			return fmt.Errorf("invalid source path: %s", src)
+		}
+	}
+
+	info, err := tableInfo(logger, tableName, sources, true)
+	if err != nil {
+		return fmt.Errorf("failed to get table info for table %s at paths %v: %w", tableName, sources, err)
+	}
+
+	oldestSegmentAge := uint64(time.Since(info.OldestSegmentSealTime).Nanoseconds())
+	newestSegmentAge := uint64(time.Since(info.NewestSegmentSealTime).Nanoseconds())
+	segmentSpan := oldestSegmentAge - newestSegmentAge
+
+	// Print table information in a human-readable format
+	logger.Infof("Table:                       %s", tableName)
+	logger.Infof("Key count:                   %s", common.CommaOMatic(info.KeyCount))
+	logger.Infof("Size:                        %s", common.PrettyPrintBytes(info.Size))
+	logger.Infof("Is snapshot:                 %t", info.IsSnapshot)
+	logger.Infof("Oldest segment age:          %s", common.PrettyPrintTime(oldestSegmentAge))
+	logger.Infof("Oldest segment seal time:    %s", info.OldestSegmentSealTime.Format(time.RFC3339))
+	logger.Infof("Newest segment age:          %s", common.PrettyPrintTime(newestSegmentAge))
+	logger.Infof("Newest segment seal time:    %s", info.NewestSegmentSealTime.Format(time.RFC3339))
+	logger.Infof("Segment span:                %s", common.PrettyPrintTime(segmentSpan))
+	logger.Infof("Lowest segment index:        %d", info.LowestSegmentIndex)
+	logger.Infof("Highest segment index:       %d", info.HighestSegmentIndex)
+	logger.Infof("Key map type:                %s", info.KeymapType)
+
+	return nil
+}
+
+// tableInfo retrieves information about a table at the specified path.
+func tableInfo(logger logging.Logger, tableName string, paths []string, fsync bool) (*TableInfo, error) {
+	if !litt.IsTableNameValid(tableName) {
+		return nil, fmt.Errorf("table name '%s' is invalid, "+
+			"must be at least one character long and contain only letters, numbers, underscores, and dashes",
+			tableName)
+	}
+
+	// Forbid touching tables in active use.
+	releaseLocks, err := util.LockDirectories(logger, paths, util.LockfileName, fsync)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire locks on paths %v: %w", paths, err)
+	}
+	defer releaseLocks()
+
+	segmentPaths, err := segment.BuildSegmentPaths(paths, "", tableName)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to build segment paths for table %s at paths %v: %w", tableName, paths, err)
+	}
+
+	for _, segmentPath := range segmentPaths {
+		if err = util.ErrIfNotExists(segmentPath.SegmentDirectory()); err != nil {
+			return nil, fmt.Errorf("segment directory %s does not exist", segmentPath.SegmentDirectory())
+		}
+	}
+
+	errorMonitor := util.NewErrorMonitor(context.Background(), logger, nil)
+
+	lowestSegmentIndex, highestSegmentIndex, segments, err := segment.GatherSegmentFiles(
+		logger,
+		errorMonitor,
+		segmentPaths,
+		false,
+		time.Now(),
+		true,
+		fsync)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to gather segment files for table %s at paths %v: %w",
+			tableName, paths, err)
+	}
+	if ok, err := errorMonitor.IsOk(); !ok {
+		// This should be impossible since we aren't doing anything on background threads that report to the
+		// error monitor, but it doesn't hurt to check.
+		return nil, fmt.Errorf("error monitor reports errors: %w", err)
+	}
+
+	if len(segments) == 0 {
+		return nil, fmt.Errorf("no segments found for table %s at paths %v", tableName, paths)
+	}
+
+	isSnapshot, err := segments[lowestSegmentIndex].IsSnapshot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if segment %d is a snapshot: %w", lowestSegmentIndex, err)
+	}
+
+	if isSnapshot {
+		if len(paths) != 1 {
+			return nil, fmt.Errorf("table %s is a snapshot, but multiple paths were provided: %v",
+				tableName, paths)
+		}
+
+		upperBoundFile, err := disktable.LoadBoundaryFile(false, path.Join(paths[0], tableName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to load boundary file for table %s at path %s: %w",
+				tableName, paths[0], err)
+		}
+
+		if upperBoundFile.IsDefined() {
+			highestSegmentIndex = upperBoundFile.BoundaryIndex()
+		}
+	}
+
+	keyCount := uint64(0)
+	size := uint64(0)
+	for _, seg := range segments {
+		if seg.SegmentIndex() > highestSegmentIndex {
+			// Do not attempt to read segments outside the limit set by the boundary file.
+			break
+		}
+
+		keyCount += uint64(seg.KeyCount())
+		size += seg.Size()
+	}
+
+	_, _, keymapTypeFile, err := littbuilder.FindKeymapLocation(paths, tableName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find keymap location for table %s at paths %v: %w",
+			tableName, paths, err)
+	}
+
+	keymapType := "none (will be rebuilt on next LittDB startup)"
+	if keymapTypeFile != nil {
+		keymapType = (string)(keymapTypeFile.Type())
+	}
+
+	return &TableInfo{
+		KeyCount:              keyCount,
+		Size:                  size,
+		IsSnapshot:            isSnapshot,
+		OldestSegmentSealTime: segments[lowestSegmentIndex].GetSealTime(),
+		NewestSegmentSealTime: segments[highestSegmentIndex].GetSealTime(),
+		LowestSegmentIndex:    lowestSegmentIndex,
+		HighestSegmentIndex:   highestSegmentIndex,
+		KeymapType:            keymapType,
+	}, nil
+}

--- a/litt/cli/table_info_test.go
+++ b/litt/cli/table_info_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/common/testutils/random"
+	"github.com/Layr-Labs/eigenda/litt"
+	"github.com/Layr-Labs/eigenda/litt/littbuilder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableInfo(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+	directory := t.TempDir()
+
+	logger, err := common.NewLogger(common.DefaultConsoleLoggerConfig())
+	require.NoError(t, err)
+
+	// Spread data across several root directories.
+	rootCount := rand.Uint32Range(2, 5)
+	roots := make([]string, 0, rootCount)
+	for i := 0; i < int(rootCount); i++ {
+		roots = append(roots, fmt.Sprintf("%s/root-%d", directory, i))
+	}
+
+	config, err := litt.DefaultConfig(roots...)
+	require.NoError(t, err)
+
+	// Make it so that we have at least as many shards as roots.
+	config.ShardingFactor = rootCount * rand.Uint32Range(1, 4)
+
+	// Settings that should be enabled for LittDB unit tests.
+	config.DoubleWriteProtection = true
+	config.Fsync = false
+
+	// Use small segments to ensure that we create a few segments per table.
+	config.TargetSegmentFileSize = 100
+
+	// Enable snapshotting.
+	snapshotDir := t.TempDir()
+	config.SnapshotDirectory = snapshotDir
+
+	// Build the DB and a handful of tables.
+	db, err := littbuilder.NewDB(config)
+	require.NoError(t, err)
+
+	tableCount := rand.Uint32Range(2, 5)
+	tables := make([]litt.Table, 0, tableCount)
+	expectedData := make(map[string]map[string][]byte)
+	tableNames := make([]string, 0, tableCount)
+	for i := 0; i < int(tableCount); i++ {
+		tableName := fmt.Sprintf("table-%d-%s", i, rand.PrintableBytes(8))
+		table, err := db.GetTable(tableName)
+		require.NoError(t, err)
+		tables = append(tables, table)
+		expectedData[table.Name()] = make(map[string][]byte)
+		tableNames = append(tableNames, tableName)
+	}
+
+	// Insert some data into the tables.
+	for _, table := range tables {
+		for i := 0; i < 100; i++ {
+			key := rand.PrintableBytes(32)
+			value := rand.PrintableVariableBytes(10, 200)
+			expectedData[table.Name()][string(key)] = value
+			err = table.Put(key, value)
+			require.NoError(t, err, "Failed to put key-value pair in table %s", table.Name())
+		}
+		err = table.Flush()
+		require.NoError(t, err, "Failed to flush table %s", table.Name())
+	}
+
+	// Verify that the data is correctly stored in the tables.
+	for _, table := range tables {
+		for key, expectedValue := range expectedData[table.Name()] {
+			value, ok, err := table.Get([]byte(key))
+			require.NoError(t, err, "Failed to get value for key %s in table %s", key, table.Name())
+			require.True(t, ok, "Key %s not found in table %s", key, table.Name())
+			require.Equal(t, expectedValue, value,
+				"Value mismatch for key %s in table %s", key, table.Name())
+		}
+	}
+
+	// We should not be able to call table-info on the core directories while the table holds a lock.
+	_, err = tableInfo(logger, tableNames[0], config.Paths, false)
+	require.Error(t, err)
+
+	// Even when the DB is running, it should always be possible to check the snapshot directory.
+	lsResult, err := ls(logger, snapshotDir, true, false)
+	require.NoError(t, err)
+	require.Equal(t, tableNames, lsResult)
+
+	for _, tableName := range tableNames {
+		info, err := tableInfo(logger, tableName, []string{snapshotDir}, false)
+		require.NoError(t, err)
+
+		require.True(t, info.IsSnapshot)
+		require.Greater(t, info.Size, uint64(0))
+		require.Greater(t, info.KeyCount, uint64(0))
+		require.LessOrEqual(t, info.KeyCount, uint64(100))
+		require.Equal(t, "none (will be rebuilt on next LittDB startup)", info.KeymapType)
+	}
+
+	// Getting info on a table that doesn't exist should return an error.
+	_, err = tableInfo(logger, "nonexistent-table", config.Paths, false)
+	require.Error(t, err)
+
+	err = db.Close()
+	require.NoError(t, err)
+
+	// Now that the DB is closed, we should be able to call table-info on the core directories.
+	for _, tableName := range tableNames {
+		info, err := tableInfo(logger, tableName, config.Paths, false)
+		require.NoError(t, err)
+
+		require.False(t, info.IsSnapshot)
+		require.Greater(t, info.Size, uint64(0))
+		require.Equal(t, info.KeyCount, uint64(100))
+		require.Equal(t, "LevelDBKeymap", info.KeymapType)
+	}
+
+	// A non-existent table should return an error for the core directories as well.
+	_, err = tableInfo(logger, "nonexistent-table", config.Paths, false)
+	require.Error(t, err, "Expected error when querying info for a non-existent table after DB close")
+}


### PR DESCRIPTION
## Why are these changes needed?

Adds an implementation for the `litt table-info` command.

To test locally, first generate a LittDB table via `litt benchmark`. Then, run the following:

`litt table-info -s ~/benchmark/volume1 -s ~/benchmark/volume2 -s ~/benchmark/volume3 benchmark`
```
Aug  4 08:16:13.542 INF cli/table_info.go:76 Table:                       benchmark
Aug  4 08:16:13.542 INF cli/table_info.go:77 Key count:                   1,309
Aug  4 08:16:13.542 INF cli/table_info.go:78 Size:                        2.56 GiB
Aug  4 08:16:13.542 INF cli/table_info.go:79 Is snapshot:                 false
Aug  4 08:16:13.542 INF cli/table_info.go:80 Oldest segment age:          6.93 days
Aug  4 08:16:13.542 INF cli/table_info.go:81 Oldest segment seal time:    2025-07-28T09:51:56-05:00
Aug  4 08:16:13.542 INF cli/table_info.go:82 Newest segment age:          405.19 ms
Aug  4 08:16:13.542 INF cli/table_info.go:83 Newest segment seal time:    2025-08-04T08:16:13-05:00
Aug  4 08:16:13.542 INF cli/table_info.go:84 Segment span:                6.93 days
Aug  4 08:16:13.542 INF cli/table_info.go:85 Lowest segment index:        0
Aug  4 08:16:13.542 INF cli/table_info.go:86 Highest segment index:       1313
Aug  4 08:16:13.542 INF cli/table_info.go:87 Key map type:                LevelDBKeymap

```
