### PR TITLE
refactor: refactor accountant metrics passing

### DIFF
--- a/api/clients/v2/accountant.go
+++ b/api/clients/v2/accountant.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/meterer"
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ErrZeroSymbols is returned when the requested number of symbols is zero.
@@ -47,8 +48,8 @@ type PeriodRecord struct {
 	Usage uint64
 }
 
-func NewUnpopulatedAccountant(accountID gethcommon.Address, metrics metrics.AccountantMetricer) *Accountant {
-	return NewAccountant(accountID, nil, nil, 0, 0, 0, 0, metrics)
+func NewUnpopulatedAccountant(accountID gethcommon.Address, registry *prometheus.Registry) *Accountant {
+	return NewAccountant(accountID, nil, nil, 0, 0, 0, 0, registry)
 }
 
 func NewAccountant(
@@ -59,12 +60,14 @@ func NewAccountant(
 	pricePerSymbol uint64,
 	minNumSymbols uint64,
 	numBins uint32,
-	metrics metrics.AccountantMetricer,
+	registry *prometheus.Registry,
 ) *Accountant {
 	periodRecords := make([]PeriodRecord, max(numBins, uint32(meterer.MinNumBins)))
 	for i := range periodRecords {
 		periodRecords[i] = PeriodRecord{Index: uint32(i), Usage: 0}
 	}
+
+	metrics := metrics.NewAccountantMetrics(registry)
 	a := Accountant{
 		accountID:         accountID,
 		reservation:       reservation,

--- a/api/clients/v2/accountant_test.go
+++ b/api/clients/v2/accountant_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	disperser_rpc "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/core/meterer"
@@ -70,7 +69,7 @@ func TestNewAccountant(t *testing.T) {
 				tt.pricePerSymbol,
 				tt.minNumSymbols,
 				numBins,
-				metrics.NoopAccountantMetrics,
+				nil,
 			)
 
 			assert.NotNil(t, accountant)
@@ -118,7 +117,7 @@ func TestAccountBlob_Reservation(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -217,7 +216,7 @@ func TestAccountBlob_OnDemand(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -285,7 +284,7 @@ func TestAccountBlob_InsufficientOnDemand(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -349,7 +348,7 @@ func TestAccountBlobCallSeries(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -460,7 +459,7 @@ func TestAccountBlob_BinRotation(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -562,7 +561,7 @@ func TestConcurrentBinRotationAndAccountBlob(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -636,7 +635,7 @@ func TestAccountBlob_ReservationWithOneOverflow(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -736,7 +735,7 @@ func TestAccountBlob_ReservationOverflowReset(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -845,7 +844,7 @@ func TestAccountBlob_ReservationOverflowWithWindow(t *testing.T) {
 		pricePerSymbol,
 		minNumSymbols,
 		numBins,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 
 	quorums := []uint8{0, 1}
@@ -1191,7 +1190,7 @@ func TestSetPaymentState(t *testing.T) {
 				0,
 				0,
 				numBins,
-				metrics.NoopAccountantMetrics,
+				nil,
 			)
 			err := accountant.SetPaymentState(tt.state)
 

--- a/api/clients/v2/examples/client_construction.go
+++ b/api/clients/v2/examples/client_construction.go
@@ -209,11 +209,18 @@ func createDisperserClient(privateKey string, kzgProver *prover.Prover) (clients
 		UseSecureGrpcFlag: true,
 	}
 
+	accountID, err := signer.GetAccountID()
+	if err != nil {
+		return nil, fmt.Errorf("get account ID: %w", err)
+	}
+
+	accountant := clients.NewUnpopulatedAccountant(accountID, nil)
+
 	return clients.NewDisperserClient(
 		disperserClientConfig,
 		signer,
 		kzgProver,
-		nil)
+		accountant)
 }
 
 func createKzgVerifier() (*verifier.Verifier, error) {

--- a/api/clients/v2/metrics/accountant.go
+++ b/api/clients/v2/metrics/accountant.go
@@ -26,7 +26,7 @@ type AccountantMetrics struct {
 
 func NewAccountantMetrics(registry *prometheus.Registry) AccountantMetricer {
 	if registry == nil {
-		return &noopAccountantMetricer{}
+		return NoopAccountantMetrics
 	}
 
 	return &AccountantMetrics{

--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -44,8 +44,6 @@ import (
 	geth_common "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
-
-	metrics_v2 "github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 )
 
 // BuildStoreManager is the main builder for proxy's store.
@@ -578,12 +576,11 @@ func buildPayloadDisperser(
 
 	accountId, err := signer.GetAccountID()
 	if err != nil {
-		return nil, fmt.Errorf("error getting account ID: %w", err)
+		return nil, fmt.Errorf("get account ID: %w", err)
 	}
 
-	accountantMetrics := metrics_v2.NewAccountantMetrics(registry)
 	// The accountant is populated lazily by disperserClient.PopulateAccountant
-	accountant := clients_v2.NewUnpopulatedAccountant(accountId, accountantMetrics)
+	accountant := clients_v2.NewUnpopulatedAccountant(accountId, registry)
 
 	disperserClient, err := clients_v2.NewDisperserClient(
 		&clientConfigV2.DisperserClientCfg,

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Layr-Labs/eigenda/api/clients"
 	clientsv2 "github.com/Layr-Labs/eigenda/api/clients/v2"
-	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/payloaddispersal"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/payloadretrieval"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/relay"
@@ -261,7 +260,7 @@ func setupPayloadDisperserWithRouter() error {
 		0,
 		0,
 		0,
-		metrics.NoopAccountantMetrics,
+		nil,
 	)
 	disperserClient, err := clientsv2.NewDisperserClient(disperserClientConfig, signer, nil, accountant)
 	if err != nil {

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -11,7 +11,6 @@ import (
 
 	clientsv2 "github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
-	metricsv2 "github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/payloaddispersal"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/payloadretrieval"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/relay"
@@ -149,7 +148,7 @@ func NewTestClient(
 		UseSecureGrpcFlag: true,
 	}
 
-	accountant := clientsv2.NewUnpopulatedAccountant(accountId, metricsv2.NoopAccountantMetrics)
+	accountant := clientsv2.NewUnpopulatedAccountant(accountId, nil)
 	disperserClient, err := clientsv2.NewDisperserClient(disperserConfig, signer, kzgProver, accountant)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create disperser client: %w", err)

--- a/test/v2/live/live_network_test.go
+++ b/test/v2/live/live_network_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
-	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/relay"
 	"github.com/Layr-Labs/eigenda/core"
 	auth "github.com/Layr-Labs/eigenda/core/auth/v2"
@@ -499,7 +498,7 @@ func dispersalWithInvalidSignatureTest(t *testing.T, environment string) {
 		UseSecureGrpcFlag: true,
 	}
 
-	accountant := clients.NewUnpopulatedAccountant(accountId, metrics.NoopAccountantMetrics)
+	accountant := clients.NewUnpopulatedAccountant(accountId, nil)
 	disperserClient, err := clients.NewDisperserClient(disperserConfig, signer, nil, accountant)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Refactors the accountant constructors to accept a
`*prometheus.Registry` argument instead of a `Accountant.Metricer`

Moves `NewAccountantMetrics` call inside `NewAccountant`

Updates example

## Why are these changes needed?

Passing the registry brings this inline with other metrics patterns.

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
