### PR TITLE
refactor: expose payload disperser probe to proxy

### DIFF
--- a/api/proxy/cmd/server/entrypoint.go
+++ b/api/proxy/cmd/server/entrypoint.go
@@ -86,7 +86,8 @@ func StartProxySvr(cliCtx *cli.Context) error {
 
 	if cfg.MetricsServerConfig.Enabled {
 		log.Info("Starting metrics server", "addr", cfg.MetricsServerConfig.Host, "port", cfg.MetricsServerConfig.Port)
-		svr, err := metrics.StartServer(cfg.MetricsServerConfig.Host, cfg.MetricsServerConfig.Port)
+		svr := proxy_metrics.NewServer(registry, cfg.MetricsServerConfig)
+		err := svr.Start()
 		if err != nil {
 			return fmt.Errorf("failed to start metrics server: %w", err)
 		}

--- a/api/proxy/cmd/server/entrypoint.go
+++ b/api/proxy/cmd/server/entrypoint.go
@@ -46,7 +46,7 @@ func StartProxySvr(cliCtx *cli.Context) error {
 	log.Infof("Initializing EigenDA proxy server with config (\"*****\" fields are hidden): %v", configString)
 
 	registry := prometheus.NewRegistry()
-	metrics := proxy_metrics.NewMetrics(registry, "default")
+	metrics := proxy_metrics.NewMetrics(registry)
 
 	ctx, ctxCancel := context.WithCancel(cliCtx.Context)
 	defer ctxCancel()

--- a/api/proxy/cmd/server/entrypoint.go
+++ b/api/proxy/cmd/server/entrypoint.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Layr-Labs/eigenda/api/proxy/store/builder"
 	"github.com/Layr-Labs/eigenda/api/proxy/store/generated_key/memstore/memconfig"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
@@ -44,7 +45,8 @@ func StartProxySvr(cliCtx *cli.Context) error {
 
 	log.Infof("Initializing EigenDA proxy server with config (\"*****\" fields are hidden): %v", configString)
 
-	metrics := proxy_metrics.NewMetrics("default")
+	registry := prometheus.NewRegistry()
+	metrics := proxy_metrics.NewMetrics(registry, "default")
 
 	ctx, ctxCancel := context.WithCancel(cliCtx.Context)
 	defer ctxCancel()
@@ -55,6 +57,7 @@ func StartProxySvr(cliCtx *cli.Context) error {
 		metrics,
 		cfg.StoreBuilderConfig,
 		cfg.SecretConfig,
+		registry,
 	)
 	if err != nil {
 		return fmt.Errorf("build storage manager: %w", err)

--- a/api/proxy/cmd/server/main.go
+++ b/api/proxy/cmd/server/main.go
@@ -38,7 +38,7 @@ func main() {
 	app.Commands = []*cli.Command{
 		{
 			Name:        "doc",
-			Subcommands: doc.NewSubcommands(metrics.NewMetrics("default")),
+			Subcommands: doc.NewSubcommands(metrics.NewMetrics(nil, "default")),
 		},
 	}
 

--- a/api/proxy/cmd/server/main.go
+++ b/api/proxy/cmd/server/main.go
@@ -38,7 +38,7 @@ func main() {
 	app.Commands = []*cli.Command{
 		{
 			Name:        "doc",
-			Subcommands: doc.NewSubcommands(metrics.NewMetrics(nil, "default")),
+			Subcommands: doc.NewSubcommands(metrics.NewMetrics(nil)),
 		},
 	}
 

--- a/api/proxy/metrics/metrics.go
+++ b/api/proxy/metrics/metrics.go
@@ -44,9 +44,9 @@ type Metrics struct {
 
 var _ Metricer = (*Metrics)(nil)
 
-func NewMetrics(registry *prometheus.Registry) *Metrics {
+func NewMetrics(registry *prometheus.Registry) Metricer {
 	if registry == nil {
-		return nil
+		return NoopMetrics
 	}
 
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))

--- a/api/proxy/metrics/metrics.go
+++ b/api/proxy/metrics/metrics.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	namespace           = "eigenda_proxy"
+	subsystem           = "default"
 	httpServerSubsystem = "http_server"
 	secondarySubsystem  = "secondary"
 )
@@ -57,12 +58,9 @@ type Metrics struct {
 
 var _ Metricer = (*Metrics)(nil)
 
-func NewMetrics(registry *prometheus.Registry, subsystem string) *Metrics {
+func NewMetrics(registry *prometheus.Registry) *Metrics {
 	if registry == nil {
 		return nil
-	}
-	if subsystem == "" {
-		subsystem = "default"
 	}
 
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))

--- a/api/proxy/metrics/metrics.go
+++ b/api/proxy/metrics/metrics.go
@@ -57,12 +57,14 @@ type Metrics struct {
 
 var _ Metricer = (*Metrics)(nil)
 
-func NewMetrics(subsystem string) *Metrics {
+func NewMetrics(registry *prometheus.Registry, subsystem string) *Metrics {
+	if registry == nil {
+		return nil
+	}
 	if subsystem == "" {
 		subsystem = "default"
 	}
 
-	registry := prometheus.NewRegistry()
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(collectors.NewGoCollector())
 	factory := metrics.With(registry)

--- a/api/proxy/metrics/metrics.go
+++ b/api/proxy/metrics/metrics.go
@@ -1,16 +1,9 @@
 package metrics
 
 import (
-	"fmt"
-	"net"
-	"strconv"
-
-	ophttp "github.com/ethereum-optimism/optimism/op-service/httputil"
-
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -19,13 +12,6 @@ const (
 	httpServerSubsystem = "http_server"
 	secondarySubsystem  = "secondary"
 )
-
-// Config ... Metrics server configuration
-type Config struct {
-	Host    string
-	Port    int
-	Enabled bool
-}
 
 // Metricer ... Interface for metrics
 type Metricer interface {
@@ -165,23 +151,6 @@ func (m *Metrics) RecordSecondaryRequest(bt string, method string) func(status s
 		m.SecondaryRequestsTotal.WithLabelValues(bt, method, status).Inc()
 		timer.ObserveDuration()
 	}
-}
-
-// StartServer starts the metrics server on the given hostname and port.
-// If port is 0, it automatically assigns an available port and returns the actual port.
-func (m *Metrics) StartServer(hostname string, port int) (*ophttp.HTTPServer, error) {
-	address := net.JoinHostPort(hostname, strconv.Itoa(port))
-
-	h := promhttp.InstrumentMetricHandler(
-		m.registry, promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}),
-	)
-
-	server, err := ophttp.StartHTTPServer(address, h)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start HTTP server: %w", err)
-	}
-
-	return server, nil
 }
 
 func (m *Metrics) Document() []metrics.DocumentedMetric {

--- a/api/proxy/metrics/server.go
+++ b/api/proxy/metrics/server.go
@@ -1,0 +1,27 @@
+package metrics
+
+import (
+	"net"
+	"strconv"
+
+	ophttp "github.com/ethereum-optimism/optimism/op-service/httputil"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Config ... Metrics server configuration
+type Config struct {
+	Host    string
+	Port    int
+	Enabled bool
+}
+
+func NewServer(registry *prometheus.Registry, cfg Config) *ophttp.HTTPServer {
+	address := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+
+	h := promhttp.InstrumentMetricHandler(
+		registry, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+	)
+
+	return ophttp.NewHTTPServer(address, h)
+}

--- a/api/proxy/server/routing_test.go
+++ b/api/proxy/server/routing_test.go
@@ -23,7 +23,7 @@ func TestRouting(t *testing.T) {
 	defer ctrl.Finish()
 	mockRouter := mocks.NewMockIManager(ctrl)
 
-	m := metrics.NewMetrics(prometheus.NewRegistry(), "default")
+	m := metrics.NewMetrics(prometheus.NewRegistry())
 	server := NewServer(testCfg, mockRouter, testLogger, m)
 	r := mux.NewRouter()
 	err := server.Start(r)

--- a/api/proxy/server/routing_test.go
+++ b/api/proxy/server/routing_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Layr-Labs/eigenda/api/proxy/metrics"
 	"github.com/Layr-Labs/eigenda/api/proxy/test/mocks"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -22,7 +23,7 @@ func TestRouting(t *testing.T) {
 	defer ctrl.Finish()
 	mockRouter := mocks.NewMockIManager(ctrl)
 
-	m := metrics.NewMetrics("default")
+	m := metrics.NewMetrics(prometheus.NewRegistry(), "default")
 	server := NewServer(testCfg, mockRouter, testLogger, m)
 	r := mux.NewRouter()
 	err := server.Start(r)

--- a/api/proxy/test/testutils/test_suite.go
+++ b/api/proxy/test/testutils/test_suite.go
@@ -72,6 +72,7 @@ func CreateTestSuite(
 		metrics,
 		appConfig.StoreBuilderConfig,
 		appConfig.SecretConfig,
+		nil,
 	)
 	if err != nil {
 		panic(fmt.Sprintf("build storage manager: %v", err.Error()))

--- a/test/v2/client/proxy_wrapper.go
+++ b/test/v2/client/proxy_wrapper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/api/proxy/store/builder"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ProxyWrapper starts an instance of the proxy in background goroutines, and then facilitates communication with it.
@@ -34,7 +35,8 @@ func NewProxyWrapper(
 		return nil, fmt.Errorf("check proxy config: %w", err)
 	}
 
-	proxyMetrics := proxymetrics.NewMetrics("default")
+	registry := prometheus.NewRegistry()
+	proxyMetrics := proxymetrics.NewMetrics(registry, "default")
 
 	storeManager, err := builder.BuildStoreManager(
 		ctx,
@@ -42,6 +44,7 @@ func NewProxyWrapper(
 		proxyMetrics,
 		proxyConfig.StoreBuilderConfig,
 		proxyConfig.SecretConfig,
+		registry,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build store manager: %w", err)

--- a/test/v2/client/proxy_wrapper.go
+++ b/test/v2/client/proxy_wrapper.go
@@ -36,7 +36,7 @@ func NewProxyWrapper(
 	}
 
 	registry := prometheus.NewRegistry()
-	proxyMetrics := proxymetrics.NewMetrics(registry, "default")
+	proxyMetrics := proxymetrics.NewMetrics(registry)
 
 	storeManager, err := builder.BuildStoreManager(
 		ctx,


### PR DESCRIPTION
Closes DAINT-680

Refactors the proxy metrics constructor:
* Removes the internal call to `prometheus.NewRegistry()`
* Adds `registry` argument

Passes the `prometheus.Registry` created in `StartProxySvr` down to `NewPayloadDisperser` in order to create a `StageTimer`

## Why are these changes needed?

The disperser probe is not currently exposed to the proxy as the registry required to construct the `StageTimer` is set to `nil`.

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [x] Local e2e tests

