### PR TITLE
feat(metrics): add v2 disperser client metrics

### DIFF
--- a/api/clients/v2/examples/client_construction.go
+++ b/api/clients/v2/examples/client_construction.go
@@ -213,6 +213,7 @@ func createDisperserClient(privateKey string, kzgProver *prover.Prover) (clients
 		disperserClientConfig,
 		signer,
 		kzgProver,
+		nil,
 		nil)
 }
 

--- a/api/clients/v2/metrics/accountant.go
+++ b/api/clients/v2/metrics/accountant.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	namespace           = "eigenda"
 	accountantSubsystem = "accountant"
 )
 

--- a/api/clients/v2/metrics/dispersal.go
+++ b/api/clients/v2/metrics/dispersal.go
@@ -1,0 +1,75 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	dispersalSubsystem = "dispersal"
+)
+
+type DispersalMetricer interface {
+	RecordBlobSize(size uint)
+	RecordSymbolLength(length uint)
+}
+
+type DispersalMetrics struct {
+	BlobSize     *prometheus.HistogramVec
+	SymbolLength *prometheus.HistogramVec
+}
+
+func NewDispersalMetrics(registry *prometheus.Registry) DispersalMetricer {
+	if registry == nil {
+		return NoopDispersalMetrics
+	}
+
+	// Define size buckets for payload and blob size measurements
+	// Starting from 1KB up to 16MB with exponential growth
+	sizeBuckets := []float64{
+		1024,     // 1KB
+		4096,     // 4KB
+		16384,    // 16KB
+		65536,    // 64KB
+		262144,   // 256KB
+		1048576,  // 1MB
+		4194304,  // 4MB
+		16777216, // 16MB
+	}
+
+	return &DispersalMetrics{
+		BlobSize: promauto.With(registry).NewHistogramVec(prometheus.HistogramOpts{
+			Name:      "blob_size",
+			Namespace: namespace,
+			Subsystem: dispersalSubsystem,
+			Help:      "Size of blobs created from payloads in bytes",
+			Buckets:   sizeBuckets,
+		}, []string{}),
+		SymbolLength: promauto.With(registry).NewHistogramVec(prometheus.HistogramOpts{
+			Name:      "symbol_length",
+			Namespace: namespace,
+			Subsystem: dispersalSubsystem,
+			Help:      "Size of payloads being dispersed in bytes",
+			Buckets:   sizeBuckets,
+		}, []string{}),
+	}
+}
+
+func (m *DispersalMetrics) RecordBlobSize(size uint) {
+	m.BlobSize.WithLabelValues().Observe(float64(size))
+}
+
+func (m *DispersalMetrics) RecordSymbolLength(length uint) {
+	m.SymbolLength.WithLabelValues().Observe(float64(length))
+}
+
+type noopDispersalMetricer struct {
+}
+
+var NoopDispersalMetrics DispersalMetricer = new(noopDispersalMetricer)
+
+func (n *noopDispersalMetricer) RecordBlobSize(_ uint) {
+}
+
+func (n *noopDispersalMetricer) RecordSymbolLength(_ uint) {
+}

--- a/api/clients/v2/metrics/metrics.go
+++ b/api/clients/v2/metrics/metrics.go
@@ -1,0 +1,5 @@
+package metrics
+
+const (
+	namespace = "eigenda"
+)

--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -590,6 +590,7 @@ func buildPayloadDisperser(
 		signer,
 		kzgProver,
 		accountant,
+		registry,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new disperser client: %w", err)

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -263,7 +263,7 @@ func setupPayloadDisperserWithRouter() error {
 		0,
 		metrics.NoopAccountantMetrics,
 	)
-	disperserClient, err := clientsv2.NewDisperserClient(disperserClientConfig, signer, nil, accountant)
+	disperserClient, err := clientsv2.NewDisperserClient(disperserClientConfig, signer, nil, accountant, nil)
 	if err != nil {
 		return err
 	}

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -150,7 +150,7 @@ func NewTestClient(
 	}
 
 	accountant := clientsv2.NewUnpopulatedAccountant(accountId, metricsv2.NoopAccountantMetrics)
-	disperserClient, err := clientsv2.NewDisperserClient(disperserConfig, signer, kzgProver, accountant)
+	disperserClient, err := clientsv2.NewDisperserClient(disperserConfig, signer, kzgProver, accountant, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create disperser client: %w", err)
 	}

--- a/test/v2/live/live_network_test.go
+++ b/test/v2/live/live_network_test.go
@@ -500,7 +500,7 @@ func dispersalWithInvalidSignatureTest(t *testing.T, environment string) {
 	}
 
 	accountant := clients.NewUnpopulatedAccountant(accountId, metrics.NoopAccountantMetrics)
-	disperserClient, err := clients.NewDisperserClient(disperserConfig, signer, nil, accountant)
+	disperserClient, err := clients.NewDisperserClient(disperserConfig, signer, nil, accountant, nil)
 	require.NoError(t, err)
 
 	payloadBytes := rand.VariableBytes(units.KiB, 2*units.KiB)


### PR DESCRIPTION
Closes DAINT-692

Adds metrics for the v2 disperser client

## Why are these changes needed?

Adding more metrics here gives use more data and allows users to optimize their dispersal costs.

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
