### PR TITLE
feat(payments): Add reservation remaining capacity metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ lightnode/docker/args.sh
 .idea
 .env
 .vscode
+.serena
 
 icicle/*
 

--- a/api/clients/v2/metrics/accountant.go
+++ b/api/clients/v2/metrics/accountant.go
@@ -68,6 +68,8 @@ func (m *AccountantMetrics) RecordCumulativePayment(accountID string, wei *big.I
 }
 
 func (m *AccountantMetrics) RecordReservationPayment(accountID string, remainingCapacity float64) {
+	// We are expecting at most 100s of reservation, so the number of accountIDs (prom dimensions) won't be excessively
+	// large
 	m.ReservationRemainingCapacity.WithLabelValues(accountID).Set(remainingCapacity)
 }
 

--- a/api/proxy/docs/metrics_out.txt
+++ b/api/proxy/docs/metrics_out.txt
@@ -8,5 +8,6 @@
 | eigenda_proxy_secondary_requests_total              | Total requests to the secondary storage            | backend_type,method,status                 | counter   |
 | eigenda_proxy_secondary_request_duration_seconds    | Histogram of secondary storage request durations   | backend_type                               | histogram |
 | eigenda_accountant_cumulative_payment               | Current cumulative payment balance (gwei)          | account_id                                 | gauge     |
+| eigenda_accountant_reservation_remaining_capacity   | Remaining capacity in reservation bucket (symbols) | account_id                                 | gauge     |
 | eigenda_dispersal_blob_size_bytes                   | Size of blobs created from payloads in bytes       |                                            | histogram |
 | eigenda_retrieval_payload_size_bytes                | Size of decoded payloads in bytes                  |                                            | histogram |

--- a/api/proxy/docs/metrics_out.txt
+++ b/api/proxy/docs/metrics_out.txt
@@ -8,6 +8,6 @@
 | eigenda_proxy_secondary_requests_total              | Total requests to the secondary storage            | backend_type,method,status                 | counter   |
 | eigenda_proxy_secondary_request_duration_seconds    | Histogram of secondary storage request durations   | backend_type                               | histogram |
 | eigenda_accountant_cumulative_payment               | Current cumulative payment balance (gwei)          | account_id                                 | gauge     |
-| eigenda_accountant_reservation_remaining_capacity   | Remaining capacity in reservation bucket (symbols) | account_id                                 | gauge     |
+| eigenda_accountant_reservation_remaining_capacity   | Remaining capacity in reservation bucket (symbols) |                                            | gauge     |
 | eigenda_dispersal_blob_size_bytes                   | Size of blobs created from payloads in bytes       |                                            | histogram |
 | eigenda_retrieval_payload_size_bytes                | Size of decoded payloads in bytes                  |                                            | histogram |

--- a/core/payments/clientledger/client_ledger.go
+++ b/core/payments/clientledger/client_ledger.go
@@ -154,7 +154,7 @@ func (cl *ClientLedger) debitReservationOnly(
 		panic(fmt.Sprintf("reservation debit failed: %v", err))
 	}
 
-	cl.accountantMetricer.RecordReservationPayment(cl.accountID.Hex(), remainingCapacity)
+	cl.accountantMetricer.RecordReservationPayment(remainingCapacity)
 
 	if !success {
 		return nil, fmt.Errorf(
@@ -211,7 +211,7 @@ func (cl *ClientLedger) debitReservationOrOnDemand(
 		panic(fmt.Sprintf("reservation debit failed: %v", err))
 	}
 
-	cl.accountantMetricer.RecordReservationPayment(cl.accountID.Hex(), remainingCapacity)
+	cl.accountantMetricer.RecordReservationPayment(remainingCapacity)
 
 	if success {
 		paymentMetadata, err := core.NewPaymentMetadata(cl.accountID, now, nil)
@@ -269,7 +269,7 @@ func (cl *ClientLedger) RevertDebit(
 			return fmt.Errorf("revert reservation debit: %w", err)
 		}
 
-		cl.accountantMetricer.RecordReservationPayment(cl.accountID.Hex(), remainingCapacity)
+		cl.accountantMetricer.RecordReservationPayment(remainingCapacity)
 	}
 
 	return nil

--- a/core/payments/clientledger/client_ledger.go
+++ b/core/payments/clientledger/client_ledger.go
@@ -142,7 +142,7 @@ func (cl *ClientLedger) debitReservationOnly(
 ) (*core.PaymentMetadata, error) {
 	// As the client, "now" and the dispersal time are the same. The client is responsible for populating the
 	// dispersal time when constructing the payment header, and it does so with its conception of "now"
-	success, err := cl.reservationLedger.Debit(now, now, blobLengthSymbols, quorums)
+	success, remainingCapacity, err := cl.reservationLedger.Debit(now, now, blobLengthSymbols, quorums)
 	if err != nil {
 		var timeMovedBackwardErr *reservation.TimeMovedBackwardError
 		if errors.As(err, &timeMovedBackwardErr) {
@@ -153,6 +153,8 @@ func (cl *ClientLedger) debitReservationOnly(
 		// all other modes of failure are fatal
 		panic(fmt.Sprintf("reservation debit failed: %v", err))
 	}
+
+	cl.accountantMetricer.RecordReservationPayment(cl.accountID.Hex(), remainingCapacity)
 
 	if !success {
 		return nil, fmt.Errorf(
@@ -197,7 +199,7 @@ func (cl *ClientLedger) debitReservationOrOnDemand(
 ) (*core.PaymentMetadata, error) {
 	// As the client, "now" and the dispersal time are the same. The client is responsible for populating the
 	// dispersal time when constructing the payment header, and it does so with its conception of "now"
-	success, err := cl.reservationLedger.Debit(now, now, blobLengthSymbols, quorums)
+	success, remainingCapacity, err := cl.reservationLedger.Debit(now, now, blobLengthSymbols, quorums)
 	if err != nil {
 		var timeMovedBackwardErr *reservation.TimeMovedBackwardError
 		if errors.As(err, &timeMovedBackwardErr) {
@@ -208,6 +210,8 @@ func (cl *ClientLedger) debitReservationOrOnDemand(
 		// all other modes of failure are fatal
 		panic(fmt.Sprintf("reservation debit failed: %v", err))
 	}
+
+	cl.accountantMetricer.RecordReservationPayment(cl.accountID.Hex(), remainingCapacity)
 
 	if success {
 		paymentMetadata, err := core.NewPaymentMetadata(cl.accountID, now, nil)
@@ -260,10 +264,12 @@ func (cl *ClientLedger) RevertDebit(
 		enforce.NotNil(cl.reservationLedger,
 			"payment metadata is for a reservation payment, but ReservationLedger is nil")
 
-		err := cl.reservationLedger.RevertDebit(cl.getNow(), blobSymbolCount)
+		remainingCapacity, err := cl.reservationLedger.RevertDebit(cl.getNow(), blobSymbolCount)
 		if err != nil {
 			return fmt.Errorf("revert reservation debit: %w", err)
 		}
+
+		cl.accountantMetricer.RecordReservationPayment(cl.accountID.Hex(), remainingCapacity)
 	}
 
 	return nil

--- a/core/payments/clientledger/client_ledger_test.go
+++ b/core/payments/clientledger/client_ledger_test.go
@@ -449,7 +449,7 @@ func buildReservationLedger(t *testing.T) *reservation.ReservationLedger {
 	require.NoError(t, err)
 
 	reservationLedgerConfig, err := reservation.NewReservationLedgerConfig(
-		*res, false, reservation.OverfillOncePermitted, time.Minute)
+		*res, 1, false, reservation.OverfillOncePermitted, time.Minute)
 	require.NotNil(t, reservationLedgerConfig)
 	require.NoError(t, err)
 

--- a/core/payments/ondemand/on_demand_ledger.go
+++ b/core/payments/ondemand/on_demand_ledger.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/core/payments"
 )
 
 // Keeps track of the cumulative payment state for on-demand dispersals for a single account.
@@ -263,11 +264,7 @@ func (odl *OnDemandLedger) UpdateTotalDeposits(newTotalDeposits *big.Int) error 
 
 // Computes the on demand cost of a number of symbols
 func (odl *OnDemandLedger) computeCost(symbolCount uint32) *big.Int {
-	billableSymbols := symbolCount
-	if billableSymbols < odl.minNumSymbols {
-		billableSymbols = odl.minNumSymbols
-	}
-
+	billableSymbols := payments.CalculateBillableSymbols(symbolCount, odl.minNumSymbols)
 	billableSymbolsBig := new(big.Int).SetUint64(uint64(billableSymbols))
 	return billableSymbolsBig.Mul(billableSymbolsBig, odl.pricePerSymbol)
 }

--- a/core/payments/reservation/leaky_bucket.go
+++ b/core/payments/reservation/leaky_bucket.go
@@ -181,3 +181,10 @@ func (lb *LeakyBucket) leak(now time.Time) error {
 	lb.previousLeakTime = now
 	return nil
 }
+
+// Gets the amount of capacity available in the bucket, i.e. how much could be dispersed right now.
+//
+// May be negative if the bucket is currently overfilled
+func (lb *LeakyBucket) GetRemainingCapacity() float64 {
+	return lb.bucketCapacity - lb.currentFillLevel
+}

--- a/core/payments/reservation/reservation_ledger_config.go
+++ b/core/payments/reservation/reservation_ledger_config.go
@@ -9,6 +9,8 @@ import (
 type ReservationLedgerConfig struct {
 	// Contains the parameters of the reservation that the [ReservationLedger] is responsible for
 	reservation Reservation
+	// Minimum number of symbols to bill for any dispersal
+	minNumSymbols uint32
 	// Whether the underlying reservation [LeakyBucket] should start full or empty.
 	// This asymmetric approach is necessary to handle restart scenarios correctly for different entities.
 	//
@@ -47,6 +49,7 @@ type ReservationLedgerConfig struct {
 
 func NewReservationLedgerConfig(
 	reservation Reservation,
+	minNumSymbols uint32,
 	startFull bool,
 	overfillBehavior OverfillBehavior,
 	bucketCapacityDuration time.Duration,
@@ -57,6 +60,7 @@ func NewReservationLedgerConfig(
 
 	return &ReservationLedgerConfig{
 		reservation:            reservation,
+		minNumSymbols:          minNumSymbols,
 		startFull:              startFull,
 		overfillBehavior:       overfillBehavior,
 		bucketCapacityDuration: bucketCapacityDuration,

--- a/core/payments/utils.go
+++ b/core/payments/utils.go
@@ -1,0 +1,14 @@
+package payments
+
+// Computes the number of symbols to bill for a blob dispersal.
+//
+// If the actual symbol count is less than the minimum billable threshold, returns the minimum. Otherwise, returns the
+// input symbol count.
+//
+// minNumSymbols is a parameter defined in the PaymentVault contract
+func CalculateBillableSymbols(symbolCount uint32, minNumSymbols uint32) uint32 {
+	if symbolCount < minNumSymbols {
+		return minNumSymbols
+	}
+	return symbolCount
+}


### PR DESCRIPTION
- Adds reservation remaining capacity metric
- Makes necessary underlying changes to support the new metric
- Fixes a bug where the minimum number of billable symbols wasn't being respected by the `ReservationLedger`