### PR TITLE
feat(cli): add `doc metrics` cli command to proxy

### DIFF
--- a/api/clients/v2/metrics/metrics.go
+++ b/api/clients/v2/metrics/metrics.go
@@ -1,5 +1,138 @@
 package metrics
 
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
 const (
 	namespace = "eigenda"
 )
+
+type Factory interface {
+	NewCounter(opts prometheus.CounterOpts) prometheus.Counter
+	NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec
+	NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge
+	NewGaugeFunc(opts prometheus.GaugeOpts, function func() float64) prometheus.GaugeFunc
+	NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec
+	NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram
+	NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec
+	NewSummary(opts prometheus.SummaryOpts) prometheus.Summary
+	NewSummaryVec(opts prometheus.SummaryOpts, labelNames []string) *prometheus.SummaryVec
+	Document() []DocumentedMetric
+}
+
+type DocumentedMetric struct {
+	Type   string   `json:"type"`
+	Name   string   `json:"name"`
+	Help   string   `json:"help"`
+	Labels []string `json:"labels"`
+}
+
+type documentor struct {
+	metrics []DocumentedMetric
+	factory promauto.Factory
+}
+
+func With(registry *prometheus.Registry) Factory {
+	return &documentor{
+		factory: promauto.With(registry),
+	}
+}
+
+func (d *documentor) NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type: "counter",
+		Name: fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help: opts.Help,
+	})
+	return d.factory.NewCounter(opts)
+}
+
+func (d *documentor) NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type:   "counter",
+		Name:   fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help:   opts.Help,
+		Labels: labelNames,
+	})
+	return d.factory.NewCounterVec(opts, labelNames)
+}
+
+func (d *documentor) NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type: "gauge",
+		Name: fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help: opts.Help,
+	})
+	return d.factory.NewGauge(opts)
+}
+
+func (d *documentor) NewGaugeFunc(opts prometheus.GaugeOpts, function func() float64) prometheus.GaugeFunc {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type: "gauge",
+		Name: fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help: opts.Help,
+	})
+	return d.factory.NewGaugeFunc(opts, function)
+}
+
+func (d *documentor) NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type:   "gauge",
+		Name:   fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help:   opts.Help,
+		Labels: labelNames,
+	})
+	return d.factory.NewGaugeVec(opts, labelNames)
+}
+
+func (d *documentor) NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type: "histogram",
+		Name: fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help: opts.Help,
+	})
+	return d.factory.NewHistogram(opts)
+}
+
+func (d *documentor) NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type:   "histogram",
+		Name:   fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help:   opts.Help,
+		Labels: labelNames,
+	})
+	return d.factory.NewHistogramVec(opts, labelNames)
+}
+
+func (d *documentor) NewSummary(opts prometheus.SummaryOpts) prometheus.Summary {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type: "summary",
+		Name: fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help: opts.Help,
+	})
+	return d.factory.NewSummary(opts)
+}
+
+func (d *documentor) NewSummaryVec(opts prometheus.SummaryOpts, labelNames []string) *prometheus.SummaryVec {
+	d.metrics = append(d.metrics, DocumentedMetric{
+		Type:   "summary",
+		Name:   fullName(opts.Namespace, opts.Subsystem, opts.Name),
+		Help:   opts.Help,
+		Labels: labelNames,
+	})
+	return d.factory.NewSummaryVec(opts, labelNames)
+}
+
+func (d *documentor) Document() []DocumentedMetric {
+	return d.metrics
+}
+
+func fullName(ns, subsystem, name string) string {
+	out := ns
+	if subsystem != "" {
+		out += "_" + subsystem
+	}
+	return out + "_" + name
+}

--- a/api/proxy/cmd/server/main.go
+++ b/api/proxy/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/Layr-Labs/eigenda/api/proxy/config"
+	"github.com/Layr-Labs/eigenda/api/proxy/metrics"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/joho/godotenv"
 	"github.com/urfave/cli/v2"
