### PR TITLE
chore(proxy): output `doc metrics` to ci checked file

### DIFF
--- a/api/proxy/Makefile
+++ b/api/proxy/Makefile
@@ -63,8 +63,11 @@ format:
 ## calls --help on binary and routes output to file while ignoring dynamic fields specific
 ## to indivdual builds (e.g, version)
 gen-static-help-output: build
-	@echo "Storing binary output to docs/help_out.txt"
+	@echo "Storing proxy help output to docs/help_out.txt"
+# removes the VERSION line which makes the output non-deterministic (changes with each commit)
 	@./bin/eigenda-proxy --help | sed '/^VERSION:/ {N;d;}' > docs/help_out.txt
+	@echo "Storing proxy metrics output to docs/metrics_out.txt"
+	@./bin/eigenda-proxy doc metrics > docs/metrics_out.txt
 
 mocks:
 	@echo "generating go mocks..."

--- a/api/proxy/docs/metrics_out.txt
+++ b/api/proxy/docs/metrics_out.txt
@@ -1,0 +1,12 @@
+|                       METRIC                        |                    DESCRIPTION                     |                   LABELS                   |   TYPE    |
+|-----------------------------------------------------|----------------------------------------------------|--------------------------------------------|-----------|
+| eigenda_proxy_default_up                            | 1 if the proxy server has finished starting up     |                                            | gauge     |
+| eigenda_proxy_default_info                          | Pseudo-metric tracking version and config info     | version                                    | gauge     |
+| eigenda_proxy_http_server_requests_total            | Total requests to the HTTP server                  | method,status,commitment_mode,cert_version | counter   |
+| eigenda_proxy_http_server_requests_bad_header_total | Total requests to the HTTP server with bad headers | method,error_type                          | counter   |
+| eigenda_proxy_http_server_request_duration_seconds  | Histogram of HTTP server request durations         | method                                     | histogram |
+| eigenda_proxy_secondary_requests_total              | Total requests to the secondary storage            | backend_type,method,status                 | counter   |
+| eigenda_proxy_secondary_request_duration_seconds    | Histogram of secondary storage request durations   | backend_type                               | histogram |
+| eigenda_accountant_cumulative_payment               | Current cumulative payment balance (gwei)          | account_id                                 | gauge     |
+| eigenda_dispersal_blob_size_bytes                   | Size of blobs created from payloads in bytes       |                                            | histogram |
+| eigenda_retrieval_payload_size_bytes                | Size of decoded payloads in bytes                  |                                            | histogram |


### PR DESCRIPTION
Same way as we do for the other cli output.

@iquidus `eigenda-proxy doc metrics` is currently segfaulting. Any idea?

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
