### PR TITLE
fix(cert-verifier): add error codes so fct doesnt revert on invalid certs

### DIFF
--- a/contracts/bindings/EigenDACertVerifier/binding.go
+++ b/contracts/bindings/EigenDACertVerifier/binding.go
@@ -29,15 +29,83 @@ var (
 	_ = abi.ConvertType
 )
 
+// BN254G1Point is an auto generated low-level Go binding around an user-defined struct.
+type BN254G1Point struct {
+	X *big.Int
+	Y *big.Int
+}
+
+// BN254G2Point is an auto generated low-level Go binding around an user-defined struct.
+type BN254G2Point struct {
+	X [2]*big.Int
+	Y [2]*big.Int
+}
+
+// EigenDACertTypesEigenDACertV3 is an auto generated low-level Go binding around an user-defined struct.
+type EigenDACertTypesEigenDACertV3 struct {
+	BatchHeader                 EigenDATypesV2BatchHeaderV2
+	BlobInclusionInfo           EigenDATypesV2BlobInclusionInfo
+	NonSignerStakesAndSignature EigenDATypesV1NonSignerStakesAndSignature
+	SignedQuorumNumbers         []byte
+}
+
+// EigenDATypesV1NonSignerStakesAndSignature is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV1NonSignerStakesAndSignature struct {
+	NonSignerQuorumBitmapIndices []uint32
+	NonSignerPubkeys             []BN254G1Point
+	QuorumApks                   []BN254G1Point
+	ApkG2                        BN254G2Point
+	Sigma                        BN254G1Point
+	QuorumApkIndices             []uint32
+	TotalStakeIndices            []uint32
+	NonSignerStakeIndices        [][]uint32
+}
+
 // EigenDATypesV1SecurityThresholds is an auto generated low-level Go binding around an user-defined struct.
 type EigenDATypesV1SecurityThresholds struct {
 	ConfirmationThreshold uint8
 	AdversaryThreshold    uint8
 }
 
