### PR TITLE
refactor: remove `op-service/metrics` dependency from proxy

### DIFF
--- a/api/proxy/cmd/server/main.go
+++ b/api/proxy/cmd/server/main.go
@@ -33,6 +33,10 @@ func main() {
 	app.Usage = "EigenDA Proxy Sidecar Service"
 	app.Description = "Service for more trustless and secure interactions with EigenDA"
 	app.Action = StartProxySvr
+	// TODO(iquidus): Add new `doc metrics` command to display all supported metrics.
+	// The `doc metrics` command was removed as it only displayed metrics created by
+	// the op-service/metrics factory. The new command should display all metrics
+	// created via promauto or registered directly with the prometheus registry.
 
 	// load env file (if applicable)
 	if p := os.Getenv("ENV_PATH"); p != "" {

--- a/api/proxy/cmd/server/main.go
+++ b/api/proxy/cmd/server/main.go
@@ -12,11 +12,9 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/urfave/cli/v2"
 
-	"github.com/Layr-Labs/eigenda/api/proxy/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum-optimism/optimism/op-service/metrics/doc"
 )
 
 var (
@@ -35,12 +33,6 @@ func main() {
 	app.Usage = "EigenDA Proxy Sidecar Service"
 	app.Description = "Service for more trustless and secure interactions with EigenDA"
 	app.Action = StartProxySvr
-	app.Commands = []*cli.Command{
-		{
-			Name:        "doc",
-			Subcommands: doc.NewSubcommands(metrics.NewMetrics("default")),
-		},
-	}
 
 	// load env file (if applicable)
 	if p := os.Getenv("ENV_PATH"); p != "" {

--- a/api/proxy/docs/help_out.txt
+++ b/api/proxy/docs/help_out.txt
@@ -9,7 +9,6 @@ DESCRIPTION:
    Service for more trustless and secure interactions with EigenDA
 
 COMMANDS:
-   doc      
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:

--- a/api/proxy/metrics/memory.go
+++ b/api/proxy/metrics/memory.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -98,11 +97,6 @@ func NewEmulatedMetricer() *EmulatedMetricer {
 }
 
 var _ Metricer = NewEmulatedMetricer()
-
-// Document ... noop
-func (n *EmulatedMetricer) Document() []metrics.DocumentedMetric {
-	return nil
-}
 
 // RecordInfo ... noop
 func (n *EmulatedMetricer) RecordInfo(_ string) {

--- a/api/proxy/server/middleware/request_context_test.go
+++ b/api/proxy/server/middleware/request_context_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Layr-Labs/eigenda/api/proxy/common/types/commitments"
 	"github.com/Layr-Labs/eigensdk-go/logging"
-	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,7 +62,4 @@ func (m *MockMetricer) RecordRPCServerRequest(method string) func(status string,
 }
 func (m *MockMetricer) RecordSecondaryRequest(bt string, method string) func(status string) {
 	return func(status string) {}
-}
-func (m *MockMetricer) Document() []opmetrics.DocumentedMetric {
-	return nil
 }


### PR DESCRIPTION
Closes DAINT-683

This PR refactors the proxy metrics to: 

* Replace the metrics `factory` provided by `op-service/metrics` with `promauto`.
* Remove the `eigenda-proxy doc metrics` command (provided by the `factory`).
* Remove the `op-service/metrics` dependency altogether

## Why are these changes needed?

The `eigenda-proxy doc metrics` command only displays metrics created via it's `factory`, ignoring all other metrics. We are using `promauto` everywhere else. Removing the `factory` and using `promauto` aligns the proxy metrics with the rest of the codebase.

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [x]  Local e2e tests
