### PR TITLE
chore(proxy): configure with eigendadirectory exclusively

### DIFF
--- a/api/proxy/common/client_config_v2.go
+++ b/api/proxy/common/client_config_v2.go
@@ -34,10 +34,8 @@ type ClientConfigV2 struct {
 	// RetrieversToEnable specifies which retrievers should be enabled
 	RetrieversToEnable []RetrieverType
 
-	// Fields required for validator payload retrieval
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
-	EigenDADirectory              string
+	// EigenDADirectory address is used to get addresses for all EigenDA contracts needed.
+	EigenDADirectory string
 
 	// Allowed distance (in L1 blocks) between the eigenDA cert's reference block number (RBN)
 	// and the L1 block number at which the cert was included in the rollup's batch inbox.
@@ -80,16 +78,6 @@ func (cfg *ClientConfigV2) Check() error {
 	if slices.Contains(cfg.RetrieversToEnable, ValidatorRetrieverType) {
 		if cfg.EigenDADirectory == "" {
 			return fmt.Errorf("EigenDA directory is required for validator retrieval in EigenDA V2 backend")
-		}
-
-		if cfg.BLSOperatorStateRetrieverAddr == "" {
-			return fmt.Errorf(
-				"BLS operator state retriever address is required for validator retrieval in EigenDA V2 backend")
-		}
-
-		if cfg.EigenDAServiceManagerAddr == "" {
-			return fmt.Errorf(
-				"EigenDA service manager address is required for validator retrieval in EigenDA V2 backend")
 		}
 	}
 

--- a/api/proxy/common/eigenda_network.go
+++ b/api/proxy/common/eigenda_network.go
@@ -18,79 +18,40 @@ const (
 
 // GetEigenDADirectory returns, as a string, the address of the EigenDADirectory contract for the network.
 // For more information about networks and contract addresses, see https://docs.eigenlayer.xyz/eigenda/networks/
-func (n EigenDANetwork) GetEigenDADirectory() (string, error) {
+func (n EigenDANetwork) GetEigenDADirectory() string {
 	// TODO: These hardcoded addresses should eventually be fetched from the EigenDADirectory contract
 	// to reduce duplication and ensure consistency across the codebase
 	switch n {
 	case MainnetEigenDANetwork:
-		return "0x64AB2e9A86FA2E183CB6f01B2D4050c1c2dFAad4", nil
+		return "0x64AB2e9A86FA2E183CB6f01B2D4050c1c2dFAad4"
 	case HoleskyTestnetEigenDANetwork:
-		return "0x90776Ea0E99E4c38aA1Efe575a61B3E40160A2FE", nil
+		return "0x90776Ea0E99E4c38aA1Efe575a61B3E40160A2FE"
 	case HoleskyPreprodEigenDANetwork:
-		return "0xfB676e909f376efFDbDee7F17342aCF55f6Ec502", nil
+		return "0xfB676e909f376efFDbDee7F17342aCF55f6Ec502"
 	case SepoliaTestnetEigenDANetwork:
-		return "0x9620dC4B3564198554e4D2b06dEFB7A369D90257", nil
+		return "0x9620dC4B3564198554e4D2b06dEFB7A369D90257"
 	default:
-		return "", fmt.Errorf("unknown network type: %s", n)
-	}
-}
-
-// GetServiceManagerAddress returns, as a string, the address of the EigenDAServiceManager contract for the network.
-// For more information about networks and contract addresses, see https://docs.eigenlayer.xyz/eigenda/networks/
-// TODO: these should be fetched from the EigenDADirectory contract instead.
-func (n EigenDANetwork) GetServiceManagerAddress() (string, error) {
-	// TODO: These hardcoded addresses should eventually be fetched from the EigenDADirectory contract
-	// to reduce duplication and ensure consistency across the codebase
-	switch n {
-	case MainnetEigenDANetwork:
-		return "0x870679E138bCdf293b7Ff14dD44b70FC97e12fc0", nil
-	case HoleskyTestnetEigenDANetwork:
-		return "0xD4A7E1Bd8015057293f0D0A557088c286942e84b", nil
-	case HoleskyPreprodEigenDANetwork:
-		return "0x54A03db2784E3D0aCC08344D05385d0b62d4F432", nil
-	case SepoliaTestnetEigenDANetwork:
-		return "0x3a5acf46ba6890B8536420F4900AC9BC45Df4764", nil
-	default:
-		return "", fmt.Errorf("unknown network type: %s", n)
+		panic(fmt.Sprintf("unknown EigenDA network: %s", n))
 	}
 }
 
 // GetDisperserAddress gets a string representing the address of the disperser for the network.
 // The format of the returned address is "<hostname>:<port>"
 // For more information about networks and disperser endpoints, see https://docs.eigenlayer.xyz/eigenda/networks/
-func (n EigenDANetwork) GetDisperserAddress() (string, error) {
+func (n EigenDANetwork) GetDisperserAddress() string {
 	// TODO: These hardcoded addresses should eventually be fetched from the EigenDADirectory contract
 	// to reduce duplication and ensure consistency across the codebase
 	switch n {
 	case MainnetEigenDANetwork:
-		return "disperser.eigenda.xyz:443", nil
+		return "disperser.eigenda.xyz:443"
 	case HoleskyTestnetEigenDANetwork:
-		return "disperser-testnet-holesky.eigenda.xyz:443", nil
+		return "disperser-testnet-holesky.eigenda.xyz:443"
 	case HoleskyPreprodEigenDANetwork:
-		return "disperser-preprod-holesky.eigenda.xyz:443", nil
+		return "disperser-preprod-holesky.eigenda.xyz:443"
 	case SepoliaTestnetEigenDANetwork:
-		return "disperser-testnet-sepolia.eigenda.xyz:443", nil
+		return "disperser-testnet-sepolia.eigenda.xyz:443"
 	default:
-		return "", fmt.Errorf("unknown network type: %s", n)
-	}
-}
-
-// GetBLSOperatorStateRetrieverAddress returns, as a string, the address of the OperatorStateRetriever contract for the
-// network
-// For more information about networks and contract addresses, see https://docs.eigenlayer.xyz/eigenda/networks/
-// TODO: these should be fetched from the EigenDADirectory contract instead.
-func (n EigenDANetwork) GetBLSOperatorStateRetrieverAddress() (string, error) {
-	// TODO: These hardcoded addresses should eventually be fetched from the EigenDADirectory contract
-	// to reduce duplication and ensure consistency across the codebase
-	switch n {
-	case MainnetEigenDANetwork:
-		return "0xEC35aa6521d23479318104E10B4aA216DBBE63Ce", nil
-	case HoleskyTestnetEigenDANetwork, HoleskyPreprodEigenDANetwork:
-		return "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7", nil
-	case SepoliaTestnetEigenDANetwork:
-		return "0x22478d082E9edaDc2baE8443E4aC9473F6E047Ff", nil
-	default:
-		return "", fmt.Errorf("unknown network: %s", n)
+		panic(fmt.Sprintf("unknown EigenDA network: %s", n))
 	}
 }
 

--- a/api/proxy/config/flags.go
+++ b/api/proxy/config/flags.go
@@ -50,6 +50,7 @@ func init() {
 	Flags = append(Flags, verify.KZGCLIFlags(GlobalEnvVarPrefix, KZGCategory)...)
 
 	Flags = append(Flags, eigendaflags.DeprecatedCLIFlags(GlobalEnvVarPrefix, EigenDAClientCategory)...)
+	Flags = append(Flags, eigenda_v2_flags.DeprecatedCLIFlags(GlobalEnvVarPrefix, EigenDAV2ClientCategory)...)
 	Flags = append(Flags, verify.DeprecatedCLIFlags(GlobalEnvVarPrefix, VerifierCategory)...)
 	Flags = append(Flags, store.DeprecatedCLIFlags(GlobalEnvVarPrefix, StorageFlagsCategory)...)
 }

--- a/api/proxy/config/v2/eigendaflags/deprecated.go
+++ b/api/proxy/config/v2/eigendaflags/deprecated.go
@@ -1,0 +1,45 @@
+package eigendaflags
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	deprecatedServiceManagerAddrFlagName        = withFlagPrefix("service-manager-addr")
+	deprecatedBLSOperatorStateRetrieverFlagName = withFlagPrefix("bls-operator-state-retriever-addr")
+)
+
+func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     deprecatedServiceManagerAddrFlagName,
+			Usage:    "[Deprecated: use EigenDADirectory instead] Address of the EigenDA Service Manager contract.",
+			EnvVars:  []string{withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR")},
+			Category: category,
+			Required: false,
+			Hidden:   true,
+			Action: func(c *cli.Context, s string) error {
+				return fmt.Errorf("--%s is deprecated. Contract addresses shall now be read from the "+
+					"EigenDA Directory contract (via the --%s flag) instead. "+
+					"See https://docs.eigencloud.xyz/products/eigenda/networks/mainnet#contract-addresses for more details",
+					s, EigenDADirectoryFlagName)
+			},
+		},
+		&cli.StringFlag{
+			Name:     deprecatedBLSOperatorStateRetrieverFlagName,
+			Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state retriever contract.",
+			EnvVars:  []string{withEnvPrefix(envPrefix, "BLS_OPERATOR_STATE_RETRIEVER_ADDR")},
+			Category: category,
+			Required: false,
+			Hidden:   true,
+			Action: func(c *cli.Context, s string) error {
+				return fmt.Errorf("--%s is deprecated. Contract addresses shall now be read from the "+
+					"EigenDA Directory contract (via the --%s flag) instead. "+
+					"See https://docs.eigencloud.xyz/products/eigenda/networks/mainnet#contract-addresses for more details",
+					s, EigenDADirectoryFlagName)
+			},
+		},
+	}
+}

--- a/api/proxy/config/v2/eigendaflags/deprecated.go
+++ b/api/proxy/config/v2/eigendaflags/deprecated.go
@@ -20,11 +20,11 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Category: category,
 			Required: false,
 			Hidden:   true,
-			Action: func(c *cli.Context, s string) error {
+			Action: func(c *cli.Context, _ string) error {
 				return fmt.Errorf("--%s is deprecated. Contract addresses shall now be read from the "+
 					"EigenDA Directory contract (via the --%s flag) instead. "+
 					"See https://docs.eigencloud.xyz/products/eigenda/networks/mainnet#contract-addresses for more details",
-					s, EigenDADirectoryFlagName)
+					deprecatedServiceManagerAddrFlagName, EigenDADirectoryFlagName)
 			},
 		},
 		&cli.StringFlag{
@@ -34,11 +34,11 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Category: category,
 			Required: false,
 			Hidden:   true,
-			Action: func(c *cli.Context, s string) error {
+			Action: func(c *cli.Context, _ string) error {
 				return fmt.Errorf("--%s is deprecated. Contract addresses shall now be read from the "+
 					"EigenDA Directory contract (via the --%s flag) instead. "+
 					"See https://docs.eigencloud.xyz/products/eigenda/networks/mainnet#contract-addresses for more details",
-					s, EigenDADirectoryFlagName)
+					deprecatedBLSOperatorStateRetrieverFlagName, EigenDADirectoryFlagName)
 			},
 		},
 	}

