### PR TITLE
feat: semaphore primitive

### DIFF
--- a/common/semaphore.go
+++ b/common/semaphore.go
@@ -1,0 +1,260 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+)
+
+// semaphoreChannelSize is the size of the channels used to communicate with the semaphore control loop.
+const semaphoreChannelSize = 64
+
+// Implements a semaphore. It baffles me why this is not in the standard libraries.
+//
+// This semaphore is "fair". That is, if N sequential calls to Acquire() are made, then each call will acquire their
+// tokens in the order that they were requested. If call N requests many tokens and is temporarily blocked, and if
+// call N+1 requests few tokens and those tokens are technically available, then call N+1 will not be able to acquire
+// those tokens until call N has acquired its tokens (or timed out).
+type Semaphore struct {
+	// The total number of tokens available in the semaphore.
+	totalTokens uint64
+
+	// The number of tokens currently taken by calls to Acquire().
+	acquiredTokens uint64
+
+	// Requests to acquire tokens are sent to this channel.
+	acquireChan chan *acquireReqeust
+
+	// Requests to release tokens are sent to this channel.
+	releaseChan chan *releaseRequest
+
+	// This channel is closed when the semaphore is closed.
+	shutdownChan chan struct{}
+
+	// Used to make calling Close() idempotent.
+	closeCalled atomic.Bool
+
+	// The next acquireRequest that will be processed. May be nil. Only accessed from the control loop goroutine.
+	nextAcquireRequest *acquireReqeust
+}
+
+// NewSemaphore creates a new semaphore with the specified number of available tokens.
+func NewSemaphore(tokens uint64) (*Semaphore, error) {
+	if tokens == 0 {
+		return nil, fmt.Errorf("tokens must be greater than zero")
+	}
+
+	sem := &Semaphore{
+		totalTokens:  tokens,
+		acquireChan:  make(chan *acquireReqeust, semaphoreChannelSize),
+		releaseChan:  make(chan *releaseRequest, semaphoreChannelSize),
+		shutdownChan: make(chan struct{}),
+	}
+	go sem.controlLoop()
+
+	return sem, nil
+}
+
+// A message sent to the control loop that requests a certain number of tokens to be acquired.
+type acquireReqeust struct {
+	// The context used by the caller to await for the acquire request to complete. If this context is canceled,
+	// then we can abort without allocating any tokens.
+	ctx context.Context
+
+	// The number of tokens requested.
+	tokens uint64
+
+	// this channel produces a value when either the tokens are acquired (true), or the request failed (false).
+	acquiredChan chan bool
+}
+
+// A message sent to the control loop that requests a certain number of tokens to be released.
+type releaseRequest struct {
+	// The number of tokens to release.
+	tokens uint64
+
+	// this channel produces a value when the tokens are released (true), or the request failed (false). The request
+	// will only fail if more tokens are released than were acquired.
+	releaseChan chan bool
+}
+
+// Acquire acquires the specified number of tokens from the semaphore, blocking until they are available.
+// If the context is canceled, it returns immediately with an error. If this method does not return an error,
+// Release MUST be called with the same number of tokens to release them back to the semaphore. If this method does
+// return an error, Release MUST NOT be called, and the tokens should be treated as if they were never acquired.
+func (s *Semaphore) Acquire(ctx context.Context, tokens uint64) error {
+
+	if tokens > s.totalTokens {
+		return fmt.Errorf("cannot acquire %d tokens, only %d available", tokens, s.totalTokens)
+	}
+
+	// Send the request to the control loop.
+
+	request := &acquireReqeust{
+		ctx:          ctx,
+		tokens:       tokens,
+		acquiredChan: make(chan bool, 1),
+	}
+
+	select {
+	case <-s.shutdownChan:
+		// Close() has been called.
+		return fmt.Errorf("semaphore closed")
+	case <-ctx.Done():
+		// Context was canceled before we could send the request.
+		// The tokens were never acquired, no need to release them.
+		return fmt.Errorf("context canceled")
+	case s.acquireChan <- request:
+		// Request was successfully sent to the control loop.
+	}
+
+	// Await a response from the control loop.
+
+	select {
+	case <-s.shutdownChan:
+		// Close() has been called. It doesn't matter if we release the tokens or not.
+		return fmt.Errorf("semaphore closed")
+	case <-ctx.Done():
+		// The context was canceled after we sent the request, but before we got a response.
+		// Depending on the response, we may need to release these tokens.
+		go func() {
+			select {
+			case <-s.shutdownChan:
+				// Close() has been called, no need to release the tokens.
+				return
+			case success := <-request.acquiredChan:
+				if success {
+					// We acquired the tokens, but the caller will not release them.
+					_ = s.Release(tokens)
+				}
+			}
+		}()
+		return fmt.Errorf("context canceled")
+	case success := <-request.acquiredChan:
+		// We got a response from the control loop.
+		if success {
+			// Tokens were successfully acquired.
+			return nil
+		}
+		return fmt.Errorf("failed to acquire %d tokens", tokens)
+	}
+}
+
+// Release releases the specified number of tokens back to the semaphore. Must be called with the same number of
+// tokens that were acquired. It is legal to release tokens in smaller amounts than were acquired. If more tokens
+// are released than were acquired, an error will be returned. Do not call this method if the Acquire() call
+// returned an error, as the tokens were never acquired in that case.
+func (s *Semaphore) Release(tokens uint64) error {
+	if tokens > s.totalTokens {
+		return fmt.Errorf("cannot release %d tokens, only %d available", tokens, s.totalTokens)
+	}
+
+	// Unlike Acquire(), this method does not accept a context from the caller. Although this method may block
+	// for a very short amount of time, the control loop will immediately process release requests as fast
+	// as it can pop them out of the channel. In practice, this means that Release() will always return
+	// very quickly, and will never block for more than a few microseconds.
+
+	// Send the request to the control loop.
+
+	request := &releaseRequest{
+		tokens:      tokens,
+		releaseChan: make(chan bool, 1),
+	}
+
+	select {
+	case <-s.shutdownChan:
+		// Close() has been called. It's ok to abort and return immediately, since releasing tokens no longer matters.
+		return fmt.Errorf("semaphore closed")
+	case s.releaseChan <- request:
+		// Request was successfully sent to the control loop.
+	}
+
+	select {
+	case <-s.shutdownChan:
+		// Close() has been called. It's ok to abort and return immediately, since releasing tokens no longer matters.
+		return fmt.Errorf("semaphore closed")
+	case success := <-request.releaseChan:
+		if success {
+			return nil
+		}
+		return fmt.Errorf("failed to release %d tokens", tokens)
+	}
+}
+
+// Close releases resources associated with the semaphore. If there are pending Acquire() or Release() calls, those
+// methods may return an error as a result to this call to Close().
+func (s *Semaphore) Close() {
+	if s.closeCalled.CompareAndSwap(false, true) {
+		close(s.shutdownChan)
+	}
+}
+
+// controlLoop is the main loop that processes acquire and release requests. Operations are run in serialized order
+// here to simplify threading logic/safety.
+func (s *Semaphore) controlLoop() {
+	for {
+		if s.nextAcquireRequest == nil {
+			// We don't currently have any pending acquire requests.
+			select {
+			case <-s.shutdownChan:
+				// Close() has been called, exit the loop.
+				return
+			case req := <-s.releaseChan:
+				// Important: handle release requests before acquire requests
+				s.handleReleaseRequest(req)
+			case req := <-s.acquireChan:
+				// We have a new acquire request.
+				s.nextAcquireRequest = req
+				s.handleAcquireRequest()
+			}
+		} else {
+			// There is currently a pending acquire request. We will only hit this block if we previously had a request
+			// that we could not immediately fulfill. In that case, we need to wait for the next release request to
+			// come in the door before we can process the pending request, or for the pending request to time out.
+
+			select {
+			case <-s.shutdownChan:
+				// Close() has been called, exit the loop.
+				return
+			case req := <-s.releaseChan:
+				// Important: handle release requests before acquire requests
+				s.handleReleaseRequest(req)
+
+				// make another attempt at processing the pending acquire request now that we've freed up some tokens
+				s.handleAcquireRequest()
+			case <-s.nextAcquireRequest.ctx.Done():
+				// The context for the pending acquire request was canceled.
+				s.nextAcquireRequest.acquiredChan <- false
+				s.nextAcquireRequest = nil
+			}
+		}
+	}
+}
+
+// handle a request to release tokens
+func (s *Semaphore) handleReleaseRequest(req *releaseRequest) {
+	if req.tokens > s.acquiredTokens {
+		// error case: more tokens released than previously acquired
+		req.releaseChan <- false
+	} else {
+		// success case: release the tokens
+		s.acquiredTokens -= req.tokens
+		req.releaseChan <- true
+	}
+}
+
+// handle the pending acquire request stored in s.nextAcquireRequest.
+func (s *Semaphore) handleAcquireRequest() {
+	request := s.nextAcquireRequest
+
+	remainingTokens := s.totalTokens - s.acquiredTokens
+	if request.tokens <= remainingTokens {
+		s.acquiredTokens += request.tokens
+		request.acquiredChan <- true
+		s.nextAcquireRequest = nil
+	}
+
+	// If we get here without acquiring the tokens, it means that we could not fulfill the request immediately.
+	// We will make another attempt to process this request either when the request's context is canceled, or when
+	// a release request comes in that frees up some tokens.
+}