+// EigenDATypesV2BatchHeaderV2 is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BatchHeaderV2 struct {
+	BatchRoot            [32]byte
+	ReferenceBlockNumber uint32
+}
+
+// EigenDATypesV2BlobCertificate is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BlobCertificate struct {
+	BlobHeader EigenDATypesV2BlobHeaderV2
+	Signature  []byte
+	RelayKeys  []uint32
+}
+
+// EigenDATypesV2BlobCommitment is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BlobCommitment struct {
+	Commitment       BN254G1Point
+	LengthCommitment BN254G2Point
+	LengthProof      BN254G2Point
+	Length           uint32
+}
+
+// EigenDATypesV2BlobHeaderV2 is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BlobHeaderV2 struct {
+	Version           uint16
+	QuorumNumbers     []byte
+	Commitment        EigenDATypesV2BlobCommitment
+	PaymentHeaderHash [32]byte
+}
+
+// EigenDATypesV2BlobInclusionInfo is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BlobInclusionInfo struct {
+	BlobCertificate EigenDATypesV2BlobCertificate
+	BlobIndex       uint32
+	InclusionProof  []byte
+}
+
 // ContractEigenDACertVerifierMetaData contains all meta data concerning the ContractEigenDACertVerifier contract.
 var ContractEigenDACertVerifierMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"initEigenDAThresholdRegistry\",\"type\":\"address\",\"internalType\":\"contractIEigenDAThresholdRegistry\"},{\"name\":\"initEigenDASignatureVerifier\",\"type\":\"address\",\"internalType\":\"contractIEigenDASignatureVerifier\"},{\"name\":\"initSecurityThresholds\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.SecurityThresholds\",\"components\":[{\"name\":\"confirmationThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"adversaryThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]},{\"name\":\"initQuorumNumbersRequired\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"certVersion\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"checkDACert\",\"inputs\":[{\"name\":\"abiEncodedCert\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenDASignatureVerifier\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenDASignatureVerifier\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenDAThresholdRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenDAThresholdRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"quorumNumbersRequired\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"securityThresholds\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.SecurityThresholds\",\"components\":[{\"name\":\"confirmationThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"adversaryThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"semver\",\"inputs\":[],\"outputs\":[{\"name\":\"major\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"minor\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"patch\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"pure\"},{\"type\":\"error\",\"name\":\"InvalidSecurityThresholds\",\"inputs\":[]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"initEigenDAThresholdRegistry\",\"type\":\"address\",\"internalType\":\"contractIEigenDAThresholdRegistry\"},{\"name\":\"initEigenDASignatureVerifier\",\"type\":\"address\",\"internalType\":\"contractIEigenDASignatureVerifier\"},{\"name\":\"initSecurityThresholds\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.SecurityThresholds\",\"components\":[{\"name\":\"confirmationThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"adversaryThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]},{\"name\":\"initQuorumNumbersRequired\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"_decodeCert\",\"inputs\":[{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"cert\",\"type\":\"tuple\",\"internalType\":\"structEigenDACertTypes.EigenDACertV3\",\"components\":[{\"name\":\"batchHeader\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BatchHeaderV2\",\"components\":[{\"name\":\"batchRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"referenceBlockNumber\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]},{\"name\":\"blobInclusionInfo\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BlobInclusionInfo\",\"components\":[{\"name\":\"blobCertificate\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BlobCertificate\",\"components\":[{\"name\":\"blobHeader\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BlobHeaderV2\",\"components\":[{\"name\":\"version\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"quorumNumbers\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BlobCommitment\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structBN254.G1Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"Y\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"lengthCommitment\",\"type\":\"tuple\",\"internalType\":\"structBN254.G2Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"},{\"name\":\"Y\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"}]},{\"name\":\"lengthProof\",\"type\":\"tuple\",\"internalType\":\"structBN254.G2Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"},{\"name\":\"Y\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"}]},{\"name\":\"length\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]},{\"name\":\"paymentHeaderHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"relayKeys\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"}]},{\"name\":\"blobIndex\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"inclusionProof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"nonSignerStakesAndSignature\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.NonSignerStakesAndSignature\",\"components\":[{\"name\":\"nonSignerQuorumBitmapIndices\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"nonSignerPubkeys\",\"type\":\"tuple[]\",\"internalType\":\"structBN254.G1Point[]\",\"components\":[{\"name\":\"X\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"Y\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"quorumApks\",\"type\":\"tuple[]\",\"internalType\":\"structBN254.G1Point[]\",\"components\":[{\"name\":\"X\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"Y\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"apkG2\",\"type\":\"tuple\",\"internalType\":\"structBN254.G2Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"},{\"name\":\"Y\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"}]},{\"name\":\"sigma\",\"type\":\"tuple\",\"internalType\":\"structBN254.G1Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"Y\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"quorumApkIndices\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"totalStakeIndices\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"nonSignerStakeIndices\",\"type\":\"uint32[][]\",\"internalType\":\"uint32[][]\"}]},{\"name\":\"signedQuorumNumbers\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"certVersion\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"checkDACert\",\"inputs\":[{\"name\":\"abiEncodedCert\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenDASignatureVerifier\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenDASignatureVerifier\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenDAThresholdRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenDAThresholdRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"quorumNumbersRequired\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"securityThresholds\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.SecurityThresholds\",\"components\":[{\"name\":\"confirmationThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"adversaryThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"semver\",\"inputs\":[],\"outputs\":[{\"name\":\"major\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"minor\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"patch\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"pure\"},{\"type\":\"error\",\"name\":\"InvalidSecurityThresholds\",\"inputs\":[]}]",
 }
 
 // ContractEigenDACertVerifierABI is the input ABI used to generate the binding from.
