### PR TITLE
fix: update `NewDisperserClient` errors

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -95,16 +95,16 @@ func NewDisperserClient(
 ) (*disperserClient, error) {
 
 	if config == nil {
-		return nil, api.NewErrorInvalidArg("config must be provided")
+		return nil, fmt.Errorf("config must be provided")
 	}
 	if config.Hostname == "" {
-		return nil, api.NewErrorInvalidArg("hostname must be provided")
+		return nil, fmt.Errorf("hostname must be provided")
 	}
 	if config.Port == "" {
-		return nil, api.NewErrorInvalidArg("port must be provided")
+		return nil, fmt.Errorf("port must be provided")
 	}
 	if signer == nil {
-		return nil, api.NewErrorInvalidArg("signer must be provided")
+		return nil, fmt.Errorf("signer must be provided")
 	}
 
 	var connectionCount uint

--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -97,10 +98,10 @@ func NewDisperserClient(
 	if config == nil {
 		return nil, fmt.Errorf("config must be provided")
 	}
-	if config.Hostname == "" {
+	if strings.TrimSpace(config.Hostname) == "" {
 		return nil, fmt.Errorf("hostname must be provided")
 	}
-	if config.Port == "" {
+	if strings.TrimSpace(config.Port) == "" {
 		return nil, fmt.Errorf("port must be provided")
 	}
 	if signer == nil {


### PR DESCRIPTION
Closes DAINT-704

Replaces the returned 400 errors with standard errors

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