--- a/api/proxy/docs/help_out.txt
+++ b/api/proxy/docs/help_out.txt
@@ -53,7 +53,6 @@ GLOBAL OPTIONS:
    --eigenda.v2.blob-status-poll-interval value  Duration to query for blob status updates during dispersal. (default: 1s) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_STATUS_POLL_INTERVAL]
    --eigenda.v2.blob-version value               Blob params version used when dispersing. This refers to a global version maintained by EigenDA
 governance and is injected in the BlobHeader before dispersing. Currently only supports (0). (default: 0) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION]
-   --eigenda.v2.bls-operator-state-retriever-addr value                [Deprecated: use EigenDADirectory instead] Address of the BLS operator state retriever contract. [$EIGENDA_PROXY_EIGENDA_V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR]
    --eigenda.v2.cert-verifier-router-or-immutable-verifier-addr value  Address of either the EigenDACertVerifierRouter or immutable EigenDACertVerifier (V3 or above) contract. Required for performing eth_calls to verify EigenDA certificates, as well as fetching required_quorums and signature_thresholds needed when creating new EigenDA certificates during dispersals (POST routes). [$EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ROUTER_OR_IMMUTABLE_VERIFIER_ADDR]
    --eigenda.v2.contract-call-timeout value                            Timeout used when performing smart contract call operation (i.e, eth_call). (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_CONTRACT_CALL_TIMEOUT]
    --eigenda.v2.disable-point-evaluation                               Disables IFFT transformation done during payload encoding. Using this mode results in blobs that can't be proven. (default: false) [$EIGENDA_PROXY_EIGENDA_V2_DISABLE_POINT_EVALUATION]