@@ -184,6 +252,37 @@ func (_ContractEigenDACertVerifier *ContractEigenDACertVerifierTransactorRaw) Tr
 // Transact invokes the (paid) contract method with params as input values.
 func (_ContractEigenDACertVerifier *ContractEigenDACertVerifierTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
 	return _ContractEigenDACertVerifier.Contract.contract.Transact(opts, method, params...)
+}
+
+// DecodeCert is a free data retrieval call binding the contract method 0x693194fa.
+//
+// Solidity: function _decodeCert(bytes data) pure returns(((bytes32,uint32),(((uint16,bytes,((uint256,uint256),(uint256[2],uint256[2]),(uint256[2],uint256[2]),uint32),bytes32),bytes,uint32[]),uint32,bytes),(uint32[],(uint256,uint256)[],(uint256,uint256)[],(uint256[2],uint256[2]),(uint256,uint256),uint32[],uint32[],uint32[][]),bytes) cert)
+func (_ContractEigenDACertVerifier *ContractEigenDACertVerifierCaller) DecodeCert(opts *bind.CallOpts, data []byte) (EigenDACertTypesEigenDACertV3, error) {
+	var out []interface{}
+	err := _ContractEigenDACertVerifier.contract.Call(opts, &out, "_decodeCert", data)
+
+	if err != nil {
+		return *new(EigenDACertTypesEigenDACertV3), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(EigenDACertTypesEigenDACertV3)).(*EigenDACertTypesEigenDACertV3)
+
+	return out0, err
+
+}
+
+// DecodeCert is a free data retrieval call binding the contract method 0x693194fa.
+//
+// Solidity: function _decodeCert(bytes data) pure returns(((bytes32,uint32),(((uint16,bytes,((uint256,uint256),(uint256[2],uint256[2]),(uint256[2],uint256[2]),uint32),bytes32),bytes,uint32[]),uint32,bytes),(uint32[],(uint256,uint256)[],(uint256,uint256)[],(uint256[2],uint256[2]),(uint256,uint256),uint32[],uint32[],uint32[][]),bytes) cert)
+func (_ContractEigenDACertVerifier *ContractEigenDACertVerifierSession) DecodeCert(data []byte) (EigenDACertTypesEigenDACertV3, error) {
+	return _ContractEigenDACertVerifier.Contract.DecodeCert(&_ContractEigenDACertVerifier.CallOpts, data)
+}
+
+// DecodeCert is a free data retrieval call binding the contract method 0x693194fa.
+//
+// Solidity: function _decodeCert(bytes data) pure returns(((bytes32,uint32),(((uint16,bytes,((uint256,uint256),(uint256[2],uint256[2]),(uint256[2],uint256[2]),uint32),bytes32),bytes,uint32[]),uint32,bytes),(uint32[],(uint256,uint256)[],(uint256,uint256)[],(uint256[2],uint256[2]),(uint256,uint256),uint32[],uint32[],uint32[][]),bytes) cert)
+func (_ContractEigenDACertVerifier *ContractEigenDACertVerifierCallerSession) DecodeCert(data []byte) (EigenDACertTypesEigenDACertV3, error) {
+	return _ContractEigenDACertVerifier.Contract.DecodeCert(&_ContractEigenDACertVerifier.CallOpts, data)
 }
 
 // CertVersion is a free data retrieval call binding the contract method 0x2ead0b96.

--- a/contracts/bindings/v2/EigenDACertVerifier/binding.go
+++ b/contracts/bindings/v2/EigenDACertVerifier/binding.go
@@ -24,15 +24,83 @@ var (
 	_ = abi.ConvertType
 )
 
+// BN254G1Point is an auto generated low-level Go binding around an user-defined struct.
+type BN254G1Point struct {
+	X *big.Int
+	Y *big.Int
+}
+
+// BN254G2Point is an auto generated low-level Go binding around an user-defined struct.
+type BN254G2Point struct {
+	X [2]*big.Int
+	Y [2]*big.Int
+}
+
+// EigenDACertTypesEigenDACertV3 is an auto generated low-level Go binding around an user-defined struct.
+type EigenDACertTypesEigenDACertV3 struct {
+	BatchHeader                 EigenDATypesV2BatchHeaderV2
+	BlobInclusionInfo           EigenDATypesV2BlobInclusionInfo
+	NonSignerStakesAndSignature EigenDATypesV1NonSignerStakesAndSignature
+	SignedQuorumNumbers         []byte
+}
+
+// EigenDATypesV1NonSignerStakesAndSignature is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV1NonSignerStakesAndSignature struct {
+	NonSignerQuorumBitmapIndices []uint32
+	NonSignerPubkeys             []BN254G1Point
+	QuorumApks                   []BN254G1Point
+	ApkG2                        BN254G2Point
+	Sigma                        BN254G1Point
+	QuorumApkIndices             []uint32
+	TotalStakeIndices            []uint32
+	NonSignerStakeIndices        [][]uint32
+}
+
 // EigenDATypesV1SecurityThresholds is an auto generated low-level Go binding around an user-defined struct.
 type EigenDATypesV1SecurityThresholds struct {
 	ConfirmationThreshold uint8
 	AdversaryThreshold    uint8
 }
 
