### PR TITLE
chore: Deprecate ginko

### DIFF
--- a/core/indexer/indexer_suite_test.go
+++ b/core/indexer/indexer_suite_test.go
@@ -3,19 +3,21 @@ package indexer_test
 import (
 	"context"
 	"flag"
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
 	"github.com/Layr-Labs/eigenda/test"
 	"github.com/Layr-Labs/eigenda/test/testbed"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var (
-	anvilContainer *testbed.AnvilContainer
-	templateName   string
-	testName       string
+	anvilContainer  *testbed.AnvilContainer
+	templateName    string
+	testName        string
+	headerStoreType string
 
 	testConfig *deploy.Config
 )
@@ -23,54 +25,57 @@ var (
 func init() {
 	flag.StringVar(&templateName, "config", "testconfig-anvil-nochurner.yaml", "Name of the config file (in `inabox/templates`)")
 	flag.StringVar(&testName, "testname", "", "Name of the test (in `inabox/testdata`)")
+	flag.StringVar(&headerStoreType, "headerStore", "leveldb",
+		"The header store implementation to be used (inmem, leveldb)")
 }
 
-func TestIntegration(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Integration Suite")
-}
+func TestMain(m *testing.M) {
+	flag.Parse()
 
-var _ = BeforeSuite(func() {
-	By("bootstrapping test environment")
+	if testing.Short() {
+		fmt.Println("Skipping integration tests in short mode")
+		os.Exit(0)
+	}
 
-	if !testing.Short() {
-		rootPath := "../../"
+	rootPath := "../../"
+	logger := test.GetLogger()
 
-		if testName == "" {
-			var err error
-			testName, err = deploy.CreateNewTestDirectory(templateName, rootPath)
-			if err != nil {
-				Expect(err).To(BeNil())
-			}
-		}
-
-		testConfig = deploy.NewTestConfig(testName, rootPath)
-		testConfig.Deployers[0].DeploySubgraphs = false
-		logger := test.GetLogger()
-
-		if testConfig.Environment.IsLocal() {
-			logger.Info("Starting anvil")
-			var err error
-			anvilContainer, err = testbed.NewAnvilContainerWithOptions(context.Background(), testbed.AnvilOptions{
-				ExposeHostPort: true, // This will bind container port 8545 to host port 8545
-				Logger:         logger,
-			})
-			if err != nil {
-				panic(err)
-			}
-
-			logger.Info("Deploying experiment")
-			if err := testConfig.DeployExperiment(); err != nil {
-				panic(err)
-			}
+	if testName == "" {
+		var err error
+		testName, err = deploy.CreateNewTestDirectory(templateName, rootPath)
+		if err != nil {
+			logger.Fatal("Failed to create test directory:", err)
 		}
 	}
 
-})
+	testConfig = deploy.NewTestConfig(testName, rootPath)
+	testConfig.Deployers[0].DeploySubgraphs = false
 
-var _ = AfterSuite(func() {
-	if !testing.Short() && testConfig.Environment.IsLocal() {
-		_ = anvilContainer.Terminate(context.Background())
+	if testConfig.Environment.IsLocal() {
+		logger.Info("Starting anvil")
+		var err error
+		anvilContainer, err = testbed.NewAnvilContainerWithOptions(context.Background(), testbed.AnvilOptions{
+			ExposeHostPort: true, // This will bind container port 8545 to host port 8545
+			Logger:         logger,
+		})
+		if err != nil {
+			logger.Fatal("Failed to start anvil container:", err)
+		}
+
+		logger.Info("Deploying experiment")
+		if err := testConfig.DeployExperiment(); err != nil {
+			logger.Fatal("Failed to deploy experiment:", err)
+		}
 	}
 
-})
+	code := m.Run()
+
+	// Cleanup
+	if testConfig != nil && testConfig.Environment.IsLocal() && anvilContainer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = anvilContainer.Terminate(ctx)
+	}
+
+	os.Exit(code)
+}

--- a/core/indexer/state_test.go
+++ b/core/indexer/state_test.go
@@ -59,7 +59,12 @@ func mustRegisterOperators(t *testing.T, env *deploy.Config, logger logging.Logg
 	}
 }
 
-func mustMakeOperatorTransactor(t *testing.T, env *deploy.Config, op deploy.OperatorVars, logger logging.Logger) core.Writer {
+func mustMakeOperatorTransactor(
+	t *testing.T,
+	env *deploy.Config,
+	op deploy.OperatorVars,
+	logger logging.Logger,
+) core.Writer {
 	t.Helper()
 	deployer, ok := env.GetDeployer(env.EigenDA.Deployer)
 	require.True(t, ok, "deployer not found")
@@ -79,7 +84,12 @@ func mustMakeOperatorTransactor(t *testing.T, env *deploy.Config, op deploy.Oper
 	return tx
 }
 
-func mustMakeTestClients(t *testing.T, env *deploy.Config, privateKey string, logger logging.Logger) (common.EthClient, common.RPCEthClient) {
+func mustMakeTestClients(
+	t *testing.T,
+	env *deploy.Config,
+	privateKey string,
+	logger logging.Logger,
+) (common.EthClient, common.RPCEthClient) {
 	t.Helper()
 	deployer, ok := env.GetDeployer(env.EigenDA.Deployer)
 	require.True(t, ok, "deployer not found")
@@ -100,7 +110,12 @@ func mustMakeTestClients(t *testing.T, env *deploy.Config, privateKey string, lo
 	return client, rpcClient
 }
 
-func mustMakeChainState(t *testing.T, env *deploy.Config, _ indexer.HeaderStore, logger logging.Logger) *coreindexer.IndexedChainState {
+func mustMakeChainState(
+	t *testing.T,
+	env *deploy.Config,
+	_ indexer.HeaderStore,
+	logger logging.Logger,
+) *coreindexer.IndexedChainState {
 	t.Helper()
 	client, rpcClient := mustMakeTestClients(t, env, env.Batcher[0].BATCHER_PRIVATE_KEY, logger)
 

--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,6 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/joho/godotenv v1.5.1
 	github.com/minio/minio-go/v7 v7.0.85
-	github.com/onsi/ginkgo/v2 v2.20.0
-	github.com/onsi/gomega v1.34.1
 	github.com/pingcap/errors v0.11.4
 	github.com/prometheus/client_golang v1.21.1
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466
@@ -148,15 +146,12 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.1 // indirect
-	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/pprof v0.0.0-20241009165004-a3522334989c // indirect
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,6 @@ github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXS
 github.com/go-playground/validator/v10 v10.14.1 h1:9c50NUPC30zyuKprjL3vNZ0m5oG+jU0zvx4AqHGnv4k=
 github.com/go-playground/validator/v10 v10.14.1/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
-github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.4 h1:JSwxQzIqKfmFX1swYPpUThQZp/Ka4wzJdK0LWVytLPM=
 github.com/goccy/go-json v0.10.4/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
@@ -285,8 +283,6 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8 h1:Ep/joEub9YwcjRY6ND3+Y/w0ncE540RtGatVhtZL0/Q=
 github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20241009165004-a3522334989c h1:NDovD0SMpBYXlE1zJmS1q55vWB/fUQBcPAqAboZSccA=
-github.com/google/pprof v0.0.0-20241009165004-a3522334989c/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
@@ -445,14 +441,11 @@ github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vv
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
-github.com/onsi/ginkgo/v2 v2.20.0 h1:PE84V2mHqoT1sglvHc8ZdQtPcwmvvt29WLEEO3xmdZw=
-github.com/onsi/ginkgo/v2 v2.20.0/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
-github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -115,7 +115,7 @@ func setupSuite() {
 	logger.Info("bootstrapping test environment")
 
 	// Create a context with 1 minute timeout for setup
-	ctx, cancelSetup := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancelSetup := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancelSetup()
 
 	// Channel to track setup completion
@@ -506,7 +506,7 @@ func teardownSuite() {
 	logger.Info("Tearing down test environment")
 
 	// Create a context with 1 minute timeout for teardown
-	ctx, cancelTeardown := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancelTeardown := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancelTeardown()
 
 	// Channel to track teardown completion

--- a/inabox/tests/integration_test.go
+++ b/inabox/tests/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"math/big"
+	"testing"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api/clients"
@@ -16,154 +17,152 @@ import (
 	"github.com/Layr-Labs/eigenda/disperser"
 
 	"github.com/Layr-Labs/eigenda/encoding/utils/codec"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
-func mineAnvilBlocks(numBlocks int) {
+func mineAnvilBlocks(t *testing.T, numBlocks int) {
+	t.Helper()
 	for i := 0; i < numBlocks; i++ {
-		err := rpcClient.CallContext(context.Background(), nil, "evm_mine")
-		Expect(err).To(BeNil())
+		err := rpcClient.CallContext(t.Context(), nil, "evm_mine")
+		require.NoError(t, err)
 	}
 }
 
-var _ = Describe("Inabox Integration", func() {
-	It("test end to end scenario", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
-		defer cancel()
+func TestEndToEndScenario(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+	defer cancel()
 
-		privateKeyHex := "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcded"
-		signer := auth.NewLocalBlobRequestSigner(privateKeyHex)
+	privateKeyHex := "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcded"
+	signer := auth.NewLocalBlobRequestSigner(privateKeyHex)
 
-		disp, err := clients.NewDisperserClient(&clients.Config{
-			Hostname: "localhost",
-			Port:     "32003",
-			Timeout:  10 * time.Second,
-		}, signer)
-		Expect(err).To(BeNil())
-		Expect(disp).To(Not(BeNil()))
+	disp, err := clients.NewDisperserClient(&clients.Config{
+		Hostname: "localhost",
+		Port:     "32003",
+		Timeout:  10 * time.Second,
+	}, signer)
+	require.NoError(t, err)
+	require.NotNil(t, disp)
 
-		data := make([]byte, 1024)
-		_, err = rand.Read(data)
-		Expect(err).To(BeNil())
+	data := make([]byte, 1024)
+	_, err = rand.Read(data)
+	require.NoError(t, err)
 
-		paddedData := codec.ConvertByPaddingEmptyByte(data)
+	paddedData := codec.ConvertByPaddingEmptyByte(data)
 
-		blobStatus1, key1, err := disp.DisperseBlob(ctx, paddedData, []uint8{})
-		Expect(err).To(BeNil())
-		Expect(key1).To(Not(BeNil()))
-		Expect(blobStatus1).To(Not(BeNil()))
-		Expect(*blobStatus1).To(Equal(disperser.Processing))
+	blobStatus1, key1, err := disp.DisperseBlob(ctx, paddedData, []uint8{})
+	require.NoError(t, err)
+	require.NotNil(t, key1)
+	require.NotNil(t, blobStatus1)
+	require.Equal(t, disperser.Processing, *blobStatus1)
 
-		blobStatus2, key2, err := disp.DisperseBlobAuthenticated(ctx, paddedData, []uint8{})
-		Expect(err).To(BeNil())
-		Expect(key2).To(Not(BeNil()))
-		Expect(blobStatus2).To(Not(BeNil()))
-		Expect(*blobStatus2).To(Equal(disperser.Processing))
+	blobStatus2, key2, err := disp.DisperseBlobAuthenticated(ctx, paddedData, []uint8{})
+	require.NoError(t, err)
+	require.NotNil(t, key2)
+	require.NotNil(t, blobStatus2)
+	require.Equal(t, disperser.Processing, *blobStatus2)
 
-		ticker := time.NewTicker(time.Second * 1)
-		defer ticker.Stop()
+	ticker := time.NewTicker(time.Second * 1)
+	defer ticker.Stop()
 
-		var reply1 *disperserpb.BlobStatusReply
-		var reply2 *disperserpb.BlobStatusReply
+	var reply1 *disperserpb.BlobStatusReply
+	var reply2 *disperserpb.BlobStatusReply
 
-		for loop := true; loop; {
-			select {
-			case <-ctx.Done():
-				Fail("timed out")
-			case <-ticker.C:
-				reply1, err = disp.GetBlobStatus(context.Background(), key1)
-				Expect(err).To(BeNil())
-				Expect(reply1).To(Not(BeNil()))
-				blobStatus1, err = disperser.FromBlobStatusProto(reply1.GetStatus())
-				Expect(err).To(BeNil())
+	for loop := true; loop; {
+		select {
+		case <-ctx.Done():
+			t.Fatal("timed out")
+		case <-ticker.C:
+			reply1, err = disp.GetBlobStatus(ctx, key1)
+			require.NoError(t, err)
+			require.NotNil(t, reply1)
+			blobStatus1, err = disperser.FromBlobStatusProto(reply1.GetStatus())
+			require.NoError(t, err)
 
-				reply2, err = disp.GetBlobStatus(context.Background(), key2)
-				Expect(err).To(BeNil())
-				Expect(reply2).To(Not(BeNil()))
-				blobStatus2, err = disperser.FromBlobStatusProto(reply2.GetStatus())
-				Expect(err).To(BeNil())
+			reply2, err = disp.GetBlobStatus(ctx, key2)
+			require.NoError(t, err)
+			require.NotNil(t, reply2)
+			blobStatus2, err = disperser.FromBlobStatusProto(reply2.GetStatus())
+			require.NoError(t, err)
 
-				if *blobStatus1 != disperser.Confirmed || *blobStatus2 != disperser.Confirmed {
-					mineAnvilBlocks(numConfirmations + 1)
-					continue
-				}
-				blobHeader := blobHeaderFromProto(reply1.GetInfo().GetBlobHeader())
-				verificationProof := blobVerificationProofFromProto(reply1.GetInfo().GetBlobVerificationProof())
-				err = eigenDACertVerifierV1.VerifyDACertV1(&bind.CallOpts{}, blobHeader, verificationProof)
-				Expect(err).To(BeNil())
-				mineAnvilBlocks(numConfirmations + 1)
-
-				blobHeader = blobHeaderFromProto(reply2.GetInfo().GetBlobHeader())
-				verificationProof = blobVerificationProofFromProto(reply2.GetInfo().GetBlobVerificationProof())
-				err = eigenDACertVerifierV1.VerifyDACertV1(&bind.CallOpts{}, blobHeader, verificationProof)
-				Expect(err).To(BeNil())
-				loop = false
+			if *blobStatus1 != disperser.Confirmed || *blobStatus2 != disperser.Confirmed {
+				mineAnvilBlocks(t, numConfirmations+1)
+				continue
 			}
+			blobHeader := blobHeaderFromProto(reply1.GetInfo().GetBlobHeader())
+			verificationProof := blobVerificationProofFromProto(reply1.GetInfo().GetBlobVerificationProof())
+			err = eigenDACertVerifierV1.VerifyDACertV1(&bind.CallOpts{}, blobHeader, verificationProof)
+			require.NoError(t, err)
+			mineAnvilBlocks(t, numConfirmations+1)
+
+			blobHeader = blobHeaderFromProto(reply2.GetInfo().GetBlobHeader())
+			verificationProof = blobVerificationProofFromProto(reply2.GetInfo().GetBlobVerificationProof())
+			err = eigenDACertVerifierV1.VerifyDACertV1(&bind.CallOpts{}, blobHeader, verificationProof)
+			require.NoError(t, err)
+			loop = false
 		}
-		Expect(*blobStatus1).To(Equal(disperser.Confirmed))
-		Expect(*blobStatus2).To(Equal(disperser.Confirmed))
+	}
+	require.Equal(t, disperser.Confirmed, *blobStatus1)
+	require.Equal(t, disperser.Confirmed, *blobStatus2)
 
-		ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
-		defer cancel()
-		retrieved, err := retrievalClient.RetrieveBlob(ctx,
-			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
-			reply1.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
-			uint(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
-			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
-			0, // retrieve blob 1 from quorum 0
-		)
-		Expect(err).To(BeNil())
+	ctx, cancel = context.WithTimeout(t.Context(), time.Second*5)
+	defer cancel()
+	retrieved, err := retrievalClient.RetrieveBlob(ctx,
+		[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
+		reply1.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
+		uint(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
+		[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
+		0, // retrieve blob 1 from quorum 0
+	)
+	require.NoError(t, err)
 
-		restored := codec.RemoveEmptyByteFromPaddedBytes(retrieved)
-		Expect(bytes.TrimRight(restored, "\x00")).To(Equal(bytes.TrimRight(data, "\x00")))
+	restored := codec.RemoveEmptyByteFromPaddedBytes(retrieved)
+	require.Equal(t, bytes.TrimRight(data, "\x00"), bytes.TrimRight(restored, "\x00"))
 
-		_, err = retrievalClient.RetrieveBlob(ctx,
-			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
-			reply1.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
-			uint(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
-			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
-			1, // retrieve blob 1 from quorum 1
-		)
-		Expect(err).To(BeNil())
+	_, err = retrievalClient.RetrieveBlob(ctx,
+		[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
+		reply1.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
+		uint(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
+		[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
+		1, // retrieve blob 1 from quorum 1
+	)
+	require.NoError(t, err)
 
-		_, err = retrievalClient.RetrieveBlob(ctx,
-			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
-			reply1.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
-			uint(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
-			[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
-			2, // retrieve blob 1 from quorum 2
-		)
-		Expect(err).NotTo(BeNil())
+	_, err = retrievalClient.RetrieveBlob(ctx,
+		[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
+		reply1.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
+		uint(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
+		[32]byte(reply1.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
+		2, // retrieve blob 1 from quorum 2
+	)
+	require.Error(t, err)
 
-		retrieved, err = retrievalClient.RetrieveBlob(ctx,
-			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
-			reply2.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
-			uint(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
-			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
-			0, // retrieve from quorum 0
-		)
-		Expect(err).To(BeNil())
-		restored = codec.RemoveEmptyByteFromPaddedBytes(retrieved)
-		Expect(bytes.TrimRight(restored, "\x00")).To(Equal(bytes.TrimRight(data, "\x00")))
-		_, err = retrievalClient.RetrieveBlob(ctx,
-			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
-			reply2.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
-			uint(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
-			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
-			1, // retrieve from quorum 1
-		)
-		Expect(err).To(BeNil())
-		_, err = retrievalClient.RetrieveBlob(ctx,
-			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
-			reply2.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
-			uint(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
-			[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
-			2, // retrieve from quorum 2
-		)
-		Expect(err).NotTo(BeNil())
-	})
-})
+	retrieved, err = retrievalClient.RetrieveBlob(ctx,
+		[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
+		reply2.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
+		uint(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
+		[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
+		0, // retrieve from quorum 0
+	)
+	require.NoError(t, err)
+	restored = codec.RemoveEmptyByteFromPaddedBytes(retrieved)
+	require.Equal(t, bytes.TrimRight(data, "\x00"), bytes.TrimRight(restored, "\x00"))
+	_, err = retrievalClient.RetrieveBlob(ctx,
+		[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
+		reply2.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
+		uint(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
+		[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
+		1, // retrieve from quorum 1
+	)
+	require.NoError(t, err)
+	_, err = retrievalClient.RetrieveBlob(ctx,
+		[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeaderHash()),
+		reply2.GetInfo().GetBlobVerificationProof().GetBlobIndex(),
+		uint(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetReferenceBlockNumber()),
+		[32]byte(reply2.GetInfo().GetBlobVerificationProof().GetBatchMetadata().GetBatchHeader().GetBatchRoot()),
+		2, // retrieve from quorum 2
+	)
+	require.Error(t, err)
+}
 
 func blobHeaderFromProto(blobHeader *disperserpb.BlobHeader) certTypes.EigenDATypesV1BlobHeader {
 	quorums := make([]certTypes.EigenDATypesV1QuorumBlobParam, len(blobHeader.GetBlobQuorumParams()))

--- a/inabox/tests/integration_v2_test.go
+++ b/inabox/tests/integration_v2_test.go
@@ -102,12 +102,20 @@ func TestEndToEndV2Scenario(t *testing.T) {
 	// ensure that a verifier can't be added at the latest block number
 	latestBlock, err := ethClient.BlockNumber(ctx)
 	require.NoError(t, err)
-	_, err = eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock), gethcommon.HexToAddress("0x0"))
+	_, err = eigenDACertVerifierRouter.AddCertVerifier(
+		deployerTransactorOpts,
+		uint32(latestBlock),
+		gethcommon.HexToAddress("0x0"),
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), getSolidityFunctionSig("ABNNotInFuture(uint32)"))
 
 	// ensure that a verifier #2 can be added two blocks in the future where activation_block_number = latestBlock + 2
-	tx, err := eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock)+2, gethcommon.HexToAddress("0x0"))
+	tx, err := eigenDACertVerifierRouter.AddCertVerifier(
+		deployerTransactorOpts,
+		uint32(latestBlock)+2,
+		gethcommon.HexToAddress("0x0"),
+	)
 	require.NoError(t, err)
 	mineAnvilBlocks(t, 1)
 
@@ -138,7 +146,11 @@ func TestEndToEndV2Scenario(t *testing.T) {
 	latestBlock, err = ethClient.BlockNumber(ctx)
 	require.NoError(t, err)
 
-	tx, err = eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock)+2, gethcommon.HexToAddress(testConfig.EigenDA.CertVerifier))
+	tx, err = eigenDACertVerifierRouter.AddCertVerifier(
+		deployerTransactorOpts,
+		uint32(latestBlock)+2,
+		gethcommon.HexToAddress(testConfig.EigenDA.CertVerifier),
+	)
 	require.NoError(t, err)
 	mineAnvilBlocks(t, 10)
 

--- a/inabox/tests/integration_v2_test.go
+++ b/inabox/tests/integration_v2_test.go
@@ -6,65 +6,17 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
-
-	"github.com/Layr-Labs/eigenda/encoding"
+	"testing"
 
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
-	"github.com/consensys/gnark-crypto/ecc/bn254"
-	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
 )
 
-func RandomG1Point() (encoding.G1Commitment, error) {
-	// 1) pick r ← 𝐹ᵣ at random
-	var r fr.Element
-	if _, err := r.SetRandom(); err != nil {
-		return encoding.G1Commitment{}, err
-	}
-
-	// 2) compute P = r·G₁ in Jacobian form
-	G1Jac, _, _, _ := bn254.Generators()
-	var Pjac bn254.G1Jac
-
-	var rBigInt big.Int
-	r.BigInt(&rBigInt)
-	Pjac.ScalarMultiplication(&G1Jac, &rBigInt)
-
-	// 3) convert to affine (x, y)
-	var Paff bn254.G1Affine
-	Paff.FromJacobian(&Pjac)
-	return encoding.G1Commitment(Paff), nil
-}
-
-func RandomG2Point() (encoding.G2Commitment, error) {
-
-	// 1) pick r ← 𝐹ᵣ at random
-	var r fr.Element
-	if _, err := r.SetRandom(); err != nil {
-		return encoding.G2Commitment{}, err
-	}
-
-	// 2) compute P = r·G₂ in Jacobian form
-	_, g2Jac, _, _ := bn254.Generators()
-	var Pjac bn254.G2Jac
-
-	var rBigInt big.Int
-	r.BigInt(&rBigInt)
-	Pjac.ScalarMultiplication(&g2Jac, &rBigInt)
-
-	// 3) convert to affine (x, y)
-	var Paff bn254.G2Affine
-	Paff.FromJacobian(&Pjac)
-	return encoding.G2Commitment(Paff), nil
-}
-
-var _ = Describe("Inabox v2 Integration", func() {
+func TestEndToEndV2Scenario(t *testing.T) {
 	/*
 		This end to end test ensures that:
 		1. a blob can be dispersed using the lower level disperser client to successfully produce a blob status response
@@ -76,160 +28,158 @@ var _ = Describe("Inabox v2 Integration", func() {
 
 		TODO: Decompose this test into smaller tests that cover each of the above steps individually.
 	*/
-	It("test end to end scenario", func() {
-		ctx := context.Background()
-		// mine finalization_delay # of blocks given sometimes registry coordinator updates can sometimes happen
-		// in-between the current_block_number - finalization_block_delay. This ensures consistent test execution.
-		mineAnvilBlocks(6)
+	ctx := t.Context()
+	// mine finalization_delay # of blocks given sometimes registry coordinator updates can sometimes happen
+	// in-between the current_block_number - finalization_block_delay. This ensures consistent test execution.
+	mineAnvilBlocks(t, 6)
 
-		payload1 := randomPayload(992)
-		payload2 := randomPayload(123)
+	payload1 := randomPayload(992)
+	payload2 := randomPayload(123)
 
-		// certificates are verified within the payload disperser client
-		cert1, err := payloadDisperser.SendPayload(ctx, payload1)
-		Expect(err).To(BeNil())
+	// certificates are verified within the payload disperser client
+	cert1, err := payloadDisperser.SendPayload(ctx, payload1)
+	require.NoError(t, err)
 
-		cert2, err := payloadDisperser.SendPayload(ctx, payload2)
-		Expect(err).To(BeNil())
+	cert2, err := payloadDisperser.SendPayload(ctx, payload2)
+	require.NoError(t, err)
 
-		err = staticCertVerifier.CheckDACert(ctx, cert1)
-		Expect(err).To(BeNil())
+	err = staticCertVerifier.CheckDACert(ctx, cert1)
+	require.NoError(t, err)
 
-		err = routerCertVerifier.CheckDACert(ctx, cert1)
-		Expect(err).To(BeNil())
+	err = routerCertVerifier.CheckDACert(ctx, cert1)
+	require.NoError(t, err)
 
-		// test onchain verification using cert #2
-		err = staticCertVerifier.CheckDACert(ctx, cert2)
-		Expect(err).To(BeNil())
+	// test onchain verification using cert #2
+	err = staticCertVerifier.CheckDACert(ctx, cert2)
+	require.NoError(t, err)
 
-		err = routerCertVerifier.CheckDACert(ctx, cert2)
-		Expect(err).To(BeNil())
+	err = routerCertVerifier.CheckDACert(ctx, cert2)
+	require.NoError(t, err)
 
-		eigenDAV3Cert1, ok := cert1.(*coretypes.EigenDACertV3)
-		Expect(ok).To(BeTrue())
+	eigenDAV3Cert1, ok := cert1.(*coretypes.EigenDACertV3)
+	require.True(t, ok)
 
-		eigenDAV3Cert2, ok := cert2.(*coretypes.EigenDACertV3)
-		Expect(ok).To(BeTrue())
+	eigenDAV3Cert2, ok := cert2.(*coretypes.EigenDACertV3)
+	require.True(t, ok)
 
-		// test retrieval from disperser relay subnet
-		actualPayload1, err := relayRetrievalClientV2.GetPayload(ctx, eigenDAV3Cert1)
-		Expect(err).To(BeNil())
-		Expect(actualPayload1).To(Not(BeNil()))
-		Expect(actualPayload1).To(Equal(payload1))
+	// test retrieval from disperser relay subnet
+	actualPayload1, err := relayRetrievalClientV2.GetPayload(ctx, eigenDAV3Cert1)
+	require.NoError(t, err)
+	require.NotNil(t, actualPayload1)
+	require.Equal(t, payload1, actualPayload1)
 
-		actualPayload2, err := relayRetrievalClientV2.GetPayload(ctx, eigenDAV3Cert2)
-		Expect(err).To(BeNil())
-		Expect(actualPayload2).To(Not(BeNil()))
-		Expect(actualPayload2).To(Equal(payload2))
+	actualPayload2, err := relayRetrievalClientV2.GetPayload(ctx, eigenDAV3Cert2)
+	require.NoError(t, err)
+	require.NotNil(t, actualPayload2)
+	require.Equal(t, payload2, actualPayload2)
 
-		// test distributed retrieval from DA network validator nodes
-		actualPayload1, err = validatorRetrievalClientV2.GetPayload(
-			ctx,
-			eigenDAV3Cert1,
-		)
-		Expect(err).To(BeNil())
-		Expect(actualPayload1).To(Not(BeNil()))
-		Expect(actualPayload1).To(Equal(payload1))
+	// test distributed retrieval from DA network validator nodes
+	actualPayload1, err = validatorRetrievalClientV2.GetPayload(
+		ctx,
+		eigenDAV3Cert1,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, actualPayload1)
+	require.Equal(t, payload1, actualPayload1)
 
-		actualPayload2, err = validatorRetrievalClientV2.GetPayload(
-			ctx,
-			eigenDAV3Cert2,
-		)
-		Expect(err).To(BeNil())
-		Expect(actualPayload2).To(Not(BeNil()))
-		Expect(actualPayload2).To(Equal(payload2))
+	actualPayload2, err = validatorRetrievalClientV2.GetPayload(
+		ctx,
+		eigenDAV3Cert2,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, actualPayload2)
+	require.Equal(t, payload2, actualPayload2)
 
-		/*
-			enforce correct functionality of the EigenDACertVerifierRouter contract:
-				1. ensure that a verifier can't be added at the latest block number
-				2. ensure that a verifier can be added two blocks in the future
-				3. ensure that the new verifier can be read from the contract when queried using a future rbn
-				4. ensure that the old verifier can still be read from the contract when queried using the latest block number
-				5. ensure that the new verifier is used to verify a cert at the future rbn after dispersal
-		*/
+	/*
+		enforce correct functionality of the EigenDACertVerifierRouter contract:
+			1. ensure that a verifier can't be added at the latest block number
+			2. ensure that a verifier can be added two blocks in the future
+			3. ensure that the new verifier can be read from the contract when queried using a future rbn
+			4. ensure that the old verifier can still be read from the contract when queried using the latest block number
+			5. ensure that the new verifier is used to verify a cert at the future rbn after dispersal
+	*/
 
-		// ensure that a verifier can't be added at the latest block number
-		latestBlock, err := ethClient.BlockNumber(ctx)
-		Expect(err).To(BeNil())
-		_, err = eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock), gethcommon.HexToAddress("0x0"))
-		Expect(err).Error()
-		Expect(err.Error()).To(ContainSubstring(getSolidityFunctionSig("ABNNotInFuture(uint32)")))
+	// ensure that a verifier can't be added at the latest block number
+	latestBlock, err := ethClient.BlockNumber(ctx)
+	require.NoError(t, err)
+	_, err = eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock), gethcommon.HexToAddress("0x0"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), getSolidityFunctionSig("ABNNotInFuture(uint32)"))
 
-		// ensure that a verifier #2 can be added two blocks in the future where activation_block_number = latestBlock + 2
-		tx, err := eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock)+2, gethcommon.HexToAddress("0x0"))
-		Expect(err).To(BeNil())
-		mineAnvilBlocks(1)
+	// ensure that a verifier #2 can be added two blocks in the future where activation_block_number = latestBlock + 2
+	tx, err := eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock)+2, gethcommon.HexToAddress("0x0"))
+	require.NoError(t, err)
+	mineAnvilBlocks(t, 1)
 
-		// ensure that tx successfully executed
-		err = validateTxReceipt(ctx, tx.Hash())
-		Expect(err).To(BeNil())
+	// ensure that tx successfully executed
+	err = validateTxReceipt(ctx, tx.Hash())
+	require.NoError(t, err)
 
-		// ensure that new verifier can be read from the contract at the future rbn
-		verifier, err := eigenDACertVerifierRouterCaller.GetCertVerifierAt(&bind.CallOpts{}, uint32(latestBlock+2))
-		Expect(err).To(BeNil())
-		Expect(verifier).To(Equal(gethcommon.HexToAddress("0x0")))
+	// ensure that new verifier can be read from the contract at the future rbn
+	verifier, err := eigenDACertVerifierRouterCaller.GetCertVerifierAt(&bind.CallOpts{}, uint32(latestBlock+2))
+	require.NoError(t, err)
+	require.Equal(t, gethcommon.HexToAddress("0x0"), verifier)
 
-		// and that old one still lives at the latest block number - 1
-		verifier, err = eigenDACertVerifierRouterCaller.GetCertVerifierAt(&bind.CallOpts{}, uint32(latestBlock-1))
-		Expect(err).To(BeNil())
-		Expect(verifier.String()).To(Equal(testConfig.EigenDA.CertVerifier))
+	// and that old one still lives at the latest block number - 1
+	verifier, err = eigenDACertVerifierRouterCaller.GetCertVerifierAt(&bind.CallOpts{}, uint32(latestBlock-1))
+	require.NoError(t, err)
+	require.Equal(t, testConfig.EigenDA.CertVerifier, verifier.String())
 
-		// progress anvil chain 10 blocks
-		mineAnvilBlocks(10)
+	// progress anvil chain 10 blocks
+	mineAnvilBlocks(t, 10)
 
-		// disperse blob #3 to trigger the new cert verifier which should fail
-		// since the address is not a valid cert verifier and the GetQuorums call will fail
-		payload3 := randomPayload(1234)
-		cert3, err := payloadDisperser.SendPayload(ctx, payload3)
-		Expect(err.Error()).To(ContainSubstring("no contract code at given address"))
-		Expect(cert3).To(BeNil())
+	// disperse blob #3 to trigger the new cert verifier which should fail
+	// since the address is not a valid cert verifier and the GetQuorums call will fail
+	payload3 := randomPayload(1234)
+	cert3, err := payloadDisperser.SendPayload(ctx, payload3)
+	require.Contains(t, err.Error(), "no contract code at given address")
+	require.Nil(t, cert3)
 
-		latestBlock, err = ethClient.BlockNumber(ctx)
-		Expect(err).To(BeNil())
+	latestBlock, err = ethClient.BlockNumber(ctx)
+	require.NoError(t, err)
 
-		tx, err = eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock)+2, gethcommon.HexToAddress(testConfig.EigenDA.CertVerifier))
-		Expect(err).To(BeNil())
-		mineAnvilBlocks(10)
+	tx, err = eigenDACertVerifierRouter.AddCertVerifier(deployerTransactorOpts, uint32(latestBlock)+2, gethcommon.HexToAddress(testConfig.EigenDA.CertVerifier))
+	require.NoError(t, err)
+	mineAnvilBlocks(t, 10)
 
-		err = validateTxReceipt(ctx, tx.Hash())
-		Expect(err).To(BeNil())
+	err = validateTxReceipt(ctx, tx.Hash())
+	require.NoError(t, err)
 
-		// ensure that new verifier #3 can be used for successful verification
-		// now disperse blob #4 to trigger the new cert verifier which should pass
-		// ensure that a verifier can be added two blocks in the future
-		payload4 := randomPayload(1234)
-		cert4, err := payloadDisperser.SendPayload(ctx, payload4)
-		Expect(err).To(BeNil())
-		err = routerCertVerifier.CheckDACert(ctx, cert4)
-		Expect(err).To(BeNil())
+	// ensure that new verifier #3 can be used for successful verification
+	// now disperse blob #4 to trigger the new cert verifier which should pass
+	// ensure that a verifier can be added two blocks in the future
+	payload4 := randomPayload(1234)
+	cert4, err := payloadDisperser.SendPayload(ctx, payload4)
+	require.NoError(t, err)
+	err = routerCertVerifier.CheckDACert(ctx, cert4)
+	require.NoError(t, err)
 
-		err = staticCertVerifier.CheckDACert(ctx, cert4)
-		Expect(err).To(BeNil())
+	err = staticCertVerifier.CheckDACert(ctx, cert4)
+	require.NoError(t, err)
 
-		// now force verification to fail by modifying the cert contents
-		eigenDAV3Cert4, ok := cert4.(*coretypes.EigenDACertV3)
-		Expect(ok).To(BeTrue())
+	// now force verification to fail by modifying the cert contents
+	eigenDAV3Cert4, ok := cert4.(*coretypes.EigenDACertV3)
+	require.True(t, ok)
 
-		// modify the merkle root of the batch header and ensure verification fails
-		// TODO: Test other cert verification failure cases as well
-		eigenDAV3Cert4.BatchHeader.BatchRoot = gethcommon.Hash{0x1, 0x2, 0x3, 0x4}
+	// modify the merkle root of the batch header and ensure verification fails
+	// TODO: Test other cert verification failure cases as well
+	eigenDAV3Cert4.BatchHeader.BatchRoot = gethcommon.Hash{0x1, 0x2, 0x3, 0x4}
 
-		var certErr *verification.CertVerifierInvalidCertError
-		err = routerCertVerifier.CheckDACert(ctx, eigenDAV3Cert4)
-		Expect(err).To(BeAssignableToTypeOf(&verification.CertVerifierInvalidCertError{}))
-		Expect(errors.As(err, &certErr)).To(BeTrue())
-		// TODO(samlaf): after we update to CertVerifier 4.0.0 whose checkDACert will return error bytes,
-		// we should check that extra bytes returned start with signature of the InvalidInclusionProof error
-		Expect(certErr.StatusCode).To(Equal(verification.StatusInvalidCert))
+	var certErr *verification.CertVerifierInvalidCertError
+	err = routerCertVerifier.CheckDACert(ctx, eigenDAV3Cert4)
+	require.IsType(t, &verification.CertVerifierInvalidCertError{}, err)
+	require.True(t, errors.As(err, &certErr))
+	// TODO(samlaf): after we update to CertVerifier 4.0.0 whose checkDACert will return error bytes,
+	// we should check that extra bytes returned start with signature of the InvalidInclusionProof error
+	require.Equal(t, verification.StatusInvalidCert, certErr.StatusCode)
 
-		err = staticCertVerifier.CheckDACert(ctx, eigenDAV3Cert4)
-		Expect(err).To(BeAssignableToTypeOf(&verification.CertVerifierInvalidCertError{}))
-		Expect(errors.As(err, &certErr)).To(BeTrue())
-		// TODO(samlaf): after we update to CertVerifier 4.0.0 whose checkDACert will return error bytes,
-		// we should check that extra bytes returned start with signature of the InvalidInclusionProof error
-		Expect(certErr.StatusCode).To(Equal(verification.StatusInvalidCert))
-	})
-})
+	err = staticCertVerifier.CheckDACert(ctx, eigenDAV3Cert4)
+	require.IsType(t, &verification.CertVerifierInvalidCertError{}, err)
+	require.True(t, errors.As(err, &certErr))
+	// TODO(samlaf): after we update to CertVerifier 4.0.0 whose checkDACert will return error bytes,
+	// we should check that extra bytes returned start with signature of the InvalidInclusionProof error
+	require.Equal(t, verification.StatusInvalidCert, certErr.StatusCode)
+}
 
 func validateTxReceipt(ctx context.Context, txHash gethcommon.Hash) error {
 	receipt, err := ethClient.TransactionReceipt(ctx, txHash)

--- a/inabox/tests/ratelimit_test.go
+++ b/inabox/tests/ratelimit_test.go
@@ -32,6 +32,7 @@ type result struct {
 }
 
 func disperse(t *testing.T, ctx context.Context, client clients.DisperserClient, resultChan chan result, data []byte, param core.SecurityParam) {
+	t.Helper()
 
 	blobStatus, key, err := client.DisperseBlob(ctx, data, []uint8{param.QuorumID})
 	if err != nil {
@@ -75,6 +76,7 @@ func disperse(t *testing.T, ctx context.Context, client clients.DisperserClient,
 }
 
 func retrieve(t *testing.T, ctx context.Context, client retriever.RetrieverClient, result result) error {
+	t.Helper()
 
 	reply, err := client.RetrieveBlob(ctx, &retriever.BlobRequest{
 		BatchHeaderHash:      result.BlobVerificationProof.GetBatchMetadata().GetBatchHeaderHash(),
@@ -103,8 +105,9 @@ type ratelimitTestCase struct {
 }
 
 func testRatelimit(t *testing.T, testConfig *deploy.Config, c ratelimitTestCase) (int, int) {
+	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	defer cancel()
 
 	disp, err := clients.NewDisperserClient(&clients.Config{
@@ -168,7 +171,6 @@ func testRatelimit(t *testing.T, testConfig *deploy.Config, c ratelimitTestCase)
 	}
 
 	return dispersalErrors, retrievalErrors
-
 }
 
 func TestRatelimit(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?

Standarize on using the standard go testing framework for inabox + random indexer test.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
