### PR TITLE
feat(metrics): add v2 client metrics and expose them to the proxy

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api"
+	client_metrics "github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	disperser_rpc "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
@@ -57,6 +58,7 @@ type disperserClient struct {
 	prover             encoding.Prover
 	accountant         *Accountant
 	accountantLock     sync.Mutex
+	clientMetrics      client_metrics.ClientMetricer
 }
 
 var _ DisperserClient = &disperserClient{}
@@ -112,6 +114,9 @@ func (c *disperserClient) PopulateAccountant(ctx context.Context) error {
 			return fmt.Errorf("error getting account ID: %w", err)
 		}
 		c.accountant = NewAccountant(accountId, nil, nil, 0, 0, 0, 0)
+		if c.clientMetrics != nil {
+			c.accountant.SetMetrics(c.clientMetrics)
+		}
 	}
 
 	paymentState, err := c.GetPaymentState(ctx)
@@ -419,4 +424,8 @@ func (c *disperserClient) initOncePopulateAccountant(ctx context.Context) error 
 		return fmt.Errorf("populating accountant: %w", initErr)
 	}
 	return nil
+}
+
+func (c *disperserClient) SetClientMetrics(metrics client_metrics.ClientMetricer) {
+	c.clientMetrics = metrics
 }

--- a/api/clients/v2/metrics/metrics.go
+++ b/api/clients/v2/metrics/metrics.go
@@ -1,0 +1,106 @@
+package metrics
+
+import (
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	accountantSubsystem = "accountant"
+	disperserSubsystem  = "disperser_client"
+)
+
+type ClientMetricer interface {
+	// accountant
+	ReportPaymentUsed(accountID string, method string, symbols uint64)
+	ReportOnDemandPayment(accountID string, amount *big.Int)
+	ReportCumulativePayment(accountID string, amount *big.Int)
+	ReportPaymentFailure(accountID string, reason string)
+}
+
+type ClientMetrics struct {
+	// accountant
+	PaymentMethodUsed *prometheus.CounterVec
+	OnDemandPayment   *prometheus.CounterVec
+	CumulativePayment *prometheus.GaugeVec
+	PaymentFailures   *prometheus.CounterVec
+}
+
+func NewClientMetrics(namespace string, factory metrics.Factory) ClientMetrics {
+	return ClientMetrics{
+		PaymentMethodUsed: factory.NewCounterVec(prometheus.CounterOpts{
+			Name:      "payment_method_used_total",
+			Namespace: namespace,
+			Subsystem: accountantSubsystem,
+			Help:      "Total number of payments by method (reservation or on-demand)",
+		}, []string{
+			"account_id",
+			"method",
+		}),
+		OnDemandPayment: factory.NewCounterVec(prometheus.CounterOpts{
+			Name:      "on_demand_payment_total",
+			Namespace: namespace,
+			Subsystem: accountantSubsystem,
+			Help:      "Total on-demand payments made",
+		}, []string{
+			"account_id",
+		}),
+		CumulativePayment: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Name:      "cumulative_payment",
+			Namespace: namespace,
+			Subsystem: accountantSubsystem,
+			Help:      "Current cumulative payment balance",
+		}, []string{
+			"account_id",
+		}),
+		PaymentFailures: factory.NewCounterVec(prometheus.CounterOpts{
+			Name:      "payment_failures_total",
+			Namespace: namespace,
+			Subsystem: accountantSubsystem,
+			Help:      "Total payment failures by reason",
+		}, []string{
+			"account_id",
+			"reason",
+		}),
+	}
+}
+
+func (m *ClientMetrics) ReportPaymentUsed(accountID string, method string, symbols uint64) {
+	m.PaymentMethodUsed.WithLabelValues(accountID, method).Add(float64(symbols))
+}
+
+// ReportOnDemandPayment records an on-demand payment amount in wei
+func (m *ClientMetrics) ReportOnDemandPayment(accountID string, amount *big.Int) {
+	// Convert big.Int to float64 for prometheus
+	weiFloat, _ := amount.Float64() // TODO(iquidus)
+	m.OnDemandPayment.WithLabelValues(accountID).Add(weiFloat)
+}
+
+func (m *ClientMetrics) ReportCumulativePayment(accountID string, amount *big.Int) {
+	// Convert big.Int to float64 for prometheus
+	weiFloat, _ := amount.Float64() // TODO(iquidus)
+	m.CumulativePayment.WithLabelValues(accountID).Set(weiFloat)
+}
+
+func (m *ClientMetrics) ReportPaymentFailure(accountID string, reason string) {
+	m.PaymentFailures.WithLabelValues(accountID, reason).Inc()
+}
+
+type NoopAccountantMetricer struct {
+}
+
+var NoopAccountantMetrics ClientMetricer = new(NoopAccountantMetricer)
+
+func (m *NoopAccountantMetricer) ReportPaymentUsed(_ string, _ string, _ uint64) {
+}
+
+func (m *NoopAccountantMetricer) ReportOnDemandPayment(_ string, _ *big.Int) {
+}
+
+func (m *NoopAccountantMetricer) ReportCumulativePayment(_ string, _ *big.Int) {
+}
+
+func (m *NoopAccountantMetricer) ReportPaymentFailure(_ string, _ string) {
+}

