### PR TITLE
feat: validator flag for littDB snapshots

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -140,6 +140,14 @@ type Config struct {
 	// Set this to zero to disable this feature.
 	LittMinimumFlushInterval time.Duration
 
+	// If set, the directory where littDB incremental snapshots are stored.
+	//
+	// WARNING: if snapshots are written to this directory, the responsibility of pruning those snapshots lies
+	// external to the node. LittDB will write to this directory, but never delete anything from it. If data is not
+	// periodically pruned, the disk will eventually fill up. It is highly suggested to use the LittDB cli
+	// for managing this directory.
+	LittSnapshotDirectory string
+
 	// The rate limit for the number of bytes served by the GetChunks API if the data is in the cache.
 	// Unit is in megabytes per second.
 	GetChunksHotCacheReadLimitMB float64
@@ -421,6 +429,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		LittDBStoragePaths:            ctx.GlobalStringSlice(flags.LittDBStoragePathsFlag.Name),
 		LittRespectLocks:              ctx.GlobalBool(flags.LittRespectLocksFlag.Name),
 		LittMinimumFlushInterval:      ctx.GlobalDuration(flags.LittMinimumFlushIntervalFlag.Name),
+		LittSnapshotDirectory:         ctx.GlobalString(flags.LittSnapshotDirectoryFlag.Name),
 		DownloadPoolSize:              ctx.GlobalInt(flags.DownloadPoolSizeFlag.Name),
 		GetChunksHotCacheReadLimitMB:  ctx.GlobalFloat64(flags.GetChunksHotCacheReadLimitMBFlag.Name),
 		GetChunksHotBurstLimitMB:      ctx.GlobalFloat64(flags.GetChunksHotBurstLimitMBFlag.Name),

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -461,6 +461,12 @@ var (
 		Value:    100 * time.Millisecond,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_MINIMUM_FLUSH_INTERVAL"),
 	}
+	LittSnapshotDirectoryFlag = cli.StringFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "litt-snapshot-directory"),
+		Usage:    "The directory where LittDB snapshots are stored. If not provided, no snapshots are taken.",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "LITT_SNAPSHOT_DIRECTORY"),
+	}
 	DownloadPoolSizeFlag = cli.IntFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "download-pool-size"),
 		Usage:    "The size of the download pool.",
@@ -684,6 +690,7 @@ var optionalFlags = []cli.Flag{
 	StoreChunksBufferSizeGBFlag,
 	StoreChunksBufferSizeFractionFlag,
 	OperatorStateCacheSizeFlag,
+	LittSnapshotDirectoryFlag,
 }
 
 func init() {

--- a/node/validator_store.go
+++ b/node/validator_store.go
@@ -115,6 +115,7 @@ func NewValidatorStore(
 	littConfig.DoubleWriteProtection = config.LittDBDoubleWriteProtection
 	littConfig.PurgeLocks = !config.LittRespectLocks
 	littConfig.MinimumFlushInterval = config.LittMinimumFlushInterval
+	littConfig.SnapshotDirectory = config.LittSnapshotDirectory
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new litt config: %w", err)
 	}


### PR DESCRIPTION
## Why are these changes needed?

Add a flag on the validators to enable LittDB snapshotting.