@@ -78,7 +77,6 @@ in the rollup's batch inbox. A cert is valid when cert.RBN < certL1InclusionBloc
 and otherwise is considered stale and verification will fail, and a 418 HTTP error will be returned.
 This check is optional and will be skipped when set to 0. (default: 0) [$EIGENDA_PROXY_EIGENDA_V2_RBN_RECENCY_WINDOW_SIZE]
    --eigenda.v2.relay-timeout value           Timeout used when querying an individual relay for blob contents. (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT]
-   --eigenda.v2.service-manager-addr value    [Deprecated: use EigenDADirectory instead] Address of the EigenDA Service Manager contract. [$EIGENDA_PROXY_EIGENDA_V2_SERVICE_MANAGER_ADDR]
    --eigenda.v2.signer-payment-key-hex value  Hex-encoded signer private key. Used for authorizing payments with EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX]
    --eigenda.v2.validator-timeout value       Timeout used when retrieving chunks directly from EigenDA validators. This is a secondary retrieval method, in case retrieval from the relay network fails. (default: 2m0s) [$EIGENDA_PROXY_EIGENDA_V2_VALIDATOR_TIMEOUT]
 

--- a/api/proxy/store/builder/config_test.go
+++ b/api/proxy/store/builder/config_test.go
@@ -68,8 +68,6 @@ func validCfg() Config {
 			},
 			EigenDACertVerifierOrRouterAddress: "0x0000000000032443134",
 			MaxBlobSizeBytes:                   maxBlobLengthBytes,
