### PR TITLE
docs(proxy): remove readme section that overlaps with spec

### DIFF
--- a/api/proxy/README.md
+++ b/api/proxy/README.md
@@ -199,7 +199,7 @@ For `alt-da` Optimism rollups using EigenDA, the following [commitment schemas](
 
 `keccak256` (commitment_type 0x00) uses an S3 storage backend where a simple keccak hash commitment of the `DA Cert` is used as the lookup key.
 
-For `generic` commitments, only `da_layer_byte` 0x00` is supported, which represents EigenDA. This byte is not currently processed by OP Stack chains and serves solely as an evolvability placeholder.
+For `generic` commitments, only `da_layer_byte` `0x00` is supported, which represents EigenDA. This byte is not currently processed by OP Stack chains and serves solely as an evolvability placeholder.
 
 #### Standard Commitment Mode
 For standard clients (i.e, `clients/standard_client/client.go`) communicating with proxy (e.g, arbitrum nitro), the following commitment schema is supported:


### PR DESCRIPTION
Proxy README contained some spec-like sections that we wrote before the spec existed.
They largely overlapped with the spec pages https://layr-labs.github.io/eigenda/integration/spec.html and https://layr-labs.github.io/eigenda/integration/spec/5-lifecycle-phases.html, and were likely outdated.

We prefer that users refer to the spec instead of the README for spec-like documentation. The spec is linked at the top of the README already.