@@ -33,10 +34,12 @@ func main() {
 	app.Usage = "EigenDA Proxy Sidecar Service"
 	app.Description = "Service for more trustless and secure interactions with EigenDA"
 	app.Action = StartProxySvr
-	// TODO(iquidus): Add new `doc metrics` command to display all supported metrics.
-	// The `doc metrics` command was removed as it only displayed metrics created by
-	// the op-service/metrics factory. The new command should display all metrics
-	// created via promauto or registered directly with the prometheus registry.
+	app.Commands = []*cli.Command{
+		{
+			Name:        "doc",
+			Subcommands: metrics.NewSubcommands(),
+		},
+	}
 
 	// load env file (if applicable)
 	if p := os.Getenv("ENV_PATH"); p != "" {

--- a/api/proxy/docs/help_out.txt
+++ b/api/proxy/docs/help_out.txt
@@ -9,6 +9,7 @@ DESCRIPTION:
    Service for more trustless and secure interactions with EigenDA
 
 COMMANDS:
+   doc
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:

--- a/api/proxy/metrics/cli.go
+++ b/api/proxy/metrics/cli.go
@@ -3,7 +3,13 @@ package metrics
 import (
 	"errors"
 	"math"
+	"os"
+	"slices"
+	"strings"
 
+	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
+	"github.com/olekukonko/tablewriter"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -74,5 +80,42 @@ func ReadConfig(ctx *cli.Context) Config {
 		Enabled: ctx.Bool(EnabledFlagName),
 		Host:    ctx.String(ListenAddrFlagName),
 		Port:    ctx.Int(PortFlagName),
+	}
+}
+
+// NewSubcommands is used by `doc metrics` to output all supported metrics to
+// stdout. For metrics to be included in the output they need to be created
+// using the factory defined in `api/clients/v2/metrics/metrics.go`, and the
+// metrics interface must have a `Document()` func. See interfaces and structs
+// defined in `api/clients/v2/metrics` or `api/proxy/metrics/metrics.go` for
+// supported usage.
+func NewSubcommands() cli.Commands {
+	return cli.Commands{
+		{
+			Name:  "metrics",
+			Usage: "Dumps a list of supported metrics to stdout",
+			Action: func(*cli.Context) error {
+				registry := prometheus.NewRegistry()
+				proxyMetrics := NewMetrics(registry).Document()
+				accountantMetrics := metrics.NewAccountantMetrics(registry).Document()
+				dispersalMetrics := metrics.NewDispersalMetrics(registry).Document()
+
+				supportedMetrics := slices.Concat(proxyMetrics, accountantMetrics, dispersalMetrics)
+
+				table := tablewriter.NewWriter(os.Stdout)
+				table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+				table.SetCenterSeparator("|")
+				table.SetAutoWrapText(false)
+				table.SetHeader([]string{"Metric", "Description", "Labels", "Type"})
+				data := make([][]string, 0, len(supportedMetrics))
+				for _, metric := range supportedMetrics {
+					labels := strings.Join(metric.Labels, ",")
+					data = append(data, []string{metric.Name, metric.Help, labels, metric.Type})
+				}
+				table.AppendBulk(data)
+				table.Render()
+				return nil
+			},
+		},
 	}
 }

--- a/api/proxy/metrics/memory.go
+++ b/api/proxy/metrics/memory.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -124,4 +125,9 @@ func (n *EmulatedMetricer) RecordSecondaryRequest(x string, y string) func(statu
 			panic(err)
 		}
 	}
+}
+
+// Document ... noop
+func (n *EmulatedMetricer) Document() []metrics.DocumentedMetric {
+	return []metrics.DocumentedMetric{}
 }

