### PR TITLE
fix(payments): Copy cumulative payment before returning from `Accountant`

### DIFF
--- a/api/clients/v2/accountant.go
+++ b/api/clients/v2/accountant.go
@@ -134,6 +134,8 @@ func (a *Accountant) blobPaymentInfo(
 		}
 		a.cumulativePayment.Add(a.cumulativePayment, incrementRequired)
 		a.metrics.RecordCumulativePayment(a.cumulativePayment)
+
+		// make a copy so we don't randomly mutate this on someone later
 		return new(big.Int).Set(a.cumulativePayment), nil
 	}
 	return big.NewInt(0), fmt.Errorf(

--- a/api/clients/v2/accountant.go
+++ b/api/clients/v2/accountant.go
@@ -134,7 +134,7 @@ func (a *Accountant) blobPaymentInfo(
 		}
 		a.cumulativePayment.Add(a.cumulativePayment, incrementRequired)
 		a.metrics.RecordCumulativePayment(a.cumulativePayment)
-		return a.cumulativePayment, nil
+		return new(big.Int).Set(a.cumulativePayment), nil
 	}
 	return big.NewInt(0), fmt.Errorf(
 		"invalid payments: no available bandwidth reservation found for account %s, and current cumulativePayment balance insufficient "+


### PR DESCRIPTION
NOTE: this fix must be cherry picked into the release branch which has already been cut!

### Bug Impact

- A bug was introduced in https://github.com/Layr-Labs/eigenda/pull/2001
- The impact of the bug is that very rapid on-demand dispersals can cause dispersals to fail on the client side: dispersals will actually succeed, but the client _thinks_ that the dispersal failed
    - It's hard to say exactly how rapid. I've only been able to trigger the error with sub-second time between on-demand dispersals

### Bug Description

- Previously, the `accountantLock` was held in the `DisperserClient` while verifying the `blobKey` returned by the `Disperser`

`accountantLock` logic
```
	if paymentMetadata.CumulativePayment == nil || paymentMetadata.CumulativePayment.Sign() == 0 {
		// This request is using reserved bandwidth, no need to prevent parallel dispersal.
		c.accountantLock.Unlock()
	} else {
		// This request is using on-demand bandwidth, current implementation requires sequential dispersal.
		defer c.accountantLock.Unlock()
	}
```

`BlobKey` verification:
```
	if verifyReceivedBlobKey(blobHeader, reply) != nil {
		return nil, [32]byte{}, fmt.Errorf("verify received blob key: %w", err)
	}
```

- The problem arose when I moved the `BlobKey` verification out of the `DisperserClient`, and into the `PayloadDisperser`
- Therefore, the `BlobKey` check was no longer protected by the `accountantLock`
- The `Accountant` is implemented in such a way that future on-demand dispersals will cause the `CumulativePayment`s from previous dispersals to change after being returned:

`Accountant.blobPaymentInfo`:
```
		return a.cumulativePayment, nil
```

- Since the `BlobKey` was being computed within the lock protection, this was never a problem before
- After I moved the computation of the `BlobKey` out of the locked region, sometimes the `cumulativePayment` value would be modified before computing the key for a given blob, and the verification would then fail

### Bug Solution

- The solution is to create a copy of the cumulative payment before returning, so that the value isn't unexpectedly mutated

