### PR TITLE
Potential fix for code scanning alert no. 59: Incorrect conversion between integer types

### DIFF
--- a/litt/disktable/boundary_file.go
+++ b/litt/disktable/boundary_file.go
@@ -2,6 +2,7 @@ package disktable
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"strconv"
@@ -136,6 +137,9 @@ func (b *BoundaryFile) deserialize(data []byte) error {
 	boundaryIndex, err := strconv.Atoi(string(data))
 	if err != nil {
 		return fmt.Errorf("failed to parse boundary index from data: %v", err)
+	}
+	if boundaryIndex < 0 || boundaryIndex > int(math.MaxUint32) {
+		return fmt.Errorf("boundary index out of uint32 range: %d", boundaryIndex)
 	}
 	b.boundaryIndex = uint32(boundaryIndex)
 	return nil


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/eigenda/security/code-scanning/59](https://github.com/Layr-Labs/eigenda/security/code-scanning/59)

To fix the problem, we need to ensure that the value parsed from the string is within the valid range for a `uint32` before performing the conversion. This means checking that the parsed value is greater than or equal to 0 and less than or equal to `math.MaxUint32` (4294967295). If the value is out of bounds, the function should return an error indicating the invalid input. The fix should be applied in the `deserialize` method in `litt/disktable/boundary_file.go`, specifically between lines 136 and 141. We will need to import the `math` package to access `math.MaxUint32`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
