### PR TITLE
docs(proxy): explain g2 srs flags better

### DIFF
--- a/api/proxy/docs/help_out.txt
+++ b/api/proxy/docs/help_out.txt
@@ -86,10 +86,10 @@ This check is optional and will be skipped when set to 0. (default: 0) [$EIGENDA
 
    KZG
 
-   --eigenda.cache-path value        path to SRS tables for caching. This resource is not currently used, but needed because of the shared eigenda KZG library that we use. We will eventually fix this. (default: "resources/SRSTables/") [$EIGENDA_PROXY_EIGENDA_TARGET_CACHE_PATH]
+   --eigenda.cache-path value        Path to SRS tables for caching. This resource is not currently used, but needed because of the shared eigenda KZG library that we use. We will eventually fix this. (default: "resources/SRSTables/") [$EIGENDA_PROXY_EIGENDA_TARGET_CACHE_PATH]
    --eigenda.g1-path value           path to g1.point file. (default: "resources/g1.point") [$EIGENDA_PROXY_EIGENDA_TARGET_KZG_G1_PATH]
-   --eigenda.g2-path value           path to g2.point file. (default: "resources/g2.point") [$EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_PATH]
-   --eigenda.g2-path-trailing value  path to g2.trailing.point file. (default: "resources/g2.trailing.point") [$EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_TRAILING_PATH]
+   --eigenda.g2-path value           Path to g2.point file, which is needed to generate and verify blob length proofs. If this flag doesn't point to a complete 16GiB G2 SRS file, then the --eigenda.g2-path-trailing flag must be used to specify a trailing segment of that file, of equivalent length to the initial segment pointed to by this flag. (default: "resources/g2.point") [$EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_PATH]
+   --eigenda.g2-path-trailing value  Path to g2.trailing.point file, which is needed to generate and verify blob length proofs. If --eigenda.g2-path is pointing to the entire 16GiB G2 SRS file which contains 268435456 G2 points, this flag is not needed. Otherwise, users can truncate the G2 file by taking an initial segment, and a trailing segment (both of the same size). (default: "resources/g2.trailing.point") [$EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_TRAILING_PATH]
 
    Logging
 

--- a/api/proxy/store/generated_key/eigenda/verify/cli.go
+++ b/api/proxy/store/generated_key/eigenda/verify/cli.go
@@ -72,7 +72,7 @@ func KZGCLIFlags(envPrefix, category string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:    G2PowerOf2PathFlagNameDeprecated,
-			Usage:   "path to g2.point.powerOf2 file. Deprecated.",
+			Usage:   "Path to g2.point.powerOf2 file. Deprecated.",
 			EnvVars: []string{withEnvPrefix(envPrefix, "TARGET_KZG_G2_POWER_OF_2_PATH")},
 			Action: func(_ *cli.Context, _ string) error {
 				return fmt.Errorf(
@@ -83,22 +83,28 @@ func KZGCLIFlags(envPrefix, category string) []cli.Flag {
 			Hidden:   true,
 		},
 		&cli.StringFlag{
-			Name:     G2PathFlagName,
-			Usage:    "path to g2.point file.",
+			Name: G2PathFlagName,
+			Usage: fmt.Sprintf("Path to g2.point file, which is needed to generate and verify blob length proofs. "+
+				"If this flag doesn't point to a complete 16GiB G2 SRS file, "+
+				"then the --%s flag must be used to specify a trailing segment of that file, of equivalent length "+
+				"to the initial segment pointed to by this flag.", G2TrailingPathFlagName),
 			EnvVars:  []string{withEnvPrefix(envPrefix, "TARGET_KZG_G2_PATH")},
 			Value:    "resources/g2.point",
 			Category: category,
 		},
 		&cli.StringFlag{
-			Name:     G2TrailingPathFlagName,
-			Usage:    "path to g2.trailing.point file.",
+			Name: G2TrailingPathFlagName,
+			Usage: fmt.Sprintf("Path to g2.trailing.point file, which is needed to generate and verify blob length proofs. "+
+				"If --%s is pointing to the entire 16GiB G2 SRS file which contains 268435456 G2 points, this flag is not needed. "+
+				"Otherwise, users can truncate the G2 file by taking an initial segment, and a trailing segment (both of the same size).",
+				G2PathFlagName),
 			EnvVars:  []string{withEnvPrefix(envPrefix, "TARGET_KZG_G2_TRAILING_PATH")},
 			Value:    "resources/g2.trailing.point",
 			Category: category,
 		},
 		&cli.StringFlag{
 			Name:     CachePathFlagName,
-			Usage:    "path to SRS tables for caching. This resource is not currently used, but needed because of the shared eigenda KZG library that we use. We will eventually fix this.",
+			Usage:    "Path to SRS tables for caching. This resource is not currently used, but needed because of the shared eigenda KZG library that we use. We will eventually fix this.",
 			EnvVars:  []string{withEnvPrefix(envPrefix, "TARGET_CACHE_PATH")},
 			Value:    "resources/SRSTables/",
 			Category: category,


### PR DESCRIPTION
Closes DAINT-745.

The explanation was lacking before, which caused some confusion. Took the explanation from the KZG flags that we use for the operator nodes, and ammended them to match proxy use case.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