--- a/api/proxy/metrics/metrics.go
+++ b/api/proxy/metrics/metrics.go
@@ -1,9 +1,9 @@
 package metrics
 
 import (
+	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
@@ -20,6 +20,8 @@ type Metricer interface {
 
 	RecordRPCServerRequest(method string) func(status string, mode string, ver string)
 	RecordSecondaryRequest(bt string, method string) func(status string)
+
+	Document() []metrics.DocumentedMetric
 }
 
 // Metrics ... Metrics struct
@@ -36,7 +38,7 @@ type Metrics struct {
 	SecondaryRequestsTotal      *prometheus.CounterVec
 	SecondaryRequestDurationSec *prometheus.HistogramVec
 
-	registry *prometheus.Registry
+	factory metrics.Factory
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -48,15 +50,16 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(collectors.NewGoCollector())
+	factory := metrics.With(registry)
 
 	return &Metrics{
-		Up: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
+		Up: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "up",
 			Help:      "1 if the proxy server has finished starting up",
 		}),
-		Info: promauto.With(registry).NewGaugeVec(prometheus.GaugeOpts{
+		Info: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "info",
@@ -64,7 +67,7 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		}, []string{
 			"version",
 		}),
-		HTTPServerRequestsTotal: promauto.With(registry).NewCounterVec(prometheus.CounterOpts{
+		HTTPServerRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: httpServerSubsystem,
 			Name:      "requests_total",
@@ -72,7 +75,7 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		}, []string{
 			"method", "status", "commitment_mode", "cert_version",
 		}),
-		HTTPServerBadRequestHeader: promauto.With(registry).NewCounterVec(prometheus.CounterOpts{
+		HTTPServerBadRequestHeader: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: httpServerSubsystem,
 			Name:      "requests_bad_header_total",
@@ -80,7 +83,7 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		}, []string{
 			"method", "error_type",
 		}),
-		HTTPServerRequestDurationSeconds: promauto.With(registry).NewHistogramVec(prometheus.HistogramOpts{
+		HTTPServerRequestDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: httpServerSubsystem,
 			Name:      "request_duration_seconds",
@@ -92,7 +95,7 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		}, []string{
 			"method", // no status on histograms because those are very expensive
 		}),
-		SecondaryRequestsTotal: promauto.With(registry).NewCounterVec(prometheus.CounterOpts{
+		SecondaryRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: secondarySubsystem,
 			Name:      "requests_total",
@@ -100,7 +103,7 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		}, []string{
 			"backend_type", "method", "status",
 		}),
-		SecondaryRequestDurationSec: promauto.With(registry).NewHistogramVec(prometheus.HistogramOpts{
+		SecondaryRequestDurationSec: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: secondarySubsystem,
 			Name:      "request_duration_seconds",
@@ -109,7 +112,7 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		}, []string{
 			"backend_type",
 		}),
-		registry: registry,
+		factory: factory,
 	}
 }
 
@@ -148,6 +151,10 @@ func (m *Metrics) RecordSecondaryRequest(bt string, method string) func(status s
 	}
 }
 
+func (m *Metrics) Document() []metrics.DocumentedMetric {
+	return m.factory.Document()
+}
+
 type noopMetricer struct {
 }
 
@@ -165,4 +172,8 @@ func (n *noopMetricer) RecordRPCServerRequest(string) func(status, mode, ver str
 
 func (n *noopMetricer) RecordSecondaryRequest(string, string) func(status string) {
 	return func(string) {}
+}
+
+func (m *noopMetricer) Document() []metrics.DocumentedMetric {
+	return []metrics.DocumentedMetric{}
 }

--- a/api/proxy/server/middleware/request_context_test.go
+++ b/api/proxy/server/middleware/request_context_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/Layr-Labs/eigenda/api/proxy/common/types/commitments"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/stretchr/testify/require"
@@ -62,4 +63,8 @@ func (m *MockMetricer) RecordRPCServerRequest(method string) func(status string,
 }
 func (m *MockMetricer) RecordSecondaryRequest(bt string, method string) func(status string) {
 	return func(status string) {}
+}
+
+func (m *MockMetricer) Document() []metrics.DocumentedMetric {
+	return []metrics.DocumentedMetric{}
 }


### PR DESCRIPTION
Adds the `doc metrics` cli command back to the proxy without the `op-service` dependency.

Refactors existing proxy and v2 client metrics to use the added promauto factory wrapper for metric Document() support.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
