### PR TITLE
fix(docker-bake): wrong proxy-release target repo (#1899) - CHERRY-PICK

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -341,7 +341,4 @@ target "nodeplugin-release" {
 
 target "proxy-release" {
   inherits = ["proxy", "_release"]
-  # We push to layr-labs/ directly instead of layr-labs/eigenda/ for historical reasons,
-  # since proxy was previously in its own repo: https://github.com/Layr-Labs/eigenda-proxy
-  tags     = ["${REGISTRY}/eigenda-proxy:${BUILD_TAG}"]
 }


### PR DESCRIPTION
Cherry-picking this PR that fixes docker-bake.
Github action to publish proxy failed on v2.2.0 tag: https://github.com/Layr-Labs/eigenda/actions/runs/17082031957/attempts/1
After this is cherry-picked, I will tag with v2.2.1 and make a new release.

it was pushing to ghcr.io/eigenda-proxy instead of ghcr.io/layr-labs/eigenda-proxy. See https://github.com/Layr-Labs/eigenda/actions/runs/17082031957/job/48438124219

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
