### PR TITLE
perf: larger memory safety buffer

### DIFF
--- a/common/memory/memory.go
+++ b/common/memory/memory.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/docker/go-units"
 	"github.com/shirou/gopsutil/mem"
 )
@@ -56,10 +55,7 @@ func GetMaximumAvailableMemory() (uint64, error) {
 
 // SetGCMemorySafetyBuffer tells the garbage collector to aggressively garbage collect when there is only safetyBuffer
 // bytes of memory available. Useful for preventing kubernetes from OOM-killing the process.
-func SetGCMemorySafetyBuffer(
-	logger logging.Logger,
-	safetyBuffer uint64,
-) error {
+func SetGCMemorySafetyBuffer(safetyBuffer uint64) error {
 
 	maxMemory, err := GetMaximumAvailableMemory()
 	if err != nil {
@@ -73,12 +69,6 @@ func SetGCMemorySafetyBuffer(
 	limit := maxMemory - safetyBuffer
 
 	debug.SetMemoryLimit(int64(limit))
-
-	logger.Infof("Detected %.2fGB available memory. "+
-		"Setting GC target memory limit to %.2f in order to maintain a safety buffer of %.2fGB",
-		float64(maxMemory)/float64(units.GiB),
-		float64(limit)/float64(units.GiB),
-		float64(safetyBuffer)/float64(units.GiB))
 
 	return nil
 }

--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -8,14 +8,11 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common/geth"
-	"github.com/Layr-Labs/eigenda/common/memory"
-	coreeth "github.com/Layr-Labs/eigenda/core/eth"
-	rpccalls "github.com/Layr-Labs/eigensdk-go/metrics/collectors/rpc_calls"
-	"github.com/docker/go-units"
-
 	"github.com/Layr-Labs/eigenda/common/pubip"
 	"github.com/Layr-Labs/eigenda/common/ratelimit"
 	"github.com/Layr-Labs/eigenda/common/store"
+	coreeth "github.com/Layr-Labs/eigenda/core/eth"
+	rpccalls "github.com/Layr-Labs/eigensdk-go/metrics/collectors/rpc_calls"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/urfave/cli"
@@ -59,14 +56,6 @@ func NodeMain(ctx *cli.Context) error {
 	logger, err := common.NewLogger(&config.LoggerConfig)
 	if err != nil {
 		return err
-	}
-
-	if config.GCSafetyBufferSizeGB > 0 {
-		safetyBuffer := uint64(config.GCSafetyBufferSizeGB * float64(units.GiB))
-		err = memory.SetGCMemorySafetyBuffer(logger, safetyBuffer)
-		if err != nil {
-			return fmt.Errorf("failed to set memory limit: %w", err)
-		}
 	}
 
 	pubIPProvider := pubip.ProviderOrDefault(logger, config.PubIPProviders...)

--- a/node/config.go
+++ b/node/config.go
@@ -123,6 +123,10 @@ type Config struct {
 	// this config value overrides the LittDBWriteCacheSizeFraction value.
 	LittDBWriteCacheSizeGB float64
 
+	// This is a derived value based on the configuration provided by LittDBWriteCacheSizeGB and
+	// LittDBWriteCacheSizeFraction. Stores the size of the LittDB write cache in bytes.
+	littDBWriteCacheSize uint64
+
 	// The percentage of the total memory to use for the read cache in littDB as a fraction of 1.0, where 1.0
 	// means that all available memory will be used for the read cache (don't actually use 1.0, that leaves no buffer
 	// for other stuff). Ignored if LittDBReadCacheSizeGB is set.
@@ -131,6 +135,10 @@ type Config struct {
 	// The size of the cache for storing recently read chunks in littDB, in gigabytes. Ignored if 0. If set,
 	// this config value overrides the LittDBReadCacheSizeFraction value.
 	LittDBReadCacheSizeGB float64
+
+	// This is a derived value based on the configuration provided by LittDBReadCacheSizeGB and
+	// LittDBReadCacheSizeFraction. Stores the size of the LittDB read cache in bytes.
+	littDBReadCacheSize uint64
 
 	// The list of paths to the littDB storage directories. Data is spread across these directories.
 	// Directories do not need to be on the same filesystem.
@@ -171,9 +179,15 @@ type Config struct {
 	// Unit is in megabytes.
 	GetChunksColdBurstLimitMB float64
 
-	// Defines a safety buffer for the garbage collector. If non-zero, then the garbage collector will be instructed
+	// GCSafetyBufferSizeFraction is the fraction of the total memory to use as a safety buffer for the garbage
+	// collector. If non-zero, the garbage collector will be instructed to aggressively garbage collect so as to
+	// keep this amount of memory free. Useful for preventing kubernetes from OOM-killing the process. Ignored if
+	// GCSafetyBufferSizeGB is greater than 0.
+	GCSafetyBufferSizeFraction float64
+
+	// Defines a safety buffer for the garbage collector. If non-zero, the garbage collector will be instructed
 	// to aggressively garbage collect so as to keep this amount of memory free. Useful for preventing kubernetes
-	// from OOM-killing the process.
+	// from OOM-killing the process. Overrides the GCSafetyBufferSizeFraction value if greater than 0.
 	GCSafetyBufferSizeGB float64
 }
 
@@ -419,5 +433,6 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		GetChunksColdCacheReadLimitMB:       ctx.GlobalFloat64(flags.GetChunksColdCacheReadLimitMBFlag.Name),
 		GetChunksColdBurstLimitMB:           ctx.GlobalFloat64(flags.GetChunksColdBurstLimitMBFlag.Name),
 		GCSafetyBufferSizeGB:                ctx.GlobalFloat64(flags.GCSafetyBufferSizeGBFlag.Name),
+		GCSafetyBufferSizeFraction:          ctx.GlobalFloat64(flags.GCSafetyBufferSizeFractionFlag.Name),
 	}, nil
 }

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -418,7 +418,7 @@ var (
 	LittDBWriteCacheSizeGBFlag = cli.IntFlag{
 		Name: common.PrefixFlag(FlagPrefix, "litt-db-write-cache-size-gb"),
 		Usage: "The size of the LittDB write cache in gigabytes. Overrides " +
-			"LITT_DB_WRITE_CACHE_SIZE_FRACTION if > 0, otherwise is ignored.",
+			"NODE_LITT_DB_WRITE_CACHE_SIZE_FRACTION if > 0, otherwise is ignored.",
 		Required: false,
 		Value:    0,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_WRITE_CACHE_SIZE_GB"),
@@ -433,7 +433,7 @@ var (
 	LittDBReadCacheSizeGBFlag = cli.IntFlag{
 		Name: common.PrefixFlag(FlagPrefix, "litt-db-read-cache-size-gb"),
 		Usage: "The size of the LittDB read cache in gigabytes. Overrides " +
-			"LITT_DB_READ_CACHE_SIZE_FRACTION if > 0, otherwise is ignored.",
+			"NODE_LITT_DB_READ_CACHE_SIZE_FRACTION if > 0, otherwise is ignored.",
 		Required: false,
 		Value:    0,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_DB_READ_CACHE_SIZE_GB"),
@@ -493,11 +493,20 @@ var (
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "GET_CHUNKS_COLD_BURST_LIMIT_MB"),
 	}
 	GCSafetyBufferSizeGBFlag = cli.IntFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "gc-safety-buffer-size-gb"),
-		Usage:    "The size of the safety buffer for garbage collection in gigabytes.",
+		Name: common.PrefixFlag(FlagPrefix, "gc-safety-buffer-size-gb"),
+		Usage: "The size of the safety buffer for garbage collection in gigabytes. If zero, is ignored and " +
+			"NODE_GC_SAFETY_BUFFER_SIZE_FRACTION will be used instead.",
 		Required: false,
-		Value:    1,
+		Value:    0,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "GC_SAFETY_BUFFER_SIZE_GB"),
+	}
+	GCSafetyBufferSizeFractionFlag = cli.Float64Flag{
+		Name: common.PrefixFlag(FlagPrefix, "gc-safety-buffer-size-fraction"),
+		Usage: "The fraction of the total memory to use for the safety buffer for garbage collection. Is" +
+			" ignored if NODE_GC_SAFETY_BUFFER_SIZE_GB > 0.",
+		Required: false,
+		Value:    0.2,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "GC_SAFETY_BUFFER_SIZE_FRACTION"),
 	}
 
 	/////////////////////////////////////////////////////////////////////////////

--- a/node/validator_store.go
+++ b/node/validator_store.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
-	"github.com/Layr-Labs/eigenda/common/memory"
 	"github.com/Layr-Labs/eigenda/core"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/litt"
@@ -129,46 +128,12 @@ func NewValidatorStore(
 		return nil, fmt.Errorf("failed to get chunks table: %w", err)
 	}
 
-	maxMemory, err := memory.GetMaximumAvailableMemory()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get maximum available memory: %w", err)
-	}
-
-	writeCacheSize := uint64(0)
-	if config.LittDBWriteCacheSizeGB > 0 {
-		writeCacheSize = uint64(config.LittDBWriteCacheSizeGB * units.GiB)
-		logger.Infof("LittDB write cache size configured to use %.2f GB.\n", config.LittDBWriteCacheSizeGB)
-	} else {
-		writeCacheSize = uint64(config.LittDBWriteCacheSizeFraction * float64(maxMemory))
-		logger.Infof("LittDB write cache is configured to use %.1f%% of %.2f GB available (%.2f GB).",
-			config.LittDBWriteCacheSizeFraction*100.0,
-			float64(maxMemory)/float64(units.GiB),
-			float64(writeCacheSize)/float64(units.GiB))
-	}
-
-	readCacheSize := uint64(0)
-	if config.LittDBReadCacheSizeGB > 0 {
-		readCacheSize = uint64(config.LittDBReadCacheSizeGB * units.GiB)
-		logger.Infof("LittDB read cache size configured to use %.2f GB.\n", config.LittDBReadCacheSizeGB)
-	} else {
-		readCacheSize = uint64(config.LittDBReadCacheSizeFraction * float64(maxMemory))
-		logger.Infof("LittDB read cache is configured to use %.1f%% of %.2f GB available (%.2f GB).",
-			config.LittDBReadCacheSizeFraction*100.0,
-			float64(maxMemory)/float64(units.GiB),
-			float64(readCacheSize)/float64(units.GiB))
-	}
-
-	if writeCacheSize+readCacheSize >= maxMemory {
-		return nil, fmt.Errorf("write cache size + read cache size must be less than max memory. "+
-			"Write cache size: %d, read cache size: %d, max memory: %d", writeCacheSize, readCacheSize, maxMemory)
-	}
-
-	err = chunkTable.SetWriteCacheSize(writeCacheSize)
+	err = chunkTable.SetWriteCacheSize(config.littDBWriteCacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set write cache size for chunks table: %w", err)
 	}
 
-	err = chunkTable.SetReadCacheSize(readCacheSize)
+	err = chunkTable.SetReadCacheSize(config.littDBReadCacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set read cache size for chunks table: %w", err)
 	}


### PR DESCRIPTION
## Why are these changes needed?

Increase the default size of the memory safety buffer, and allow it to be configured as a percentage of the total memory.
