### PR TITLE
Fix: Replace hardcoded block number with configurable contract deployment block

### DIFF
--- a/indexer/cli.go
+++ b/indexer/cli.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	PullIntervalFlagName = "indexer-pull-interval"
+	PullIntervalFlagName            = "indexer-pull-interval"
+	ContractDeploymentBlockFlagName = "indexer-contract-deployment-block"
 )
 
 func CLIFlags(envPrefix string) []cli.Flag {
@@ -20,11 +21,19 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			EnvVar:   common.PrefixEnvVar(envPrefix, "INDEXER_PULL_INTERVAL"),
 			Value:    1 * time.Second,
 		},
+		cli.Uint64Flag{
+			Name:     ContractDeploymentBlockFlagName,
+			Usage:    "Block number at which the contract was deployed (used as starting point when no headers exist)",
+			Required: false,
+			EnvVar:   common.PrefixEnvVar(envPrefix, "INDEXER_CONTRACT_DEPLOYMENT_BLOCK"),
+			Value:    0,
+		},
 	}
 }
 
 func ReadIndexerConfig(ctx *cli.Context) Config {
 	return Config{
-		PullInterval: ctx.GlobalDuration(PullIntervalFlagName),
+		PullInterval:            ctx.GlobalDuration(PullIntervalFlagName),
+		ContractDeploymentBlock: ctx.GlobalUint64(ContractDeploymentBlockFlagName),
 	}
 }

--- a/indexer/config.go
+++ b/indexer/config.go
@@ -3,5 +3,6 @@ package indexer
 import "time"
 
 type Config struct {
-	PullInterval time.Duration
+	PullInterval            time.Duration
+	ContractDeploymentBlock uint64 // The block number at which the contract was deployed
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -42,7 +42,8 @@ type indexer struct {
 	HeaderStore        HeaderStore
 	UpgradeForkWatcher UpgradeForkWatcher
 
-	PullInterval time.Duration
+	PullInterval            time.Duration
+	ContractDeploymentBlock uint64
 }
 
 var _ Indexer = (*indexer)(nil)
@@ -61,12 +62,13 @@ func New(
 	}
 
 	return &indexer{
-		Handlers:           handlers,
-		HeaderService:      headerSrvc,
-		HeaderStore:        headerStore,
-		UpgradeForkWatcher: upgradeForkWatcher,
-		PullInterval:       config.PullInterval,
-		Logger:             logger,
+		Handlers:                handlers,
+		HeaderService:           headerSrvc,
+		HeaderStore:             headerStore,
+		UpgradeForkWatcher:      upgradeForkWatcher,
+		PullInterval:            config.PullInterval,
+		ContractDeploymentBlock: config.ContractDeploymentBlock,
+		Logger:                  logger,
 	}
 }
 
@@ -138,9 +140,9 @@ func (i *indexer) Index(ctx context.Context) error {
 			default:
 				latestFinalizedHeader, err := i.HeaderStore.GetLatestHeader(true)
 				if errors.Is(err, ErrNoHeaders) {
-					// TODO: Set the latestFinalized to a config value reflecting the point at which the contract was deployed
+					// Use the configured contract deployment block as the starting point
 					latestFinalizedHeader = &Header{
-						Number: 0,
+						Number: i.ContractDeploymentBlock,
 					}
 				} else if err != nil {
 					i.Logger.Error("Error getting latest header", "err", err)


### PR DESCRIPTION
Fixes the TODO in indexer.go by replacing the hardcoded `Number: 0` with a configurable `ContractDeploymentBlock` parameter.

When no headers exist in the store, the indexer now starts from the actual contract deployment block rather than genesis. This prevents unnecessary processing of blocks before the contract existed.