-			BLSOperatorStateRetrieverAddr:      "0x000000000004324311",
-			EigenDAServiceManagerAddr:          "0x000000000005324322",
 			EigenDADirectory:                   "0x000000000006324333",
 			RetrieversToEnable: []common.RetrieverType{
 				common.RelayRetrieverType,

--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -35,6 +35,7 @@ import (
 
 	auth "github.com/Layr-Labs/eigenda/core/auth/v2"
 	"github.com/Layr-Labs/eigenda/core/eth"
+	"github.com/Layr-Labs/eigenda/core/eth/directory"
 	core_v2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/encoding/kzg/prover"
 	kzgverifier "github.com/Layr-Labs/eigenda/encoding/kzg/verifier"
@@ -275,11 +276,6 @@ func buildEigenDAV2Backend(
 			return nil, fmt.Errorf("build router address provider: %w", err)
 		}
 	}
-
-	ethReader, err := buildEthReader(log, config.ClientConfigV2, ethClient)
-	if err != nil {
-		return nil, fmt.Errorf("build eth reader: %w", err)
-	}
 	certVerifier, err := verification.NewCertVerifier(
 		log,
 		ethClient,
@@ -288,6 +284,7 @@ func buildEigenDAV2Backend(
 	if err != nil {
 		return nil, fmt.Errorf("new cert verifier: %w", err)
 	}
+
 	if !isRouter {
 		// We call GetCertVersion to ensure that the cert verifier is of a supported version. See
 		// https://github.com/Layr-Labs/eigenda/blob/d0a14fa44/contracts/src/integrations/cert/interfaces/IVersionedEigenDACertVerifier.sol#L12
@@ -311,13 +308,28 @@ func buildEigenDAV2Backend(
 		}
 	}
 
+	var eigenDAServiceManagerAddr, blsOperatorStateRetrieverAddr geth_common.Address
+	contractDirectory, err := directory.NewContractDirectory(ctx, log, ethClient,
+		geth_common.HexToAddress(config.ClientConfigV2.EigenDADirectory))
+	if err != nil {
+		return nil, fmt.Errorf("new contract directory: %w", err)
+	}
+	eigenDAServiceManagerAddr, err = contractDirectory.GetContractAddress(ctx, directory.ServiceManager)
+	if err != nil {
+		return nil, fmt.Errorf("get eigenDAServiceManagerAddr: %w", err)
+	}
+	blsOperatorStateRetrieverAddr, err = contractDirectory.GetContractAddress(ctx, directory.BLSOperatorStateRetriever)
+	if err != nil {
+		return nil, fmt.Errorf("get blsOperatorStateRetrieverAddr: %w", err)
+	}
+
 	var retrievers []clients_v2.PayloadRetriever
 	for _, retrieverType := range config.ClientConfigV2.RetrieversToEnable {
 		switch retrieverType {
 		case common.RelayRetrieverType:
 			log.Info("Initializing relay payload retriever")
 			relayPayloadRetriever, err := buildRelayPayloadRetriever(
-				log, config.ClientConfigV2, ethClient, kzgProver.Srs.G1, ethReader.GetRelayRegistryAddress())
+				ctx, log, config.ClientConfigV2, ethClient, kzgProver.Srs.G1, geth_common.HexToAddress(config.ClientConfigV2.EigenDADirectory))
 			if err != nil {
 				return nil, fmt.Errorf("build relay payload retriever: %w", err)
 			}
@@ -325,7 +337,9 @@ func buildEigenDAV2Backend(
 		case common.ValidatorRetrieverType:
 			log.Info("Initializing validator payload retriever")
 			validatorPayloadRetriever, err := buildValidatorPayloadRetriever(
-				log, config.ClientConfigV2, ethClient, ethReader, kzgVerifier, kzgProver.Srs.G1)
+				log, config.ClientConfigV2, ethClient,
+				blsOperatorStateRetrieverAddr, eigenDAServiceManagerAddr,
+				kzgVerifier, kzgProver.Srs.G1)
 			if err != nil {
 				return nil, fmt.Errorf("build validator payload retriever: %w", err)
 			}
@@ -348,7 +362,8 @@ func buildEigenDAV2Backend(
 		ethClient,
 		kzgProver,
 		certVerifier,
-		ethReader,
+		blsOperatorStateRetrieverAddr,
+		eigenDAServiceManagerAddr,
 		registry,
 	)
 	if err != nil {
@@ -457,13 +472,22 @@ func buildEthClient(ctx context.Context, log logging.Logger, secretConfigV2 comm
 }
 
 func buildRelayPayloadRetriever(
+	ctx context.Context,
 	log logging.Logger,
 	clientConfigV2 common.ClientConfigV2,
 	ethClient common_eigenda.EthClient,
 	g1Srs []bn254.G1Affine,
-	relayRegistryAddress geth_common.Address,
+	eigenDADirectoryAddr geth_common.Address,
 ) (*payloadretrieval.RelayPayloadRetriever, error) {
-	relayClient, err := buildRelayClient(log, clientConfigV2, ethClient, relayRegistryAddress)
+	contractDirectory, err := directory.NewContractDirectory(ctx, log, ethClient, eigenDADirectoryAddr)
+	if err != nil {
+		return nil, fmt.Errorf("new contract directory: %w", err)
+	}
+	relayRegistryAddr, err := contractDirectory.GetContractAddress(ctx, directory.RelayRegistry)
+	if err != nil {
+		return nil, fmt.Errorf("get relay registry address: %w", err)
+	}
+	relayClient, err := buildRelayClient(log, clientConfigV2, ethClient, relayRegistryAddr)
 	if err != nil {
 		return nil, fmt.Errorf("build relay client: %w", err)
 	}
@@ -514,10 +538,20 @@ func buildValidatorPayloadRetriever(
 	log logging.Logger,
 	clientConfigV2 common.ClientConfigV2,
 	ethClient common_eigenda.EthClient,
-	ethReader *eth.Reader,
+	blsOperatorStateRetrieverAddr geth_common.Address,
+	eigenDAServiceManagerAddr geth_common.Address,
 	kzgVerifier *kzgverifier.Verifier,
 	g1Srs []bn254.G1Affine,
 ) (*payloadretrieval.ValidatorPayloadRetriever, error) {
+	ethReader, err := eth.NewReader(
+		log,
+		ethClient,
+		blsOperatorStateRetrieverAddr.String(),
+		eigenDAServiceManagerAddr.String(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new reader: %w", err)
+	}
 	chainState := eth.NewChainState(ethReader, ethClient)
 
 	retrievalClient := client_validator.NewValidatorClient(
@@ -543,23 +577,6 @@ func buildValidatorPayloadRetriever(
 	return validatorRetriever, nil
 }
 
-func buildEthReader(log logging.Logger,
-	clientConfigV2 common.ClientConfigV2,
-	ethClient common_eigenda.EthClient,
-) (*eth.Reader, error) {
-	ethReader, err := eth.NewReader(
-		log,
-		ethClient,
-		clientConfigV2.BLSOperatorStateRetrieverAddr,
-		clientConfigV2.EigenDAServiceManagerAddr,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("new reader: %w", err)
-	}
-
-	return ethReader, nil
-}
-
 func buildPayloadDisperser(
 	ctx context.Context,
 	log logging.Logger,
@@ -568,7 +585,8 @@ func buildPayloadDisperser(
 	ethClient common_eigenda.EthClient,
 	kzgProver *prover.Prover,
 	certVerifier *verification.CertVerifier,
-	ethReader *eth.Reader,
+	blsOperatorStateRetrieverAddr geth_common.Address,
+	registryCoordinatorAddr geth_common.Address,
 	registry *prometheus.Registry,
 ) (*payloaddispersal.PayloadDisperser, error) {
 	signer, err := buildLocalSigner(ctx, log, secrets, ethClient)
@@ -606,12 +624,7 @@ func buildPayloadDisperser(
 	}
 
 	certBuilder, err := clients_v2.NewCertBuilder(
-		log,
-		geth_common.HexToAddress(clientConfigV2.BLSOperatorStateRetrieverAddr),
-		ethReader.GetRegistryCoordinatorAddress(),
-		ethClient,
-	)
-
+		log, blsOperatorStateRetrieverAddr, registryCoordinatorAddr, ethClient)
 	if err != nil {
 		return nil, fmt.Errorf("new cert builder: %w", err)
 	}

--- a/api/proxy/test/testutils/setup.go
+++ b/api/proxy/test/testutils/setup.go
@@ -42,23 +42,17 @@ const (
 	host             = "127.0.0.1"
 	disperserPort    = "443"
 
-	disperserPreprodHostname                = "disperser-preprod-holesky.eigenda.xyz"
-	preprodCertVerifierAddress              = "0xCCFE3d87fB7D369f1eeE65221a29A83f1323043C"
-	preprodSvcManagerAddress                = "0x54A03db2784E3D0aCC08344D05385d0b62d4F432"
-	preprodBLSOperatorStateRetrieverAddress = "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7"
-	preprodEigenDADirectory                 = "0xfB676e909f376efFDbDee7F17342aCF55f6Ec502"
+	disperserPreprodHostname   = "disperser-preprod-holesky.eigenda.xyz"
+	preprodCertVerifierAddress = "0xCCFE3d87fB7D369f1eeE65221a29A83f1323043C"
+	preprodEigenDADirectory    = "0xfB676e909f376efFDbDee7F17342aCF55f6Ec502"
 
-	disperserTestnetHostname                = "disperser-testnet-holesky.eigenda.xyz"
-	testnetCertVerifierAddress              = "0xd305aeBcdEc21D00fDF8796CE37d0e74836a6B6e"
-	testnetSvcManagerAddress                = "0xD4A7E1Bd8015057293f0D0A557088c286942e84b"
-	testnetBLSOperatorStateRetrieverAddress = "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7"
-	testnetEigenDADirectory                 = "0x90776Ea0E99E4c38aA1Efe575a61B3E40160A2FE"
+	disperserTestnetHostname   = "disperser-testnet-holesky.eigenda.xyz"
+	testnetCertVerifierAddress = "0xd305aeBcdEc21D00fDF8796CE37d0e74836a6B6e"
+	testnetEigenDADirectory    = "0x90776Ea0E99E4c38aA1Efe575a61B3E40160A2FE"
 
-	disperserSepoliaHostname                = "disperser-testnet-sepolia.eigenda.xyz"
-	sepoliaCertVerifierAddress              = "0x58D2B844a894f00b7E6F9F492b9F43aD54Cd4429"
-	sepoliaSvcManagerAddress                = "0x3a5acf46ba6890B8536420F4900AC9BC45Df4764"
-	sepoliaBLSOperatorStateRetrieverAddress = "0x22478d082E9edaDc2baE8443E4aC9473F6E047Ff"
-	sepoliaEigenDADirectory                 = "0x9620dC4B3564198554e4D2b06dEFB7A369D90257"
+	disperserSepoliaHostname   = "disperser-testnet-sepolia.eigenda.xyz"
+	sepoliaCertVerifierAddress = "0x58D2B844a894f00b7E6F9F492b9F43aD54Cd4429"
+	sepoliaEigenDADirectory    = "0x9620dC4B3564198554e4D2b06dEFB7A369D90257"
 )
 
 var (
@@ -266,7 +260,6 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 	var disperserHostname string
 	var certVerifierAddress string
 	var svcManagerAddress string
-	var blsOperatorStateRetrieverAddress string
 	var eigenDADirectory string
 	switch testCfg.Backend {
 	case MemstoreBackend:
@@ -274,20 +267,14 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 	case PreprodBackend:
 		disperserHostname = disperserPreprodHostname
 		certVerifierAddress = preprodCertVerifierAddress
-		svcManagerAddress = preprodSvcManagerAddress
-		blsOperatorStateRetrieverAddress = preprodBLSOperatorStateRetrieverAddress
 		eigenDADirectory = preprodEigenDADirectory
 	case TestnetBackend:
 		disperserHostname = disperserTestnetHostname
 		certVerifierAddress = testnetCertVerifierAddress
-		svcManagerAddress = testnetSvcManagerAddress
-		blsOperatorStateRetrieverAddress = testnetBLSOperatorStateRetrieverAddress
 		eigenDADirectory = testnetEigenDADirectory
 	case SepoliaBackend:
 		disperserHostname = disperserSepoliaHostname
 		certVerifierAddress = sepoliaCertVerifierAddress
-		svcManagerAddress = sepoliaSvcManagerAddress
-		blsOperatorStateRetrieverAddress = sepoliaBLSOperatorStateRetrieverAddress
 		eigenDADirectory = sepoliaEigenDADirectory
 	default:
 		panic("Unsupported backend")
@@ -360,8 +347,6 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 			PutTries:                           3,
 			MaxBlobSizeBytes:                   maxBlobLengthBytes,
 			EigenDACertVerifierOrRouterAddress: certVerifierAddress,
-			BLSOperatorStateRetrieverAddr:      blsOperatorStateRetrieverAddress,
-			EigenDAServiceManagerAddr:          svcManagerAddress,
 			EigenDADirectory:                   eigenDADirectory,
 			RetrieversToEnable:                 testCfg.Retrievers,
 		},

--- a/core/chainio.go
+++ b/core/chainio.go
@@ -121,9 +121,6 @@ type Reader interface {
 	// GetNumBlobVersions returns the number of blob versions.
 	GetNumBlobVersions(ctx context.Context) (uint16, error)
 
-	// GetVersionedBlobParams returns the blob version parameters for the given block number and blob version.
-	GetVersionedBlobParams(ctx context.Context, blobVersion uint16) (*BlobVersionParameters, error)
-
 	// GetAllVersionedBlobParams returns the blob version parameters for all blob versions at the given block number.
 	GetAllVersionedBlobParams(ctx context.Context) (map[uint16]*BlobVersionParameters, error)
 

--- a/core/eth/directory/contract_directory.go
+++ b/core/eth/directory/contract_directory.go
@@ -93,7 +93,7 @@ func (d *ContractDirectory) GetContractAddress(
 
 	address, err := d.caller.GetAddress0(&bind.CallOpts{Context: ctx}, (string)(contractName))
 	if err != nil {
-		return gethcommon.Address{}, fmt.Errorf("GetAddress0: %w", err)
+		return gethcommon.Address{}, fmt.Errorf("eth-call: EigenDADirectory.GetAddress0: %w", err)
 	}
 
 	if address == (gethcommon.Address{}) {

--- a/core/eth/directory/contract_names.go
+++ b/core/eth/directory/contract_names.go
@@ -4,12 +4,16 @@ package directory
 // It is ok to remove contracts from this list if the offchain code doesn't interact with them anymore.
 
 const (
-	ServiceManager         ContractName = "SERVICE_MANAGER"
-	EigenDAEjectionManager ContractName = "EIGEN_DA_EJECTION_MANAGER"
+	ServiceManager            ContractName = "SERVICE_MANAGER"
+	BLSOperatorStateRetriever ContractName = "OPERATOR_STATE_RETRIEVER"
+	EigenDAEjectionManager    ContractName = "EIGEN_DA_EJECTION_MANAGER"
+	RelayRegistry             ContractName = "RELAY_REGISTRY"
 )
 
 // a list of all contracts currently known to the EigenDA offchain code.
 var knownContracts = []ContractName{
 	ServiceManager,
+	BLSOperatorStateRetriever,
 	EigenDAEjectionManager,
+	RelayRegistry,
 }

--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -93,6 +93,7 @@ func NewReader(
 // TODO: update to use address directory contract once all contracts are written into the directory
 func (t *Reader) updateContractBindings(blsOperatorStateRetrieverAddr, eigenDAServiceManagerAddr gethcommon.Address) error {
 
+	t.logger.Info("eigendaServiceManagerAddr", "addr", eigenDAServiceManagerAddr.Hex())
 	contractEigenDAServiceManager, err := eigendasrvmg.NewContractEigenDAServiceManager(eigenDAServiceManagerAddr, t.ethClient)
 	if err != nil {
 		t.logger.Error("Failed to fetch IEigenDAServiceManager contract", "err", err)

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -382,8 +382,6 @@ func NewTestClient(
 					PutTries:                           3,
 					MaxBlobSizeBytes:                   16 * units.MiB,
 					EigenDACertVerifierOrRouterAddress: config.EigenDACertVerifierAddressQuorums0_1,
-					BLSOperatorStateRetrieverAddr:      config.BLSOperatorStateRetrieverAddr,
-					EigenDAServiceManagerAddr:          config.EigenDAServiceManagerAddr,
 					EigenDADirectory:                   config.EigenDADirectory,
 					RetrieversToEnable: []proxycommon.RetrieverType{
 						proxycommon.RelayRetrieverType,

--- a/tools/discovery/main.go
+++ b/tools/discovery/main.go
@@ -111,10 +111,7 @@ func discoverAddresses(ctx *cli.Context) error {
 
 	directoryAddr := ctx.String(discoverAddressFlag.Name)
 	if directoryAddr == "" {
-		directoryAddr, err = network.GetEigenDADirectory()
-		if err != nil {
-			return fmt.Errorf("GetEigenDADirectory: %w", err)
-		}
+		directoryAddr = network.GetEigenDADirectory()
 		logger.Printf("No explicit directory address provided, auto-detected EigenDADirectory address %s for network %s", directoryAddr, network)
 	}
 


### PR DESCRIPTION
Closes DAINT-653.

Deprecate blsOperatorRetriever and ServiceManager addr flags. Proxy will crash on startup if those are passed.
Instead we force the EigenDADirectory addr to be passed, and fetch the other contract addresses from it.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
