### PR TITLE
ci: Add encoder-icicle to docker build pipeline

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -123,6 +123,8 @@ target "encoder" {
 target "encoder-icicle" {
   context    = "."
   dockerfile = "./disperser/cmd/encoder/icicle.Dockerfile"
+  // Currently needed because Dockerfile has amd64 hardcoded in a few places.
+  // TODO: make Dockerfile also work for arm.
   platforms  = ["linux/amd64"]
   tags       = ["${REGISTRY}/${REPO}/encoder-icicle:${BUILD_TAG}"]
 }


### PR DESCRIPTION
## Why are these changes needed?

Adds encoder-icicle to "all" group so that we build it in the `docker-publish-internal` pipeline. This will help catch any issues with the icicle encoder build earlier.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