--- a/api/clients/v2/payloadretrieval/validator_payload_retriever.go
+++ b/api/clients/v2/payloadretrieval/validator_payload_retriever.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
+	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/validator"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
@@ -21,6 +22,7 @@ type ValidatorPayloadRetriever struct {
 	config          ValidatorPayloadRetrieverConfig
 	retrievalClient validator.ValidatorClient
 	g1Srs           []bn254.G1Affine
+	metrics         metrics.ClientMetricer
 }
 
 var _ clients.PayloadRetriever = &ValidatorPayloadRetriever{}
@@ -175,4 +177,8 @@ func (pr *ValidatorPayloadRetriever) retrieveBlobWithTimeout(
 	}
 
 	return blob, nil
+}
+
+func (pr *ValidatorPayloadRetriever) SetMetrics(metrics metrics.ClientMetricer) {
+	pr.metrics = metrics
 }

--- a/api/proxy/metrics/memory.go
+++ b/api/proxy/metrics/memory.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"sync"
 
+	client_metrics "github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -84,6 +85,7 @@ func (cm *CountMap) Get(labels ...string) (uint64, error) {
 // and is only used for E2E testing. This is needed since prometheus/client_golang doesn't provide
 // an interface for reading the count values from the codified metric.
 type EmulatedMetricer struct {
+	client_metrics.NoopAccountantMetricer
 	HTTPServerRequestsTotal *CountMap
 	// secondary metrics
 	SecondaryRequestsTotal *CountMap

--- a/api/proxy/metrics/metrics.go
+++ b/api/proxy/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	ophttp "github.com/ethereum-optimism/optimism/op-service/httputil"
 
+	client_metrics "github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -28,6 +29,7 @@ type Config struct {
 
 // Metricer ... Interface for metrics
 type Metricer interface {
+	client_metrics.ClientMetricer
 	RecordInfo(version string)
 	RecordUp()
 
@@ -39,6 +41,7 @@ type Metricer interface {
 
 // Metrics ... Metrics struct
 type Metrics struct {
+	client_metrics.ClientMetrics
 	Info *prometheus.GaugeVec
 	Up   prometheus.Gauge
 
@@ -65,7 +68,9 @@ func NewMetrics(subsystem string) *Metrics {
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(collectors.NewGoCollector())
+
 	factory := metrics.With(registry)
+	clientMetrics := client_metrics.NewClientMetrics(namespace, factory)
 
 	return &Metrics{
 		Up: factory.NewGauge(prometheus.GaugeOpts{
@@ -127,6 +132,8 @@ func NewMetrics(subsystem string) *Metrics {
 		}, []string{
 			"backend_type",
 		}),
+		ClientMetrics: clientMetrics,
+
 		registry: registry,
 		factory:  factory,
 	}
@@ -189,6 +196,7 @@ func (m *Metrics) Document() []metrics.DocumentedMetric {
 }
 
 type noopMetricer struct {
+	client_metrics.NoopAccountantMetricer
 }
 
 var NoopMetrics Metricer = new(noopMetricer)

--- a/api/proxy/server/middleware/request_context_test.go
+++ b/api/proxy/server/middleware/request_context_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	client_metrics "github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/Layr-Labs/eigenda/api/proxy/common/types/commitments"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -48,6 +49,7 @@ func TestRequestContext_CertVersionCanBeReadFromMetricsMiddleware(t *testing.T) 
 // Only used to make sure that the call to recordDur(strconv.Itoa(scw.status), string(mode), certVersion)
 // in the metrics middleware contains the correct cert version.
 type MockMetricer struct {
+	client_metrics.NoopAccountantMetricer
 	recordDurCertVersion string
 }
 

--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -345,7 +345,7 @@ func buildEigenDAV2Backend(
 		kzgProver,
 		certVerifier,
 		ethReader,
-		metrics, // TODO(iquidus): prometheus registry
+		metrics,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build payload disperser: %w", err)


### PR DESCRIPTION
Closes DAINT-654

## Why are these changes needed?

Adds additional v2 client metrics and exposes them to the proxy

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
