### PR TITLE
chore: collapse Node.Start() into the constructor

### DIFF
--- a/node/cmd/main.go
+++ b/node/cmd/main.go
@@ -107,15 +107,9 @@ func NodeMain(ctx *cli.Context) error {
 		return fmt.Errorf("failed to get ServiceManager address: %w", err)
 	}
 
-	// Create the node.
+	// Create and start the node.
 	node, err := node.NewNode(context.Background(), reg, config, contractDirectory, pubIPProvider, client, logger)
 	if err != nil {
-		return err
-	}
-
-	err = node.Start(context.Background())
-	if err != nil {
-		node.Logger.Error("could not start node", "error", err)
 		return err
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -478,7 +478,7 @@ func (n *Node) checkValidatorRegistration(ctx context.Context, socket string) {
 	registeredSocket, err := n.Transactor.GetOperatorSocket(ctx, n.Config.ID)
 	// Error out if registration on-chain is a requirement
 	if err != nil {
-		n.Logger.Warnf("failed to get operator socket: %w", err)
+		n.Logger.Warnf("failed to get operator socket: %v", err)
 	}
 	if registeredSocket != socket {
 		n.Logger.Warnf("registered socket %s does not match expected socket %s", registeredSocket, socket)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,8 +1,6 @@
 package node_test
 
 import (
-	"context"
-	"errors"
 	"os"
 	"runtime"
 	"testing"
@@ -13,7 +11,6 @@ import (
 
 	clientsmock "github.com/Layr-Labs/eigenda/api/clients/v2/mock"
 	"github.com/Layr-Labs/eigenda/common"
-	"github.com/Layr-Labs/eigenda/common/geth"
 	"github.com/Layr-Labs/eigenda/core"
 	coremock "github.com/Layr-Labs/eigenda/core/mock"
 	v2 "github.com/Layr-Labs/eigenda/core/v2"
@@ -116,62 +113,6 @@ func newComponents(t *testing.T, operatorID [32]byte) *components {
 		tx:          tx,
 		relayClient: clientsmock.NewRelayClient(),
 	}
-}
-
-func TestNodeStartNoAddress(t *testing.T) {
-	c := newComponents(t, op0)
-	c.node.Config.RegisterNodeAtStart = false
-
-	c.tx.On("GetOperatorSocket", mock.Anything).Return("", errors.New("failed to get operator socket"))
-
-	err := c.node.Start(context.Background())
-	assert.NoError(t, err)
-}
-
-func TestNodeStartOperatorIDMatch(t *testing.T) {
-	c := newComponents(t, op0)
-	c.node.Config.RegisterNodeAtStart = true
-	c.node.Config.EthClientConfig = geth.EthClientConfig{
-		RPCURLs:          []string{"http://localhost:8545"},
-		PrivateKeyString: privateKey,
-		NumConfirmations: 1,
-	}
-	c.tx.On("GetRegisteredQuorumIdsForOperator", mock.Anything).Return([]core.QuorumID{}, nil)
-	c.tx.On("GetOperatorSetParams", mock.Anything, mock.Anything).Return(&core.OperatorSetParam{
-		MaxOperatorCount:         uint32(4),
-		ChurnBIPsOfOperatorStake: uint16(1000),
-		ChurnBIPsOfTotalStake:    uint16(10),
-	}, nil)
-	c.tx.On("GetNumberOfRegisteredOperatorForQuorum", mock.Anything, mock.Anything).Return(uint32(0), nil)
-	c.tx.On("RegisterOperator", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-
-	c.tx.On("OperatorAddressToID", mock.Anything).Return(core.OperatorID(op0), nil)
-
-	err := c.node.Start(context.Background())
-	assert.NoError(t, err)
-}
-
-func TestNodeStartOperatorIDDoesNotMatch(t *testing.T) {
-	c := newComponents(t, op0)
-	c.node.Config.RegisterNodeAtStart = true
-	c.node.Config.EthClientConfig = geth.EthClientConfig{
-		RPCURLs:          []string{"http://localhost:8545"},
-		PrivateKeyString: privateKey,
-		NumConfirmations: 1,
-	}
-	c.tx.On("GetRegisteredQuorumIdsForOperator", mock.Anything).Return([]core.QuorumID{}, nil)
-	c.tx.On("GetOperatorSetParams", mock.Anything, mock.Anything).Return(&core.OperatorSetParam{
-		MaxOperatorCount:         uint32(4),
-		ChurnBIPsOfOperatorStake: uint16(1000),
-		ChurnBIPsOfTotalStake:    uint16(10),
-	}, nil)
-	c.tx.On("GetNumberOfRegisteredOperatorForQuorum", mock.Anything, mock.Anything).Return(uint32(0), nil)
-	c.tx.On("RegisterOperator", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-
-	c.tx.On("OperatorAddressToID", mock.Anything).Return(core.OperatorID{1}, nil)
-
-	err := c.node.Start(context.Background())
-	assert.ErrorContains(t, err, "operator ID mismatch")
 }
 
 func TestGetReachabilityURL(t *testing.T) {

--- a/test/v1/integration_test.go
+++ b/test/v1/integration_test.go
@@ -162,10 +162,6 @@ func TestDispersalAndRetrieval(t *testing.T) {
 		idStr := hexutil.Encode(op.Node.Config.ID[:])
 		fmt.Println("Operator: ", idStr)
 
-		fmt.Println("Starting node")
-		err = op.Node.Start(ctx)
-		require.NoError(t, err)
-
 		fmt.Println("Starting server")
 		err = nodegrpc.RunServers(op.ServerV1, op.ServerV2, op.Node.Config, logger)
 		require.NoError(t, err)


### PR DESCRIPTION
## Why are these changes needed?

The validator's startup logic is currently split between the constructor and the `Start()` method, which makes updating the order of operations during startup tricky.

This PR merges `Start()` into the constructor, and encapsulates some of that code in helper methods for improved readability.
