### PR TITLE
fix(relay): Pass chainReader into the relay server struct

### DIFF
--- a/relay/server.go
+++ b/relay/server.go
@@ -159,6 +159,7 @@ func NewServer(
 		authenticator:    authenticator,
 		replayGuardian:   replayGuardian,
 		metrics:          relayMetrics,
+		chainReader:      chainReader,
 	}, nil
 }
 

--- a/relay/server_test.go
+++ b/relay/server_test.go
@@ -62,7 +62,8 @@ func defaultConfig() *Config {
 			InternalGetProofsTimeout:       10 * time.Second,
 			InternalGetCoefficientsTimeout: 10 * time.Second,
 		},
-		MetricsPort: 9101,
+		MetricsPort:                 9101,
+		OnchainStateRefreshInterval: 1 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
## Why are these changes needed?

Claude randomly noticed that we weren't passing the chainReader into the server struct. This means that we are currently not refreshing the on chain state due to this:
```go
	if s.chainReader != nil && s.metadataProvider != nil {
		go func() {
			_ = s.RefreshOnchainState(ctx)
		}()
	}
```

Not a huge deal since it's only used to refresh blob version parameters.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
