### PR TITLE
fix(inabox): network issues

### DIFF
--- a/inabox/Makefile
+++ b/inabox/Makefile
@@ -18,7 +18,7 @@ localstack:
 exp: 
 	go run ./deploy/cmd exp
 
-deploy-all:
+deploy-all: new-anvil
 	go run ./deploy/cmd  -localstack-port 4570 -deploy-resources true  all
 
 stop-infra:


### PR DESCRIPTION
There was actually a few errors that we ran into. graph couldnt connect to chain. added better error handling as well in deploy-all.

Most importantly creating a network instance for anvil and graph to run in. test-containers doesn't allow naming this network... so we end up with a lot of garbage UUID docker networks... these will need to be pruned individually (or by `docker system prune -A`).