### PR TITLE
perf: reduce size of LittDB cache

### DIFF
--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -427,7 +427,7 @@ var (
 		Name:     common.PrefixFlag(FlagPrefix, "litt-db-write-cache-size-fraction"),
 		Usage:    "The fraction of the total memory to use for the LittDB write cache.",
 		Required: false,
-		Value:    0.45,
+		Value:    0.15,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_WRITE_CACHE_SIZE_FRACTION"),
 	}
 	LittDBReadCacheSizeGBFlag = cli.IntFlag{


### PR DESCRIPTION
## Why are these changes needed?

In order to reduce memory pressure on validators, decrease total size of LittDB cache from 50% system memory to 20% system memory.
