### PR TITLE
feat(payments): Integrate ClientLedger into `PayloadDisperser`

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
-	dispv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
 	"github.com/Layr-Labs/eigenda/encoding"
 	"github.com/Layr-Labs/eigenda/encoding/rs"
 	"github.com/Layr-Labs/eigensdk-go/logging"
@@ -31,29 +30,7 @@ type DisperserClientConfig struct {
 }
 
 // DisperserClient manages communication with the disperser server.
-type DisperserClient interface {
-	// Close closes the grpc connection to the disperser server.
-	Close() error
-	// DisperseBlob disperses a blob with the given data, blob version, and quorums.
-	DisperseBlob(
-		ctx context.Context,
-		data []byte,
-		blobVersion corev2.BlobVersion,
-		quorums []core.QuorumID) (*dispv2.BlobStatus, corev2.BlobKey, error)
-	// DisperseBlobWithProbe is similar to DisperseBlob, but also takes a SequenceProbe to capture metrics.
-	// If the probe is nil, no metrics are captured.
-	DisperseBlobWithProbe(
-		ctx context.Context,
-		data []byte,
-		blobVersion corev2.BlobVersion,
-		quorums []core.QuorumID,
-		probe *common.SequenceProbe) (*dispv2.BlobStatus, corev2.BlobKey, error)
-	// GetBlobStatus returns the status of a blob with the given blob key.
-	GetBlobStatus(ctx context.Context, blobKey corev2.BlobKey) (*disperser_rpc.BlobStatusReply, error)
-	// GetBlobCommitment returns the blob commitment for a given blob payload.
-	GetBlobCommitment(ctx context.Context, data []byte) (*disperser_rpc.BlobCommitmentReply, error)
-}
-type disperserClient struct {
+type DisperserClient struct {
 	logger                  logging.Logger
 	config                  *DisperserClientConfig
 	signer                  corev2.BlobRequestSigner
@@ -65,8 +42,6 @@ type disperserClient struct {
 	initOnceAccountantError error
 	metrics                 metrics.DispersalMetricer
 }
-
-var _ DisperserClient = &disperserClient{}
 
 // DisperserClient maintains a single underlying grpc connection to the disperser server,
 // through which it sends requests to disperse blobs and get blob status.
@@ -95,7 +70,7 @@ func NewDisperserClient(
 	prover encoding.Prover,
 	accountant *Accountant,
 	metrics metrics.DispersalMetricer,
-) (*disperserClient, error) {
+) (*DisperserClient, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config must be provided")
 	}
@@ -132,7 +107,7 @@ func NewDisperserClient(
 		return nil, fmt.Errorf("new grpc client pool: %w", err)
 	}
 
-	return &disperserClient{
+	return &DisperserClient{
 		logger:     logger,
 		config:     config,
 		signer:     signer,
@@ -144,7 +119,7 @@ func NewDisperserClient(
 }
 
 // PopulateAccountant populates the accountant with the payment state from the disperser.
-func (c *disperserClient) PopulateAccountant(ctx context.Context) error {
+func (c *DisperserClient) PopulateAccountant(ctx context.Context) error {
 	if c.accountant == nil {
 		return fmt.Errorf("accountant is nil")
 	}
@@ -164,7 +139,7 @@ func (c *disperserClient) PopulateAccountant(ctx context.Context) error {
 
 // Close closes the grpc connection to the disperser server.
 // It is thread safe and can be called multiple times.
-func (c *disperserClient) Close() error {
+func (c *DisperserClient) Close() error {
 	if c.clientPool != nil {
 		err := c.clientPool.Close()
 		if err != nil {
@@ -174,69 +149,70 @@ func (c *disperserClient) Close() error {
 	return nil
 }
 
-func (c *disperserClient) DisperseBlob(
-	ctx context.Context,
-	data []byte,
-	blobVersion corev2.BlobVersion,
-	quorums []core.QuorumID,
-) (*dispv2.BlobStatus, corev2.BlobKey, error) {
-	return c.DisperseBlobWithProbe(ctx, data, blobVersion, quorums, nil)
-}
-
-// DisperseBlobWithProbe disperses a blob with the given data, blob version, and quorums. If sequenceProbe is not nil,
-// the probe is used to capture metrics during the dispersal process.
-func (c *disperserClient) DisperseBlobWithProbe(
+// Disperses a blob with the given data, blob version, and quorums.
+//
+// Returns the BlobHeader of the blob that was dispersed, and the DisperseBlobReply that was received from the
+// disperser, if the dispersal was successful. Otherwise returns an error
+func (c *DisperserClient) DisperseBlob(
 	ctx context.Context,
 	data []byte,
 	blobVersion corev2.BlobVersion,
 	quorums []core.QuorumID,
 	probe *common.SequenceProbe,
-) (*dispv2.BlobStatus, corev2.BlobKey, error) {
-
+	// if this is nil, that indicates we will use the legacy payment system to create the paymentMetadata
+	paymentMetadata *core.PaymentMetadata,
+) (*corev2.BlobHeader, *disperser_rpc.DisperseBlobReply, error) {
 	if len(quorums) == 0 {
-		return nil, [32]byte{}, api.NewErrorInvalidArg("quorum numbers must be provided")
+		//nolint:wrapcheck
+		return nil, nil, api.NewErrorInvalidArg("quorum numbers must be provided")
 	}
 	if c.signer == nil {
-		return nil, [32]byte{}, api.NewErrorInternal("uninitialized signer for authenticated dispersal")
+		//nolint:wrapcheck
+		return nil, nil, api.NewErrorInternal("uninitialized signer for authenticated dispersal")
 	}
 	for _, q := range quorums {
 		if q > corev2.MaxQuorumID {
-			return nil, [32]byte{}, api.NewErrorInvalidArg("quorum number must be less than 256")
+			//nolint:wrapcheck
+			return nil, nil, api.NewErrorInvalidArg("quorum number must be less than 256")
 		}
 	}
 
-	probe.SetStage("acquire_accountant_lock")
-	c.accountantLock.Lock()
-
-	probe.SetStage("accountant")
-
-	err := c.initOncePopulateAccountant(ctx)
-	if err != nil {
-		c.accountantLock.Unlock()
-		return nil, [32]byte{}, fmt.Errorf("error initializing accountant: %w", err)
-	}
-
 	symbolLength := encoding.GetBlobLengthPowerOf2(uint(len(data)))
-	payment, err := c.accountant.AccountBlob(time.Now().UnixNano(), uint64(symbolLength), quorums)
-	if err != nil {
-		c.accountantLock.Unlock()
-		return nil, [32]byte{}, fmt.Errorf("error accounting blob: %w", err)
-	}
 
-	if payment.CumulativePayment == nil || payment.CumulativePayment.Sign() == 0 {
-		// This request is using reserved bandwidth, no need to prevent parallel dispersal.
-		c.accountantLock.Unlock()
-	} else {
-		// This request is using on-demand bandwidth, current implementation requires sequential dispersal.
-		defer c.accountantLock.Unlock()
+	if paymentMetadata == nil {
+		// we are using the legacy payment system
+		probe.SetStage("acquire_accountant_lock")
+		c.accountantLock.Lock()
+
+		probe.SetStage("accountant")
+
+		err := c.initOncePopulateAccountant(ctx)
+		if err != nil {
+			c.accountantLock.Unlock()
+			return nil, nil, fmt.Errorf("error initializing accountant: %w", err)
+		}
+
+		paymentMetadata, err = c.accountant.AccountBlob(time.Now().UnixNano(), uint64(symbolLength), quorums)
+		if err != nil {
+			c.accountantLock.Unlock()
+			return nil, nil, fmt.Errorf("error accounting blob: %w", err)
+		}
+
+		if paymentMetadata.CumulativePayment == nil || paymentMetadata.CumulativePayment.Sign() == 0 {
+			// This request is using reserved bandwidth, no need to prevent parallel dispersal.
+			c.accountantLock.Unlock()
+		} else {
+			// This request is using on-demand bandwidth, current implementation requires sequential dispersal.
+			defer c.accountantLock.Unlock()
+		}
 	}
 
 	probe.SetStage("verify_field_element")
 
 	// check every 32 bytes of data are within the valid range for a bn254 field element
-	_, err = rs.ToFrArray(data)
+	_, err := rs.ToFrArray(data)
 	if err != nil {
-		return nil, [32]byte{}, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"encountered an error to convert a 32-bytes into a valid field element, "+
 				"please use the correct format where every 32bytes(big-endian) is less than "+
 				"21888242871839275222246405745257275088548364400416034343698204186575808495617 %w", err)
@@ -250,11 +226,11 @@ func (c *disperserClient) DisperseBlobWithProbe(
 		commitments, err := c.GetBlobCommitment(ctx, data)
 		if err != nil {
 			// Failover worthy error because it means the disperser is not responsive.
-			return nil, [32]byte{}, api.NewErrorFailover(fmt.Errorf("GetBlobCommitment rpc: %w", err))
+			return nil, nil, api.NewErrorFailover(fmt.Errorf("GetBlobCommitment rpc: %w", err))
 		}
 		deserialized, err := encoding.BlobCommitmentsFromProtobuf(commitments.GetBlobCommitment())
 		if err != nil {
-			return nil, [32]byte{}, fmt.Errorf("error deserializing blob commitments: %w", err)
+			return nil, nil, fmt.Errorf("error deserializing blob commitments: %w", err)
 		}
 		blobCommitments = *deserialized
 
@@ -265,7 +241,7 @@ func (c *disperserClient) DisperseBlobWithProbe(
 		// fail, if the length claimed in the encoded payload header is larger than the blob length in the commitment.
 		lengthFromCommitment := commitments.GetBlobCommitment().GetLength()
 		if lengthFromCommitment != uint32(symbolLength) {
-			return nil, [32]byte{}, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"blob commitment length (%d) from disperser doesn't match expected length (%d): %w",
 				lengthFromCommitment, symbolLength, err)
 		}
@@ -273,7 +249,7 @@ func (c *disperserClient) DisperseBlobWithProbe(
 		// if prover is configured, get commitments from prover
 		blobCommitments, err = c.prover.GetCommitmentsForPaddedLength(data)
 		if err != nil {
-			return nil, [32]byte{}, fmt.Errorf("error getting blob commitments: %w", err)
+			return nil, nil, fmt.Errorf("error getting blob commitments: %w", err)
 		}
 	}
 
@@ -281,18 +257,18 @@ func (c *disperserClient) DisperseBlobWithProbe(
 		BlobVersion:     blobVersion,
 		BlobCommitments: blobCommitments,
 		QuorumNumbers:   quorums,
-		PaymentMetadata: *payment,
+		PaymentMetadata: *paymentMetadata,
 	}
 
 	probe.SetStage("sign_blob_request")
 
 	sig, err := c.signer.SignBlobRequest(blobHeader)
 	if err != nil {
-		return nil, [32]byte{}, fmt.Errorf("error signing blob request: %w", err)
+		return nil, nil, fmt.Errorf("error signing blob request: %w", err)
 	}
 	blobHeaderProto, err := blobHeader.ToProtobuf()
 	if err != nil {
-		return nil, [32]byte{}, fmt.Errorf("error converting blob header to protobuf: %w", err)
+		return nil, nil, fmt.Errorf("error converting blob header to protobuf: %w", err)
 	}
 	request := &disperser_rpc.DisperseBlobRequest{
 		Blob:       data,
@@ -304,61 +280,19 @@ func (c *disperserClient) DisperseBlobWithProbe(
 
 	reply, err := c.clientPool.GetClient().DisperseBlob(ctx, request)
 	if err != nil {
-		return nil, [32]byte{}, api.NewErrorFailover(fmt.Errorf("DisperseBlob rpc: %w", err))
-	}
-
-	blobStatus, err := dispv2.BlobStatusFromProtobuf(reply.GetResult())
-	if err != nil {
-		return nil, [32]byte{}, err
-	}
-
-	probe.SetStage("verify_blob_key")
-
-	if verifyReceivedBlobKey(blobHeader, reply) != nil {
-		return nil, [32]byte{}, fmt.Errorf("verify received blob key: %w", err)
+		return nil, nil, api.NewErrorFailover(fmt.Errorf("DisperseBlob rpc: %w", err))
 	}
 
 	c.metrics.RecordBlobSizeBytes(len(data))
 
-	return &blobStatus, corev2.BlobKey(reply.GetBlobKey()), nil
-}
-
-// verifyReceivedBlobKey computes the BlobKey from the BlobHeader which was sent to the disperser, and compares it with
-// the BlobKey which was returned by the disperser in the DisperseBlobReply
-//
-// A successful verification guarantees that the disperser didn't make any modifications to the BlobHeader that it
-// received from this client.
-//
-// This function returns nil if the verification succeeds, and otherwise returns an error describing the failure
-func verifyReceivedBlobKey(
-	// the blob header which was constructed locally and sent to the disperser
-	blobHeader *corev2.BlobHeader,
-	// the reply received back from the disperser
-	disperserReply *disperser_rpc.DisperseBlobReply,
-) error {
-
-	actualBlobKey, err := blobHeader.BlobKey()
-	if err != nil {
-		// this shouldn't be possible, since the blob key has already been used when signing dispersal
-		return fmt.Errorf("computing blob key: %w", err)
-	}
-
-	blobKeyFromDisperser, err := corev2.BytesToBlobKey(disperserReply.GetBlobKey())
-	if err != nil {
-		return fmt.Errorf("converting returned bytes to blob key: %w", err)
-	}
-
-	if actualBlobKey != blobKeyFromDisperser {
-		return fmt.Errorf(
-			"blob key returned by disperser (%v) doesn't match blob which was dispersed (%v)",
-			blobKeyFromDisperser, actualBlobKey)
-	}
-
-	return nil
+	return blobHeader, reply, nil
 }
 
 // GetBlobStatus returns the status of a blob with the given blob key.
-func (c *disperserClient) GetBlobStatus(ctx context.Context, blobKey corev2.BlobKey) (*disperser_rpc.BlobStatusReply, error) {
+func (c *DisperserClient) GetBlobStatus(
+	ctx context.Context,
+	blobKey corev2.BlobKey,
+) (*disperser_rpc.BlobStatusReply, error) {
 	request := &disperser_rpc.BlobStatusRequest{
 		BlobKey: blobKey[:],
 	}
@@ -370,7 +304,7 @@ func (c *disperserClient) GetBlobStatus(ctx context.Context, blobKey corev2.Blob
 }
 
 // GetPaymentState returns the payment state of the disperser client
-func (c *disperserClient) GetPaymentState(ctx context.Context) (*disperser_rpc.GetPaymentStateReply, error) {
+func (c *DisperserClient) GetPaymentState(ctx context.Context) (*disperser_rpc.GetPaymentStateReply, error) {
 	accountID, err := c.signer.GetAccountID()
 	if err != nil {
 		return nil, fmt.Errorf("error getting signer's account ID: %w", err)
@@ -399,7 +333,10 @@ func (c *disperserClient) GetPaymentState(ctx context.Context) (*disperser_rpc.G
 // While the blob commitment can be calculated by anyone, it requires SRS points to
 // be loaded. For service that does not have access to SRS points, this method can be
 // used to calculate the blob commitment in blob header, which is required for dispersal.
-func (c *disperserClient) GetBlobCommitment(ctx context.Context, data []byte) (*disperser_rpc.BlobCommitmentReply, error) {
+func (c *DisperserClient) GetBlobCommitment(
+	ctx context.Context,
+	data []byte,
+) (*disperser_rpc.BlobCommitmentReply, error) {
 	request := &disperser_rpc.BlobCommitmentRequest{
 		Blob: data,
 	}
@@ -412,7 +349,7 @@ func (c *disperserClient) GetBlobCommitment(ctx context.Context, data []byte) (*
 
 // initOncePopulateAccountant initializes the accountant if it is not already initialized.
 // If initialization fails, it caches the error and will return it on every subsequent call.
-func (c *disperserClient) initOncePopulateAccountant(ctx context.Context) error {
+func (c *DisperserClient) initOncePopulateAccountant(ctx context.Context) error {
 	c.initOnceAccountant.Do(func() {
 		err := c.PopulateAccountant(ctx)
 		if err != nil {

--- a/api/clients/v2/disperser_client_test.go
+++ b/api/clients/v2/disperser_client_test.go
@@ -1,56 +1,13 @@
 package clients
 
 import (
-	"math/big"
 	"sync"
 	"testing"
 	"time"
 
-	v2 "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
-	"github.com/Layr-Labs/eigenda/core"
-	corev2 "github.com/Layr-Labs/eigenda/core/v2"
-	"github.com/Layr-Labs/eigenda/encoding"
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
-func TestVerifyReceivedBlobKey(t *testing.T) {
-	blobCommitments := encoding.BlobCommitments{
-		Commitment:       &encoding.G1Commitment{},
-		LengthCommitment: &encoding.G2Commitment{},
-		LengthProof:      &encoding.LengthProof{},
-		Length:           4,
-	}
-
-	quorumNumbers := make([]core.QuorumID, 1)
-	quorumNumbers[0] = 8
-
-	paymentMetadata := core.PaymentMetadata{
-		AccountID:         gethcommon.Address{1},
-		Timestamp:         5,
-		CumulativePayment: big.NewInt(6),
-	}
-
-	blobHeader := &corev2.BlobHeader{
-		BlobVersion:     0,
-		BlobCommitments: blobCommitments,
-		QuorumNumbers:   quorumNumbers,
-		PaymentMetadata: paymentMetadata,
-	}
-
-	realKey, err := blobHeader.BlobKey()
-	require.NoError(t, err)
-
-	reply := v2.DisperseBlobReply{
-		BlobKey: realKey[:],
-	}
-
-	require.NoError(t, verifyReceivedBlobKey(blobHeader, &reply))
-
-	blobHeader.BlobVersion = 1
-	require.Error(t, verifyReceivedBlobKey(blobHeader, &reply),
-		"Any modification to the header should cause verification to fail")
-}
 
 // TestMutexPreventsSimultaneousRequests tests that the mutex in disperserClient
 // prevents multiple goroutines from executing critical sections concurrently.

--- a/api/clients/v2/examples/client_construction.go
+++ b/api/clients/v2/examples/client_construction.go
@@ -86,6 +86,7 @@ func createPayloadDisperser(privateKey string) (*payloaddispersal.PayloadDispers
 		certBuilder,
 		certVerifier,
 		nil,
+		nil,
 	)
 }
 
@@ -204,7 +205,7 @@ func createDisperserClient(
 	logger logging.Logger,
 	privateKey string,
 	kzgProver *prover.Prover,
-) (clients.DisperserClient, error) {
+) (*clients.DisperserClient, error) {
 	signer, err := auth.NewLocalBlobRequestSigner(privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("create blob request signer: %w", err)

--- a/api/clients/v2/payloaddispersal/payload_disperser.go
+++ b/api/clients/v2/payloaddispersal/payload_disperser.go
@@ -8,12 +8,16 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api"
-	"github.com/Layr-Labs/eigenda/api/clients/v2"
+	clients "github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
 	dispgrpc "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
 	"github.com/Layr-Labs/eigenda/common"
-	core "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/Layr-Labs/eigenda/common/enforce"
+	"github.com/Layr-Labs/eigenda/core"
+	"github.com/Layr-Labs/eigenda/core/payments/clientledger"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
+	dispv2 "github.com/Layr-Labs/eigenda/disperser/common/v2"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -24,11 +28,12 @@ import (
 type PayloadDisperser struct {
 	logger          logging.Logger
 	config          PayloadDisperserConfig
-	disperserClient clients.DisperserClient
+	disperserClient *clients.DisperserClient
 	blockMonitor    *verification.BlockNumberMonitor
 	certBuilder     *clients.CertBuilder
 	certVerifier    *verification.CertVerifier
 	stageTimer      *common.StageTimer
+	clientLedger    *clientledger.ClientLedger
 }
 
 // NewPayloadDisperser creates a PayloadDisperser from subcomponents that have already been constructed and initialized.
@@ -43,10 +48,12 @@ func NewPayloadDisperser(
 	// TODO: In the future, an optimized method of commitment verification using fiat shamir transformation will
 	//  be implemented. This feature will allow a PayloadDisperser to offload commitment generation onto the
 	//  disperser, but the disperser's commitments will be verifiable without needing a full-fledged prover
-	disperserClient clients.DisperserClient,
+	disperserClient *clients.DisperserClient,
 	blockMonitor *verification.BlockNumberMonitor,
 	certBuilder *clients.CertBuilder,
 	certVerifier *verification.CertVerifier,
+	// Manages payment state for the client. May be nil for legacy payment mode.
+	clientLedger *clientledger.ClientLedger,
 	// if nil, then no metrics will be collected
 	registry *prometheus.Registry,
 ) (*PayloadDisperser, error) {
@@ -66,6 +73,7 @@ func NewPayloadDisperser(
 		certBuilder:     certBuilder,
 		certVerifier:    certVerifier,
 		stageTimer:      stageTimer,
+		clientLedger:    clientLedger,
 	}, nil
 }
 
@@ -108,31 +116,75 @@ func (pd *PayloadDisperser) SendPayload(
 		return nil, fmt.Errorf("get quorum numbers required: %w", err)
 	}
 
+	symbolCount := blob.LenSymbols()
+
+	var paymentMetadata *core.PaymentMetadata
+	if pd.clientLedger != nil {
+		// we are using the new payment system if clientLedger is non nil
+		probe.SetStage("debit")
+		paymentMetadata, err = pd.clientLedger.Debit(ctx, symbolCount, requiredQuorums)
+		if err != nil {
+			return nil, fmt.Errorf("debit: %w", err)
+		}
+	}
+
 	timeoutCtx, cancel = context.WithTimeout(ctx, pd.config.DisperseBlobTimeout)
 	defer cancel()
 
-	// TODO (litt3): eventually, we should consider making DisperseBlob accept an actual blob object, instead of the
+	// TODO (litt3): DisperseBlob should accept an actual blob object, instead of the
 	//  serialized bytes. The operations taking place in DisperseBlob require the bytes to be converted into field
 	//  elements anyway, so serializing the blob here is unnecessary work. This will be a larger change that affects
 	//  many areas of code, though.
-	blobStatus, blobKey, err := pd.disperserClient.DisperseBlobWithProbe(
+	blobHeader, reply, err := pd.disperserClient.DisperseBlob(
 		timeoutCtx,
 		blob.Serialize(),
 		pd.config.BlobVersion,
 		requiredQuorums,
-		probe)
+		probe,
+		paymentMetadata)
 	if err != nil {
+		if pd.clientLedger != nil {
+			revertErr := pd.clientLedger.RevertDebit(ctx, paymentMetadata, symbolCount)
+			if revertErr != nil {
+				return nil, fmt.Errorf("disperse blob and revert debit: %w", errors.Join(err, revertErr))
+			}
+		}
+
 		return nil, fmt.Errorf("disperse blob: %w", err)
 	}
-	pd.logger.Debug("Successful DisperseBlob", "blobStatus", blobStatus.String(), "blobKey", blobKey.Hex())
+
+	probe.SetStage("verify_blob_key")
+
+	blobKey, err := verifyReceivedBlobKey(blobHeader, reply)
+	if err != nil {
+		return nil, fmt.Errorf("verify received blob key: %w", err)
+	}
+
+	initialBlobStatus, err := dispv2.BlobStatusFromProtobuf(reply.GetResult())
+	if err != nil {
+		return nil, fmt.Errorf("blob status from protobuf: %w", err)
+	}
+
+	return pd.buildEigenDACert(ctx, initialBlobStatus, blobKey, probe)
+}
+
+// Waits for a blob to be signed, and builds the EigenDA cert with the operator signatures
+//
+// If the blob does not become fully signed before the BlobCompleteTimeout timeout elapses, returns an error
+func (pd *PayloadDisperser) buildEigenDACert(
+	ctx context.Context,
+	initialBlobStatus dispv2.BlobStatus,
+	blobKey corev2.BlobKey,
+	probe *common.SequenceProbe,
+) (coretypes.EigenDACert, error) {
 
 	probe.SetStage("QUEUED")
 
 	// poll the disperser for the status of the blob until it's received adequate signatures in regards to
 	// confirmation thresholds, a terminal error, or a timeout
-	timeoutCtx, cancel = context.WithTimeout(ctx, pd.config.BlobCompleteTimeout)
+	timeoutCtx, cancel := context.WithTimeout(ctx, pd.config.BlobCompleteTimeout)
 	defer cancel()
-	blobStatusReply, err := pd.pollBlobStatusUntilSigned(timeoutCtx, blobKey, blobStatus.ToProfobuf(), probe)
+	blobStatusReply, err := pd.pollBlobStatusUntilSigned(timeoutCtx, blobKey, initialBlobStatus.ToProfobuf(), probe)
 	if err != nil {
 		return nil, fmt.Errorf("poll blob status until signed: %w", err)
 	}
@@ -144,12 +196,14 @@ func (pd *PayloadDisperser) SendPayload(
 	// generic function or helper to enhance DRY
 	timeoutCtx, cancel = context.WithTimeout(ctx, pd.config.ContractCallTimeout)
 	defer cancel()
-	err = pd.blockMonitor.WaitForBlockNumber(timeoutCtx, blobStatusReply.GetSignedBatch().GetHeader().GetReferenceBlockNumber())
+	err = pd.blockMonitor.WaitForBlockNumber(
+		timeoutCtx, blobStatusReply.GetSignedBatch().GetHeader().GetReferenceBlockNumber())
 	if err != nil {
 		return nil, fmt.Errorf("wait for block number: %w", err)
 	}
 
-	certVersion, err := pd.certVerifier.GetCertVersion(ctx, blobStatusReply.GetSignedBatch().GetHeader().GetReferenceBlockNumber())
+	certVersion, err := pd.certVerifier.GetCertVersion(
+		ctx, blobStatusReply.GetSignedBatch().GetHeader().GetReferenceBlockNumber())
 	if err != nil {
 		return nil, fmt.Errorf("get certificate version: %w", err)
 	}
@@ -173,8 +227,8 @@ func (pd *PayloadDisperser) SendPayload(
 		var errInvalidCert *verification.CertVerifierInvalidCertError
 		if errors.As(err, &errInvalidCert) {
 			// Regardless of whether the cert is invalid (400) or certVerifier contract has a bug (500),
-			// we send a failover signal. If we can't construct a valid cert after retrying a few times (proxy retry policy),
-			// then its safer for the rollup to failover to another DA layer.
+			// we send a failover signal. If we can't construct a valid cert after retrying a few times (proxy retry
+			// policy), then its safer for the rollup to failover to another DA layer.
 			return nil, api.NewErrorFailover(fmt.Errorf("checkDACert failed with blobKey %v: %w", blobKey.Hex(), err))
 		}
 		return nil, fmt.Errorf("verify cert for blobKey %v: %w", blobKey.Hex(), err)
@@ -187,7 +241,7 @@ func (pd *PayloadDisperser) SendPayload(
 
 // logSigningPercentages logs the signing percentage of each quorum for a blob that has been dispersed and satisfied
 // required signing thresholds
-func (pd *PayloadDisperser) logSigningPercentages(blobKey core.BlobKey, blobStatusReply *dispgrpc.BlobStatusReply) {
+func (pd *PayloadDisperser) logSigningPercentages(blobKey corev2.BlobKey, blobStatusReply *dispgrpc.BlobStatusReply) {
 	attestation := blobStatusReply.GetSignedBatch().GetAttestation()
 	if len(attestation.GetQuorumNumbers()) != len(attestation.GetQuorumSignedPercentages()) {
 		pd.logger.Error("quorum number count and signed percentage count don't match. This should never happen",
@@ -231,7 +285,7 @@ func (pd *PayloadDisperser) Close() error {
 // failure.
 func (pd *PayloadDisperser) pollBlobStatusUntilSigned(
 	ctx context.Context,
-	blobKey core.BlobKey,
+	blobKey corev2.BlobKey,
 	initialStatus dispgrpc.BlobStatus,
 	probe *common.SequenceProbe,
 ) (*dispgrpc.BlobStatusReply, error) {
@@ -317,4 +371,36 @@ func (pd *PayloadDisperser) pollBlobStatusUntilSigned(
 			}
 		}
 	}
+}
+
+// verifyReceivedBlobKey computes the BlobKey from the BlobHeader which was sent to the disperser, and compares it with
+// the BlobKey which was returned by the disperser in the DisperseBlobReply
+//
+// A successful verification guarantees that the disperser didn't make any modifications to the BlobHeader that it
+// received from this client.
+//
+// This function returns the verified blob key if the verification succeeds, and otherwise returns an error describing
+// the failure
+func verifyReceivedBlobKey(
+	// the blob header which was constructed locally and sent to the disperser
+	blobHeader *corev2.BlobHeader,
+	// the reply received back from the disperser
+	disperserReply *dispgrpc.DisperseBlobReply,
+) (corev2.BlobKey, error) {
+
+	actualBlobKey, err := blobHeader.BlobKey()
+	enforce.NilError(err, "compute blob key")
+
+	blobKeyFromDisperser, err := corev2.BytesToBlobKey(disperserReply.GetBlobKey())
+	if err != nil {
+		return corev2.BlobKey{}, fmt.Errorf("converting returned bytes to blob key: %w", err)
+	}
+
+	if actualBlobKey != blobKeyFromDisperser {
+		return corev2.BlobKey{}, fmt.Errorf(
+			"blob key returned by disperser (%v) doesn't match blob which was dispersed (%v)",
+			blobKeyFromDisperser, actualBlobKey)
+	}
+
+	return blobKeyFromDisperser, nil
 }

--- a/api/clients/v2/payloaddispersal/payload_disperser_test.go
+++ b/api/clients/v2/payloaddispersal/payload_disperser_test.go
@@ -1,0 +1,53 @@
+package payloaddispersal
+
+import (
+	"math/big"
+	"testing"
+
+	dispgrpc "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
+	"github.com/Layr-Labs/eigenda/core"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/Layr-Labs/eigenda/encoding"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyReceivedBlobKey(t *testing.T) {
+	blobCommitments := encoding.BlobCommitments{
+		Commitment:       &encoding.G1Commitment{},
+		LengthCommitment: &encoding.G2Commitment{},
+		LengthProof:      &encoding.LengthProof{},
+		Length:           4,
+	}
+
+	quorumNumbers := make([]core.QuorumID, 1)
+	quorumNumbers[0] = 8
+
+	paymentMetadata := core.PaymentMetadata{
+		AccountID:         gethcommon.Address{1},
+		Timestamp:         5,
+		CumulativePayment: big.NewInt(6),
+	}
+
+	blobHeader := &corev2.BlobHeader{
+		BlobVersion:     0,
+		BlobCommitments: blobCommitments,
+		QuorumNumbers:   quorumNumbers,
+		PaymentMetadata: paymentMetadata,
+	}
+
+	realKey, err := blobHeader.BlobKey()
+	require.NoError(t, err)
+
+	reply := dispgrpc.DisperseBlobReply{
+		BlobKey: realKey[:],
+	}
+
+	verifiedKey, err := verifyReceivedBlobKey(blobHeader, &reply)
+	require.NoError(t, err)
+	require.Equal(t, realKey, verifiedKey)
+
+	blobHeader.BlobVersion = 1
+	_, err = verifyReceivedBlobKey(blobHeader, &reply)
+	require.Error(t, err, "Any modification to the header should cause verification to fail")
+}

--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -635,6 +635,7 @@ func buildPayloadDisperser(
 		blockNumMonitor,
 		certBuilder,
 		certVerifier,
+		nil,
 		registry)
 	if err != nil {
 		return nil, fmt.Errorf("new payload disperser: %w", err)

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -293,6 +293,7 @@ func setupPayloadDisperserWithRouter() error {
 		certBuilder,
 		routerCertVerifier,
 		nil,
+		nil,
 	)
 
 	return err

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -57,7 +57,7 @@ type TestClient struct {
 	payloadClientConfig         *clientsv2.PayloadClientConfig
 	logger                      logging.Logger
 	certVerifierAddressProvider *test.TestCertVerifierAddressProvider
-	disperserClient             clientsv2.DisperserClient
+	disperserClient             *clientsv2.DisperserClient
 	payloadDisperser            *payloaddispersal.PayloadDisperser
 	relayClient                 relay.RelayClient
 	relayPayloadRetriever       *payloadretrieval.RelayPayloadRetriever
@@ -258,6 +258,7 @@ func NewTestClient(
 		blockMon,
 		certBuilder,
 		certVerifier,
+		nil,
 		registry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payload disperser: %w", err)
@@ -526,7 +527,7 @@ func (c *TestClient) SetCertVerifierAddress(certVerifierAddress string) {
 }
 
 // GetDisperserClient returns the test client's disperser client.
-func (c *TestClient) GetDisperserClient() clientsv2.DisperserClient {
+func (c *TestClient) GetDisperserClient() *clientsv2.DisperserClient {
 	return c.disperserClient
 }
 

--- a/test/v2/live/live_network_test.go
+++ b/test/v2/live/live_network_test.go
@@ -72,7 +72,7 @@ func emptyBlobDispersalTest(t *testing.T, environment string) {
 	// We have to use the disperser client directly, since it's not possible for the PayloadDisperser to
 	// attempt dispersal of an empty blob
 	// This should fail with "data is empty" error
-	_, _, err := c.GetDisperserClient().DisperseBlob(ctx, blobBytes, 0, quorums)
+	_, _, err := c.GetDisperserClient().DisperseBlob(ctx, blobBytes, 0, quorums, nil, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, clients.ErrZeroSymbols.Error())
 }
@@ -150,7 +150,7 @@ func zeroBlobDispersalTest(t *testing.T, environment string) {
 
 	// We have to use the disperser client directly, since it's not possible for the PayloadDisperser to
 	// attempt dispersal of a blob containing all 0s
-	_, _, err := c.GetDisperserClient().DisperseBlob(ctx, blobBytes, 0, quorums)
+	_, _, err := c.GetDisperserClient().DisperseBlob(ctx, blobBytes, 0, quorums, nil, nil)
 	require.NoError(t, err)
 }
 
@@ -526,7 +526,7 @@ func dispersalWithInvalidSignatureTest(t *testing.T, environment string) {
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 
-	_, _, err = disperserClient.DisperseBlob(ctx, blob.Serialize(), 0, quorums)
+	_, _, err = disperserClient.DisperseBlob(ctx, blob.Serialize(), 0, quorums, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error accounting blob")
 }


### PR DESCRIPTION
- Wires the `ClientLedger` into the `PayloadDisperser`
- The `ClientLedger` is only used if non-nil, but it's currently passed in as nil everywhere, so the logic won't actually run
- This PR makes some tweaks to the division of labor between the `PayloadDisperser` and the `DisperserClient`
    - The reason for this is client ledger debit reversion: we only want to revert a debit if there was an error _before_ sending the dispersal to validator nodes. The previous impl of the `DisperserClient` was doing additional checks after a successful dispersal, so it wasn't possible for the `PayloadDisperser` to always interpret and error as "you should revert the debit"
    - To solve this, I moved the additional checks into the `PayloadDisperser`, so that now we can just always revert the debit if `DisperserClient.DisperseBlob` returns an error
- This PR also makes some architectural simplifications, including deleting the `PayloadDisperser` interface, which is unnecessary since there is only a single impl