### PR TITLE
fix(payments): Rely on test context cancelation, instead of doing it manually

### DIFF
--- a/core/payments/ondemand/on_demand_vault_monitor_test.go
+++ b/core/payments/ondemand/on_demand_vault_monitor_test.go
@@ -1,7 +1,6 @@
 package ondemand
 
 import (
-	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -44,8 +43,7 @@ func TestNewOnDemandVaultMonitorInvalidInterval(t *testing.T) {
 }
 
 func TestOnDemandVaultMonitor(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
 	updateInterval := time.Millisecond
 
 	accounts := []gethcommon.Address{
@@ -120,8 +118,7 @@ func TestOnDemandVaultMonitor(t *testing.T) {
 }
 
 func TestOnDemandVaultMonitorNoBatching(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
 	updateInterval := time.Millisecond
 
 	// Create multiple accounts to verify they're all fetched in a single batch

--- a/core/payments/reservation/reservation_vault_monitor_test.go
+++ b/core/payments/reservation/reservation_vault_monitor_test.go
@@ -1,7 +1,6 @@
 package reservation
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -46,8 +45,7 @@ func TestNewReservationVaultMonitorInvalidInterval(t *testing.T) {
 func TestReservationVaultMonitor(t *testing.T) {
 	testTime := time.Date(1971, 8, 15, 0, 0, 0, 0, time.UTC)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
 	updateInterval := time.Millisecond
 
 	accounts := []gethcommon.Address{
@@ -135,8 +133,7 @@ func TestReservationVaultMonitor(t *testing.T) {
 func TestReservationVaultMonitorNoBatching(t *testing.T) {
 	testTime := time.Date(1971, 8, 15, 0, 0, 0, 0, time.UTC)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
 	updateInterval := time.Millisecond
 
 	// Create multiple accounts to verify they're all fetched in a single batch


### PR DESCRIPTION
- Cleans up messy test cancellation