### PR TITLE
refactor: move certificate verification logic to verify package

### DIFF
--- a/api/proxy/store/builder/config.go
+++ b/api/proxy/store/builder/config.go
@@ -139,20 +139,11 @@ func (cfg *Config) checkV1Config() error {
 		}
 	}
 
-	// cert verification is enabled
-	// TODO: move this verification logic to verify/cli.go
-	if cfg.VerifierConfigV1.VerifyCerts {
-		if cfg.MemstoreEnabled {
-			return fmt.Errorf(
-				"cannot enable cert verification when memstore is enabled. use --%s",
-				verify.CertVerificationDisabledFlagName)
-		}
-		if cfg.VerifierConfigV1.RPCURL == "" {
-			return fmt.Errorf("cert verification enabled but eth rpc is not set")
-		}
-		if cfg.ClientConfigV1.EdaClientCfg.SvcManagerAddr == "" || cfg.VerifierConfigV1.SvcManagerAddr == "" {
-			return fmt.Errorf("cert verification enabled but svc manager address is not set")
-		}
+	// validate verifier configuration using centralized validation logic
+	err := verify.ValidateVerifierConfig(cfg.VerifierConfigV1, cfg.MemstoreEnabled,
+		cfg.ClientConfigV1.EdaClientCfg.EthRpcUrl, cfg.ClientConfigV1.EdaClientCfg.SvcManagerAddr)
+	if err != nil {
+		return fmt.Errorf("verifier config validation failed: %w", err)
 	}
 
 	return nil

--- a/api/proxy/store/generated_key/eigenda/verify/cli.go
+++ b/api/proxy/store/generated_key/eigenda/verify/cli.go
@@ -140,3 +140,24 @@ func ReadConfig(ctx *cli.Context, clientConfigV1 common.ClientConfigV1) Config {
 		WaitForFinalization:  clientConfigV1.EdaClientCfg.WaitForFinalization,
 	}
 }
+
+// ValidateVerifierConfig validates certificate verification configuration
+// This logic was moved from api/proxy/store/builder/config.go to centralize validation
+func ValidateVerifierConfig(verifierConfig Config, memstoreEnabled bool, ethRpcUrl string, svcManagerAddr string) error {
+	// cert verification is enabled
+	if verifierConfig.VerifyCerts {
+		if memstoreEnabled {
+			return fmt.Errorf(
+				"cannot enable cert verification when memstore is enabled. use --%s",
+				CertVerificationDisabledFlagName)
+		}
+		if verifierConfig.RPCURL == "" {
+			return fmt.Errorf("cert verification enabled but eth rpc is not set")
+		}
+		if ethRpcUrl == "" || svcManagerAddr == "" || verifierConfig.SvcManagerAddr == "" {
+			return fmt.Errorf("cert verification enabled but svc manager address is not set")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Moved certificate verification validation logic from `api/proxy/store/builder/config.go` to `api/proxy/store/generated_key/eigenda/verify/cli.go` to improve code organization.

Remove todo