### PR TITLE
Secure pprof: bind to localhost by default, add timeouts, make host configurable

### DIFF
--- a/common/pprof/server.go
+++ b/common/pprof/server.go
@@ -3,8 +3,9 @@ package pprof
 import (
 	"fmt"
 	"net/http"
-
-	_ "net/http/pprof"
+	pprofhttp "net/http/pprof"
+	"os"
+	"time"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 )
@@ -23,9 +24,27 @@ func NewPprofProfiler(httpPort string, logger logging.Logger) *PprofProfiler {
 
 // Start the pprof server
 func (p *PprofProfiler) Start() {
-	pprofAddr := fmt.Sprintf("%s:%s", "0.0.0.0", p.httpPort)
+	host := os.Getenv("EIGENDA_PPROF_HOST")
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	addr := fmt.Sprintf("%s:%s", host, p.httpPort)
 
-	if err := http.ListenAndServe(pprofAddr, nil); err != nil {
-		p.logger.Error("pprof server failed", "error", err, "pprofAddr", pprofAddr)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprofhttp.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprofhttp.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprofhttp.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprofhttp.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprofhttp.Trace)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		p.logger.Error("pprof server failed", "error", err, "pprofAddr", addr)
 	}
 }


### PR DESCRIPTION

- **What**
  - Bind `pprof` to `127.0.0.1` by default in `common/pprof/server.go`.
  - Use explicit `ServeMux` for `pprof` handlers.
  - Add `http.Server` timeouts (`ReadHeaderTimeout`, `IdleTimeout`).
  - Make host configurable via `EIGENDA_PPROF_HOST`.

- **Why**
  - Prevent accidental exposure of `/debug/pprof/*` on public interfaces (info leak / DoS).
  - Defense-in-depth with minimal surface change.

