### PR TITLE
fix(payments): Properly synchronize vault monitor tests

### DIFF
--- a/core/payments/ondemand/test/on_demand_vault_monitor_test.go
+++ b/core/payments/ondemand/test/on_demand_vault_monitor_test.go
@@ -2,6 +2,7 @@ package ondemand_test
 
 import (
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -60,8 +61,11 @@ func TestOnDemandVaultMonitor(t *testing.T) {
 		testVault.SetTotalDeposit(addr, big.NewInt(int64(1000+i*100)))
 	}
 
+	var mu sync.Mutex
 	capturedUpdates := make(map[gethcommon.Address]*big.Int)
 	updateTotalDeposit := func(accountID gethcommon.Address, newTotalDeposit *big.Int) error {
+		mu.Lock()
+		defer mu.Unlock()
 		capturedUpdates[accountID] = newTotalDeposit
 		return nil
 	}
@@ -79,29 +83,38 @@ func TestOnDemandVaultMonitor(t *testing.T) {
 	require.NotNil(t, monitor)
 
 	test.AssertEventuallyEquals(t, len(accounts), func() int {
+		mu.Lock()
+		defer mu.Unlock()
 		return len(capturedUpdates)
 	}, time.Second)
 
+	mu.Lock()
 	for i, addr := range accounts {
 		deposit, ok := capturedUpdates[addr]
 		require.True(t, ok, "account %s should have been updated", addr.Hex())
 		require.NotNil(t, deposit)
 		require.Equal(t, big.NewInt(int64(1000+i*100)), deposit)
 	}
+	mu.Unlock()
 
 	// update one of the deposits
 	testAccount := accounts[2]
 	testVault.SetTotalDeposit(testAccount, big.NewInt(9999)) // Changed
 
 	// Clear captured updates to verify new updates
+	mu.Lock()
 	capturedUpdates = make(map[gethcommon.Address]*big.Int)
+	mu.Unlock()
 
 	// Wait for the monitor to fetch the updated deposits
 	test.AssertEventuallyEquals(t, len(accounts), func() int {
+		mu.Lock()
+		defer mu.Unlock()
 		return len(capturedUpdates)
 	}, time.Second)
 
 	// Check that the specific account was updated correctly
+	mu.Lock()
 	updatedDeposit, ok := capturedUpdates[testAccount]
 	require.True(t, ok, "account %s should have been updated", testAccount.Hex())
 	require.NotNil(t, updatedDeposit)
@@ -116,6 +129,7 @@ func TestOnDemandVaultMonitor(t *testing.T) {
 			require.Equal(t, big.NewInt(int64(1000+i*100)), deposit)
 		}
 	}
+	mu.Unlock()
 }
 
 func TestOnDemandVaultMonitorNoBatching(t *testing.T) {
@@ -133,8 +147,11 @@ func TestOnDemandVaultMonitorNoBatching(t *testing.T) {
 		testVault.SetTotalDeposit(addr, big.NewInt(int64(2000+i*200)))
 	}
 
+	var mu sync.Mutex
 	capturedUpdates := make(map[gethcommon.Address]*big.Int)
 	updateTotalDeposit := func(accountID gethcommon.Address, newTotalDeposit *big.Int) error {
+		mu.Lock()
+		defer mu.Unlock()
 		capturedUpdates[accountID] = newTotalDeposit
 		return nil
 	}
@@ -153,12 +170,16 @@ func TestOnDemandVaultMonitorNoBatching(t *testing.T) {
 
 	// Wait for updates
 	test.AssertEventuallyEquals(t, len(accounts), func() int {
+		mu.Lock()
+		defer mu.Unlock()
 		return len(capturedUpdates)
 	}, time.Second)
+	mu.Lock()
 	for i, addr := range accounts {
 		deposit, ok := capturedUpdates[addr]
 		require.True(t, ok, "account %s should have been updated", addr.Hex())
 		require.NotNil(t, deposit)
 		require.Equal(t, big.NewInt(int64(2000+i*200)), deposit)
 	}
+	mu.Unlock()
 }


### PR DESCRIPTION
- Old test code was flaky. I added mutexes, so that the concurrent map access is actually safe