### PR TITLE
refactor: pass blobkey by value

### DIFF
--- a/api/clients/v2/cert_builder.go
+++ b/api/clients/v2/cert_builder.go
@@ -133,7 +133,6 @@ func (cb *CertBuilder) getNonSignerStakesAndSignature(
 	}
 	checkSigIndices, err := cb.opsrCaller.GetCheckSignaturesIndices(&bind.CallOpts{Context: ctx, BlockNumber: big.NewInt(int64(rbn))},
 		cb.registryCoordinatorAddr, uint32(rbn), quorumNumbers, nonSignerOperatorIDs)
-
 	if err != nil {
 		// We log the call parameters for debugging purposes: input them into tenderly to simulate the call and get more context.
 		cb.logger.Error("eth-call failed",

--- a/api/clients/v2/coretypes/eigenda_cert.go
+++ b/api/clients/v2/coretypes/eigenda_cert.go
@@ -108,7 +108,7 @@ type RetrievableEigenDACert interface {
 	RelayKeys() []coreV2.RelayKey
 	QuorumNumbers() []byte
 	ReferenceBlockNumber() uint64
-	ComputeBlobKey() (*coreV2.BlobKey, error)
+	ComputeBlobKey() (coreV2.BlobKey, error)
 	BlobHeader() (*coreV2.BlobHeaderWithHashedPayment, error)
 	Commitments() (*encoding.BlobCommitments, error)
 	Serialize(ct CertSerializationType) ([]byte, error)
@@ -168,11 +168,11 @@ func (c *EigenDACertV3) ReferenceBlockNumber() uint64 {
 
 // ComputeBlobKey computes the blob key used for looking up the blob against an EigenDA network retrieval
 // entrypoint (e.g, a relay or a validator node)
-func (c *EigenDACertV3) ComputeBlobKey() (*coreV2.BlobKey, error) {
+func (c *EigenDACertV3) ComputeBlobKey() (coreV2.BlobKey, error) {
 	blobHeader := c.BlobInclusionInfo.BlobCertificate.BlobHeader
 	blobCommitments, err := c.Commitments()
 	if err != nil {
-		return nil, fmt.Errorf("blob commitments from protobuf: %w", err)
+		return coreV2.BlobKey{}, fmt.Errorf("blob commitments from protobuf: %w", err)
 	}
 
 	blobKeyBytes, err := coreV2.ComputeBlobKey(
@@ -182,13 +182,13 @@ func (c *EigenDACertV3) ComputeBlobKey() (*coreV2.BlobKey, error) {
 		blobHeader.PaymentHeaderHash,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("compute blob key: %w", err)
+		return coreV2.BlobKey{}, fmt.Errorf("compute blob key: %w", err)
 	}
 	blobKey, err := coreV2.BytesToBlobKey(blobKeyBytes[:])
 	if err != nil {
-		return nil, fmt.Errorf("bytes to blob key: %w", err)
+		return coreV2.BlobKey{}, fmt.Errorf("bytes to blob key: %w", err)
 	}
-	return &blobKey, nil
+	return blobKey, nil
 }
 
 // BlobHeader returns the blob header of the EigenDACertV3
@@ -359,12 +359,12 @@ func (c *EigenDACertV2) Serialize(ct CertSerializationType) ([]byte, error) {
 }
 
 // ComputeBlobKey computes the BlobKey of the blob that belongs to the EigenDACertV2
-func (c *EigenDACertV2) ComputeBlobKey() (*coreV2.BlobKey, error) {
+func (c *EigenDACertV2) ComputeBlobKey() (coreV2.BlobKey, error) {
 	blobHeader := c.BlobInclusionInfo.BlobCertificate.BlobHeader
 
 	blobCommitments, err := BlobCommitmentsBindingToInternal(&blobHeader.Commitment)
 	if err != nil {
-		return nil, fmt.Errorf("blob commitments from protobuf: %w", err)
+		return coreV2.BlobKey{}, fmt.Errorf("blob commitments from protobuf: %w", err)
 	}
 
 	blobKeyBytes, err := coreV2.ComputeBlobKey(
@@ -373,24 +373,23 @@ func (c *EigenDACertV2) ComputeBlobKey() (*coreV2.BlobKey, error) {
 		blobHeader.QuorumNumbers,
 		blobHeader.PaymentHeaderHash,
 	)
-
 	if err != nil {
-		return nil, fmt.Errorf("compute blob key: %w", err)
+		return coreV2.BlobKey{}, fmt.Errorf("compute blob key: %w", err)
 	}
 
 	blobKey, err := coreV2.BytesToBlobKey(blobKeyBytes[:])
 	if err != nil {
-		return nil, fmt.Errorf("bytes to blob key: %w", err)
+		return coreV2.BlobKey{}, fmt.Errorf("bytes to blob key: %w", err)
 	}
 
-	return &blobKey, nil
+	return blobKey, nil
 }
 
 // Version returns the version of the EigenDA certificate
 func (c *EigenDACertV2) isEigenDACert() {}
 
 // ToV3 converts an EigenDACertV2 to an EigenDACertV3
-func (c *EigenDACertV2) ToV3() (*EigenDACertV3, error) {
+func (c *EigenDACertV2) ToV3() *EigenDACertV3 {
 	// Convert BlobInclusionInfo from V2 to V3 format
 	v3BlobInclusionInfo := certTypesBinding.EigenDATypesV2BlobInclusionInfo{
 		BlobCertificate: certTypesBinding.EigenDATypesV2BlobCertificate{
@@ -446,14 +445,12 @@ func (c *EigenDACertV2) ToV3() (*EigenDACertV3, error) {
 	}
 
 	// Create the V3 certificate
-	certV3 := &EigenDACertV3{
+	return &EigenDACertV3{
 		BlobInclusionInfo:           v3BlobInclusionInfo,
 		BatchHeader:                 v3BatchHeader,
 		NonSignerStakesAndSignature: v3NonSignerStakesAndSignature,
 		SignedQuorumNumbers:         c.SignedQuorumNumbers,
 	}
-
-	return certV3, nil
 }
 
 // convertUint32SliceToRelayKeys converts []uint32 to []coreV2.RelayKey for V3 format

--- a/api/clients/v2/coretypes/eigenda_cert.go
+++ b/api/clients/v2/coretypes/eigenda_cert.go
@@ -175,7 +175,7 @@ func (c *EigenDACertV3) ComputeBlobKey() (coreV2.BlobKey, error) {
 		return coreV2.BlobKey{}, fmt.Errorf("blob commitments from protobuf: %w", err)
 	}
 
-	blobKeyBytes, err := coreV2.ComputeBlobKey(
+	blobKey, err := coreV2.ComputeBlobKey(
 		blobHeader.Version,
 		*blobCommitments,
 		blobHeader.QuorumNumbers,
@@ -183,10 +183,6 @@ func (c *EigenDACertV3) ComputeBlobKey() (coreV2.BlobKey, error) {
 	)
 	if err != nil {
 		return coreV2.BlobKey{}, fmt.Errorf("compute blob key: %w", err)
-	}
-	blobKey, err := coreV2.BytesToBlobKey(blobKeyBytes[:])
-	if err != nil {
-		return coreV2.BlobKey{}, fmt.Errorf("bytes to blob key: %w", err)
 	}
 	return blobKey, nil
 }
@@ -367,7 +363,7 @@ func (c *EigenDACertV2) ComputeBlobKey() (coreV2.BlobKey, error) {
 		return coreV2.BlobKey{}, fmt.Errorf("blob commitments from protobuf: %w", err)
 	}
 
-	blobKeyBytes, err := coreV2.ComputeBlobKey(
+	blobKey, err := coreV2.ComputeBlobKey(
 		blobHeader.Version,
 		*blobCommitments,
 		blobHeader.QuorumNumbers,
@@ -376,12 +372,6 @@ func (c *EigenDACertV2) ComputeBlobKey() (coreV2.BlobKey, error) {
 	if err != nil {
 		return coreV2.BlobKey{}, fmt.Errorf("compute blob key: %w", err)
 	}
-
-	blobKey, err := coreV2.BytesToBlobKey(blobKeyBytes[:])
-	if err != nil {
-		return coreV2.BlobKey{}, fmt.Errorf("bytes to blob key: %w", err)
-	}
-
 	return blobKey, nil
 }
 

--- a/api/clients/v2/payloaddispersal/payload_disperser.go
+++ b/api/clients/v2/payloaddispersal/payload_disperser.go
@@ -100,7 +100,7 @@ func (pd *PayloadDisperser) SendPayload(
 
 	// NOTE: there is a synchronization edge case where the disperser accredits a RBN that correlates
 	//       to a newly added immutable CertVerifier under the Router contract design. Resulting in
-	//       in potentially a few failed dispersals until the RBN advances; guaranteeing eventually consistency.
+	//       potentially a few failed dispersals until the RBN advances; guaranteeing eventual consistency.
 	//       This is a known issue and will be addressed with future enhancements.
 	requiredQuorums, err := pd.certVerifier.GetQuorumNumbersRequired(timeoutCtx)
 	if err != nil {

--- a/api/clients/v2/payloadretrieval/relay_payload_retriever.go
+++ b/api/clients/v2/payloadretrieval/relay_payload_retriever.go
@@ -165,7 +165,7 @@ func (pr *RelayPayloadRetriever) GetEncodedPayload(
 func (pr *RelayPayloadRetriever) retrieveBlobWithTimeout(
 	ctx context.Context,
 	relayKey core.RelayKey,
-	blobKey *core.BlobKey,
+	blobKey core.BlobKey,
 	// blobLengthSymbols should be taken from the eigenDACert for the blob being retrieved
 	blobLengthSymbols uint32,
 ) (*coretypes.Blob, error) {
@@ -174,7 +174,7 @@ func (pr *RelayPayloadRetriever) retrieveBlobWithTimeout(
 	defer cancel()
 
 	// TODO (litt3): eventually, we should make GetBlob return an actual blob object, instead of the serialized bytes.
-	blobBytes, err := pr.relayClient.GetBlob(timeoutCtx, relayKey, *blobKey)
+	blobBytes, err := pr.relayClient.GetBlob(timeoutCtx, relayKey, blobKey)
 	if err != nil {
 		return nil, fmt.Errorf("get blob from relay: %w", err)
 	}

--- a/api/clients/v2/payloadretrieval/relay_payload_retriever_test.go
+++ b/api/clients/v2/payloadretrieval/relay_payload_retriever_test.go
@@ -154,7 +154,7 @@ func buildCertFromBlobBytes(
 	blobKey, err := eigenDACert.ComputeBlobKey()
 	require.NoError(t, err)
 
-	return *blobKey, eigenDACert
+	return blobKey, eigenDACert
 }
 
 // TestGetPayloadSuccess tests that a blob is received without error in the happy case

--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -62,10 +62,7 @@ func (cv *CertVerifier) CheckDACert(
 	case *coretypes.EigenDACertV2:
 		// EigenDACertV3 is the only version that is supported by the CheckDACert function
 		// but the V2 cert is a simple permutation of the V3 cert fields, so we convert it.
-		certV3, err = cert.ToV3()
-		if err != nil {
-			return &CertVerifierInternalError{Msg: "convert V2 cert to V3", Err: err}
-		}
+		certV3 = cert.ToV3()
 	default:
 		// If golang had enums the world would be a better place.
 		panic(fmt.Sprintf("unsupported cert version: %T. All cert versions that we can "+

--- a/core/v2/serialization.go
+++ b/core/v2/serialization.go
@@ -44,7 +44,7 @@ func ComputeBlobKey(
 	blobCommitments encoding.BlobCommitments,
 	quorumNumbers []core.QuorumID,
 	paymentMetadataHash [32]byte,
-) ([32]byte, error) {
+) (BlobKey, error) {
 	versionType, err := abi.NewType("uint16", "", nil)
 	if err != nil {
 		return [32]byte{}, err

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -606,7 +606,7 @@ func (c *TestClient) DisperseAndVerify(ctx context.Context, payload []byte) erro
 	// read blob from ALL relays
 	err = c.ReadBlobFromRelays(
 		ctx,
-		*blobKey,
+		blobKey,
 		eigenDAV3Cert.RelayKeys(),
 		payload,
 		uint32(blobLengthSymbols),

--- a/test/v2/live/live_network_test.go
+++ b/test/v2/live/live_network_test.go
@@ -458,7 +458,7 @@ func unauthorizedGetChunksTest(t *testing.T, environment string) {
 
 	chunkRequests := make([]*relay.ChunkRequestByRange, 1)
 	chunkRequests[0] = &relay.ChunkRequestByRange{
-		BlobKey: *blobKey,
+		BlobKey: blobKey,
 		Start:   0,
 		End:     1,
 	}


### PR DESCRIPTION
## Why are these changes needed?

Was trying to cleanup some of our conversion utils... and completely gave up. Going to take more work than I thought.
But while looking around I found this inconsistency in our APIs: blobkeys were sometimes passed by value, sometimes by pointer.

Passing by value is most likely better, and cleaner. Here is Claude's take:

```
⏺ For a [32]byte, returning by value is almost always better than returning a pointer. Here's why:

  Performance Comparison

  Passing [32]byte by value:
  - Stack allocation: No heap allocation needed
  - CPU cache friendly: 32 bytes fit in a single cache line (64 bytes)
  - Copy cost: ~1-2 CPU cycles with modern processors (SIMD instructions)

  Returning *[32]byte:
  - Heap allocation: Requires garbage collector involvement
  - Pointer indirection: Extra memory access to get the actual data
  - GC pressure: Creates work for the garbage collector
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
