### PR TITLE
chore: remove testnet ci

### DIFF
--- a/.github/workflows/test-proxy.yml
+++ b/.github/workflows/test-proxy.yml
@@ -70,25 +70,6 @@ jobs:
       - run: make test-e2e-local
         working-directory: api/proxy
 
-  e2e-tests-testnet:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: jdx/mise-action@v2
-        with:
-          version: ${{ env.MISE_VERSION }}
-          experimental: true
-          working_directory: api/proxy
-      - run: go mod download
-        working-directory: api/proxy
-      - run: make test-e2e-testnet
-        working-directory: api/proxy
-        env:
-          SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }}
-          ETHEREUM_RPC: ${{ secrets.ETHEREUM_RPC }}
-
   #  TODO: preprod relay and operators no longer expose a public DNS, to minimize egress costs.
   #        We need to run these tests from inside the cluster, either using a self-hosted runner or k8s cron job live test.
   # e2e-tests-preprod:


### PR DESCRIPTION
## Why are these changes needed?

remove holesky testnet from CI. Reservation was yanked by us. It broke as expected and we should stop using it.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
