### PR TITLE
fix: downgrade logging if attestation does not exist yet

### DIFF
--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -1392,7 +1392,7 @@ func (s *BlobMetadataStore) GetSignedBatch(ctx context.Context, batchHeaderHash 
 	}
 
 	if attestation == nil {
-		return nil, nil, fmt.Errorf("%w: attestation not found for hash %x", ErrMetadataNotFound, batchHeaderHash)
+		return nil, nil, fmt.Errorf("%w: attestation not found for hash %x", ErrAttestationNotFound, batchHeaderHash)
 	}
 
 	return header, attestation, nil

--- a/disperser/common/v2/blobstore/errors.go
+++ b/disperser/common/v2/blobstore/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrMetadataNotFound       = errors.New("metadata not found")
 	ErrAlreadyExists          = errors.New("record already exists")
 	ErrInvalidStateTransition = errors.New("invalid state transition")
+	ErrAttestationNotFound    = errors.New("attestation not found")
 )


### PR DESCRIPTION
## Why are these changes needed?
when a blob has just been dispersed and has not been processed by the dispatcher, no attestations are expected and it should not emit any error logs. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