+// EigenDATypesV2BatchHeaderV2 is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BatchHeaderV2 struct {
+	BatchRoot            [32]byte
+	ReferenceBlockNumber uint32
+}
+
+// EigenDATypesV2BlobCertificate is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BlobCertificate struct {
+	BlobHeader EigenDATypesV2BlobHeaderV2
+	Signature  []byte
+	RelayKeys  []uint32
+}
+
+// EigenDATypesV2BlobCommitment is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BlobCommitment struct {
+	Commitment       BN254G1Point
+	LengthCommitment BN254G2Point
+	LengthProof      BN254G2Point
+	Length           uint32
+}
+
+// EigenDATypesV2BlobHeaderV2 is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BlobHeaderV2 struct {
+	Version           uint16
+	QuorumNumbers     []byte
+	Commitment        EigenDATypesV2BlobCommitment
+	PaymentHeaderHash [32]byte
+}
+
+// EigenDATypesV2BlobInclusionInfo is an auto generated low-level Go binding around an user-defined struct.
+type EigenDATypesV2BlobInclusionInfo struct {
+	BlobCertificate EigenDATypesV2BlobCertificate
+	BlobIndex       uint32
+	InclusionProof  []byte
+}
+
 // ContractEigenDACertVerifierMetaData contains all meta data concerning the ContractEigenDACertVerifier contract.
 var ContractEigenDACertVerifierMetaData = bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"initEigenDAThresholdRegistry\",\"type\":\"address\",\"internalType\":\"contractIEigenDAThresholdRegistry\"},{\"name\":\"initEigenDASignatureVerifier\",\"type\":\"address\",\"internalType\":\"contractIEigenDASignatureVerifier\"},{\"name\":\"initSecurityThresholds\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.SecurityThresholds\",\"components\":[{\"name\":\"confirmationThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"adversaryThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]},{\"name\":\"initQuorumNumbersRequired\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"certVersion\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"checkDACert\",\"inputs\":[{\"name\":\"abiEncodedCert\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenDASignatureVerifier\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenDASignatureVerifier\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenDAThresholdRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenDAThresholdRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"quorumNumbersRequired\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"securityThresholds\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.SecurityThresholds\",\"components\":[{\"name\":\"confirmationThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"adversaryThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"semver\",\"inputs\":[],\"outputs\":[{\"name\":\"major\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"minor\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"patch\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"pure\"},{\"type\":\"error\",\"name\":\"InvalidSecurityThresholds\",\"inputs\":[]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"initEigenDAThresholdRegistry\",\"type\":\"address\",\"internalType\":\"contractIEigenDAThresholdRegistry\"},{\"name\":\"initEigenDASignatureVerifier\",\"type\":\"address\",\"internalType\":\"contractIEigenDASignatureVerifier\"},{\"name\":\"initSecurityThresholds\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.SecurityThresholds\",\"components\":[{\"name\":\"confirmationThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"adversaryThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]},{\"name\":\"initQuorumNumbersRequired\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"_decodeCert\",\"inputs\":[{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"cert\",\"type\":\"tuple\",\"internalType\":\"structEigenDACertTypes.EigenDACertV3\",\"components\":[{\"name\":\"batchHeader\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BatchHeaderV2\",\"components\":[{\"name\":\"batchRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"referenceBlockNumber\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]},{\"name\":\"blobInclusionInfo\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BlobInclusionInfo\",\"components\":[{\"name\":\"blobCertificate\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BlobCertificate\",\"components\":[{\"name\":\"blobHeader\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BlobHeaderV2\",\"components\":[{\"name\":\"version\",\"type\":\"uint16\",\"internalType\":\"uint16\"},{\"name\":\"quorumNumbers\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV2.BlobCommitment\",\"components\":[{\"name\":\"commitment\",\"type\":\"tuple\",\"internalType\":\"structBN254.G1Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"Y\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"lengthCommitment\",\"type\":\"tuple\",\"internalType\":\"structBN254.G2Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"},{\"name\":\"Y\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"}]},{\"name\":\"lengthProof\",\"type\":\"tuple\",\"internalType\":\"structBN254.G2Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"},{\"name\":\"Y\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"}]},{\"name\":\"length\",\"type\":\"uint32\",\"internalType\":\"uint32\"}]},{\"name\":\"paymentHeaderHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"relayKeys\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"}]},{\"name\":\"blobIndex\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"inclusionProof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"nonSignerStakesAndSignature\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.NonSignerStakesAndSignature\",\"components\":[{\"name\":\"nonSignerQuorumBitmapIndices\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"nonSignerPubkeys\",\"type\":\"tuple[]\",\"internalType\":\"structBN254.G1Point[]\",\"components\":[{\"name\":\"X\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"Y\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"quorumApks\",\"type\":\"tuple[]\",\"internalType\":\"structBN254.G1Point[]\",\"components\":[{\"name\":\"X\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"Y\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"apkG2\",\"type\":\"tuple\",\"internalType\":\"structBN254.G2Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"},{\"name\":\"Y\",\"type\":\"uint256[2]\",\"internalType\":\"uint256[2]\"}]},{\"name\":\"sigma\",\"type\":\"tuple\",\"internalType\":\"structBN254.G1Point\",\"components\":[{\"name\":\"X\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"Y\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"quorumApkIndices\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"totalStakeIndices\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"},{\"name\":\"nonSignerStakeIndices\",\"type\":\"uint32[][]\",\"internalType\":\"uint32[][]\"}]},{\"name\":\"signedQuorumNumbers\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"certVersion\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"checkDACert\",\"inputs\":[{\"name\":\"abiEncodedCert\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenDASignatureVerifier\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenDASignatureVerifier\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"eigenDAThresholdRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIEigenDAThresholdRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"quorumNumbersRequired\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"securityThresholds\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structEigenDATypesV1.SecurityThresholds\",\"components\":[{\"name\":\"confirmationThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"adversaryThreshold\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"semver\",\"inputs\":[],\"outputs\":[{\"name\":\"major\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"minor\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"patch\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"pure\"},{\"type\":\"error\",\"name\":\"InvalidSecurityThresholds\",\"inputs\":[]}]",
 	ID:  "ContractEigenDACertVerifier",
 }
 
