### PR TITLE
feat(inabox): Spin up encoder + encoder v2 as goroutines in inabox integration tests

### DIFF
--- a/disperser/apiserver/server_test.go
+++ b/disperser/apiserver/server_test.go
@@ -644,8 +644,9 @@ func setup() {
 		// Deploy resources using the testbed DeployResources function
 		deployConfig := testbed.DeployResourcesConfig{
 			LocalStackEndpoint:  localstackContainer.Endpoint(),
-			MetadataTableName:   metadataTableName,
+			V1MetadataTableName: metadataTableName,
 			BucketTableName:     bucketTableName,
+			BlobStoreBucketName: s3BucketName,
 			V2MetadataTableName: v2MetadataTableName,
 			AWSConfig:           localstackContainer.GetAWSClientConfig(),
 			Logger:              logger,

--- a/disperser/encoder/server.go
+++ b/disperser/encoder/server.go
@@ -125,7 +125,10 @@ func (s *EncoderServer) Start() error {
 	}
 
 	s.logger.Info("port", s.config.GrpcPort, "address", listener.Addr().String(), "GRPC Listening")
-	return gs.Serve(listener)
+	if err := gs.Serve(listener); err != nil {
+		return fmt.Errorf("failed to serve grpc: %w", err)
+	}
+	return nil
 }
 
 // StartWithListener starts the server using the provided listener. This method will block until the server is stopped.
@@ -153,7 +156,10 @@ func (s *EncoderServer) StartWithListener(listener net.Listener) error {
 	}
 
 	s.logger.Info("port", s.config.GrpcPort, "address", listener.Addr().String(), "GRPC Listening")
-	return gs.Serve(listener)
+	if err := gs.Serve(listener); err != nil {
+		return fmt.Errorf("failed to serve grpc: %w", err)
+	}
+	return nil
 }
 
 func (s *EncoderServer) EncodeBlob(ctx context.Context, req *pb.EncodeBlobRequest) (*pb.EncodeBlobReply, error) {

--- a/disperser/encoder/server_v2.go
+++ b/disperser/encoder/server_v2.go
@@ -86,6 +86,11 @@ func (s *EncoderServerV2) Start() error {
 		log.Fatalf("Could not start tcp listener: %v", err)
 	}
 
+	return s.StartWithListener(listener)
+}
+
+// StartWithListener starts the server using the provided listener. This method will block until the server is stopped.
+func (s *EncoderServerV2) StartWithListener(listener net.Listener) error {
 	gs := grpc.NewServer(
 		grpc.UnaryInterceptor(
 			s.grpcMetrics.UnaryServerInterceptor(),

--- a/inabox/bin.sh
+++ b/inabox/bin.sh
@@ -270,19 +270,8 @@ function start_detached_for_tests {
         waiters="$waiters $!"
     done
 
-    for FILE in $(ls $testpath/envs/enc*.env); do
-        set -a
-        source $FILE
-        set +a
-        id=$(basename $FILE | tr -d -c 0-9)
-        ../disperser/bin/encoder > $testpath/logs/enc${id}.log 2>&1 &
-
-        pid="$!"
-        pids="$pids $pid"
-
-        ./wait-for 0.0.0.0:${DISPERSER_ENCODER_GRPC_PORT} -- echo "Encoder up" &
-        waiters="$waiters $!"
-    done
+    # Skip encoder v2 - it runs as a goroutine in tests
+    echo "Skipping encoder v2 (running as goroutine in tests)"
 
     for FILE in $(ls $testpath/envs/batcher*.env); do
         set -a

--- a/inabox/deploy/cmd/main.go
+++ b/inabox/deploy/cmd/main.go
@@ -122,7 +122,7 @@ func DeployAll(ctx *cli.Context) error {
 	config.RegisterRelays(ethClient, relayURLs, ethClient.GetAccountAddress())
 
 	logger.Info("Generating variables")
-	err = config.GenerateAllVariables("0.0.0.0:34001")
+	err = config.GenerateAllVariables("0.0.0.0:34000", "0.0.0.0:34001")
 	if err != nil {
 		logger.Errorf("could not generate environment variables: %v", err)
 		panic(err)

--- a/inabox/deploy/cmd/main.go
+++ b/inabox/deploy/cmd/main.go
@@ -122,7 +122,7 @@ func DeployAll(ctx *cli.Context) error {
 	config.RegisterRelays(ethClient, relayURLs, ethClient.GetAccountAddress())
 
 	logger.Info("Generating variables")
-	err = config.GenerateAllVariables()
+	err = config.GenerateAllVariables("0.0.0.0:34001")
 	if err != nil {
 		logger.Errorf("could not generate environment variables: %v", err)
 		panic(err)

--- a/inabox/deploy/cmd/main.go
+++ b/inabox/deploy/cmd/main.go
@@ -25,6 +25,7 @@ var (
 	metadataTableName   = "test-BlobMetadata"
 	bucketTableName     = "test-BucketStore"
 	metadataTableNameV2 = "test-BlobMetadata-v2"
+	blobStoreBucketName = "test-eigenda-blobstore"
 
 	logger = test.GetLogger()
 )
@@ -216,9 +217,10 @@ func startLocalstack(ctx *cli.Context, config *deploy.Config) error {
 
 	deployConfig := testbed.DeployResourcesConfig{
 		LocalStackEndpoint:  localstackContainer.Endpoint(),
-		MetadataTableName:   metadataTableName,
+		V1MetadataTableName: metadataTableName,
 		BucketTableName:     bucketTableName,
 		V2MetadataTableName: metadataTableNameV2,
+		BlobStoreBucketName: blobStoreBucketName,
 		AWSConfig:           localstackContainer.GetAWSClientConfig(),
 	}
 	if err := testbed.DeployResources(context, deployConfig); err != nil {

--- a/inabox/deploy/config.go
+++ b/inabox/deploy/config.go
@@ -326,7 +326,8 @@ func (env *Config) generateEncoderV2Vars(ind int, grpcPort string) EncoderVars {
 
 func (env *Config) generateControllerVars(
 	ind int,
-	graphUrl string) ControllerVars {
+	graphUrl string,
+	encoderV2Address string) ControllerVars {
 
 	v := ControllerVars{
 		CONTROLLER_LOG_FORMAT:                         "text",
@@ -347,7 +348,7 @@ func (env *Config) generateControllerVars(
 		CONTROLLER_AWS_ACCESS_KEY_ID:                  "",
 		CONTROLLER_AWS_SECRET_ACCESS_KEY:              "",
 		CONTROLLER_AWS_ENDPOINT_URL:                   "",
-		CONTROLLER_ENCODER_ADDRESS:                    "0.0.0.0:34001",
+		CONTROLLER_ENCODER_ADDRESS:                    encoderV2Address,
 		CONTROLLER_BATCH_METADATA_UPDATE_PERIOD:       "100ms",
 		// set to 5 to ensure payload disperser checkDACert calls pass in integration_v2 test since
 		// disperser chooses rbn = latest_block_number - finalization_block_delay
@@ -612,7 +613,7 @@ func (env *Config) getKey(name string) (key, address string, err error) {
 // GenerateAllVariables all of the config for the test environment.
 // Returns an object that corresponds to the participants of the
 // current experiment.
-func (env *Config) GenerateAllVariables() error {
+func (env *Config) GenerateAllVariables(encoderV2Address string) error {
 	// hardcode graphurl for now
 	graphUrl := "http://localhost:8000/subgraphs/name/Layr-Labs/eigenda-operator-state"
 
@@ -813,7 +814,7 @@ func (env *Config) GenerateAllVariables() error {
 	// Controller
 	name = "controller0"
 	_, _, _, envFile = env.getPaths(name)
-	controllerConfig := env.generateControllerVars(0, graphUrl)
+	controllerConfig := env.generateControllerVars(0, graphUrl, encoderV2Address)
 	if err := writeEnv(controllerConfig.getEnvMap(), envFile); err != nil {
 		return fmt.Errorf("failed to write env file: %w", err)
 	}

--- a/inabox/deploy/config.go
+++ b/inabox/deploy/config.go
@@ -235,7 +235,7 @@ func (env *Config) generateDisperserV2Vars(ind int, logPath, dbPath, grpcPort st
 }
 
 // Generates batcher .env
-func (env *Config) generateBatcherVars(ind int, key, graphUrl, logPath string) BatcherVars {
+func (env *Config) generateBatcherVars(ind int, key, graphUrl, encoderAddress string) BatcherVars {
 	v := BatcherVars{
 		BATCHER_LOG_FORMAT:                    "text",
 		BATCHER_S3_BUCKET_NAME:                "test-eigenda-blobstore",
@@ -243,6 +243,7 @@ func (env *Config) generateBatcherVars(ind int, key, graphUrl, logPath string) B
 		BATCHER_ENABLE_METRICS:                "true",
 		BATCHER_METRICS_HTTP_PORT:             "9094",
 		BATCHER_PULL_INTERVAL:                 "5s",
+		BATCHER_ENCODER_ADDRESS:               encoderAddress,
 		BATCHER_EIGENDA_DIRECTORY:             env.EigenDA.EigenDADirectory,
 		BATCHER_BLS_OPERATOR_STATE_RETRIVER:   env.EigenDA.OperatorStateRetriever,
 		BATCHER_EIGENDA_SERVICE_MANAGER:       env.EigenDA.ServiceManager,
@@ -613,7 +614,7 @@ func (env *Config) getKey(name string) (key, address string, err error) {
 // GenerateAllVariables all of the config for the test environment.
 // Returns an object that corresponds to the participants of the
 // current experiment.
-func (env *Config) GenerateAllVariables(encoderV2Address string) error {
+func (env *Config) GenerateAllVariables(encoderAddress, encoderV2Address string) error {
 	// hardcode graphurl for now
 	graphUrl := "http://localhost:8000/subgraphs/name/Layr-Labs/eigenda-operator-state"
 
@@ -731,7 +732,7 @@ func (env *Config) GenerateAllVariables(encoderV2Address string) error {
 		return fmt.Errorf("failed to get key for %s: %w", name, err)
 	}
 
-	batcherConfig := env.generateBatcherVars(0, key, graphUrl, logPath)
+	batcherConfig := env.generateBatcherVars(0, key, graphUrl, encoderAddress)
 	if err := writeEnv(batcherConfig.getEnvMap(), envFile); err != nil {
 		return fmt.Errorf("failed to write env file: %w", err)
 	}

--- a/inabox/tests/helpers.go
+++ b/inabox/tests/helpers.go
@@ -1,0 +1,29 @@
+package integration
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+// getSRSPaths returns the correct paths to SRS files based on the source file location.
+// This uses runtime.Caller to determine where this file is located and calculates
+// the relative path to the resources/srs directory from there.
+func getSRSPaths() (g1Path, g2Path string, err error) {
+	// Get the path of this source file
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", "", fmt.Errorf("failed to get caller information")
+	}
+
+	// We need to go up 2 directories from tests/ to get to inabox/, then up one more to get to the project root
+	// From project root, resources/srs is the target
+	testDir := filepath.Dir(filename)
+	inaboxDir := filepath.Dir(testDir)
+	projectRoot := filepath.Dir(inaboxDir)
+
+	g1Path = filepath.Join(projectRoot, "resources", "srs", "g1.point")
+	g2Path = filepath.Join(projectRoot, "resources", "srs", "g2.point")
+
+	return g1Path, g2Path, nil
+}

--- a/inabox/tests/setup_disperser_harness.go
+++ b/inabox/tests/setup_disperser_harness.go
@@ -101,7 +101,9 @@ func setupDisperserKeypairAndRegistrations(config DisperserHarnessConfig) error 
 
 // SetupDisperserHarness creates and initializes the disperser infrastructure
 // (LocalStack, DynamoDB tables, S3 buckets, relays)
-func SetupDisperserHarness(ctx context.Context, localstack *testbed.LocalStackContainer, config DisperserHarnessConfig) (*DisperserHarness, error) {
+func SetupDisperserHarness(
+	ctx context.Context, localstack *testbed.LocalStackContainer, config DisperserHarnessConfig,
+) (*DisperserHarness, error) {
 	// Check if localstack resources are empty
 	if config.V2MetadataTableName == "" || config.BlobStoreBucketName == "" {
 		return nil, fmt.Errorf("missing name for localstack resources")

--- a/inabox/tests/setup_disperser_v1_harness.go
+++ b/inabox/tests/setup_disperser_v1_harness.go
@@ -1,0 +1,262 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"time"
+
+	"github.com/Layr-Labs/eigenda/common"
+	"github.com/Layr-Labs/eigenda/disperser/encoder"
+	"github.com/Layr-Labs/eigenda/encoding"
+	"github.com/Layr-Labs/eigenda/encoding/kzg"
+	"github.com/Layr-Labs/eigenda/encoding/kzg/prover"
+	"github.com/Layr-Labs/eigenda/inabox/deploy"
+	"github.com/Layr-Labs/eigenda/test/testbed"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+// DisperserV1HarnessConfig contains the configuration for setting up the v1 disperser harness
+type DisperserV1HarnessConfig struct {
+	Logger              logging.Logger
+	Network             *testcontainers.DockerNetwork
+	TestConfig          *deploy.Config
+	TestName            string
+	InMemoryBlobStore   bool
+	BucketTableName     string
+	V1MetadataTableName string
+	BlobStoreBucketName string
+	EthClient           common.EthClient
+}
+
+// DisperserV1Harness is a simpler harness that only uses v1 encoder (no v2, no relays)
+type DisperserV1Harness struct {
+	LocalStack     *testbed.LocalStackContainer
+	DynamoDBTables struct {
+		BlobMetadataV1 string
+	}
+	S3Buckets struct {
+		BlobStore string
+	}
+	EncoderV1Instance *EncoderV1Instance
+}
+
+// EncoderV1Instance holds the state for a single encoder v1
+type EncoderV1Instance struct {
+	Server   *encoder.EncoderServer
+	Listener net.Listener
+	Port     string
+	URL      string
+	Logger   logging.Logger
+}
+
+// SetupDisperserV1Harness creates and initializes the v1 disperser infrastructure
+// (LocalStack, DynamoDB tables, S3 buckets, encoder v1 goroutine).
+func SetupDisperserV1Harness(ctx context.Context, localstack *testbed.LocalStackContainer, config DisperserV1HarnessConfig) (*DisperserV1Harness, error) {
+	// Check if localstack resources are empty
+	if config.V1MetadataTableName == "" || config.BucketTableName == "" || config.BlobStoreBucketName == "" {
+		return nil, fmt.Errorf("missing name for localstack resources")
+	}
+
+	harness := &DisperserV1Harness{}
+
+	// Populate the harness tables and buckets metadata
+	harness.DynamoDBTables.BlobMetadataV1 = config.V1MetadataTableName
+	harness.S3Buckets.BlobStore = config.BlobStoreBucketName
+
+	// Setup LocalStack if not using in-memory blob store
+	if !config.InMemoryBlobStore {
+		// Setup LocalStack resources (reuse the same function from main harness)
+		harnessConfig := DisperserV1HarnessConfig{
+			Logger:              config.Logger,
+			Network:             config.Network,
+			TestConfig:          config.TestConfig,
+			TestName:            config.TestName,
+			V1MetadataTableName: config.V1MetadataTableName,
+			BucketTableName:     config.BucketTableName,
+			BlobStoreBucketName: config.BlobStoreBucketName,
+			EthClient:           config.EthClient,
+		}
+
+		localstack, err := setupV1LocalStackResources(ctx, localstack, harnessConfig)
+		if err != nil {
+			return nil, err
+		}
+		harness.LocalStack = localstack
+
+		// Start encoder v1 instance as a goroutine
+		config.Logger.Info("Starting encoder v1 instance")
+		encoderInstance, err := startEncoderV1(ctx, harness, config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to start encoder v1: %w", err)
+		}
+		harness.EncoderV1Instance = encoderInstance
+	} else {
+		config.Logger.Info("Using in-memory blob store, skipping LocalStack setup")
+	}
+
+	return harness, nil
+}
+
+// setupLocalStackResources initializes LocalStack and deploys AWS resources
+func setupV1LocalStackResources(
+	ctx context.Context, localstack *testbed.LocalStackContainer, config DisperserV1HarnessConfig,
+) (*testbed.LocalStackContainer, error) {
+	// Deploy AWS resources (DynamoDB tables and S3 buckets)
+	config.Logger.Info("Deploying AWS resources in LocalStack")
+	deployConfig := testbed.DeployResourcesConfig{
+		LocalStackEndpoint:  localstack.Endpoint(),
+		V1MetadataTableName: config.V1MetadataTableName,
+		BucketTableName:     config.BucketTableName,
+		BlobStoreBucketName: config.BlobStoreBucketName,
+		AWSConfig:           localstack.GetAWSClientConfig(),
+		Logger:              config.Logger,
+	}
+	if err := testbed.DeployResources(ctx, deployConfig); err != nil {
+		return nil, fmt.Errorf("failed to deploy resources: %w", err)
+	}
+	config.Logger.Info("AWS resources deployed successfully")
+
+	return localstack, nil
+}
+
+// startEncoderV1 starts a single encoder v1 instance
+func startEncoderV1(
+	ctx context.Context,
+	harness *DisperserV1Harness,
+	config DisperserV1HarnessConfig,
+) (*EncoderV1Instance, error) {
+	config.Logger.Info("Starting encoder v1 instance")
+
+	// Get SRS paths using the same function as operator setup
+	g1Path, g2Path, err := getSRSPaths()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine SRS file paths: %w", err)
+	}
+
+	// Pre-create listener with port 0 (OS assigns port)
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listener for encoder v1: %w", err)
+	}
+
+	// Extract the actual port assigned by the OS
+	actualPort := listener.Addr().(*net.TCPAddr).Port
+	encoderURL := fmt.Sprintf("0.0.0.0:%d", actualPort)
+	port := fmt.Sprintf("%d", actualPort)
+
+	config.Logger.Info("Created listener for encoder v1", "assigned_port", actualPort)
+
+	// Create logs directory
+	logsDir := fmt.Sprintf("testdata/%s/logs", config.TestName)
+	if err := os.MkdirAll(logsDir, 0755); err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("failed to create logs directory: %w", err)
+	}
+
+	logFilePath := fmt.Sprintf("%s/encoder_v1.log", logsDir)
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("failed to open encoder v1 log file: %w", err)
+	}
+
+	// Create encoder logger
+	loggerConfig := common.LoggerConfig{
+		Format:       common.TextLogFormat,
+		OutputWriter: io.MultiWriter(os.Stdout, logFile),
+		HandlerOpts: logging.SLoggerOptions{
+			Level:     slog.LevelDebug,
+			NoColor:   true,
+			AddSource: true,
+		},
+	}
+
+	encoderLogger, err := common.NewLogger(&loggerConfig)
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("failed to create encoder v1 logger: %w", err)
+	}
+
+	// Create prover with dynamically determined paths
+	// TODO(dmanc): Make these configurable
+	kzgConfig := &kzg.KzgConfig{
+		SRSOrder:        10000,
+		SRSNumberToLoad: 10000,
+		G1Path:          g1Path,
+		G2Path:          g2Path,
+		CacheDir:        fmt.Sprintf("testdata/%s/cache/encoder", config.TestName),
+		NumWorker:       1,
+		Verbose:         false,
+		LoadG2Points:    true, // v1 encoder needs G2 points
+	}
+	encodingConfig := &encoding.Config{
+		BackendType: encoding.GnarkBackend,
+		GPUEnable:   false,
+		NumWorker:   1,
+	}
+
+	proverV1, err := prover.NewProver(kzgConfig, encodingConfig)
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("failed to create prover v1: %w", err)
+	}
+
+	// Create metrics registry
+	metricsRegistry := prometheus.NewRegistry()
+	metrics := encoder.NewMetrics(metricsRegistry, "9100", encoderLogger)
+	grpcMetrics := grpcprom.NewServerMetrics()
+	metricsRegistry.MustRegister(grpcMetrics)
+
+	// Create encoder server configuration
+	serverConfig := encoder.ServerConfig{
+		GrpcPort:              port,
+		MaxConcurrentRequests: 16,
+		RequestPoolSize:       32,
+	}
+
+	// Create encoder server
+	server := encoder.NewEncoderServer(
+		serverConfig,
+		encoderLogger,
+		proverV1,
+		metrics,
+		grpcMetrics,
+	)
+
+	// Start the encoder server in a goroutine using the pre-created listener
+	go func() {
+		encoderLogger.Info("Starting encoder v1 server with listener", "port", port)
+		if err := server.StartWithListener(listener); err != nil {
+			encoderLogger.Error("Encoder v1 server failed", "error", err)
+		}
+	}()
+
+	// Wait for server to be ready
+	time.Sleep(100 * time.Millisecond)
+	encoderLogger.Info("Encoder v1 server started successfully", "port", port, "logFile", logFilePath)
+
+	return &EncoderV1Instance{
+		Server:   server,
+		Listener: listener,
+		Port:     port,
+		URL:      encoderURL,
+		Logger:   encoderLogger,
+	}, nil
+}
+
+// Cleanup releases resources held by the DisperserV1Harness
+func (dh *DisperserV1Harness) Cleanup(ctx context.Context, logger logging.Logger) {
+	// Stop encoder v1 instance
+	if dh.EncoderV1Instance != nil {
+		logger.Info("Stopping encoder v1 instance")
+		dh.EncoderV1Instance.Logger.Info("Stopping encoder v1")
+		// TODO: Add Close method to encoder v1 server
+	}
+}

--- a/inabox/tests/setup_disperser_v1_harness.go
+++ b/inabox/tests/setup_disperser_v1_harness.go
@@ -58,7 +58,9 @@ type EncoderV1Instance struct {
 
 // SetupDisperserV1Harness creates and initializes the v1 disperser infrastructure
 // (LocalStack, DynamoDB tables, S3 buckets, encoder v1 goroutine).
-func SetupDisperserV1Harness(ctx context.Context, localstack *testbed.LocalStackContainer, config DisperserV1HarnessConfig) (*DisperserV1Harness, error) {
+func SetupDisperserV1Harness(
+	ctx context.Context, localstack *testbed.LocalStackContainer, config DisperserV1HarnessConfig,
+) (*DisperserV1Harness, error) {
 	// Check if localstack resources are empty
 	if config.V1MetadataTableName == "" || config.BucketTableName == "" || config.BlobStoreBucketName == "" {
 		return nil, fmt.Errorf("missing name for localstack resources")

--- a/inabox/tests/setup_infra.go
+++ b/inabox/tests/setup_infra.go
@@ -166,7 +166,10 @@ func SetupInfrastructure(ctx context.Context, config *InfrastructureConfig) (*In
 	// TODO(dmanc): Once all of these components are migrated to goroutines, we can remove this.
 	if testConfig != nil {
 		config.Logger.Info("Starting remaining binaries")
-		err := testConfig.GenerateAllVariables(disperserV1Harness.EncoderV1Instance.URL, disperserHarness.EncoderV2Instance.URL)
+		err := testConfig.GenerateAllVariables(
+			disperserV1Harness.EncoderV1Instance.URL,
+			disperserHarness.EncoderV2Instance.URL,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("could not generate environment variables: %w", err)
 		}

--- a/inabox/tests/setup_operator_harness.go
+++ b/inabox/tests/setup_operator_harness.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -87,28 +85,6 @@ type OperatorHarness struct {
 	chainHarness *ChainHarness
 	srsG1Path    string
 	srsG2Path    string
-}
-
-// getSRSPaths returns the correct paths to SRS files based on the source file location.
-// This uses runtime.Caller to determine where this file is located and calculates
-// the relative path to the resources/srs directory from there.
-func getSRSPaths() (g1Path, g2Path string, err error) {
-	// Get the path of this source file
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", "", fmt.Errorf("failed to get caller information")
-	}
-
-	// We need to go up 2 directories from tests/ to get to inabox/, then up one more to get to the project root
-	// From project root, resources/srs is the target
-	testDir := filepath.Dir(filename)
-	inaboxDir := filepath.Dir(testDir)
-	projectRoot := filepath.Dir(inaboxDir)
-
-	g1Path = filepath.Join(projectRoot, "resources", "srs", "g1.point")
-	g2Path = filepath.Join(projectRoot, "resources", "srs", "g2.point")
-
-	return g1Path, g2Path, nil
 }
 
 // StartOperators starts all operator nodes configured in the test config

--- a/inabox/tests/test_harness.go
+++ b/inabox/tests/test_harness.go
@@ -14,6 +14,7 @@ import (
 	verifierv1bindings "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifierV1"
 	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigenda/inabox/deploy"
+	"github.com/Layr-Labs/eigenda/test/testbed"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/testcontainers/testcontainers-go"
@@ -28,10 +29,17 @@ type InfrastructureHarness struct {
 	// Chain related components
 	ChainHarness ChainHarness
 
+	// Shared localstack container
+	SharedLocalStack *testbed.LocalStackContainer
+
 	// Operator related components
 	OperatorHarness OperatorHarness
 
-	// EigenDA components (includes relays)
+	// EigenDA V1 disperser related components
+	// Note: Once V1 is deprecated, we can remove this component
+	DisperserV1Harness DisperserV1Harness
+
+	// EigenDA V2 disperser components (includes relays)
 	DisperserHarness DisperserHarness
 
 	// Proxy

--- a/test/testbed/deploy_localstack_resources.go
+++ b/test/testbed/deploy_localstack_resources.go
@@ -48,6 +48,7 @@ type DeployResourcesConfig struct {
 }
 
 // DeployResources creates AWS resources (S3 buckets and DynamoDB tables) on LocalStack
+// TODO(dmanc): This function should be split between v1 and v2 resources.
 func DeployResources(ctx context.Context, config DeployResourcesConfig) error {
 	// Set defaults
 	if config.V2PaymentPrefix == "" {


### PR DESCRIPTION
## Why are these changes needed?

This PR also introduces `DisperserV1Harness` to deploy V1 disperser components. In addition we do some minor refactoring around localstack and resource deployment.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
