### PR TITLE
feat(metrics): add v2 client retrieval metrics

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -318,7 +318,7 @@ func (c *disperserClient) DisperseBlobWithProbe(
 		return nil, [32]byte{}, fmt.Errorf("verify received blob key: %w", err)
 	}
 
-	c.metrics.RecordBlobSizeBytes(uint(len(data)))
+	c.metrics.RecordBlobSizeBytes(len(data))
 
 	return &blobStatus, corev2.BlobKey(reply.GetBlobKey()), nil
 }

--- a/api/clients/v2/examples/client_construction.go
+++ b/api/clients/v2/examples/client_construction.go
@@ -125,7 +125,8 @@ func createRelayPayloadRetriever() (*payloadretrieval.RelayPayloadRetriever, err
 		rand.New(rand.NewSource(time.Now().UnixNano())),
 		relayPayloadRetrieverConfig,
 		relayClient,
-		kzgVerifier.Srs.G1)
+		kzgVerifier.Srs.G1,
+		metrics.NoopRetrievalMetrics)
 }
 
 func createValidatorPayloadRetriever() (*payloadretrieval.ValidatorPayloadRetriever, error) {
@@ -174,7 +175,8 @@ func createValidatorPayloadRetriever() (*payloadretrieval.ValidatorPayloadRetrie
 		logger,
 		validatorPayloadRetrieverConfig,
 		retrievalClient,
-		kzgVerifier.Srs.G1)
+		kzgVerifier.Srs.G1,
+		metrics.NoopRetrievalMetrics)
 }
 
 func createRelayClient(

--- a/api/clients/v2/metrics/dispersal.go
+++ b/api/clients/v2/metrics/dispersal.go
@@ -36,6 +36,7 @@ func NewDispersalMetrics(registry *prometheus.Registry) DispersalMetricer {
 			Help:      "Size of blobs created from payloads in bytes",
 			Buckets:   blobSizeBuckets,
 		}),
+		factory: factory,
 	}
 }
 

--- a/api/clients/v2/metrics/dispersal.go
+++ b/api/clients/v2/metrics/dispersal.go
@@ -10,7 +10,7 @@ const (
 )
 
 type DispersalMetricer interface {
-	RecordBlobSizeBytes(size uint)
+	RecordBlobSizeBytes(size int)
 
 	Document() []metrics.DocumentedMetric
 }
@@ -40,7 +40,7 @@ func NewDispersalMetrics(registry *prometheus.Registry) DispersalMetricer {
 	}
 }
 