@@ -66,6 +134,41 @@ func (contractEigenDACertVerifier *ContractEigenDACertVerifier) PackConstructor(
 		panic(err)
 	}
 	return enc
+}
+
+// PackDecodeCert is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x693194fa.  This method will panic if any
+// invalid/nil inputs are passed.
+//
+// Solidity: function _decodeCert(bytes data) pure returns(((bytes32,uint32),(((uint16,bytes,((uint256,uint256),(uint256[2],uint256[2]),(uint256[2],uint256[2]),uint32),bytes32),bytes,uint32[]),uint32,bytes),(uint32[],(uint256,uint256)[],(uint256,uint256)[],(uint256[2],uint256[2]),(uint256,uint256),uint32[],uint32[],uint32[][]),bytes) cert)
+func (contractEigenDACertVerifier *ContractEigenDACertVerifier) PackDecodeCert(data []byte) []byte {
+	enc, err := contractEigenDACertVerifier.abi.Pack("_decodeCert", data)
+	if err != nil {
+		panic(err)
+	}
+	return enc
+}
+
+// TryPackDecodeCert is the Go binding used to pack the parameters required for calling
+// the contract method with ID 0x693194fa.  This method will return an error
+// if any inputs are invalid/nil.
+//
+// Solidity: function _decodeCert(bytes data) pure returns(((bytes32,uint32),(((uint16,bytes,((uint256,uint256),(uint256[2],uint256[2]),(uint256[2],uint256[2]),uint32),bytes32),bytes,uint32[]),uint32,bytes),(uint32[],(uint256,uint256)[],(uint256,uint256)[],(uint256[2],uint256[2]),(uint256,uint256),uint32[],uint32[],uint32[][]),bytes) cert)
+func (contractEigenDACertVerifier *ContractEigenDACertVerifier) TryPackDecodeCert(data []byte) ([]byte, error) {
+	return contractEigenDACertVerifier.abi.Pack("_decodeCert", data)
+}
+
+// UnpackDecodeCert is the Go binding that unpacks the parameters returned
+// from invoking the contract method with ID 0x693194fa.
+//
+// Solidity: function _decodeCert(bytes data) pure returns(((bytes32,uint32),(((uint16,bytes,((uint256,uint256),(uint256[2],uint256[2]),(uint256[2],uint256[2]),uint32),bytes32),bytes,uint32[]),uint32,bytes),(uint32[],(uint256,uint256)[],(uint256,uint256)[],(uint256[2],uint256[2]),(uint256,uint256),uint32[],uint32[],uint32[][]),bytes) cert)
+func (contractEigenDACertVerifier *ContractEigenDACertVerifier) UnpackDecodeCert(data []byte) (EigenDACertTypesEigenDACertV3, error) {
+	out, err := contractEigenDACertVerifier.abi.Unpack("_decodeCert", data)
+	if err != nil {
+		return *new(EigenDACertTypesEigenDACertV3), err
+	}
+	out0 := *abi.ConvertType(out[0], new(EigenDACertTypesEigenDACertV3)).(*EigenDACertTypesEigenDACertV3)
+	return out0, nil
 }
 
 // PackCertVersion is the Go binding used to pack the parameters required for calling

