### PR TITLE
refactor: benchmark and simplify committer

### DIFF
--- a/encoding/kzg/committer/committer_test.go
+++ b/encoding/kzg/committer/committer_test.go
@@ -1,0 +1,52 @@
+package committer
+
+import (
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/test/random"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCommitter_Commit(b *testing.B) {
+	blobLen := uint64(1 << 19) // 2^19 = 524,288 field elements = 16 MiB
+	// Load SRS files
+	config := Config{
+		SRSNumberToLoad:   blobLen,
+		G1SRSPath:         "../../../resources/srs/g1.point",
+		G2SRSPath:         "../../../resources/srs/g2.point",
+		G2TrailingSRSPath: "../../../resources/srs/g2.trailing.point",
+	}
+	committer, err := NewFromConfig(config)
+	require.NoError(b, err)
+
+	rand := random.NewTestRandom()
+	blob := rand.FrElements(blobLen)
+
+	b.Run("blob commitment", func(b *testing.B) {
+		for b.Loop() {
+			_, err := committer.computeCommitmentV2(blob)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("blob length commitment", func(b *testing.B) {
+		for b.Loop() {
+			_, err := committer.computeLengthCommitmentV2(blob)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("blob length proof", func(b *testing.B) {
+		for b.Loop() {
+			_, err := committer.computeLengthProofV2(blob)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("all 3", func(b *testing.B) {
+		for b.Loop() {
+			_, _, _, err := committer.GetCommitments(blob)
+			require.NoError(b, err)
+		}
+	})
+}

--- a/test/random/random.go
+++ b/test/random/random.go
@@ -250,3 +250,13 @@ func (r *TestRandom) Float64Range(min, max float64) float64 {
 func (r *TestRandom) DurationRange(min time.Duration, max time.Duration) time.Duration {
 	return time.Duration(r.Int63n(int64(max-min))) + min
 }
+
+// FrElements generates a slice of num random field elements.
+func (r *TestRandom) FrElements(num uint64) []fr.Element {
+	elements := make([]fr.Element, num)
+	for i := range num {
+		b := r.Bytes(fr.Bytes)
+		_ = elements[i].SetBytes(b)
+	}
+	return elements
+}


### PR DESCRIPTION
Benchmark result on my mac m4 laptop is that for 16MiB blob:
1. blob commitment (G1) takes ~150ms
2. blob length commitment/proof (G2) each take ~500ms

Doing all 3 takes ~1.15s... despite running in concurrent goroutines.

Each of commitments/proofs uses gnark library which already saturates all cores, so our implementation with goroutines to parallelize the 3 commitments is actually useless. Simplified by removing the complexity of those goroutines, and results are the same.