### PR TITLE
fix: remove unreachable code in assignment test

### DIFF
--- a/core/v2/assignment_test.go
+++ b/core/v2/assignment_test.go
@@ -421,25 +421,5 @@ func FuzzOperatorAssignmentsV2(f *testing.F) {
 		// Assert that the sampled operators have enough unique chunks to reconstruct the blob
 		assert.GreaterOrEqual(t, uint32(len(uniqueChunkIndices)), minChunksNeeded,
 			"Sampled operators should have enough unique chunks to reconstruct the blob")
-
-		if uint32(len(uniqueChunkIndices)) < minChunksNeeded {
-
-			fmt.Println("Quorum: 0")
-			for opID, stake := range stakes[0] {
-				fmt.Println("Stake: ", stake, "Operator: ", opID.Hex())
-			}
-
-			fmt.Println("Quorum: 1")
-			for opID, stake := range stakes[1] {
-				fmt.Println("Stake: ", stake, "Operator: ", opID.Hex())
-			}
-
-			fmt.Println("Sampled operators:")
-			for _, opID := range sampledOperators {
-				fmt.Println(opID.Hex())
-			}
-
-			t.Fatal("Sampled operators should have enough unique chunks to reconstruct the blob")
-		}
 	})
 }


### PR DESCRIPTION
Removes dead code in `core/v2/assignment_test.go` where an `if` condition was checking the opposite of what was already verified by `assert.GreaterOrEqual`. 

The `if uint32(len(uniqueChunkIndices)) < minChunksNeeded` block was unreachable because:
- If the assertion passes, the condition is always false
- If the assertion fails, the test has already terminated

This appears to be leftover debug code that was never cleaned up after adding the proper assertion.