### PR TITLE
fix: test flakes

### DIFF
--- a/litt/disktable/flush_coordinator_test.go
+++ b/litt/disktable/flush_coordinator_test.go
@@ -16,7 +16,7 @@ import (
 
 // Flush 1000 times in a second, but limit actual flush rate to 10 times a second.
 func TestRapidFlushes(t *testing.T) {
-	t.Parallel()
+	// This test is inherently timing sensitive, don't parallelize it.
 
 	logger, err := common.NewLogger(common.DefaultLoggerConfig())
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestRapidFlushes(t *testing.T) {
 
 // If we flush slower than the maximum rate, then we should never wait that long for a flush.
 func TestInfrequentFlushes(t *testing.T) {
-	t.Parallel()
+	// This test is inherently timing sensitive, don't parallelize it.
 
 	logger, err := common.NewLogger(common.DefaultLoggerConfig())
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestInfrequentFlushes(t *testing.T) {
 	require.True(t, duration < minimumFlushTime,
 		"Expected third flush to take less than %v, took %v", minimumFlushTime, duration)
 	require.Equal(t, uint64(3), flushCount.Load())
-	
+
 	ok, _ := errorMonitor.IsOk()
 	require.True(t, ok)
 	errorMonitor.Shutdown()


### PR DESCRIPTION
## Why are these changes needed?

Mitigates two recently observed test flakes.

- Stops running the flush tests in parallel. These tests are inherently timing sensitive, and I don't know how to fix that short of disabling the test. If they continue to flake, I'll disable them.
- The SSH tests were building a docker image per test run, and that was timing out. Now it builds a single docker image and reuses it.