### PR TITLE
refactor: remove bls prefix from operatorStateRetriever

### DIFF
--- a/api/clients/v2/examples/client_construction.go
+++ b/api/clients/v2/examples/client_construction.go
@@ -34,8 +34,8 @@ const (
 	registryCoordinatorAddress = "0x53012C69A189cfA2D9d29eb6F19B32e0A2EA3490"
 	// These two addresses are no longer required for the Eth Client, but parameter is still being taken until we deprecate the flags
 	eigenDAServiceManagerAddress = ""
-	// blsOperatorStateRetrieverAddress is still used for CertBuilder
-	blsOperatorStateRetrieverAddress = "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7"
+	// operatorStateRetrieverAddress is still used for CertBuilder
+	operatorStateRetrieverAddress = "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7"
 )
 
 func createPayloadDisperser(privateKey string) (*payloaddispersal.PayloadDisperser, error) {
@@ -282,7 +282,7 @@ func createCertBuilder() (*clients.CertBuilder, error) {
 
 	return clients.NewCertBuilder(
 		logger,
-		gethcommon.HexToAddress(blsOperatorStateRetrieverAddress),
+		gethcommon.HexToAddress(operatorStateRetrieverAddress),
 		gethcommon.HexToAddress(registryCoordinatorAddress),
 		ethClient,
 	)
@@ -338,7 +338,7 @@ func createEthReader(logger logging.Logger, ethClient common.EthClient) (*eth.Re
 	ethReader, err := eth.NewReader(
 		logger,
 		ethClient,
-		blsOperatorStateRetrieverAddress,
+		operatorStateRetrieverAddress,
 		eigenDAServiceManagerAddress,
 	)
 	if err != nil {

--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -308,7 +308,7 @@ func buildEigenDAV2Backend(
 		}
 	}
 
-	var eigenDAServiceManagerAddr, blsOperatorStateRetrieverAddr geth_common.Address
+	var eigenDAServiceManagerAddr, operatorStateRetrieverAddr geth_common.Address
 	contractDirectory, err := directory.NewContractDirectory(ctx, log, ethClient,
 		geth_common.HexToAddress(config.ClientConfigV2.EigenDADirectory))
 	if err != nil {
@@ -318,9 +318,9 @@ func buildEigenDAV2Backend(
 	if err != nil {
 		return nil, fmt.Errorf("get eigenDAServiceManagerAddr: %w", err)
 	}
-	blsOperatorStateRetrieverAddr, err = contractDirectory.GetContractAddress(ctx, directory.BLSOperatorStateRetriever)
+	operatorStateRetrieverAddr, err = contractDirectory.GetContractAddress(ctx, directory.OperatorStateRetriever)
 	if err != nil {
-		return nil, fmt.Errorf("get blsOperatorStateRetrieverAddr: %w", err)
+		return nil, fmt.Errorf("get OperatorStateRetriever addr: %w", err)
 	}
 	registryCoordinator, err := contractDirectory.GetContractAddress(ctx, directory.RegistryCoordinator)
 	if err != nil {
@@ -346,7 +346,7 @@ func buildEigenDAV2Backend(
 			log.Info("Initializing validator payload retriever")
 			validatorPayloadRetriever, err := buildValidatorPayloadRetriever(
 				log, config.ClientConfigV2, ethClient,
-				blsOperatorStateRetrieverAddr, eigenDAServiceManagerAddr,
+				operatorStateRetrieverAddr, eigenDAServiceManagerAddr,
 				kzgVerifier, kzgProver.Srs.G1)
 			if err != nil {
 				return nil, fmt.Errorf("build validator payload retriever: %w", err)
@@ -370,7 +370,7 @@ func buildEigenDAV2Backend(
 		ethClient,
 		kzgProver,
 		certVerifier,
-		blsOperatorStateRetrieverAddr,
+		operatorStateRetrieverAddr,
 		registryCoordinator,
 		registry,
 	)
@@ -539,7 +539,7 @@ func buildValidatorPayloadRetriever(
 	log logging.Logger,
 	clientConfigV2 common.ClientConfigV2,
 	ethClient common_eigenda.EthClient,
-	blsOperatorStateRetrieverAddr geth_common.Address,
+	operatorStateRetrieverAddr geth_common.Address,
 	eigenDAServiceManagerAddr geth_common.Address,
 	kzgVerifier *kzgverifier.Verifier,
 	g1Srs []bn254.G1Affine,
@@ -547,7 +547,7 @@ func buildValidatorPayloadRetriever(
 	ethReader, err := eth.NewReader(
 		log,
 		ethClient,
-		blsOperatorStateRetrieverAddr.String(),
+		operatorStateRetrieverAddr.String(),
 		eigenDAServiceManagerAddr.String(),
 	)
 	if err != nil {
@@ -586,7 +586,7 @@ func buildPayloadDisperser(
 	ethClient common_eigenda.EthClient,
 	kzgProver *prover.Prover,
 	certVerifier *verification.CertVerifier,
-	blsOperatorStateRetrieverAddr geth_common.Address,
+	operatorStateRetrieverAddr geth_common.Address,
 	registryCoordinatorAddr geth_common.Address,
 	registry *prometheus.Registry,
 ) (*payloaddispersal.PayloadDisperser, error) {
@@ -626,7 +626,7 @@ func buildPayloadDisperser(
 	}
 
 	certBuilder, err := clients_v2.NewCertBuilder(
-		log, blsOperatorStateRetrieverAddr, registryCoordinatorAddr, ethClient)
+		log, operatorStateRetrieverAddr, registryCoordinatorAddr, ethClient)
 	if err != nil {
 		return nil, fmt.Errorf("new cert builder: %w", err)
 	}

--- a/core/eth/directory/contract_names.go
+++ b/core/eth/directory/contract_names.go
@@ -6,8 +6,8 @@ package directory
 // When you add to this list, make sure you keep things in alphabetical order.
 
 const (
-	OperatorStateRetriever ContractName = "OPERATOR_STATE_RETRIEVER"
 	EigenDAEjectionManager ContractName = "EIGEN_DA_EJECTION_MANAGER"
+	OperatorStateRetriever ContractName = "OPERATOR_STATE_RETRIEVER"
 	RegistryCoordinator    ContractName = "REGISTRY_COORDINATOR"
 	RelayRegistry          ContractName = "RELAY_REGISTRY"
 	ServiceManager         ContractName = "SERVICE_MANAGER"
@@ -15,8 +15,8 @@ const (
 
 // a list of all contracts currently known to the EigenDA offchain code.
 var knownContracts = []ContractName{
-	OperatorStateRetriever,
 	EigenDAEjectionManager,
+	OperatorStateRetriever,
 	RegistryCoordinator,
 	RelayRegistry,
 	ServiceManager,

--- a/core/eth/directory/contract_names.go
+++ b/core/eth/directory/contract_names.go
@@ -6,16 +6,16 @@ package directory
 // When you add to this list, make sure you keep things in alphabetical order.
 
 const (
-	BLSOperatorStateRetriever ContractName = "OPERATOR_STATE_RETRIEVER"
-	EigenDAEjectionManager    ContractName = "EIGEN_DA_EJECTION_MANAGER"
-	RegistryCoordinator       ContractName = "REGISTRY_COORDINATOR"
-	RelayRegistry             ContractName = "RELAY_REGISTRY"
-	ServiceManager            ContractName = "SERVICE_MANAGER"
+	OperatorStateRetriever ContractName = "OPERATOR_STATE_RETRIEVER"
+	EigenDAEjectionManager ContractName = "EIGEN_DA_EJECTION_MANAGER"
+	RegistryCoordinator    ContractName = "REGISTRY_COORDINATOR"
+	RelayRegistry          ContractName = "RELAY_REGISTRY"
+	ServiceManager         ContractName = "SERVICE_MANAGER"
 )
 
 // a list of all contracts currently known to the EigenDA offchain code.
 var knownContracts = []ContractName{
-	BLSOperatorStateRetriever,
+	OperatorStateRetriever,
 	EigenDAEjectionManager,
 	RegistryCoordinator,
 	RelayRegistry,

--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -71,7 +71,7 @@ var _ core.Reader = (*Reader)(nil)
 func NewReader(
 	logger logging.Logger,
 	client common.EthClient,
-	blsOperatorStateRetrieverHexAddr string,
+	operatorStateRetrieverHexAddr string,
 	eigenDAServiceManagerHexAddr string) (*Reader, error) {
 
 	e := &Reader{
@@ -79,10 +79,10 @@ func NewReader(
 		logger:    logger.With("component", "Reader"),
 	}
 
-	blsOperatorStateRetrieverAddr := gethcommon.HexToAddress(blsOperatorStateRetrieverHexAddr)
+	operatorStateRetrieverAddr := gethcommon.HexToAddress(operatorStateRetrieverHexAddr)
 	eigenDAServiceManagerAddr := gethcommon.HexToAddress(eigenDAServiceManagerHexAddr)
 
-	err := e.updateContractBindings(blsOperatorStateRetrieverAddr, eigenDAServiceManagerAddr)
+	err := e.updateContractBindings(operatorStateRetrieverAddr, eigenDAServiceManagerAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update contract bindings: %w", err)
 	}
@@ -91,7 +91,7 @@ func NewReader(
 
 // updateContractBindings updates the contract bindings for the reader
 // TODO: update to use address directory contract once all contracts are written into the directory
-func (t *Reader) updateContractBindings(blsOperatorStateRetrieverAddr, eigenDAServiceManagerAddr gethcommon.Address) error {
+func (t *Reader) updateContractBindings(operatorStateRetrieverAddr, eigenDAServiceManagerAddr gethcommon.Address) error {
 	contractEigenDAServiceManager, err := eigendasrvmg.NewContractEigenDAServiceManager(eigenDAServiceManagerAddr, t.ethClient)
 	if err != nil {
 		t.logger.Error("Failed to fetch IEigenDAServiceManager contract", "err", err)
@@ -145,9 +145,9 @@ func (t *Reader) updateContractBindings(blsOperatorStateRetrieverAddr, eigenDASe
 		return err
 	}
 
-	contractBLSOpStateRetr, err := opstateretriever.NewContractOperatorStateRetriever(blsOperatorStateRetrieverAddr, t.ethClient)
+	contractOprtStateRetr, err := opstateretriever.NewContractOperatorStateRetriever(operatorStateRetrieverAddr, t.ethClient)
 	if err != nil {
-		t.logger.Error("Failed to fetch BLSOperatorStateRetriever contract", "err", err)
+		t.logger.Error("Failed to fetch OperatorStateRetriever contract", "err", err)
 		return err
 	}
 
@@ -157,7 +157,7 @@ func (t *Reader) updateContractBindings(blsOperatorStateRetrieverAddr, eigenDASe
 		return err
 	}
 
-	t.logger.Debug("Addresses", "blsOperatorStateRetrieverAddr", blsOperatorStateRetrieverAddr.Hex(), "eigenDAServiceManagerAddr", eigenDAServiceManagerAddr.Hex(), "registryCoordinatorAddr", registryCoordinatorAddr.Hex(), "blsPubkeyRegistryAddr", blsPubkeyRegistryAddr.Hex())
+	t.logger.Debug("Addresses", "operatorStateRetrieverAddr", operatorStateRetrieverAddr.Hex(), "eigenDAServiceManagerAddr", eigenDAServiceManagerAddr.Hex(), "registryCoordinatorAddr", registryCoordinatorAddr.Hex(), "blsPubkeyRegistryAddr", blsPubkeyRegistryAddr.Hex())
 
 	contractBLSPubkeyReg, err := blsapkreg.NewContractBLSApkRegistry(blsPubkeyRegistryAddr, t.ethClient)
 	if err != nil {
@@ -256,7 +256,7 @@ func (t *Reader) updateContractBindings(blsOperatorStateRetrieverAddr, eigenDASe
 		RelayRegistryAddress:  relayRegistryAddress,
 		AVSDirectory:          contractAVSDirectory,
 		SocketRegistry:        contractSocketRegistry,
-		OpStateRetriever:      contractBLSOpStateRetr,
+		OpStateRetriever:      contractOprtStateRetr,
 		BLSApkRegistry:        contractBLSPubkeyReg,
 		IndexRegistry:         contractIIndexReg,
 		RegistryCoordinator:   contractIRegistryCoordinator,

--- a/core/eth/reader.go
+++ b/core/eth/reader.go
@@ -91,7 +91,9 @@ func NewReader(
 
 // updateContractBindings updates the contract bindings for the reader
 // TODO: update to use address directory contract once all contracts are written into the directory
-func (t *Reader) updateContractBindings(operatorStateRetrieverAddr, eigenDAServiceManagerAddr gethcommon.Address) error {
+func (t *Reader) updateContractBindings(
+	operatorStateRetrieverAddr, eigenDAServiceManagerAddr gethcommon.Address,
+) error {
 	contractEigenDAServiceManager, err := eigendasrvmg.NewContractEigenDAServiceManager(eigenDAServiceManagerAddr, t.ethClient)
 	if err != nil {
 		t.logger.Error("Failed to fetch IEigenDAServiceManager contract", "err", err)
@@ -145,7 +147,7 @@ func (t *Reader) updateContractBindings(operatorStateRetrieverAddr, eigenDAServi
 		return err
 	}
 
-	contractOprtStateRetr, err := opstateretriever.NewContractOperatorStateRetriever(operatorStateRetrieverAddr, t.ethClient)
+	contractOpStateRetr, err := opstateretriever.NewContractOperatorStateRetriever(operatorStateRetrieverAddr, t.ethClient)
 	if err != nil {
 		t.logger.Error("Failed to fetch OperatorStateRetriever contract", "err", err)
 		return err
@@ -157,7 +159,11 @@ func (t *Reader) updateContractBindings(operatorStateRetrieverAddr, eigenDAServi
 		return err
 	}
 
-	t.logger.Debug("Addresses", "operatorStateRetrieverAddr", operatorStateRetrieverAddr.Hex(), "eigenDAServiceManagerAddr", eigenDAServiceManagerAddr.Hex(), "registryCoordinatorAddr", registryCoordinatorAddr.Hex(), "blsPubkeyRegistryAddr", blsPubkeyRegistryAddr.Hex())
+	t.logger.Debug("Addresses",
+		"operatorStateRetrieverAddr", operatorStateRetrieverAddr.Hex(),
+		"eigenDAServiceManagerAddr", eigenDAServiceManagerAddr.Hex(),
+		"registryCoordinatorAddr", registryCoordinatorAddr.Hex(),
+		"blsPubkeyRegistryAddr", blsPubkeyRegistryAddr.Hex())
 
 	contractBLSPubkeyReg, err := blsapkreg.NewContractBLSApkRegistry(blsPubkeyRegistryAddr, t.ethClient)
 	if err != nil {
@@ -256,7 +262,7 @@ func (t *Reader) updateContractBindings(operatorStateRetrieverAddr, eigenDAServi
 		RelayRegistryAddress:  relayRegistryAddress,
 		AVSDirectory:          contractAVSDirectory,
 		SocketRegistry:        contractSocketRegistry,
-		OpStateRetriever:      contractOprtStateRetr,
+		OpStateRetriever:      contractOpStateRetr,
 		BLSApkRegistry:        contractBLSPubkeyReg,
 		IndexRegistry:         contractIIndexReg,
 		RegistryCoordinator:   contractIRegistryCoordinator,

--- a/core/eth/writer.go
+++ b/core/eth/writer.go
@@ -37,10 +37,10 @@ var _ core.Writer = (*Writer)(nil)
 func NewWriter(
 	logger logging.Logger,
 	client common.EthClient,
-	blsOperatorStateRetrieverHexAddr string,
+	operatorStateRetrieverHexAddr string,
 	eigenDAServiceManagerHexAddr string) (*Writer, error) {
 
-	r, err := NewReader(logger, client, blsOperatorStateRetrieverHexAddr, eigenDAServiceManagerHexAddr)
+	r, err := NewReader(logger, client, operatorStateRetrieverHexAddr, eigenDAServiceManagerHexAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reader with address directory: %w", err)
 	}

--- a/disperser/cmd/apiserver/flags/flags.go
+++ b/disperser/cmd/apiserver/flags/flags.go
@@ -68,9 +68,11 @@ var (
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "MAX_IDLE_CONNECTION_AGE_SECONDS"),
 		Value:    time.Minute,
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	// We keep the bls- prefix in the flag name to not break clients, but the contract
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "BLS_OPERATOR_STATE_RETRIVER"), // sigh
 	}
@@ -308,7 +310,7 @@ var optionalFlags = []cli.Flag{
 	AuthPmtStateRequestMaxPastAge,
 	AuthPmtStateRequestMaxFutureAge,
 	ReservedOnly,
-	BlsOperatorStateRetrieverFlag,
+	OperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 	EigenDADirectoryFlag,
 }

--- a/disperser/cmd/apiserver/flags/flags.go
+++ b/disperser/cmd/apiserver/flags/flags.go
@@ -68,7 +68,6 @@ var (
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "MAX_IDLE_CONNECTION_AGE_SECONDS"),
 		Value:    time.Minute,
 	}
-	// We keep the bls- prefix in the flag name to not break clients, but the contract
 	OperatorStateRetrieverFlag = cli.StringFlag{
 		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
 		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +

--- a/disperser/cmd/apiserver/lib/apiserver.go
+++ b/disperser/cmd/apiserver/lib/apiserver.go
@@ -44,7 +44,7 @@ func RunDisperserServer(ctx *cli.Context) error {
 	}
 
 	transactor, err := eth.NewReader(
-		logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+		logger, client, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		return err
 	}

--- a/disperser/cmd/apiserver/lib/config.go
+++ b/disperser/cmd/apiserver/lib/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	OnchainStateRefreshInterval time.Duration
 
 	EigenDADirectory                string
-	BLSOperatorStateRetrieverAddr   string
+	OperatorStateRetrieverAddr      string
 	EigenDAServiceManagerAddr       string
 	AuthPmtStateRequestMaxPastAge   time.Duration
 	AuthPmtStateRequestMaxFutureAge time.Duration
@@ -133,7 +133,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		OnchainStateRefreshInterval: ctx.GlobalDuration(flags.OnchainStateRefreshInterval.Name),
 
 		EigenDADirectory:                ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr:   ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
+		OperatorStateRetrieverAddr:      ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
 		EigenDAServiceManagerAddr:       ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
 		AuthPmtStateRequestMaxPastAge:   ctx.GlobalDuration(flags.AuthPmtStateRequestMaxPastAge.Name),
 		AuthPmtStateRequestMaxFutureAge: ctx.GlobalDuration(flags.AuthPmtStateRequestMaxFutureAge.Name),

--- a/disperser/cmd/batcher/config.go
+++ b/disperser/cmd/batcher/config.go
@@ -29,9 +29,9 @@ type Config struct {
 
 	IndexerDataDir string
 
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
-	EigenDADirectory              string
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
+	EigenDADirectory           string
 
 	EnableGnarkBundleEncoding bool
 }
@@ -83,15 +83,15 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			HTTPPort:      ctx.GlobalString(flags.MetricsHTTPPort.Name),
 			EnableMetrics: ctx.GlobalBool(flags.EnableMetrics.Name),
 		},
-		ChainStateConfig:              thegraph.ReadCLIConfig(ctx),
-		UseGraph:                      ctx.Bool(flags.UseGraphFlag.Name),
-		EigenDADirectory:              ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
-		IndexerDataDir:                ctx.GlobalString(flags.IndexerDataDirFlag.Name),
-		IndexerConfig:                 indexer.ReadIndexerConfig(ctx),
-		KMSKeyConfig:                  kmsConfig,
-		EnableGnarkBundleEncoding:     ctx.Bool(flags.EnableGnarkBundleEncodingFlag.Name),
+		ChainStateConfig:           thegraph.ReadCLIConfig(ctx),
+		UseGraph:                   ctx.Bool(flags.UseGraphFlag.Name),
+		EigenDADirectory:           ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
+		OperatorStateRetrieverAddr: ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
+		EigenDAServiceManagerAddr:  ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
+		IndexerDataDir:             ctx.GlobalString(flags.IndexerDataDirFlag.Name),
+		IndexerConfig:              indexer.ReadIndexerConfig(ctx),
+		KMSKeyConfig:               kmsConfig,
+		EnableGnarkBundleEncoding:  ctx.Bool(flags.EnableGnarkBundleEncodingFlag.Name),
 	}
 	return config, nil
 }

--- a/disperser/cmd/batcher/flags/flags.go
+++ b/disperser/cmd/batcher/flags/flags.go
@@ -36,9 +36,10 @@ var (
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "PULL_INTERVAL"),
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -260,7 +261,7 @@ var optionalFlags = []cli.Flag{
 	MaxNodeConnectionsFlag,
 	MaxNumRetriesPerDispersalFlag,
 	EnableGnarkBundleEncodingFlag,
-	BlsOperatorStateRetrieverFlag,
+	OperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 	EigenDADirectoryFlag,
 }

--- a/disperser/cmd/batcher/main.go
+++ b/disperser/cmd/batcher/main.go
@@ -179,7 +179,7 @@ func RunBatcher(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	tx, err := coreeth.NewWriter(logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := coreeth.NewWriter(logger, client, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		return err
 	}

--- a/disperser/cmd/controller/main.go
+++ b/disperser/cmd/controller/main.go
@@ -95,9 +95,9 @@ func RunController(ctx *cli.Context) error {
 	}
 
 	operatorStateRetrieverAddress, err :=
-		contractDirectory.GetContractAddress(context.Background(), directory.BLSOperatorStateRetriever)
+		contractDirectory.GetContractAddress(context.Background(), directory.OperatorStateRetriever)
 	if err != nil {
-		return fmt.Errorf("failed to get BLSOperatorStateRetriever address: %w", err)
+		return fmt.Errorf("failed to get OperatorStateRetriever address: %w", err)
 	}
 	serviceManagerAddress, err :=
 		contractDirectory.GetContractAddress(context.Background(), directory.ServiceManager)

--- a/disperser/cmd/dataapi/config.go
+++ b/disperser/cmd/dataapi/config.go
@@ -32,9 +32,9 @@ type Config struct {
 	ServerMode                   string
 	AllowOrigins                 []string
 
-	EigenDADirectory              string
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
+	EigenDADirectory           string
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
 
 	DisperserHostname  string
 	ChurnerHostname    string
@@ -58,18 +58,18 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			BucketName: ctx.GlobalString(flags.S3BucketNameFlag.Name),
 			TableName:  ctx.GlobalString(flags.DynamoTableNameFlag.Name),
 		},
-		AwsClientConfig:               aws.ReadClientConfig(ctx, flags.FlagPrefix),
-		EthClientConfig:               ethClientConfig,
-		LoggerConfig:                  *loggerConfig,
-		SocketAddr:                    ctx.GlobalString(flags.SocketAddrFlag.Name),
-		SubgraphApiBatchMetadataAddr:  ctx.GlobalString(flags.SubgraphApiBatchMetadataAddrFlag.Name),
-		SubgraphApiOperatorStateAddr:  ctx.GlobalString(flags.SubgraphApiOperatorStateAddrFlag.Name),
-		SubgraphApiPaymentsAddr:       ctx.GlobalString(flags.SubgraphApiPaymentsAddrFlag.Name),
-		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
-		EigenDADirectory:              ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
-		ServerMode:                    ctx.GlobalString(flags.ServerModeFlag.Name),
-		ServerVersion:                 version,
+		AwsClientConfig:              aws.ReadClientConfig(ctx, flags.FlagPrefix),
+		EthClientConfig:              ethClientConfig,
+		LoggerConfig:                 *loggerConfig,
+		SocketAddr:                   ctx.GlobalString(flags.SocketAddrFlag.Name),
+		SubgraphApiBatchMetadataAddr: ctx.GlobalString(flags.SubgraphApiBatchMetadataAddrFlag.Name),
+		SubgraphApiOperatorStateAddr: ctx.GlobalString(flags.SubgraphApiOperatorStateAddrFlag.Name),
+		SubgraphApiPaymentsAddr:      ctx.GlobalString(flags.SubgraphApiPaymentsAddrFlag.Name),
+		OperatorStateRetrieverAddr:   ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
+		EigenDAServiceManagerAddr:    ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
+		EigenDADirectory:             ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
+		ServerMode:                   ctx.GlobalString(flags.ServerModeFlag.Name),
+		ServerVersion:                version,
 		PrometheusConfig: prometheus.Config{
 			ServerURL: ctx.GlobalString(flags.PrometheusServerURLFlag.Name),
 			Username:  ctx.GlobalString(flags.PrometheusServerUsernameFlag.Name),

--- a/disperser/cmd/dataapi/flags/flags.go
+++ b/disperser/cmd/dataapi/flags/flags.go
@@ -84,9 +84,10 @@ var (
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "SUBGRAPH_PAYMENTS_API_SOCKET_ADDR"),
 		Required: true,
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -177,7 +178,7 @@ var optionalFlags = []cli.Flag{
 	MetricsHTTPPort,
 	DataApiServerVersionFlag,
 	EigenDADirectoryFlag,
-	BlsOperatorStateRetrieverFlag,
+	OperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 }
 

--- a/disperser/cmd/dataapi/main.go
+++ b/disperser/cmd/dataapi/main.go
@@ -87,7 +87,7 @@ func RunDataApi(ctx *cli.Context) error {
 		return err
 	}
 
-	tx, err := coreeth.NewReader(logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := coreeth.NewReader(logger, client, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		return err
 	}

--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -85,7 +85,7 @@ func NodeMain(ctx *cli.Context) error {
 	}
 
 	reader, err := coreeth.NewReader(
-		logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+		logger, client, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		return fmt.Errorf("cannot create eth.Reader: %w", err)
 	}

--- a/node/config.go
+++ b/node/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	LogPath                         string
 	ID                              core.OperatorID
 	EigenDADirectory                string
-	BLSOperatorStateRetrieverAddr   string
+	OperatorStateRetrieverAddr      string
 	EigenDAServiceManagerAddr       string
 	PubIPProviders                  []string
 	PubIPCheckInterval              time.Duration
@@ -381,7 +381,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		EncoderConfig:                       kzg.ReadCLIConfig(ctx),
 		LoggerConfig:                        *loggerConfig,
 		EigenDADirectory:                    ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr:       ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
+		OperatorStateRetrieverAddr:          ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
 		EigenDAServiceManagerAddr:           ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
 		PubIPProviders:                      ctx.GlobalStringSlice(flags.PubIPProviderFlag.Name),
 		PubIPCheckInterval:                  pubIPCheckInterval,

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -162,9 +162,10 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "EIGENDA_DIRECTORY"),
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -676,7 +677,7 @@ var optionalFlags = []cli.Flag{
 	GetChunksColdBurstLimitMBFlag,
 	GCSafetyBufferSizeGBFlag,
 	EigenDADirectoryFlag,
-	BlsOperatorStateRetrieverFlag,
+	OperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 	LittRespectLocksFlag,
 	StoreChunksBufferTimeoutFlag,

--- a/node/node.go
+++ b/node/node.go
@@ -135,7 +135,7 @@ func NewNode(
 	}
 
 	// Create Transactor
-	tx, err := eth.NewWriter(logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := eth.NewWriter(logger, client, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create writer: %w", err)
 	}

--- a/node/plugin/cmd/main.go
+++ b/node/plugin/cmd/main.go
@@ -33,7 +33,7 @@ func main() {
 		plugin.QuorumIDListFlag,
 		plugin.ChainRpcUrlFlag,
 		plugin.EigenDADirectoryFlag,
-		plugin.BlsOperatorStateRetrieverFlag,
+		plugin.OperatorStateRetrieverFlag,
 		plugin.EigenDAServiceManagerFlag,
 		plugin.ChurnerUrlFlag,
 		plugin.NumConfirmationsFlag,
@@ -130,7 +130,7 @@ func pluginOps(ctx *cli.Context) {
 	}
 	log.Printf("Info: ethclient created for url: %s", config.ChainRpcUrl)
 
-	tx, err := eth.NewWriter(logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := eth.NewWriter(logger, client, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		log.Printf("Error: failed to create EigenDA transactor: %v", err)
 		return

--- a/node/plugin/config.go
+++ b/node/plugin/config.go
@@ -112,9 +112,10 @@ var (
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "CHAIN_RPC"),
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     "bls-operator-state-retriever",
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: "bls-operator-state-retriever",
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(flags.EnvVarPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -146,24 +147,24 @@ var (
 )
 
 type Config struct {
-	PubIPProvider                 string
-	Operation                     string
-	EcdsaKeyFile                  string
-	BlsKeyFile                    string
-	EcdsaKeyPassword              string
-	BlsKeyPassword                string
-	BLSRemoteSignerUrl            string
-	BLSPublicKeyHex               string
-	BLSSignerCertFile             string
-	Socket                        string
-	QuorumIDList                  []core.QuorumID
-	ChainRpcUrl                   string
-	EigenDADirectory              string
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
-	ChurnerUrl                    string
-	NumConfirmations              int
-	BLSSignerAPIKey               string
+	PubIPProvider              string
+	Operation                  string
+	EcdsaKeyFile               string
+	BlsKeyFile                 string
+	EcdsaKeyPassword           string
+	BlsKeyPassword             string
+	BLSRemoteSignerUrl         string
+	BLSPublicKeyHex            string
+	BLSSignerCertFile          string
+	Socket                     string
+	QuorumIDList               []core.QuorumID
+	ChainRpcUrl                string
+	EigenDADirectory           string
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
+	ChurnerUrl                 string
+	NumConfirmations           int
+	BLSSignerAPIKey            string
 }
 
 func NewConfig(ctx *cli.Context) (*Config, error) {
@@ -189,23 +190,23 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	}
 
 	return &Config{
-		PubIPProvider:                 ctx.GlobalString(PubIPProviderFlag.Name),
-		Operation:                     op,
-		EcdsaKeyPassword:              ctx.GlobalString(EcdsaKeyPasswordFlag.Name),
-		BlsKeyPassword:                ctx.GlobalString(BlsKeyPasswordFlag.Name),
-		EcdsaKeyFile:                  ctx.GlobalString(EcdsaKeyFileFlag.Name),
-		BlsKeyFile:                    ctx.GlobalString(BlsKeyFileFlag.Name),
-		BLSRemoteSignerUrl:            ctx.GlobalString(BLSRemoteSignerUrlFlag.Name),
-		BLSPublicKeyHex:               ctx.GlobalString(BLSPublicKeyHexFlag.Name),
-		BLSSignerCertFile:             ctx.GlobalString(BLSSignerCertFileFlag.Name),
-		Socket:                        ctx.GlobalString(SocketFlag.Name),
-		QuorumIDList:                  ids,
-		ChainRpcUrl:                   ctx.GlobalString(ChainRpcUrlFlag.Name),
-		EigenDADirectory:              ctx.GlobalString(EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr: ctx.GlobalString(BlsOperatorStateRetrieverFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.GlobalString(EigenDAServiceManagerFlag.Name),
-		ChurnerUrl:                    ctx.GlobalString(ChurnerUrlFlag.Name),
-		NumConfirmations:              ctx.GlobalInt(NumConfirmationsFlag.Name),
-		BLSSignerAPIKey:               ctx.GlobalString(BLSSignerAPIKeyFlag.Name),
+		PubIPProvider:              ctx.GlobalString(PubIPProviderFlag.Name),
+		Operation:                  op,
+		EcdsaKeyPassword:           ctx.GlobalString(EcdsaKeyPasswordFlag.Name),
+		BlsKeyPassword:             ctx.GlobalString(BlsKeyPasswordFlag.Name),
+		EcdsaKeyFile:               ctx.GlobalString(EcdsaKeyFileFlag.Name),
+		BlsKeyFile:                 ctx.GlobalString(BlsKeyFileFlag.Name),
+		BLSRemoteSignerUrl:         ctx.GlobalString(BLSRemoteSignerUrlFlag.Name),
+		BLSPublicKeyHex:            ctx.GlobalString(BLSPublicKeyHexFlag.Name),
+		BLSSignerCertFile:          ctx.GlobalString(BLSSignerCertFileFlag.Name),
+		Socket:                     ctx.GlobalString(SocketFlag.Name),
+		QuorumIDList:               ids,
+		ChainRpcUrl:                ctx.GlobalString(ChainRpcUrlFlag.Name),
+		EigenDADirectory:           ctx.GlobalString(EigenDADirectoryFlag.Name),
+		OperatorStateRetrieverAddr: ctx.GlobalString(OperatorStateRetrieverFlag.Name),
+		EigenDAServiceManagerAddr:  ctx.GlobalString(EigenDAServiceManagerFlag.Name),
+		ChurnerUrl:                 ctx.GlobalString(ChurnerUrlFlag.Name),
+		NumConfirmations:           ctx.GlobalInt(NumConfirmationsFlag.Name),
+		BLSSignerAPIKey:            ctx.GlobalString(BLSSignerAPIKeyFlag.Name),
 	}, nil
 }

--- a/operators/churner/cmd/main.go
+++ b/operators/churner/cmd/main.go
@@ -74,7 +74,7 @@ func run(ctx *cli.Context) error {
 	}
 
 	tx, err := coreeth.NewWriter(
-		logger, gethClient, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+		logger, gethClient, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		log.Fatalln("could not create new transactor", err)
 	}

--- a/operators/churner/config.go
+++ b/operators/churner/config.go
@@ -16,9 +16,9 @@ type Config struct {
 	MetricsConfig    MetricsConfig
 	ChainStateConfig thegraph.Config
 
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
-	EigenDADirectory              string
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
+	EigenDADirectory           string
 
 	PerPublicKeyRateLimit time.Duration
 	ChurnApprovalInterval time.Duration
@@ -31,14 +31,14 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	}
 
 	return &Config{
-		EthClientConfig:               geth.ReadEthClientConfig(ctx),
-		LoggerConfig:                  *loggerConfig,
-		ChainStateConfig:              thegraph.ReadCLIConfig(ctx),
-		EigenDADirectory:              ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
-		PerPublicKeyRateLimit:         ctx.GlobalDuration(flags.PerPublicKeyRateLimit.Name),
-		ChurnApprovalInterval:         ctx.GlobalDuration(flags.ChurnApprovalInterval.Name),
+		EthClientConfig:            geth.ReadEthClientConfig(ctx),
+		LoggerConfig:               *loggerConfig,
+		ChainStateConfig:           thegraph.ReadCLIConfig(ctx),
+		EigenDADirectory:           ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
+		OperatorStateRetrieverAddr: ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
+		EigenDAServiceManagerAddr:  ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
+		PerPublicKeyRateLimit:      ctx.GlobalDuration(flags.PerPublicKeyRateLimit.Name),
+		ChurnApprovalInterval:      ctx.GlobalDuration(flags.ChurnApprovalInterval.Name),
 		MetricsConfig: MetricsConfig{
 			HTTPPort:      ctx.GlobalString(flags.MetricsHTTPPort.Name),
 			EnableMetrics: ctx.GlobalBool(flags.EnableMetrics.Name),

--- a/operators/churner/flags/flags.go
+++ b/operators/churner/flags/flags.go
@@ -32,9 +32,10 @@ var (
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "GRPC_PORT"),
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -91,7 +92,7 @@ var optionalFlags = []cli.Flag{
 	MetricsHTTPPort,
 	ChurnApprovalInterval,
 	EigenDADirectoryFlag,
-	BlsOperatorStateRetrieverFlag,
+	OperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 }
 

--- a/operators/churner/tests/churner_test.go
+++ b/operators/churner/tests/churner_test.go
@@ -238,11 +238,11 @@ func newTestServer(t *testing.T) *churner.Server {
 			PrivateKeyString: churnerPrivateKeyHex,
 			NumRetries:       numRetries,
 		},
-		LoggerConfig:                  *common.DefaultLoggerConfig(),
-		BLSOperatorStateRetrieverAddr: testConfig.EigenDA.OperatorStateRetriever,
-		EigenDAServiceManagerAddr:     testConfig.EigenDA.ServiceManager,
-		EigenDADirectory:              testConfig.EigenDA.EigenDADirectory,
-		ChurnApprovalInterval:         15 * time.Minute,
+		LoggerConfig:               *common.DefaultLoggerConfig(),
+		OperatorStateRetrieverAddr: testConfig.EigenDA.OperatorStateRetriever,
+		EigenDAServiceManagerAddr:  testConfig.EigenDA.ServiceManager,
+		EigenDADirectory:           testConfig.EigenDA.EigenDADirectory,
+		ChurnApprovalInterval:      15 * time.Minute,
 	}
 
 	operatorTransactorChurner, err := createTransactorFromScratch(

--- a/relay/cmd/flags/flags.go
+++ b/relay/cmd/flags/flags.go
@@ -202,9 +202,10 @@ var (
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "MAX_CONCURRENT_GET_CHUNK_OPS_CLIENT"),
 		Value:    1,
 	}
-	BlsOperatorStateRetrieverAddrFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever-addr"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state retriever",
+	OperatorStateRetrieverAddrFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever-addr"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "BLS_OPERATOR_STATE_RETRIEVER_ADDR"),
 	}
@@ -401,7 +402,7 @@ var optionalFlags = []cli.Flag{
 	GetChunksRequestMaxPastAgeFlag,
 	GetChunksRequestMaxFutureAgeFlag,
 	EigenDADirectoryFlag,
-	BlsOperatorStateRetrieverAddrFlag,
+	OperatorStateRetrieverAddrFlag,
 	EigenDAServiceManagerAddrFlag,
 	MaxConnectionAgeFlag,
 	MaxConnectionAgeGraceFlag,

--- a/relay/cmd/lib/config.go
+++ b/relay/cmd/lib/config.go
@@ -33,11 +33,11 @@ type Config struct {
 	RelayConfig relay.Config
 
 	// Configuration for the graph indexer.
-	EthClientConfig               geth.EthClientConfig
-	EigenDADirectory              string
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
-	ChainStateConfig              thegraph.Config
+	EthClientConfig            geth.EthClientConfig
+	EigenDADirectory           string
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
+	ChainStateConfig           thegraph.Config
 }
 
 func NewConfig(ctx *cli.Context) (Config, error) {
@@ -105,11 +105,11 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			MaxConnectionAgeGrace: ctx.Duration(flags.MaxConnectionAgeGraceFlag.Name),
 			MaxIdleConnectionAge:  ctx.Duration(flags.MaxIdleConnectionAgeFlag.Name),
 		},
-		EthClientConfig:               geth.ReadEthClientConfigRPCOnly(ctx),
-		EigenDADirectory:              ctx.String(flags.EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr: ctx.String(flags.BlsOperatorStateRetrieverAddrFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.String(flags.EigenDAServiceManagerAddrFlag.Name),
-		ChainStateConfig:              thegraph.ReadCLIConfig(ctx),
+		EthClientConfig:            geth.ReadEthClientConfigRPCOnly(ctx),
+		EigenDADirectory:           ctx.String(flags.EigenDADirectoryFlag.Name),
+		OperatorStateRetrieverAddr: ctx.String(flags.OperatorStateRetrieverAddrFlag.Name),
+		EigenDAServiceManagerAddr:  ctx.String(flags.EigenDAServiceManagerAddrFlag.Name),
+		ChainStateConfig:           thegraph.ReadCLIConfig(ctx),
 	}
 	for i, id := range relayKeys {
 		config.RelayConfig.RelayKeys[i] = core.RelayKey(id)

--- a/relay/cmd/lib/relay.go
+++ b/relay/cmd/lib/relay.go
@@ -55,7 +55,7 @@ func RunRelay(ctx *cli.Context) error {
 		return fmt.Errorf("failed to create eth client: %w", err)
 	}
 
-	tx, err := eth.NewWriter(logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := eth.NewWriter(logger, client, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		return fmt.Errorf("failed to create eth writer: %w", err)
 	}

--- a/retriever/cmd/main.go
+++ b/retriever/cmd/main.go
@@ -90,7 +90,7 @@ func RetrieverMain(ctx *cli.Context) error {
 		log.Fatalln("could not start tcp listener", err)
 	}
 
-	tx, err := eth.NewReader(logger, gethClient, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := eth.NewReader(logger, gethClient, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		log.Fatalln("could not start tcp listener", err)
 	}

--- a/retriever/config.go
+++ b/retriever/config.go
@@ -17,11 +17,11 @@ type Config struct {
 	LoggerConfig    common.LoggerConfig
 	MetricsConfig   MetricsConfig
 
-	Timeout                       time.Duration
-	NumConnections                int
-	EigenDADirectory              string
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
+	Timeout                    time.Duration
+	NumConnections             int
+	EigenDADirectory           string
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
 
 	EigenDAVersion int
 }
@@ -43,11 +43,11 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		MetricsConfig: MetricsConfig{
 			HTTPPort: ctx.GlobalString(flags.MetricsHTTPPortFlag.Name),
 		},
-		Timeout:                       ctx.Duration(flags.TimeoutFlag.Name),
-		NumConnections:                ctx.Int(flags.NumConnectionsFlag.Name),
-		EigenDADirectory:              ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
-		EigenDAVersion:                version,
+		Timeout:                    ctx.Duration(flags.TimeoutFlag.Name),
+		NumConnections:             ctx.Int(flags.NumConnectionsFlag.Name),
+		EigenDADirectory:           ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
+		OperatorStateRetrieverAddr: ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
+		EigenDAServiceManagerAddr:  ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
+		EigenDAVersion:             version,
 	}, nil
 }

--- a/retriever/flags/flags.go
+++ b/retriever/flags/flags.go
@@ -32,9 +32,10 @@ var (
 		Required: true,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "TIMEOUT"),
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -82,7 +83,7 @@ func RetrieverFlags(envPrefix string) []cli.Flag {
 		GrpcPortFlag,
 		TimeoutFlag,
 		EigenDADirectoryFlag,
-		BlsOperatorStateRetrieverFlag,
+		OperatorStateRetrieverFlag,
 		EigenDAServiceManagerFlag,
 		NumConnectionsFlag,
 		MetricsHTTPPortFlag,

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -209,7 +209,10 @@ func NewTestClient(
 		registry = metrics.registry
 	}
 
-	certBuilder, err := clientsv2.NewCertBuilder(logger, gethcommon.HexToAddress(config.OperatorStateRetrieverAddr), ethReader.GetRegistryCoordinatorAddress(), ethClient)
+	certBuilder, err := clientsv2.NewCertBuilder(logger,
+		gethcommon.HexToAddress(config.OperatorStateRetrieverAddr),
+		ethReader.GetRegistryCoordinatorAddress(),
+		ethClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cert builder: %w", err)
 	}

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -179,7 +179,7 @@ func NewTestClient(
 	ethReader, err := eth.NewReader(
 		logger,
 		ethClient,
-		config.BLSOperatorStateRetrieverAddr,
+		config.OperatorStateRetrieverAddr,
 		config.EigenDAServiceManagerAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Ethereum reader: %w", err)
@@ -209,7 +209,7 @@ func NewTestClient(
 		registry = metrics.registry
 	}
 
-	certBuilder, err := clientsv2.NewCertBuilder(logger, gethcommon.HexToAddress(config.BLSOperatorStateRetrieverAddr), ethReader.GetRegistryCoordinatorAddress(), ethClient)
+	certBuilder, err := clientsv2.NewCertBuilder(logger, gethcommon.HexToAddress(config.OperatorStateRetrieverAddr), ethReader.GetRegistryCoordinatorAddress(), ethClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cert builder: %w", err)
 	}

--- a/test/v2/client/test_client_config.go
+++ b/test/v2/client/test_client_config.go
@@ -35,11 +35,11 @@ type TestClientConfig struct {
 	EthRPCUrlsVar string
 	// The contract address for the EigenDA address directory, where all contract addresses are stored
 	//
-	// Currently the EigenDA address directory is just used to look up BLSOperatorStateRetrieverAddr and EigenDAServiceManagerAddr.
+	// Currently the EigenDA address directory is just used to look up OperatorStateRetrieverAddr and EigenDAServiceManagerAddr.
 	// In a later PR, ensure all addresses are populated into the directory, and use it for all contract address lookups.
 	EigenDADirectory string
 	// The contract address for the EigenDA BLS operator state retriever
-	BLSOperatorStateRetrieverAddr string
+	OperatorStateRetrieverAddr string
 	// The contract address for the EigenDA service manager
 	EigenDAServiceManagerAddr string
 	// The contract address for the EigenDA cert verifier, which specifies required quorums 0 and 1

--- a/test/v2/client/test_client_config.go
+++ b/test/v2/client/test_client_config.go
@@ -38,7 +38,7 @@ type TestClientConfig struct {
 	// Currently the EigenDADirectory is just used to look up OperatorStateRetrieverAddr and EigenDAServiceManagerAddr.
 	// TODO(samlaf): use EigenDADirectory for all contract address lookups.
 	EigenDADirectory string
-	// The contract address for the EigenDA BLS operator state retriever
+	// The contract address for the OperatorStateRetriever
 	OperatorStateRetrieverAddr string
 	// The contract address for the EigenDA service manager
 	EigenDAServiceManagerAddr string

--- a/test/v2/client/test_client_config.go
+++ b/test/v2/client/test_client_config.go
@@ -35,8 +35,8 @@ type TestClientConfig struct {
 	EthRPCUrlsVar string
 	// The contract address for the EigenDA address directory, where all contract addresses are stored
 	//
-	// Currently the EigenDA address directory is just used to look up OperatorStateRetrieverAddr and EigenDAServiceManagerAddr.
-	// In a later PR, ensure all addresses are populated into the directory, and use it for all contract address lookups.
+	// Currently the EigenDADirectory is just used to look up OperatorStateRetrieverAddr and EigenDAServiceManagerAddr.
+	// TODO(samlaf): use EigenDADirectory for all contract address lookups.
 	EigenDADirectory string
 	// The contract address for the EigenDA BLS operator state retriever
 	OperatorStateRetrieverAddr string

--- a/test/v2/config/environment/broken/preprod.json
+++ b/test/v2/config/environment/broken/preprod.json
@@ -6,7 +6,7 @@
   "EthRPCURLs": [
     "https://ethereum-holesky-rpc.publicnode.com"
   ],
-  "BLSOperatorStateRetrieverAddr":          "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7",
+  "OperatorStateRetrieverAddr":          "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7",
   "EigenDAServiceManagerAddr":              "0x54A03db2784E3D0aCC08344D05385d0b62d4F432",
   "EigenDACertVerifierAddressQuorums0_1":   "0xCCFE3d87fB7D369f1eeE65221a29A83f1323043C",
   "EigenDACertVerifierAddressQuorums0_1_2": "0x2ccB62f3349DD04FEeff189C7f0568193eFd4430",

--- a/test/v2/config/environment/testnet.json
+++ b/test/v2/config/environment/testnet.json
@@ -6,7 +6,7 @@
   "EthRPCURLs": [
     "https://ethereum-holesky-rpc.publicnode.com"
   ],
-  "BLSOperatorStateRetrieverAddr":          "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7",
+  "OperatorStateRetrieverAddr":          "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7",
   "EigenDAServiceManagerAddr":              "0xD4A7E1Bd8015057293f0D0A557088c286942e84b",
   "EigenDACertVerifierAddressQuorums0_1":   "0xd305aeBcdEc21D00fDF8796CE37d0e74836a6B6e",
   "EigenDACertVerifierAddressQuorums0_1_2": "",

--- a/tools/ejections/cmd/main.go
+++ b/tools/ejections/cmd/main.go
@@ -68,7 +68,7 @@ func RunScan(ctx *cli.Context) error {
 		return err
 	}
 
-	tx, err := eth.NewReader(logger, client, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := eth.NewReader(logger, client, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		return err
 	}

--- a/tools/ejections/config.go
+++ b/tools/ejections/config.go
@@ -15,23 +15,23 @@ type Config struct {
 	First            uint
 	Skip             uint
 
-	EthClientConfig               geth.EthClientConfig
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
-	EigenDADirectory              string
+	EthClientConfig            geth.EthClientConfig
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
+	EigenDADirectory           string
 }
 
 func ReadConfig(ctx *cli.Context) *Config {
 	return &Config{
-		Days:                          ctx.Int(flags.DaysFlag.Name),
-		OperatorId:                    ctx.String(flags.OperatorIdFlag.Name),
-		SubgraphEndpoint:              ctx.String(flags.SubgraphEndpointFlag.Name),
-		First:                         ctx.Uint(flags.FirstFlag.Name),
-		Skip:                          ctx.Uint(flags.SkipFlag.Name),
-		EthClientConfig:               geth.ReadEthClientConfig(ctx),
-		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
-		EigenDADirectory:              ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
+		Days:                       ctx.Int(flags.DaysFlag.Name),
+		OperatorId:                 ctx.String(flags.OperatorIdFlag.Name),
+		SubgraphEndpoint:           ctx.String(flags.SubgraphEndpointFlag.Name),
+		First:                      ctx.Uint(flags.FirstFlag.Name),
+		Skip:                       ctx.Uint(flags.SkipFlag.Name),
+		EthClientConfig:            geth.ReadEthClientConfig(ctx),
+		OperatorStateRetrieverAddr: ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
+		EigenDAServiceManagerAddr:  ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
+		EigenDADirectory:           ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
 	}
 }
 

--- a/tools/ejections/flags/flags.go
+++ b/tools/ejections/flags/flags.go
@@ -53,9 +53,10 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "EIGENDA_DIRECTORY"),
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -76,7 +77,7 @@ var optionalFlags = []cli.Flag{
 	DaysFlag,
 	FirstFlag,
 	EigenDADirectoryFlag,
-	BlsOperatorStateRetrieverFlag,
+	OperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 	SkipFlag,
 }

--- a/tools/quorumscan/cmd/main.go
+++ b/tools/quorumscan/cmd/main.go
@@ -59,7 +59,7 @@ func RunScan(ctx *cli.Context) error {
 		return err
 	}
 
-	tx, err := eth.NewReader(logger, gethClient, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := eth.NewReader(logger, gethClient, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		log.Fatalln("could not start eth.NewReader", err)
 	}

--- a/tools/quorumscan/config.go
+++ b/tools/quorumscan/config.go
@@ -27,9 +27,9 @@ type Config struct {
 	ChainStateConfig thegraph.Config
 	EthClientConfig  geth.EthClientConfig
 
-	EigenDADirectory              string
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
+	EigenDADirectory           string
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
 }
 
 func ReadConfig(ctx *cli.Context) *Config {
@@ -46,16 +46,16 @@ func ReadConfig(ctx *cli.Context) *Config {
 	}
 
 	return &Config{
-		ChainStateConfig:              thegraph.ReadCLIConfig(ctx),
-		EthClientConfig:               geth.ReadEthClientConfig(ctx),
-		EigenDADirectory:              ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
-		QuorumIDs:                     quorumIDs,
-		BlockNumber:                   ctx.Uint64(flags.BlockNumberFlag.Name),
-		TopN:                          ctx.Uint(flags.TopNFlag.Name),
-		OutputFormat:                  ctx.String(flags.OutputFormatFlag.Name),
-		OutputFile:                    ctx.String(flags.OutputFileFlag.Name),
+		ChainStateConfig:           thegraph.ReadCLIConfig(ctx),
+		EthClientConfig:            geth.ReadEthClientConfig(ctx),
+		EigenDADirectory:           ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
+		OperatorStateRetrieverAddr: ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
+		EigenDAServiceManagerAddr:  ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
+		QuorumIDs:                  quorumIDs,
+		BlockNumber:                ctx.Uint64(flags.BlockNumberFlag.Name),
+		TopN:                       ctx.Uint(flags.TopNFlag.Name),
+		OutputFormat:               ctx.String(flags.OutputFormatFlag.Name),
+		OutputFile:                 ctx.String(flags.OutputFileFlag.Name),
 	}
 }
 

--- a/tools/quorumscan/flags/flags.go
+++ b/tools/quorumscan/flags/flags.go
@@ -20,9 +20,10 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "EIGENDA_DIRECTORY"),
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -76,7 +77,7 @@ var optionalFlags = []cli.Flag{
 	OutputFormatFlag,
 	OutputFileFlag,
 	EigenDADirectoryFlag,
-	BlsOperatorStateRetrieverFlag,
+	OperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 }
 

--- a/tools/semverscan/cmd/main.go
+++ b/tools/semverscan/cmd/main.go
@@ -55,7 +55,7 @@ func RunScan(ctx *cli.Context) error {
 		return err
 	}
 
-	tx, err := eth.NewReader(logger, gethClient, config.BLSOperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
+	tx, err := eth.NewReader(logger, gethClient, config.OperatorStateRetrieverAddr, config.EigenDAServiceManagerAddr)
 	if err != nil {
 		log.Fatalln("could not start tcp listener", err)
 	}

--- a/tools/semverscan/config.go
+++ b/tools/semverscan/config.go
@@ -20,22 +20,22 @@ type Config struct {
 	ChainStateConfig thegraph.Config
 	EthClientConfig  geth.EthClientConfig
 
-	EigenDADirectory              string
-	BLSOperatorStateRetrieverAddr string
-	EigenDAServiceManagerAddr     string
+	EigenDADirectory           string
+	OperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr  string
 }
 
 func ReadConfig(ctx *cli.Context) *Config {
 	return &Config{
-		Timeout:                       ctx.Duration(flags.TimeoutFlag.Name),
-		Workers:                       ctx.Int(flags.WorkersFlag.Name),
-		OperatorId:                    ctx.String(flags.OperatorIdFlag.Name),
-		UseRetrievalClient:            ctx.Bool(flags.UseRetrievalClientFlag.Name),
-		ChainStateConfig:              thegraph.ReadCLIConfig(ctx),
-		EthClientConfig:               geth.ReadEthClientConfig(ctx),
-		EigenDADirectory:              ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
-		BLSOperatorStateRetrieverAddr: ctx.GlobalString(flags.BlsOperatorStateRetrieverFlag.Name),
-		EigenDAServiceManagerAddr:     ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
+		Timeout:                    ctx.Duration(flags.TimeoutFlag.Name),
+		Workers:                    ctx.Int(flags.WorkersFlag.Name),
+		OperatorId:                 ctx.String(flags.OperatorIdFlag.Name),
+		UseRetrievalClient:         ctx.Bool(flags.UseRetrievalClientFlag.Name),
+		ChainStateConfig:           thegraph.ReadCLIConfig(ctx),
+		EthClientConfig:            geth.ReadEthClientConfig(ctx),
+		EigenDADirectory:           ctx.GlobalString(flags.EigenDADirectoryFlag.Name),
+		OperatorStateRetrieverAddr: ctx.GlobalString(flags.OperatorStateRetrieverFlag.Name),
+		EigenDAServiceManagerAddr:  ctx.GlobalString(flags.EigenDAServiceManagerFlag.Name),
 	}
 }
 

--- a/tools/semverscan/flags/flags.go
+++ b/tools/semverscan/flags/flags.go
@@ -22,9 +22,10 @@ var (
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "EIGENDA_DIRECTORY"),
 	}
-	BlsOperatorStateRetrieverFlag = cli.StringFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
-		Usage:    "[Deprecated: use EigenDADirectory instead] Address of the BLS operator state Retriever",
+	OperatorStateRetrieverFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "bls-operator-state-retriever"),
+		Usage: "[Deprecated: use EigenDADirectory instead] Address of the OperatorStateRetriever contract. " +
+			"Note that the contract no longer uses the BLS prefix.",
 		Required: false,
 		EnvVar:   common.PrefixEnvVar(envPrefix, "BLS_OPERATOR_STATE_RETRIVER"),
 	}
@@ -72,7 +73,7 @@ var optionalFlags = []cli.Flag{
 	OperatorIdFlag,
 	UseRetrievalClientFlag,
 	EigenDADirectoryFlag,
-	BlsOperatorStateRetrieverFlag,
+	OperatorStateRetrieverFlag,
 	EigenDAServiceManagerFlag,
 }
 


### PR DESCRIPTION
The contract no longer has the bls prefix, so doesn't make sense for our offchain code to do. I kept the bls prefix only for flag names so as not to break customers.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
