### PR TITLE
fix(inabox): deploy-all manual launch

### DIFF
--- a/inabox/deploy/cmd/main.go
+++ b/inabox/deploy/cmd/main.go
@@ -162,7 +162,9 @@ func localstack(ctx *cli.Context) error {
 			BucketTableName:     bucketTableName,
 			V2MetadataTableName: metadataTableNameV2,
 		}
-		return fmt.Errorf("failed to deploy resources: %w", testbed.DeployResources(context, deployConfig))
+		if err := testbed.DeployResources(context, deployConfig); err != nil {
+			return fmt.Errorf("failed to deploy resources: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Error wasn't getting checked for non-nil, so it was always crashing even when deployment succeeded.

this is when starting inabox manually via:
```
make new-anvil
make deploy-all
```