--- a/common/semaphore_test.go
+++ b/common/semaphore_test.go
@@ -1,0 +1,343 @@
+package common_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/common/testutils/random"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroTokens(t *testing.T) {
+	t.Parallel()
+
+	_, err := common.NewSemaphore(0)
+	require.Error(t, err)
+}
+
+func TestRequestTooManyTokens(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+
+	tokenCount := rand.Uint64()/2 + 1
+
+	semaphore, err := common.NewSemaphore(tokenCount)
+	require.NoError(t, err)
+	defer semaphore.Close()
+
+	// We should be able to acquire the exact number of tokens available.
+	err = semaphore.Acquire(t.Context(), tokenCount)
+	require.NoError(t, err)
+	err = semaphore.Release(tokenCount)
+	require.NoError(t, err)
+
+	// We should not be able to acquire more tokens than available.
+	err = semaphore.Acquire(t.Context(), tokenCount+1)
+	require.Error(t, err)
+}
+
+func TestReleaseTooManyTokens(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+
+	tokenCount := rand.Uint64()/2 + 1
+
+	semaphore, err := common.NewSemaphore(tokenCount)
+	require.NoError(t, err)
+	defer semaphore.Close()
+
+	// release more tokens than the maximum capacity of the semaphore
+	err = semaphore.Release(tokenCount + 1)
+	require.Error(t, err)
+
+	// release a legal number of tokens, but tokens that were never acquired
+	err = semaphore.Release(tokenCount / 2)
+	require.Error(t, err)
+}
+
+func TestExclusion(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+
+	tokenCount := rand.Uint64()/2 + 1
+
+	semaphore, err := common.NewSemaphore(tokenCount)
+	require.NoError(t, err)
+	defer semaphore.Close()
+
+	// Acquire more than half of all tokens.
+	err = semaphore.Acquire(t.Context(), tokenCount/2+1)
+	require.NoError(t, err)
+
+	// Create a goroutine that tries to acquire the same number of tokens.
+	// The semaphore should prevent this.
+	acquiredTokens := atomic.Bool{}
+	acquiredTokensChan := make(chan struct{})
+	go func() {
+		err := semaphore.Acquire(t.Context(), tokenCount/2+1)
+		require.NoError(t, err)
+		acquiredTokens.Store(true)
+		acquiredTokensChan <- struct{}{}
+	}()
+
+	// Wait for a little while. Goroutine should not be able to acquire the tokens.
+	time.Sleep(10 * time.Millisecond)
+	require.False(t, acquiredTokens.Load())
+
+	// Release the tokens we acquired.
+	err = semaphore.Release(tokenCount/2 + 1)
+	require.NoError(t, err)
+
+	// Now the goroutine should be able to acquire the tokens.
+	select {
+	case <-acquiredTokensChan:
+		require.True(t, acquiredTokens.Load())
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "goroutine did not acquire tokens in time")
+	}
+
+	// Release the tokens acquired by the goroutine.
+	err = semaphore.Release(tokenCount/2 + 1)
+	require.NoError(t, err)
+}
+
+// Similar to TestExclusion, but with multiple releases prior to the goroutine acquiring tokens.
+func TestMultiExclusion(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+
+	tokenCount := rand.Uint64()/2 + 1
+
+	semaphore, err := common.NewSemaphore(tokenCount)
+	require.NoError(t, err)
+	defer semaphore.Close()
+
+	// Acquire more than half of all tokens.
+	err = semaphore.Acquire(t.Context(), tokenCount)
+	require.NoError(t, err)
+
+	// Create a goroutine that tries to acquire the same number of tokens.
+	// The semaphore should prevent this.
+	acquiredTokens := atomic.Bool{}
+	acquiredTokensChan := make(chan struct{})
+	go func() {
+		err := semaphore.Acquire(t.Context(), tokenCount)
+		require.NoError(t, err)
+		acquiredTokens.Store(true)
+		acquiredTokensChan <- struct{}{}
+	}()
+
+	// Release tokens gradually.
+	tokensToRelease := tokenCount
+	for tokensToRelease > 0 {
+		time.Sleep(time.Millisecond)
+		require.False(t, acquiredTokens.Load())
+
+		releaseCount := tokensToRelease / 2
+		if releaseCount == 0 {
+			// the last release will round 0.5 down to 0, so we need to ensure at least 1 token is released
+			releaseCount = 1
+		}
+		tokensToRelease -= releaseCount
+		err = semaphore.Release(releaseCount)
+		require.NoError(t, err)
+	}
+
+	// Now the goroutine should be able to acquire the tokens.
+	select {
+	case <-acquiredTokensChan:
+		require.True(t, acquiredTokens.Load())
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "goroutine did not acquire tokens in time")
+	}
+
+	// Release the tokens acquired by the goroutine.
+	err = semaphore.Release(tokenCount/2 + 1)
+	require.NoError(t, err)
+}
+
+// We want to make sure that the closing of the semaphore does not cause deadlocks.
+func TestClosingSemaphore(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+
+	tokenCount := rand.Uint64()/2 + 1
+
+	semaphore, err := common.NewSemaphore(tokenCount)
+	require.NoError(t, err)
+
+	err = semaphore.Acquire(t.Context(), tokenCount)
+	require.NoError(t, err)
+
+	// Create a goroutine that tries to acquire the same number of tokens.
+	// The semaphore should prevent this. As soon as the semaphore is closed, the goroutine should return an error.
+	unblocked := atomic.Bool{}
+	unblockedChan := make(chan struct{})
+	go func() {
+		err := semaphore.Acquire(t.Context(), tokenCount)
+		require.Error(t, err)
+		unblocked.Store(true)
+		unblockedChan <- struct{}{}
+	}()
+
+	// Wait for a little while. Goroutine should still be blocked.
+	time.Sleep(10 * time.Millisecond)
+	require.False(t, unblocked.Load())
+
+	// Close the semaphore. Should unblock the goroutine.
+	semaphore.Close()
+
+	select {
+	case <-unblockedChan:
+		require.True(t, unblocked.Load())
+	case <-time.After(10000 * time.Millisecond):
+		require.Fail(t, "goroutine did not unblock in time")
+	}
+
+	// Closing multiple times shouldn't cause any issues.
+	semaphore.Close()
+
+	// Additional calls to Acquire and Release after closing should return errors.
+	err = semaphore.Acquire(t.Context(), 1)
+	require.Error(t, err)
+	err = semaphore.Release(0)
+	require.Error(t, err)
+}
+
+// See what happens when the context is cancelled prior to the Acquire call.
+func TestContextImmediatelyCancelled(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+
+	tokenCount := rand.Uint64()/2 + 1
+
+	semaphore, err := common.NewSemaphore(tokenCount)
+	require.NoError(t, err)
+	defer semaphore.Close()
+
+	// Acquire more than half of all tokens.
+	err = semaphore.Acquire(t.Context(), tokenCount/2+1)
+	require.NoError(t, err)
+
+	// Create a context that is already canceled.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// This should return an error immediately without blocking.
+	err = semaphore.Acquire(ctx, tokenCount/2+1)
+	require.Error(t, err)
+}
+
+// See what happens when the context is cancelled after the Acquire call, but before the request is put on the channel
+// to the control loop.
+func TestContextCancelledBeforeSending(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+
+	tokenCount := rand.Uint64()/2 + 1
+
+	semaphore, err := common.NewSemaphore(tokenCount)
+	require.NoError(t, err)
+	defer semaphore.Close()
+
+	// Acquire all tokens.
+	err = semaphore.Acquire(t.Context(), tokenCount)
+	require.NoError(t, err)
+
+	// Fill up the channel. After this operation, Acquire() should get blocked on insertion into the channel.
+	// The channel has capacity 64, and the control loop will buffer one request. So we need to add 65 requests.
+	for i := 0; i < 65; i++ {
+		go func() {
+			// this will block until we close the semaphore
+			_ = semaphore.Acquire(t.Context(), 1)
+		}()
+	}
+
+	// Wait a little while to give the goroutines time to block. This test won't fail if not all goroutines block,
+	// but we may not exercise the code path we want to test.
+	time.Sleep(50 * time.Millisecond)
+
+	// Create a context that we will eventually cancel.
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Submit a request with that context.
+	unblocked := atomic.Bool{}
+	unblockedChan := make(chan struct{})
+	go func() {
+		err := semaphore.Acquire(ctx, 1)
+		require.Error(t, err)
+		unblocked.Store(true)
+		unblockedChan <- struct{}{}
+	}()
+
+	// Wait a little while. Goroutine should still be blocked.
+	time.Sleep(10 * time.Millisecond)
+	require.False(t, unblocked.Load())
+
+	// Cancel the context. This should unblock the goroutine and return an error.
+	cancel()
+
+	select {
+	case <-unblockedChan:
+		require.True(t, unblocked.Load())
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "goroutine did not unblock in time")
+	}
+}
+
+// See what happens when the context is cancelled after the request is sent to the control loop, but before the
+// control loop responds to the request.
+func TestContextCancelledBeforeResponse(t *testing.T) {
+	t.Parallel()
+
+	rand := random.NewTestRandom()
+
+	tokenCount := rand.Uint64()/2 + 1
+
+	semaphore, err := common.NewSemaphore(tokenCount)
+	require.NoError(t, err)
+	defer semaphore.Close()
+
+	err = semaphore.Acquire(t.Context(), tokenCount)
+	require.NoError(t, err)
+
+	// Create a context that we will eventually cancel.
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Create a goroutine that tries to acquire the same number of tokens.
+	// This should block until the context is cancelled.
+	unblocked := atomic.Bool{}
+	unblockedChan := make(chan struct{})
+	go func() {
+		err := semaphore.Acquire(ctx, tokenCount)
+		require.Error(t, err)
+		unblocked.Store(true)
+		unblockedChan <- struct{}{}
+	}()
+
+	// Wait a little while. Goroutine should still be blocked. We want the request to be sent to the control loop
+	// during this time. If that doesn't happen, this test will still pass, but we won't exercise the code path we
+	// want to test.
+	time.Sleep(50 * time.Millisecond)
+	require.False(t, unblocked.Load())
+
+	// Cancel the context. This should unblock the goroutine.
+	cancel()
+
+	select {
+	case <-unblockedChan:
+		require.True(t, unblocked.Load())
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "goroutine did not unblock in time")
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?

Creates a semaphore utility. Needed for a pending PR that will limit the memory used by `StoreChunks()` and `GetChunks()` on the validators.
