### PR TITLE
fix: write per-operator dispersal status for all dispersals

### DIFF
--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -430,6 +430,8 @@ type DispersalResponse struct {
 	Signature [32]byte
 	// Error is the error message if the dispersal failed
 	Error string
+	// Status indicates per-operator dispersal outcome: "signed", "failed", or "missed".
+	Status string
 }
 
 const (


### PR DESCRIPTION
- Enables dataapi v2 operators dispersals feed to include misses via OperatorResponseIndex
- Add Status to core/v2 DispersalResponse (signed|failed|missed)
- After finalization, write 'missed' responses for operators that did not sign within attestation timeout

## Why are these changes needed?

we were not capturing failed dispersals due to attestation timeout. this was causing discrepancy on blob-explorer ui where an operator's signing rate is < 100% but missed transactions (due to attestation timeout) were empty.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
