### PR TITLE
fix(payments): Use proper `ReservationLedger` constructor

### DIFF
--- a/core/payments/reservation/reservation_ledger.go
+++ b/core/payments/reservation/reservation_ledger.go
@@ -157,11 +157,14 @@ func (rl *ReservationLedger) UpdateReservation(newReservation *Reservation, now 
 	}
 
 	// Create new config with the updated reservation
-	newConfig := ReservationLedgerConfig{
-		reservation:            *newReservation,
-		startFull:              rl.config.startFull,
-		overfillBehavior:       rl.config.overfillBehavior,
-		bucketCapacityDuration: rl.config.bucketCapacityDuration,
+	newConfig, err := NewReservationLedgerConfig(
+		*newReservation,
+		rl.config.minNumSymbols,
+		rl.config.startFull,
+		rl.config.overfillBehavior,
+		rl.config.bucketCapacityDuration)
+	if err != nil {
+		return fmt.Errorf("new reservation ledger config: %w", err)
 	}
 
 	previousFillLevel := rl.leakyBucket.CheckFillLevel(now)
@@ -179,7 +182,7 @@ func (rl *ReservationLedger) UpdateReservation(newReservation *Reservation, now 
 
 	newLeakyBucket.currentFillLevel = previousFillLevel
 
-	rl.config = newConfig
+	rl.config = *newConfig
 	rl.leakyBucket = newLeakyBucket
 
 	return nil


### PR DESCRIPTION
- Old code was directly instantiating new config struct
- It was missing an important field
- The fix is to use the constructor, instead of raw struct instantiation