--- a/contracts/src/core/interfaces/IEigenDAThresholdRegistry.sol
+++ b/contracts/src/core/interfaces/IEigenDAThresholdRegistry.sol
@@ -44,6 +44,10 @@ interface IEigenDAThresholdRegistry {
 
     ///////////////////////// V2 ///////////////////////////////
 
+    /// @notice Returns the next blob version
+    /// @dev Can be called before calling getBlobParams to verify that an input blobVersion actually exists
+    function nextBlobVersion() external view returns (uint16);
+
     /// @notice Returns the blob params for a given blob version
     function getBlobParams(uint16 version) external view returns (DATypesV1.VersionedBlobParams memory);
 }

--- a/contracts/src/integrations/cert/EigenDACertVerifier.sol
+++ b/contracts/src/integrations/cert/EigenDACertVerifier.sol
@@ -34,7 +34,7 @@ contract EigenDACertVerifier is
     bytes internal _quorumNumbersRequired;
 
     uint8 internal constant MAJOR_VERSION = 3;
-    uint8 internal constant MINOR_VERSION = 0;
+    uint8 internal constant MINOR_VERSION = 1;
     uint8 internal constant PATCH_VERSION = 0;
 
     constructor(

--- a/contracts/src/integrations/cert/EigenDACertVerifier.sol
+++ b/contracts/src/integrations/cert/EigenDACertVerifier.sol
@@ -54,9 +54,8 @@ contract EigenDACertVerifier is
     }
 
     /// @notice Decodes a certificate from bytes to an EigenDACertV3
