### PR TITLE
fix: Check bounds before precomputing SRS table

### DIFF
--- a/encoding/kzg/prover/precompute.go
+++ b/encoding/kzg/prover/precompute.go
@@ -105,7 +105,8 @@ func (p *SRSTable) GetSubTables(
 		// We need polynomial degree m < len(SRS)
 		// (Actually we only access up to index m-cosetSize, but this simpler check is safer)
 		if m >= uint64(len(p.s1)) {
-			return nil, fmt.Errorf("cannot precompute table: insufficient SRS points loaded (have %d, need at least %d). Consider increasing loaded SRS points or using precomputed tables",
+			return nil, fmt.Errorf("cannot precompute table: insufficient SRS points loaded (have %d, need at least %d). "+
+				"Consider increasing loaded SRS points or using precomputed tables",
 				len(p.s1), m+1)
 		}
 

--- a/encoding/kzg/prover/precompute.go
+++ b/encoding/kzg/prover/precompute.go
@@ -105,7 +105,7 @@ func (p *SRSTable) GetSubTables(
 		// We need polynomial degree m < len(SRS)
 		// (Actually we only access up to index m-cosetSize, but this simpler check is safer)
 		if m >= uint64(len(p.s1)) {
-			return nil, fmt.Errorf("cannot precompute table: insufficient SRS points loaded (have %d, need at least %d). Consider increasing DISPERSER_ENCODER_SRS_LOAD or using precomputed tables",
+			return nil, fmt.Errorf("cannot precompute table: insufficient SRS points loaded (have %d, need at least %d). Consider increasing loaded SRS points or using precomputed tables",
 				len(p.s1), m+1)
 		}
 

--- a/encoding/kzg/prover/precompute.go
+++ b/encoding/kzg/prover/precompute.go
@@ -100,6 +100,15 @@ func (p *SRSTable) GetSubTables(
 	table, ok := p.Tables[param]
 	if !ok {
 		log.Printf("Table with params: DimE=%v CosetSize=%v does not exist\n", dimE, cosetSize)
+
+		// Check if we have enough SRS points loaded for precomputation
+		// We need polynomial degree m < len(SRS)
+		// (Actually we only access up to index m-cosetSize, but this simpler check is safer)
+		if m >= uint64(len(p.s1)) {
+			return nil, fmt.Errorf("cannot precompute table: insufficient SRS points loaded (have %d, need at least %d). Consider increasing DISPERSER_ENCODER_SRS_LOAD or using precomputed tables",
+				len(p.s1), m+1)
+		}
+
 		log.Printf("Generating the table. May take a while\n")
 		log.Printf("... ...\n")
 		filename := fmt.Sprintf("dimE%v.coset%v", dimE, cosetSize)

--- a/encoding/kzg/prover/precompute_test.go
+++ b/encoding/kzg/prover/precompute_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/encoding/kzg"
 	"github.com/Layr-Labs/eigenda/encoding/kzg/prover"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
 )
 
 func TestNewSRSTable_PreComputeWorks(t *testing.T) {
@@ -42,4 +43,40 @@ func TestNewSRSTable_PreComputeWorks(t *testing.T) {
 
 	// Result of non precomputed GetSubTables should equal precomputed GetSubTables
 	assert.Equal(t, fftPoints1, fftPoints2)
+}
+
+// This test reproduces the scenario where SRS_LOAD=2097152 and computing a subtable
+// with the parameters (DimE=4, CosetSize=2097152) would cause a panic.
+// The issue: m = numChunks*chunkLen - 1 = 4*2097152 - 1 = 8388607
+// When j=0, k starts at m - cosetSize = 8388607 - 2097152 = 6291455
+// Since 6291455 >= 2097152 (the length of our SRS), we get:
+// panic: runtime error: index out of range [6291455] with length 2097152
+func TestSRSTable_InsufficientSRSPoints_NoPanic(t *testing.T) {
+	// Create a limited SRS with only 2097152 points
+	limitedSRSSize := uint64(2097152)
+	limitedSRS := make([]bn254.G1Affine, limitedSRSSize)
+
+	// Initialize with some dummy points (doesn't matter what they are for this test)
+	var generator bn254.G1Affine
+	generator.X.SetString("1")
+	generator.Y.SetString("2")
+	for i := range limitedSRS {
+		limitedSRS[i] = generator
+	}
+
+	// Create SRSTable with limited SRS points
+	tempDir := t.TempDir()
+	srsTable, err := prover.NewSRSTable(tempDir, limitedSRS, 1)
+	require.NoError(t, err)
+
+	// Try to create subtables with the following parameters
+	numChunks := uint64(4)
+	chunkLen := uint64(2097152)
+
+	// This should return an error instead of panicking
+	fftPoints, err := srsTable.GetSubTables(numChunks, chunkLen)
+
+	assert.Error(t, err)
+	assert.Nil(t, fftPoints)
+	assert.Contains(t, err.Error(), "insufficient SRS points")
 }

--- a/encoding/kzg/prover/precompute_test.go
+++ b/encoding/kzg/prover/precompute_test.go
@@ -58,8 +58,10 @@ func TestSRSTable_InsufficientSRSPoints_NoPanic(t *testing.T) {
 
 	// Initialize with some dummy points (doesn't matter what they are for this test)
 	var generator bn254.G1Affine
-	generator.X.SetString("1")
-	generator.Y.SetString("2")
+	_, err := generator.X.SetString("1")
+	require.NoError(t, err)
+	_, err = generator.Y.SetString("2")
+	require.NoError(t, err)
 	for i := range limitedSRS {
 		limitedSRS[i] = generator
 	}


### PR DESCRIPTION
## Why are these changes needed?

This PR adds a defensive check to ensure that trying to generate tables > loaded SRS size will not panic but instead return an error.

### Original issue:

`2025/08/05 07:39:49 Table with params: DimE=4 CosetSize=2097152 does not exist` leads to:
```
panic: runtime error: index out of range [6291450] with length 2097152

github.com/Layr-Labs/eigenda/encoding/kzg/prover.(*SRSTable).PrecomputeSubTable(...)
    /app/encoding/kzg/prover/precompute.go:188 +0x2ca
    - Parameters: (0xc013d73a00, 0xc0134f64e8?, 0xf971255373de12?, 0x3, 0x90000000ffffffff?, 0x5, 0x200000)

github.com/Layr-Labs/eigenda/encoding/kzg/prover.(*SRSTable).precomputeWorker(...)
    /app/encoding/kzg/prover/precompute.go:151 +0x10b
    - Parameters: (0xc00590e300?, 0xc041baefd0?, 0x44843c?, 0x14054a8?, 0xa?, 0xc00590e300?, 0xc000504000?, 0xc01ddcce90?)

created by github.com/Layr-Labs/eigenda/encoding/kzg/prover.(*SRSTable).Precompute
    /app/encoding/kzg/prover/precompute.go:173 +0xa5
    - Origin goroutine: 471265176
 ```

This is because we set the following configuration
```
name: DISPERSER_ENCODER_SRS_LOAD
value: "2097152"
```

The root issue is that if an SRS table is not precomputed we will try to compute it and store it. Computing an SRS table requires more points to be loaded so we hit a panic due to overflowing the buffer.

Options are:
1. Have more points loaded.
2. Add defensive check (this PR)
3. Remove support for computing SRS tables on the fly.

This issue is not present on the V2 encoder since numChunks is fixed to 8192 which limits the amount of SRSTables we need precomputed. V1 encoding parameters are determined based on the operator state and so we've started to hit this issue due to instability on the Holesky operator state.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
