### PR TITLE
fix: Copy everything in icicle Dockerfile

### DIFF
--- a/disperser/cmd/encoder/icicle.Dockerfile
+++ b/disperser/cmd/encoder/icicle.Dockerfile
@@ -25,14 +25,7 @@ COPY api/proxy/clients ./api/proxy/clients
 RUN go mod download
 
 # Copy the rest of the source code
-COPY ./disperser /app/disperser
-COPY common /app/common
-COPY contracts /app/contracts
-COPY core /app/core
-COPY api /app/api
-COPY indexer /app/indexer
-COPY encoding /app/encoding
-COPY relay /app/relay
+COPY . .
 
 # Define Icicle versions and checksums
 ENV ICICLE_VERSION=3.4


### PR DESCRIPTION
## Why are these changes needed?

Fixes some build issue introduced recently (not sure when)

```
3.813 ../encoding/kzg/cli.go:8:2: no required module provides package github.com/Layr-Labs/eigenda/resources/srs; to add it:
3.813 	go get github.com/Layr-Labs/eigenda/resources/srs
------
icicle.Dockerfile:58
--------------------
  56 |     # Build the server with icicle backend
  57 |     WORKDIR /app/disperser
  58 | >>> RUN go build -tags=icicle -o ./bin/server ./cmd/encoder
  59 |     
  60 |     # Start a new stage for the base image
--------------------
ERROR: failed to solve: process "/bin/sh -c go build -tags=icicle -o ./bin/server ./cmd/encoder" did not complete successfully: exit code: 1
Build references
Check build summary support
Error: buildx bake failed with: ERROR: failed to solve: process "/bin/sh -c go build -tags=icicle -o ./bin/server ./cmd/encoder" did not complete successfully: exit code: 1
```

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