-    /// @dev This function should not be called directly. It is exposes as external
-    //       for the purpose of try/catch'ing it inside checkDACert.
-    function _decodeCert(bytes calldata data) external pure returns (CT.EigenDACertV3 memory cert) {
+    /// @dev This function is external for the purpose of try/catch'ing it inside checkDACert.
+    function decodeCert(bytes calldata data) external pure returns (CT.EigenDACertV3 memory cert) {
         return abi.decode(data, (CT.EigenDACertV3));
     }
 

--- a/contracts/src/integrations/cert/EigenDACertVerifier.sol
+++ b/contracts/src/integrations/cert/EigenDACertVerifier.sol
@@ -14,6 +14,14 @@ import {IEigenDASemVer} from "src/core/interfaces/IEigenDASemVer.sol";
 import {EigenDACertVerificationLib as CertLib} from "src/integrations/cert/libraries/EigenDACertVerificationLib.sol";
 import {EigenDACertTypes as CT} from "src/integrations/cert/EigenDACertTypes.sol";
 
+/// @title EigenDACertVerifier
+/// @notice Verifies EigenDA certificates
+/// @dev This contract's checkDACert function is designed to be zk provable by risczero's Steel library,
+/// which does not support zk proving reverting calls: https://github.com/risc0/risc0-ethereum/issues/438.
+/// For this reason, we avoid using revert statements and instead return error codes.
+/// The only acceptable reverts are from bugs, such as contract misconfiguration.
+/// The goal is to be able to perfectly classify into 3 categories: valid certs, invalid certs, and bugs.
+/// Bugs could be configuration mistakes (_eigenDAThresholdRegistry points to 0x0), or other unexpected logic issues.
 contract EigenDACertVerifier is
     IEigenDACertVerifier,
     IEigenDACertVerifierBase,

--- a/contracts/src/integrations/cert/EigenDACertVerifier.sol
+++ b/contracts/src/integrations/cert/EigenDACertVerifier.sol
@@ -63,7 +63,7 @@ contract EigenDACertVerifier is
     function checkDACert(bytes calldata abiEncodedCert) external view returns (uint8) {
         CT.EigenDACertV3 memory daCert;
 
-        try this._decodeCert(abiEncodedCert) returns (CT.EigenDACertV3 memory cert) {
+        try this.decodeCert(abiEncodedCert) returns (CT.EigenDACertV3 memory cert) {
             daCert = cert;
         } catch {
             return uint8(CertLib.StatusCode.CERT_DECODE_REVERT);

--- a/contracts/src/integrations/cert/interfaces/IEigenDACertVerifierBase.sol
+++ b/contracts/src/integrations/cert/interfaces/IEigenDACertVerifierBase.sol
@@ -5,5 +5,7 @@ interface IEigenDACertVerifierBase {
     /// @notice Check a DA cert's validity
     /// @param abiEncodedCert The ABI encoded certificate. Any cert verifier should decode this ABI encoding based on the certificate version.
     /// @return status An enum value. Success is always mapped to 1, and other values are errors specific to each CertVerifier.
+    /// @dev This function should never revert, because it needs to be proven using Risc0's Steel library, which doesn't support reverts.
+    //       See https://github.com/risc0/risc0-ethereum/issues/438
     function checkDACert(bytes calldata abiEncodedCert) external view returns (uint8 status);
 }

--- a/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
+++ b/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
@@ -166,7 +166,13 @@ library EigenDACertVerificationLib {
             return (err, errParams);
         }
 
-        // Verify blob quorums are a subset of confirmed quorums
+        // The different quorums are related by:
+        // requiredQuorums ⊆ blobQuorums ⊆ confirmedQuorums ⊆ signedQuorums
+        // confirmedQuorums is the list of quorums that have both been signed, and meet the threshold requirements.
+        // We now make sure that that two other relationships are true.
+
+        // Verify blobQuorums ⊆ confirmedQuorums.
+        // blobQuorums are those requested in the blobHeader dispersed by the client.
         uint256 blobQuorumsBitmap;
         (err, errParams, blobQuorumsBitmap) =
             checkBlobQuorumsSubset(blobInclusionInfo.blobCertificate.blobHeader.quorumNumbers, confirmedQuorumsBitmap);
@@ -174,7 +180,8 @@ library EigenDACertVerificationLib {
             return (err, errParams);
         }
 
-        // Verify required quorums are a subset of blob quorums
+        // Verify requiredQuorums ⊆ blobQuorums.
+        // requiredQuorums are those required by the CertVerifier contract.
         return checkRequiredQuorumsSubset(requiredQuorumNumbers, blobQuorumsBitmap);
     }
 

--- a/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
+++ b/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
@@ -138,7 +138,7 @@ library EigenDACertVerificationLib {
         }
 
         // We validate that the cert's blob_version is valid. Otherwise the getBlobParams call below
-        // would return a codingRate=0 which will cause a divide by 0 in checkSecurityParams.
+        // would return a codingRate=0 which will cause a divide by 0 error in checkSecurityParams.
         uint16 nextBlobVersion = eigenDAThresholdRegistry.nextBlobVersion();
         if (blobInclusionInfo.blobCertificate.blobHeader.version >= nextBlobVersion) {
             return (StatusCode.INVALID_BLOB_VERSION, abi.encode(blobInclusionInfo.blobCertificate.blobHeader.version));

--- a/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
+++ b/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
@@ -249,6 +249,7 @@ library EigenDACertVerificationLib {
      * @notice Checks quorum signatures and builds a bitmap of confirmed quorums
      * @param signatureVerifier The signature verifier contract
      * @param batchHashRoot The hash of the batch header
+     * signedQuorumNumbers must contain the quorums that have been aggregated in nonSignerStakesAndSignature.sigma (which is the signature over the batchHashRoot).
      * @param signedQuorumNumbers The signed quorum numbers
      * @param referenceBlockNumber The reference block number
      * @param nonSignerStakesAndSignature The non-signer stakes and signature
@@ -265,6 +266,9 @@ library EigenDACertVerificationLib {
         DATypesV1.NonSignerStakesAndSignature memory nonSignerStakesAndSignature,
         DATypesV1.SecurityThresholds memory securityThresholds
     ) internal view returns (StatusCode err, bytes memory errParams, uint256 confirmedQuorumsBitmap) {
+        // TODO: check that RBN < block.number
+        // TODO: add assert that registryCoordinator.quorumCount() > signedQuorumNumbers (but we don't have access to registryCoord here..!)
+        // TODO: deal with staleStakesForbidden state
         try signatureVerifier.checkSignatures(
             batchHashRoot, signedQuorumNumbers, referenceBlockNumber, nonSignerStakesAndSignature
         ) returns (DATypesV1.QuorumStakeTotals memory quorumStakeTotals, bytes32) {

--- a/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
+++ b/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
@@ -55,7 +55,7 @@ library EigenDACertVerificationLib {
     /// @param blobQuorumsBitmap The bitmap of blob quorums
     error RequiredQuorumsNotSubset(uint256 requiredQuorumsBitmap, uint256 blobQuorumsBitmap);
 
-    /// @notice Thrown when certificate decoding fails
+    /// @notice Thrown when certificate decoding from bytes into struct fails
     error CertDecodeRevert();
 
     /// @notice Thrown when the external call to the signature verifier reverts

--- a/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
+++ b/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
@@ -67,11 +67,11 @@ library EigenDACertVerificationLib {
     enum StatusCode {
         NULL_ERROR, // Unused error code. If this is returned, there is a bug in the code.
         SUCCESS, // Verification succeeded
-        INCLUSION_PROOF_NOT_MULTIPLE_32, // Merkle inclusion proof not right length
         INVALID_INCLUSION_PROOF, // Merkle inclusion proof is invalid
         SECURITY_ASSUMPTIONS_NOT_MET, // Security assumptions not met
         BLOB_QUORUMS_NOT_SUBSET, // Blob quorums not a subset of confirmed quorums
         REQUIRED_QUORUMS_NOT_SUBSET, // Required quorums not a subset of blob quorums
+        INCLUSION_PROOF_NOT_MULTIPLE_32, // Merkle inclusion proof not right length
         EMPTY_BLOB_QUORUMS, // Certificate quorums are empty.
         UNORDERED_OR_DUPLICATE_QUORUMS, // Quorum numbers are not ordered, or contain duplicates
         GREATER_THAN_256_QUORUMS, // Quorum numbers exceed 256

--- a/contracts/test/unit/EigenDACertVerifierV2Unit.t.sol
+++ b/contracts/test/unit/EigenDACertVerifierV2Unit.t.sol
@@ -37,13 +37,21 @@ contract EigenDACertVerifierV2Unit is MockEigenDADeployer {
         assertEq(res, 1);
     }
 
-    function test_verifyDACert_revert_InclusionProofInvalid(uint256 pseudoRandomNumber) public {
+    function test_verifyDACert_returns_InvalidInclusionProofCode_when_ProofIsInvalid(uint256 pseudoRandomNumber)
+        public
+    {
         EigenDACertTypes.EigenDACertV3 memory cert = _getDACert(pseudoRandomNumber);
-
         cert.blobInclusionInfo.inclusionProof =
             abi.encodePacked(keccak256(abi.encode(pseudoRandomNumber, "inclusion proof")));
         uint8 res = eigenDACertVerifier.checkDACert(abi.encode(cert));
         assertEq(res, uint8(CertLib.StatusCode.INVALID_INCLUSION_PROOF));
+    }
+
+    function test_verifyDACert_returns_CERT_DECODE_REVERT_when_CertIsMalformedBytes() public view {
+        bytes memory staticBytes = hex"feaf968c";
+
+        uint8 res = eigenDACertVerifier.checkDACert(staticBytes);
+        assertEq(res, uint8(CertLib.StatusCode.CERT_DECODE_REVERT));
     }
 
     function _getSignedBatchAndBlobVerificationProof(uint256 pseudoRandomNumber, uint8 version)


### PR DESCRIPTION
SUPERSEDED BY https://github.com/Layr-Labs/eigenda/pull/1938

WIP: this is a first draft to show what I'm thinking.. needs works.

We use Steel which is not able to prove functions that revert (see https://github.com/risc0/risc0-ethereum/issues/438), so we need to turn all reverts (for invalid cert reasons!) into error codes.

This commit is a first step in that direction, adding error codes for abi.decoding faling, and for the call to verifySignature failing.

This endeavor to reach no reverts for any invalid cert (that needs to be proven so using Steel in order to be discarded from a rollup's pipeline) will still require a lot more careful work and audit of our library and downstream dependencies.

TODOs:
- Do we really need the custom errors + revertOnError fct (that we're not using)? See TODO in code
- check all TODOs added by this PR
- add a check for operatorlist length < maxNumOperators in registry coordinator (malicious cert could contain a huge number of fake operator addresses which could cause an out of gas)
- go over the checkSignatureFunction require statements in detail
- extend unit tests to check all status codes