-func (m *DispersalMetrics) RecordBlobSizeBytes(size uint) {
+func (m *DispersalMetrics) RecordBlobSizeBytes(size int) {
 	m.BlobSize.Observe(float64(size))
 }
 
@@ -53,7 +53,7 @@ type noopDispersalMetricer struct {
 
 var NoopDispersalMetrics DispersalMetricer = new(noopDispersalMetricer)
 
-func (n *noopDispersalMetricer) RecordBlobSizeBytes(_ uint) {
+func (n *noopDispersalMetricer) RecordBlobSizeBytes(_ int) {
 }
 
 func (n *noopDispersalMetricer) Document() []metrics.DocumentedMetric {

--- a/api/clients/v2/metrics/dispersal.go
+++ b/api/clients/v2/metrics/dispersal.go
@@ -27,19 +27,6 @@ func NewDispersalMetrics(registry *prometheus.Registry) DispersalMetricer {
 	}
 
 	factory := metrics.With(registry)
-	// Define size buckets for payload and blob size measurements
-	// Starting from 0 up to 16MiB
-	sizeBuckets := []float64{
-		0,
-		131072,   // 128KiB
-		262144,   // 256KiB
-		524288,   // 512KiB
-		1048576,  // 1MiB
-		2097152,  // 2MiB
-		4194304,  // 4MiB
-		8388608,  // 8MiB
-		16777216, // 16MiB
-	}
 
 	return &DispersalMetrics{
 		BlobSize: factory.NewHistogram(prometheus.HistogramOpts{
@@ -47,7 +34,7 @@ func NewDispersalMetrics(registry *prometheus.Registry) DispersalMetricer {
 			Namespace: namespace,
 			Subsystem: dispersalSubsystem,
 			Help:      "Size of blobs created from payloads in bytes",
-			Buckets:   sizeBuckets,
+			Buckets:   blobSizeBuckets,
 		}),
 	}
 }

--- a/api/clients/v2/metrics/metrics.go
+++ b/api/clients/v2/metrics/metrics.go
@@ -3,3 +3,19 @@ package metrics
 const (
 	namespace = "eigenda"
 )
+
+var (
+	// Buckets for payload and blob size measurements
+	// Starting from 0 up to 16MiB
+	blobSizeBuckets = []float64{
+		0,
+		131072,   // 128KiB
+		262144,   // 256KiB
+		524288,   // 512KiB
+		1048576,  // 1MiB
+		2097152,  // 2MiB
+		4194304,  // 4MiB
+		8388608,  // 8MiB
+		16777216, // 16MiB
+	}
+)

--- a/api/clients/v2/metrics/retrieval.go
+++ b/api/clients/v2/metrics/retrieval.go
@@ -27,19 +27,6 @@ func NewRetrievalMetrics(registry *prometheus.Registry) RetrievalMetricer {
 	}
 
 	factory := metrics.With(registry)
-	// Define size buckets for payload and blob size measurements
-	// Starting from 0 up to 16MiB
-	sizeBuckets := []float64{
-		0,
-		131072,   // 128KiB
-		262144,   // 256KiB
-		524288,   // 512KiB
-		1048576,  // 1MiB
-		2097152,  // 2MiB
-		4194304,  // 4MiB
-		8388608,  // 8MiB
-		16777216, // 16MiB
-	}
 
 	return &RetrievalMetrics{
 		PayloadSize: factory.NewHistogram(prometheus.HistogramOpts{
@@ -47,7 +34,7 @@ func NewRetrievalMetrics(registry *prometheus.Registry) RetrievalMetricer {
 			Namespace: namespace,
 			Subsystem: retrievalSubsystem,
 			Help:      "Size of decoded payloads in bytes",
-			Buckets:   sizeBuckets,
+			Buckets:   blobSizeBuckets,
 		}),
 		factory: factory,
 	}

--- a/api/clients/v2/metrics/retrieval.go
+++ b/api/clients/v2/metrics/retrieval.go
@@ -1,0 +1,74 @@
+package metrics
+
+import (
+	"github.com/Layr-Labs/eigenda/common/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	retrievalSubsystem = "retrieval"
+)
+
+type RetrievalMetricer interface {
+	RecordPayloadSizeBytes(size uint)
+
+	Document() []metrics.DocumentedMetric
+}
+
+type RetrievalMetrics struct {
+	PayloadSize prometheus.Histogram
+
+	factory *metrics.Documentor
+}
+
+func NewRetrievalMetrics(registry *prometheus.Registry) RetrievalMetricer {
+	if registry == nil {
+		return NoopRetrievalMetrics
+	}
+
+	factory := metrics.With(registry)
+	// Define size buckets for payload and blob size measurements
+	// Starting from 0 up to 16MiB
+	sizeBuckets := []float64{
+		0,
+		131072,   // 128KiB
+		262144,   // 256KiB
+		524288,   // 512KiB
+		1048576,  // 1MiB
+		2097152,  // 2MiB
+		4194304,  // 4MiB
+		8388608,  // 8MiB
+		16777216, // 16MiB
+	}
+
+	return &RetrievalMetrics{
+		PayloadSize: factory.NewHistogram(prometheus.HistogramOpts{
+			Name:      "payload_size_bytes",
+			Namespace: namespace,
+			Subsystem: retrievalSubsystem,
+			Help:      "Size of decoded payloads in bytes",
+			Buckets:   sizeBuckets,
+		}),
+		factory: factory,
+	}
+}
+
+func (m *RetrievalMetrics) RecordPayloadSizeBytes(size uint) {
+	m.PayloadSize.Observe(float64(size))
+}
+
+func (m *RetrievalMetrics) Document() []metrics.DocumentedMetric {
+	return m.factory.Document()
+}
+
+type noopRetrievalMetricer struct {
+}
+
+var NoopRetrievalMetrics RetrievalMetricer = new(noopRetrievalMetricer)
+
+func (n *noopRetrievalMetricer) RecordPayloadSizeBytes(_ uint) {
+}
+
+func (n *noopRetrievalMetricer) Document() []metrics.DocumentedMetric {
+	return []metrics.DocumentedMetric{}
+}

--- a/api/clients/v2/metrics/retrieval.go
+++ b/api/clients/v2/metrics/retrieval.go
@@ -10,7 +10,7 @@ const (
 )
 
 type RetrievalMetricer interface {
-	RecordPayloadSizeBytes(size uint)
+	RecordPayloadSizeBytes(size int)
 
 	Document() []metrics.DocumentedMetric
 }
@@ -40,7 +40,7 @@ func NewRetrievalMetrics(registry *prometheus.Registry) RetrievalMetricer {
 	}
 }
 
-func (m *RetrievalMetrics) RecordPayloadSizeBytes(size uint) {
+func (m *RetrievalMetrics) RecordPayloadSizeBytes(size int) {
 	m.PayloadSize.Observe(float64(size))
 }
 
@@ -53,7 +53,7 @@ type noopRetrievalMetricer struct {
 
 var NoopRetrievalMetrics RetrievalMetricer = new(noopRetrievalMetricer)
 
-func (n *noopRetrievalMetricer) RecordPayloadSizeBytes(_ uint) {
+func (n *noopRetrievalMetricer) RecordPayloadSizeBytes(_ int) {
 }
 
 func (n *noopRetrievalMetricer) Document() []metrics.DocumentedMetric {

--- a/api/clients/v2/payloadretrieval/relay_payload_retriever.go
+++ b/api/clients/v2/payloadretrieval/relay_payload_retriever.go
@@ -88,7 +88,7 @@ func (pr *RelayPayloadRetriever) GetPayload(
 		return nil, coretypes.ErrBlobDecodingFailedDerivationError.WithMessage(err.Error())
 	}
 
-	pr.metrics.RecordPayloadSizeBytes(uint(len(payload)))
+	pr.metrics.RecordPayloadSizeBytes(len(payload))
 
 	return payload, nil
 }

--- a/api/clients/v2/payloadretrieval/relay_payload_retriever_test.go
+++ b/api/clients/v2/payloadretrieval/relay_payload_retriever_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
+	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	clientsmock "github.com/Layr-Labs/eigenda/api/clients/v2/mock"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
 	commonv2 "github.com/Layr-Labs/eigenda/api/grpc/common/v2"
@@ -69,7 +70,8 @@ func buildRelayPayloadRetrieverTester(t *testing.T) RelayPayloadRetrieverTester 
 		random.Rand,
 		clientConfig,
 		&mockRelayClient,
-		g1Srs)
+		g1Srs,
+		metrics.NoopRetrievalMetrics)
 
 	require.NotNil(t, client)
 	require.NoError(t, err)

--- a/api/clients/v2/payloadretrieval/validator_payload_retriever.go
+++ b/api/clients/v2/payloadretrieval/validator_payload_retriever.go
@@ -79,7 +79,7 @@ func (pr *ValidatorPayloadRetriever) GetPayload(
 		return nil, coretypes.ErrBlobDecodingFailedDerivationError.WithMessage(err.Error())
 	}
 
-	pr.metrics.RecordPayloadSizeBytes(uint(len(payload)))
+	pr.metrics.RecordPayloadSizeBytes(len(payload))
 
 	return payload, nil
 }

--- a/api/clients/v2/payloadretrieval/validator_payload_retriever.go
+++ b/api/clients/v2/payloadretrieval/validator_payload_retriever.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
+	"github.com/Layr-Labs/eigenda/api/clients/v2/metrics"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/validator"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
@@ -23,6 +24,7 @@ type ValidatorPayloadRetriever struct {
 	config          ValidatorPayloadRetrieverConfig
 	retrievalClient validator.ValidatorClient
 	g1Srs           []bn254.G1Affine
+	metrics         metrics.RetrievalMetricer
 }
 
 var _ clients.PayloadRetriever = &ValidatorPayloadRetriever{}
@@ -33,6 +35,7 @@ func NewValidatorPayloadRetriever(
 	config ValidatorPayloadRetrieverConfig,
 	retrievalClient validator.ValidatorClient,
 	g1Srs []bn254.G1Affine,
+	metrics metrics.RetrievalMetricer,
 ) (*ValidatorPayloadRetriever, error) {
 	err := config.checkAndSetDefaults()
 	if err != nil {
@@ -44,6 +47,7 @@ func NewValidatorPayloadRetriever(
 		config:          config,
 		retrievalClient: retrievalClient,
 		g1Srs:           g1Srs,
+		metrics:         metrics,
 	}, nil
 }
 
@@ -74,6 +78,8 @@ func (pr *ValidatorPayloadRetriever) GetPayload(
 		}
 		return nil, coretypes.ErrBlobDecodingFailedDerivationError.WithMessage(err.Error())
 	}
+
+	pr.metrics.RecordPayloadSizeBytes(uint(len(payload)))
 
 	return payload, nil
 }

--- a/api/proxy/metrics/cli.go
+++ b/api/proxy/metrics/cli.go
@@ -99,6 +99,7 @@ func NewSubcommands() cli.Commands {
 					NewMetrics(registry).Document(),
 					metrics.NewAccountantMetrics(registry).Document(),
 					metrics.NewDispersalMetrics(registry).Document(),
+					metrics.NewRetrievalMetrics(registry).Document(),
 				)
 
 				table := tablewriter.NewWriter(os.Stdout)

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -386,7 +386,8 @@ func setupRetrievalClients(testConfig *deploy.Config) error {
 		logger,
 		validatorPayloadRetrieverConfig,
 		retrievalClientV2,
-		kzgVerifier.Srs.G1)
+		kzgVerifier.Srs.G1,
+		metrics.NoopRetrievalMetrics)
 
 	if err != nil {
 		return err
@@ -416,7 +417,8 @@ func setupRetrievalClients(testConfig *deploy.Config) error {
 		rand.New(rand.NewSource(time.Now().UnixNano())),
 		relayPayloadRetrieverConfig,
 		relayClient,
-		kzgVerifier.Srs.G1)
+		kzgVerifier.Srs.G1,
+		metrics.NoopRetrievalMetrics)
 
 	return err
 }

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -312,7 +312,8 @@ func NewTestClient(
 		rand.Rand,
 		*relayPayloadRetrieverConfig,
 		relayClient,
-		blobVerifier.Srs.G1)
+		blobVerifier.Srs.G1,
+		metricsv2.NoopRetrievalMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create relay payload retriever: %w", err)
 	}
@@ -349,7 +350,8 @@ func NewTestClient(
 		logger,
 		*validatorPayloadRetrieverConfig,
 		retrievalClient,
-		blobVerifier.Srs.G1)
+		blobVerifier.Srs.G1,
+		metricsv2.NoopRetrievalMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create validator payload retriever: %w", err)
 	}


### PR DESCRIPTION
Closes DAINT-693

Adds retrieval metrics for payload retrieval via both relay and validator paths

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
