### PR TITLE
fix: use the router for live tests and traffic generator

### DIFF
--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Layr-Labs/eigenda/api/clients/v2/validator"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/validator/mock"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
-	"github.com/Layr-Labs/eigenda/api/clients/v2/verification/test"
 	proxycommon "github.com/Layr-Labs/eigenda/api/proxy/common"
 	proxyconfig "github.com/Layr-Labs/eigenda/api/proxy/config"
 	"github.com/Layr-Labs/eigenda/api/proxy/config/enablement"
@@ -56,7 +55,7 @@ type TestClient struct {
 	config                      *TestClientConfig
 	payloadClientConfig         *clientsv2.PayloadClientConfig
 	logger                      logging.Logger
-	certVerifierAddressProvider *test.TestCertVerifierAddressProvider
+	certVerifierAddressProvider clientsv2.CertVerifierAddressProvider
 	disperserClient             *clientsv2.DisperserClient
 	payloadDisperser            *payloaddispersal.PayloadDisperser
 	relayClient                 relay.RelayClient
@@ -164,7 +163,7 @@ func NewTestClient(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create disperser client: %w", err)
 	}
-	err = disperserClient.PopulateAccountant(context.Background())
+	err = disperserClient.PopulateAccountant(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to populate accountant: %w", err)
 	}
@@ -210,7 +209,15 @@ func NewTestClient(
 		return nil, fmt.Errorf("failed to create Ethereum reader: %w", err)
 	}
 
-	certVerifierAddressProvider := &test.TestCertVerifierAddressProvider{}
+	routerAddress, err := contractDirectory.GetContractAddress(ctx, directory.CertVerifierRouter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CertVerifierRouter address from contract directory: %w", err)
+	}
+
+	certVerifierAddressProvider, err := verification.BuildRouterAddressProvider(routerAddress, ethClient, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cert verifier address provider: %w", err)
+	}
 
 	certVerifier, err := verification.NewCertVerifier(logger, ethClient, certVerifierAddressProvider)
 	if err != nil {
@@ -374,7 +381,7 @@ func NewTestClient(
 		onlyDownloadClientConfig,
 		validatorClientMetrics)
 
-	proxyWrapper, err := NewProxyWrapper(context.Background(), logger,
+	proxyWrapper, err := NewProxyWrapper(ctx, logger,
 		&proxyconfig.AppConfig{
 			SecretConfig: proxycommon.SecretConfigV2{
 				SignerPaymentKey: privateKey,
@@ -428,7 +435,7 @@ func NewTestClient(
 					VaultMonitorInterval:               time.Second * 30,
 					PutTries:                           3,
 					MaxBlobSizeBytes:                   16 * units.MiB,
-					EigenDACertVerifierOrRouterAddress: config.EigenDACertVerifierAddressQuorums0_1,
+					EigenDACertVerifierOrRouterAddress: routerAddress.Hex(),
 					EigenDADirectory:                   contractDirectoryAddress.Hex(),
 					RetrieversToEnable: []proxycommon.RetrieverType{
 						proxycommon.RelayRetrieverType,
@@ -532,12 +539,6 @@ func (c *TestClient) GetConfig() *TestClientConfig {
 // GetLogger returns the test client's logger.
 func (c *TestClient) GetLogger() logging.Logger {
 	return c.logger
-}
-
-// SetCertVerifierAddress sets the address string which will be returned by the cert verifier address to all users of
-// the provider
-func (c *TestClient) SetCertVerifierAddress(certVerifierAddress string) {
-	c.certVerifierAddressProvider.SetCertVerifierAddress(gethcommon.HexToAddress(certVerifierAddress))
 }
 
 // GetDisperserClient returns the test client's disperser client.
@@ -654,7 +655,7 @@ func (c *TestClient) DisperseAndVerify(ctx context.Context, payload []byte) erro
 		blobKey,
 		eigenDAV3Cert.RelayKeys(),
 		payload,
-		uint32(blobLengthSymbols),
+		blobLengthSymbols,
 		0)
 	if err != nil {
 		return fmt.Errorf("failed to read blob from relays: %w", err)
@@ -876,7 +877,7 @@ func (c *TestClient) ReadBlobFromValidators(
 			return fmt.Errorf("failed to read blob from validators, %s", err)
 		}
 
-		blobLengthSymbols := uint32(header.BlobCommitments.Length)
+		blobLengthSymbols := header.BlobCommitments.Length
 		var blob *coretypes.Blob
 		blob, err = coretypes.DeserializeBlob(retrievedBlobBytes, blobLengthSymbols)
 		if err != nil {

--- a/test/v2/client/test_client_config.go
+++ b/test/v2/client/test_client_config.go
@@ -36,19 +36,6 @@ type TestClientConfig struct {
 	EthRPCUrlsVar string
 	// The contract address for the EigenDA address directory, where all contract addresses are stored
 	ContractDirectoryAddress string
-	// The contract address for the OperatorStateRetriever
-	// The contract address for the EigenDA cert verifier, which specifies required quorums 0 and 1
-	//
-	// If this value is not set, that tests utilizing it will be skipped
-	EigenDACertVerifierAddressQuorums0_1 string
-	// The contract address for the EigenDA cert verifier, which specifies required quorums 0, 1, and 2
-	//
-	// If this value is not set, that tests utilizing it will be skipped
-	EigenDACertVerifierAddressQuorums0_1_2 string
-	// The contract address for the EigenDA cert verifier, which specifies required quorum 2
-	//
-	// If this value is not set, that tests utilizing it will be skipped
-	EigenDACertVerifierAddressQuorums2 string
 	// The URL/IP of a subgraph to use for the chain state
 	SubgraphURL string
 	// The SRS order to use for the test

--- a/test/v2/config/environment/broken/preprod.json
+++ b/test/v2/config/environment/broken/preprod.json
@@ -7,9 +7,6 @@
     "https://ethereum-holesky-rpc.publicnode.com"
   ],
   "ContractDirectoryAddress": "0xfB676e909f376efFDbDee7F17342aCF55f6Ec502",
-  "EigenDACertVerifierAddressQuorums0_1": "0xCCFE3d87fB7D369f1eeE65221a29A83f1323043C",
-  "EigenDACertVerifierAddressQuorums0_1_2": "0x2ccB62f3349DD04FEeff189C7f0568193eFd4430",
-  "EigenDACertVerifierAddressQuorums2": "0xBC23d765540b77803910E65F62BF01a9F8CaB30A",
   "SubgraphURL": "https://subgraph.satsuma-prod.com/51caed8fa9cb/eigenlabs/eigenda-operator-state-preprod-holesky/version/v0.7.0/api",
   "DisableMetrics": true
 }

--- a/test/v2/config/environment/broken/testnet-holesky.json
+++ b/test/v2/config/environment/broken/testnet-holesky.json
@@ -7,9 +7,6 @@
     "https://ethereum-holesky-rpc.publicnode.com"
   ],
   "ContractDirectoryAddress": "0x90776Ea0E99E4c38aA1Efe575a61B3E40160A2FE",
-  "EigenDACertVerifierAddressQuorums0_1": "0xd305aeBcdEc21D00fDF8796CE37d0e74836a6B6e",
-  "EigenDACertVerifierAddressQuorums0_1_2": "",
-  "EigenDACertVerifierAddressQuorums2": "",
   "SubgraphURL": "https://subgraph.satsuma-prod.com/b0b35e5616aa/eigenlabs/eigenda-operator-state-holesky/version/v0.7.0/api",
   "DisableMetrics": true
 }

--- a/test/v2/config/environment/testnet-sepolia.json
+++ b/test/v2/config/environment/testnet-sepolia.json
@@ -7,9 +7,6 @@
     "https://ethereum-sepolia-rpc.publicnode.com"
   ],
   "ContractDirectoryAddress": "0x9620dC4B3564198554e4D2b06dEFB7A369D90257",
-  "EigenDACertVerifierAddressQuorums0_1": "0x58D2B844a894f00b7E6F9F492b9F43aD54Cd4429",
-  "EigenDACertVerifierAddressQuorums0_1_2": "",
-  "EigenDACertVerifierAddressQuorums2": "",
   "ClientLedgerPaymentMode": "reservation-and-on-demand",
   "SubgraphURL": "https://subgraph.satsuma-prod.com/b0b35e5616aa/eigenlabs/eigenda-operator-state-sepolia/version/v0.7.0/api",
   "DisableMetrics": true

--- a/test/v2/live/live_network_test.go
+++ b/test/v2/live/live_network_test.go
@@ -33,17 +33,6 @@ func getEnvironmentName(environment string) string {
 	return environmentName
 }
 
-// checkAndSetCertVerifierAddress checks whether the input address string is empty, and skips the test if it is
-//
-// If the input address is not empty, this method configures the test client to use the input address as the cert
-// verifier address.
-func checkAndSetCertVerifierAddress(t *testing.T, c *client.TestClient, certVerifierAddress string) {
-	if certVerifierAddress == "" {
-		t.Skip("Requested cert verifier address is not configured")
-	}
-	c.SetCertVerifierAddress(certVerifierAddress)
-}
-
 // Tests the basic dispersal workflow:
 // - disperse a blob
 // - wait for it to be confirmed
@@ -61,7 +50,7 @@ func testBasicDispersal(t *testing.T, c *client.TestClient, payload []byte) erro
 // Disperse a 0 byte blob.
 // Empty blobs are not allowed by the disperser
 func emptyBlobDispersalTest(t *testing.T, environment string) {
-	blobBytes := []byte{}
+	var blobBytes []byte
 	quorums := []core.QuorumID{0, 1}
 
 	c := client.GetTestClient(t, environment)
@@ -88,15 +77,11 @@ func TestEmptyBlobDispersal(t *testing.T) {
 
 // Disperse an empty payload. Blob will not be empty, since payload encoding entails adding bytes
 func emptyPayloadDispersalTest(t *testing.T, environment string) {
-	payload := []byte{}
-
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
+	var payload []byte
 
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = testBasicDispersal(t, c, payload)
+	err := testBasicDispersal(t, c, payload)
 	require.NoError(t, err)
 }
 
@@ -115,13 +100,9 @@ func TestEmptyPayloadDispersal(t *testing.T) {
 func testZeroPayloadDispersalTest(t *testing.T, environment string) {
 	payload := make([]byte, 1000)
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = testBasicDispersal(t, c, payload)
+	err := testBasicDispersal(t, c, payload)
 	require.NoError(t, err)
 }
 
@@ -167,13 +148,9 @@ func TestZeroBlobDispersal(t *testing.T) {
 func microscopicBlobDispersalTest(t *testing.T, environment string) {
 	payload := []byte{1}
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = testBasicDispersal(t, c, payload)
+	err := testBasicDispersal(t, c, payload)
 	require.NoError(t, err)
 }
 
@@ -192,13 +169,9 @@ func TestMicroscopicBlobDispersal(t *testing.T) {
 func microscopicBlobDispersalWithPadding(t *testing.T, environment string) {
 	payload := []byte{1}
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = testBasicDispersal(t, c, payload)
+	err := testBasicDispersal(t, c, payload)
 	require.NoError(t, err)
 }
 
@@ -218,13 +191,9 @@ func smallBlobDispersalTest(t *testing.T, environment string) {
 	rand := random.NewTestRandom()
 	payload := rand.VariableBytes(units.KiB, 2*units.KiB)
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = testBasicDispersal(t, c, payload)
+	err := testBasicDispersal(t, c, payload)
 	require.NoError(t, err)
 }
 
@@ -244,13 +213,9 @@ func mediumBlobDispersalTest(t *testing.T, environment string) {
 	rand := random.NewTestRandom()
 	payload := rand.VariableBytes(100*units.KiB, 200*units.KiB)
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = testBasicDispersal(t, c, payload)
+	err := testBasicDispersal(t, c, payload)
 	require.NoError(t, err)
 }
 
@@ -276,7 +241,6 @@ func largeBlobDispersalTest(t *testing.T, environment string) {
 	payload := rand.VariableBytes(maxBlobSize/2, maxBlobSize*3/4)
 
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
 	err = testBasicDispersal(t, c, payload)
 	require.NoError(t, err)
@@ -298,28 +262,23 @@ func smallBlobDispersalAllQuorumsSetsTest(t *testing.T, environment string) {
 	rand := random.NewTestRandom()
 	payload := rand.VariableBytes(units.KiB, 2*units.KiB)
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
 	c := client.GetTestClient(t, environment)
 
 	t.Run("0 1", func(t *testing.T) {
-		checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
-		err = testBasicDispersal(t, c, payload)
+		err := testBasicDispersal(t, c, payload)
 		require.NoError(t, err)
 	})
 
-	t.Run("0 1 2", func(t *testing.T) {
-		checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1_2)
-		err = testBasicDispersal(t, c, payload)
-		require.NoError(t, err)
-	})
-
-	t.Run("2", func(t *testing.T) {
-		checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums2)
-		err = testBasicDispersal(t, c, payload)
-		require.NoError(t, err)
-	})
+	// We need to eventually re-enable testing with quorum set {0,1,2} and {2}
+	//t.Run("0 1 2", func(t *testing.T) {
+	//	err := testBasicDispersal(t, c, payload)
+	//	require.NoError(t, err)
+	//})
+	//
+	//t.Run("2", func(t *testing.T) {
+	//	err := testBasicDispersal(t, c, payload)
+	//	require.NoError(t, err)
+	//})
 }
 
 func TestSmallBlobDispersalAllQuorumsSets(t *testing.T) {
@@ -348,7 +307,6 @@ func maximumSizedBlobDispersalTest(t *testing.T, environment string) {
 	payload := rand.Bytes(int(maxPermissibleDataLength))
 
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
 	err = testBasicDispersal(t, c, payload)
 	require.NoError(t, err)
@@ -377,7 +335,6 @@ func tooLargeBlobDispersalTest(t *testing.T, environment string) {
 	payload := rand.Bytes(int(maxPermissibleDataLength) + 1)
 
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
 	err = testBasicDispersal(t, c, payload)
 	require.Error(t, err)
@@ -403,12 +360,7 @@ func doubleDispersalTest(t *testing.T, environment string) {
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
-	c.SetCertVerifierAddress(config.EigenDACertVerifierAddressQuorums0_1)
-
-	err = c.DisperseAndVerify(ctx, payload)
+	err := c.DisperseAndVerify(ctx, payload)
 	require.NoError(t, err)
 
 	// disperse again
@@ -433,15 +385,11 @@ func TestDoubleDispersal(t *testing.T) {
 func unauthorizedGetChunksTest(t *testing.T, environment string) {
 	rand := random.NewTestRandom()
 	c := client.GetTestClient(t, environment)
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
 
 	payload := rand.VariableBytes(units.KiB, 2*units.KiB)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
-
-	c.SetCertVerifierAddress(config.EigenDACertVerifierAddressQuorums0_1)
 
 	eigenDACert, err := c.DispersePayload(ctx, payload)
 	require.NoError(t, err)

--- a/test/v2/live/proxy_test.go
+++ b/test/v2/live/proxy_test.go
@@ -13,15 +13,11 @@ import (
 
 // Disperse an empty payload. Blob will not be empty, since payload encoding entails adding bytes
 func emptyPayloadProxyDispersalTest(t *testing.T, environment string) {
-	payload := []byte{}
-
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
+	var payload []byte
 
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = c.DisperseAndVerifyWithProxy(t.Context(), payload)
+	err := c.DisperseAndVerifyWithProxy(t.Context(), payload)
 	require.NoError(t, err)
 }
 
@@ -40,13 +36,9 @@ func TestEmptyPayloadProxyDispersal(t *testing.T) {
 func microscopicBlobProxyDispersalTest(t *testing.T, environment string) {
 	payload := []byte{1}
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = c.DisperseAndVerifyWithProxy(t.Context(), payload)
+	err := c.DisperseAndVerifyWithProxy(t.Context(), payload)
 	require.NoError(t, err)
 }
 
@@ -66,13 +58,9 @@ func smallBlobProxyDispersalTest(t *testing.T, environment string) {
 	rand := random.NewTestRandom()
 	payload := rand.VariableBytes(units.KiB, 2*units.KiB)
 
-	config, err := client.GetConfig(environment)
-	require.NoError(t, err)
-
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
-	err = c.DisperseAndVerifyWithProxy(t.Context(), payload)
+	err := c.DisperseAndVerifyWithProxy(t.Context(), payload)
 	require.NoError(t, err)
 }
 
@@ -100,7 +88,6 @@ func maximumSizedBlobProxyDispersalTest(t *testing.T, environment string) {
 	payload := rand.Bytes(int(maxPermissibleDataLength))
 
 	c := client.GetTestClient(t, environment)
-	checkAndSetCertVerifierAddress(t, c, config.EigenDACertVerifierAddressQuorums0_1)
 
 	err = c.DisperseAndVerifyWithProxy(t.Context(), payload)
 	require.NoError(t, err)

--- a/test/v2/load/load_generator.go
+++ b/test/v2/load/load_generator.go
@@ -115,8 +115,6 @@ func NewLoadGenerator(
 		client.GetLogger().Info("Enabled pprof", "port", config.PprofHttpPort)
 	}
 
-	client.SetCertVerifierAddress(client.GetConfig().EigenDACertVerifierAddressQuorums0_1)
-
 	// Initialize a pool for random number generators
 	randPool := &sync.Pool{
 		New: func() interface{} {


### PR DESCRIPTION
## Why are these changes needed?

We should be exercising the router in the live test panel and traffic generator.
