### PR TITLE
Add support for --block-time in anvil testbed

### DIFF
--- a/inabox/deploy/cmd/main.go
+++ b/inabox/deploy/cmd/main.go
@@ -126,6 +126,7 @@ func startChainInfra(ctx *cli.Context, config *deploy.Config) error {
 		HostPort:       "8545",
 		Logger:         logger,
 		Network:        dockerNetwork,
+		BlockTime:      1, // 1 second block times
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start anvil container: %w", err)

--- a/test/testbed/deploy_anvil_test.go
+++ b/test/testbed/deploy_anvil_test.go
@@ -1,0 +1,46 @@
+package testbed_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/eigenda/test"
+	"github.com/Layr-Labs/eigenda/test/testbed"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAnvilBlockNumberReachesFive verifies that Anvil will eventually reach block 5
+func TestAnvilBlockNumberReachesFive(t *testing.T) {
+	ctx := t.Context()
+	logger := test.GetLogger()
+
+	// Start Anvil container with 1 second block time
+	anvil, err := testbed.NewAnvilContainerWithOptions(ctx, testbed.AnvilOptions{
+		ExposeHostPort: true,
+		Logger:         logger,
+		BlockTime:      1, // 1 second block intervals
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = anvil.Terminate(ctx)
+	}()
+
+	// Connect to Anvil RPC
+	client, err := ethclient.Dial(anvil.RpcURL())
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Assert that block number eventually reaches at least 5
+	require.Eventually(t, func() bool {
+		blockNum, err := client.BlockNumber(ctx)
+		if err != nil {
+			logger.Warn("Failed to get block number", "error", err)
+			return false
+		}
+		logger.Debug("Current block number", "block", blockNum)
+		return blockNum >= 5
+	}, 10*time.Second, 500*time.Millisecond, "Block number should reach at least 5 within 10 seconds")
+
+	logger.Info("Successfully reached block 5")
+}


### PR DESCRIPTION
## Why are these changes needed?

Adding this option to support the inabox devnet mode. Previously we stopped mining after all the contract deployment steps and we had to manually run `cast rpc anvil_mine 10` to get the proxy dispersal working.

Unfortunately, this causes the initial contract deployment to take minutes. 

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
