### PR TITLE
fix: "blob not found" error handling

### DIFF
--- a/disperser/common/v2/blobstore/s3_blob_store.go
+++ b/disperser/common/v2/blobstore/s3_blob_store.go
@@ -49,7 +49,7 @@ func (b *BlobStore) GetBlob(ctx context.Context, key corev2.BlobKey) ([]byte, er
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to download blob from bucket %s: %v", b.bucketName, err)
+		return nil, fmt.Errorf("%s %s: %v", ErrBlobNotFound, b.bucketName, err)
 	}
 	return data, nil
 }

--- a/disperser/common/v2/blobstore/s3_blob_store.go
+++ b/disperser/common/v2/blobstore/s3_blob_store.go
@@ -34,7 +34,7 @@ func (b *BlobStore) StoreBlob(ctx context.Context, key corev2.BlobKey, data []by
 
 	err = b.s3Client.UploadObject(ctx, b.bucketName, s3.ScopedBlobKey(key), data)
 	if err != nil {
-		b.logger.Errorf("failed to upload blob in bucket %s: %v", b.bucketName, err)
+		b.logger.Errorf("failed to upload blob in bucket %s: %w", b.bucketName, err)
 		return err
 	}
 	return nil
@@ -49,7 +49,7 @@ func (b *BlobStore) GetBlob(ctx context.Context, key corev2.BlobKey) ([]byte, er
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("%s %s: %v", ErrBlobNotFound, b.bucketName, err)
+		return nil, fmt.Errorf("%s %s: %w", ErrBlobNotFound, b.bucketName, err)
 	}
 	return data, nil
 }

--- a/disperser/common/v2/blobstore/s3_blob_store.go
+++ b/disperser/common/v2/blobstore/s3_blob_store.go
@@ -49,7 +49,7 @@ func (b *BlobStore) GetBlob(ctx context.Context, key corev2.BlobKey) ([]byte, er
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("%s %s: %w", ErrBlobNotFound, b.bucketName, err)
+		return nil, fmt.Errorf("%s, bucket: %s,: %w", ErrBlobNotFound.Error(), b.bucketName, err)
 	}
 	return data, nil
 }


### PR DESCRIPTION
## Why are these changes needed?

Better error handling for when the relay can't find a blob.