### PR TITLE
feat: reuse operator state during signature aggregation

### DIFF
--- a/core/aggregation.go
+++ b/core/aggregation.go
@@ -90,9 +90,7 @@ type SignatureAggregator interface {
 	// AggregateSignatures takes attestation result by quorum and aggregates the signatures across them.
 	// If the aggregated signature is invalid, an error is returned.
 	AggregateSignatures(
-		ctx context.Context,
-		ics IndexedChainState,
-		referenceBlockNumber uint,
+		indexedOperatorState *IndexedOperatorState,
 		quorumAttestation *QuorumAttestation,
 		quorumIDs []QuorumID,
 	) (*SignatureAggregation, error)
@@ -112,8 +110,7 @@ func NewStdSignatureAggregator(logger logging.Logger, transactor Reader) (*StdSi
 	}
 
 	return &StdSignatureAggregator{
-		Logger: logger.With(
-			"component", "SignatureAggregator"),
+		Logger:            logger.With("component", "SignatureAggregator"),
 		Transactor:        transactor,
 		OperatorAddresses: operatorAddrs,
 	}, nil
@@ -338,9 +335,7 @@ func (a *StdSignatureAggregator) ReceiveSignatures(
 }
 
 func (a *StdSignatureAggregator) AggregateSignatures(
-	ctx context.Context,
-	ics IndexedChainState,
-	referenceBlockNumber uint,
+	indexedOperatorState *IndexedOperatorState,
 	quorumAttestation *QuorumAttestation,
 	quorumIDs []QuorumID,
 ) (*SignatureAggregation, error) {
@@ -377,10 +372,6 @@ func (a *StdSignatureAggregator) AggregateSignatures(
 	}
 
 	nonSignerKeys := make([]*G1Point, 0)
-	indexedOperatorState, err := ics.GetIndexedOperatorState(ctx, referenceBlockNumber, quorumIDs)
-	if err != nil {
-		return nil, err
-	}
 	for id, op := range indexedOperatorState.IndexedOperators {
 		_, found := quorumAttestation.SignerMap[id]
 		if !found {

--- a/core/aggregation_test.go
+++ b/core/aggregation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda/test"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -193,7 +194,10 @@ func TestAggregateSignaturesStatus(t *testing.T) {
 				}
 			}
 
-			sigAgg, err := agg.AggregateSignatures(ctx, dat, 0, aq, quorumIDs)
+			indexedOperatorState, err := dat.GetIndexedOperatorState(ctx, 0, quorumIDs)
+			require.NoError(t, err)
+
+			sigAgg, err := agg.AggregateSignatures(indexedOperatorState, aq, quorumIDs)
 			assert.NoError(t, err)
 
 			for i, quorum := range tt.quorums {
@@ -227,7 +231,11 @@ func TestSortNonsigners(t *testing.T) {
 		message,
 		update)
 	assert.NoError(t, err)
-	sigAgg, err := agg.AggregateSignatures(ctx, dat, 0, aq, quorums)
+
+	indexedOperatorState, err := dat.GetIndexedOperatorState(ctx, 0, quorums)
+	require.NoError(t, err)
+
+	sigAgg, err := agg.AggregateSignatures(indexedOperatorState, aq, quorums)
 	assert.NoError(t, err)
 
 	for i := range sigAgg.NonSigners {
@@ -291,7 +299,11 @@ func TestFilterQuorums(t *testing.T) {
 
 	// Only consider quorum 0
 	quorums := []core.QuorumID{0}
-	sigAgg, err := agg.AggregateSignatures(ctx, dat, 0, aq, quorums)
+
+	indexedOperatorState, err := dat.GetIndexedOperatorState(ctx, 0, quorums)
+	require.NoError(t, err)
+
+	sigAgg, err := agg.AggregateSignatures(indexedOperatorState, aq, quorums)
 	assert.NoError(t, err)
 	assert.Len(t, sigAgg.NonSigners, 4)
 	assert.ElementsMatch(t, sigAgg.NonSigners, []*core.G1Point{
@@ -321,7 +333,11 @@ func TestFilterQuorums(t *testing.T) {
 
 	// Only consider quorum 1
 	quorums = []core.QuorumID{1}
-	sigAgg, err = agg.AggregateSignatures(ctx, dat, 0, aq, quorums)
+
+	indexedOperatorState, err = dat.GetIndexedOperatorState(ctx, 0, quorums)
+	require.NoError(t, err)
+
+	sigAgg, err = agg.AggregateSignatures(indexedOperatorState, aq, quorums)
 	assert.NoError(t, err)
 	assert.Len(t, sigAgg.NonSigners, 1)
 	assert.ElementsMatch(t, sigAgg.NonSigners, []*core.G1Point{

--- a/disperser/controller/dispatcher.go
+++ b/disperser/controller/dispatcher.go
@@ -488,9 +488,7 @@ func (d *Dispatcher) updateAttestation(
 
 	aggregationStartTime := time.Now()
 	signatureAggregation, err := d.aggregator.AggregateSignatures(
-		ctx,
-		d.chainState,
-		uint(batchData.Batch.BatchHeader.ReferenceBlockNumber),
+		batchData.OperatorState,
 		quorumAttestation,
 		sortedNonZeroQuorums)
 	d.metrics.reportAggregateSignaturesLatency(time.Since(aggregationStartTime))


### PR DESCRIPTION
## Why are these changes needed?
Cherry pick of https://github.com/Layr-Labs/eigenda/pull/2093
