### PR TITLE
feat(proxy): read-only mode when no privateKey provided (v2 only)

### DIFF
--- a/api/proxy/.env.example
+++ b/api/proxy/.env.example
@@ -27,7 +27,8 @@ EIGENDA_PROXY_STORAGE_CACHE_TARGETS=""
 # === V2 Configuration ===
 
 # Hex-encoded signer private key for payments with EigenDA V2 disperser.
-EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX="0000000000000000000100000000000000000000000000000000000000000000"
+# Optional and only needed if you want to use PUT routes.
+EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX=""
 
 # JSON RPC node endpoint for the Ethereum network.
 EIGENDA_PROXY_EIGENDA_V2_ETH_RPC=https://ethereum-sepolia.rpc.subquery.network/public

--- a/api/proxy/common/secret_config.go
+++ b/api/proxy/common/secret_config.go
@@ -13,13 +13,9 @@ type SecretConfigV2 struct {
 
 // Check checks config invariants, and returns an error if there is a problem with the config struct
 func (s *SecretConfigV2) Check() error {
-	if s.SignerPaymentKey == "" {
-		return fmt.Errorf("signer payment private key is required for using EigenDA V2 backend")
-	}
-
 	if s.EthRPCURL == "" {
 		return fmt.Errorf("eth rpc url is required for using EigenDA V2 backend")
 	}
-
+	// Empty SignerPaymentKey is allowed, and puts the proxy in read-only mode.
 	return nil
 }

--- a/api/proxy/common/secret_config_test.go
+++ b/api/proxy/common/secret_config_test.go
@@ -27,7 +27,8 @@ func TestSignerPaymentKeyMissing(t *testing.T) {
 	cfg.SignerPaymentKey = ""
 
 	err := cfg.Check()
-	require.Error(t, err)
+	// allowed because it puts the proxy in read-only mode
+	require.NoError(t, err)
 }
 
 func TestEthRPCMissing(t *testing.T) {

--- a/api/proxy/config/v2/eigendaflags/cli.go
+++ b/api/proxy/config/v2/eigendaflags/cli.go
@@ -68,8 +68,10 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			Category: category,
 		},
 		&cli.StringFlag{
-			Name:     SignerPaymentKeyHexFlagName,
-			Usage:    "Hex-encoded signer private key. Used for authorizing payments with EigenDA disperser. Should not be associated with an Ethereum address holding any funds.",
+			Name: SignerPaymentKeyHexFlagName,
+			Usage: "Optional hex-encoded signer private key. Used for authorizing payments with EigenDA disperser in PUT routes. " +
+				"If not provided, proxy will be started in read-only mode, and will not be able to submit blobs to EigenDA. " +
+				"Should not be associated with an Ethereum address holding any funds.",
 			EnvVars:  []string{withEnvPrefix(envPrefix, "SIGNER_PRIVATE_KEY_HEX")},
 			Category: category,
 		},

--- a/api/proxy/docs/help_out.txt
+++ b/api/proxy/docs/help_out.txt
@@ -86,7 +86,7 @@ and otherwise is considered stale and verification will fail, and a 418 HTTP err
 This check is optional and will be skipped when set to 0. (default: 0) [$EIGENDA_PROXY_EIGENDA_V2_RBN_RECENCY_WINDOW_SIZE]
    --eigenda.v2.relay-connection-pool-size value  Number of gRPC connections to maintain to each relay. (default: 1) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_CONNECTION_POOL_SIZE]
    --eigenda.v2.relay-timeout value               Timeout used when querying an individual relay for blob contents. (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT]
-   --eigenda.v2.signer-payment-key-hex value      Hex-encoded signer private key. Used for authorizing payments with EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX]
+   --eigenda.v2.signer-payment-key-hex value      Optional hex-encoded signer private key. Used for authorizing payments with EigenDA disperser in PUT routes. If not provided, proxy will be started in read-only mode, and will not be able to submit blobs to EigenDA. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX]
    --eigenda.v2.validator-timeout value           Timeout used when retrieving chunks directly from EigenDA validators. This is a secondary retrieval method, in case retrieval from the relay network fails. (default: 2m0s) [$EIGENDA_PROXY_EIGENDA_V2_VALIDATOR_TIMEOUT]
 
    Enabled APIs

--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -359,30 +359,37 @@ func buildEigenDAV2Backend(
 		return nil, fmt.Errorf("no payload retrievers enabled, please enable at least one retriever type")
 	}
 
-	payloadDisperser, err := buildPayloadDisperser(
-		ctx,
-		log,
-		config.ClientConfigV2,
-		secrets,
-		ethClient,
-		kzgCommitter,
-		contractDirectory,
-		certVerifier,
-		operatorStateRetrieverAddr,
-		registryCoordinator,
-		registry,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("build payload disperser: %w", err)
+	var payloadDisperser *payloaddispersal.PayloadDisperser
+
+	if secrets.SignerPaymentKey == "" {
+		log.Warn("No SignerPaymentKey provided: EigenDA V2 backend configured in read-only mode")
+	} else {
+		log.Info("SignerPaymentKey available: EigenDA V2 backend configured with write support")
+		payloadDisperser, err = buildPayloadDisperser(
+			ctx,
+			log,
+			config.ClientConfigV2,
+			secrets,
+			ethClient,
+			kzgCommitter,
+			contractDirectory,
+			certVerifier,
+			operatorStateRetrieverAddr,
+			registryCoordinator,
+			registry,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("build payload disperser: %w", err)
+		}
 	}
 
 	eigenDAV2Store, err := eigenda_v2.NewStore(
 		log,
-		config.ClientConfigV2.PutTries,
-		config.ClientConfigV2.RBNRecencyWindowSize,
 		payloadDisperser,
-		retrievers,
+		config.ClientConfigV2.PutTries,
 		certVerifier,
+		config.ClientConfigV2.RBNRecencyWindowSize,
+		retrievers,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create v2 store: %w", err)

--- a/api/proxy/store/generated_key/v2/eigenda.go
+++ b/api/proxy/store/generated_key/v2/eigenda.go
@@ -26,11 +26,16 @@ import (
 type Store struct {
 	log logging.Logger
 
+	// Dispersal related fields. disperser is is optional, and PUT routes will return 500s if not set.
+	disperser *payloaddispersal.PayloadDisperser
 	// Number of times to try blob dispersals:
 	// - If > 0: Try N times total
 	// - If < 0: Retry indefinitely until success
 	// - If = 0: Not permitted
 	putTries int
+
+	// Verification related fields.
+	certVerifier *verification.CertVerifier
 	// Allowed distance (in L1 blocks) between the eigenDA cert's reference block number (RBN)
 	// and the L1 block number at which the cert was included in the rollup's batch inbox.
 	// If cert.L1InclusionBlock > batch.RBN + rbnRecencyWindowSize, an
@@ -38,20 +43,19 @@ type Store struct {
 	// This check is optional and will be skipped when rbnRecencyWindowSize is set to 0.
 	rbnRecencyWindowSize uint64
 
-	disperser    *payloaddispersal.PayloadDisperser
-	retrievers   []clients.PayloadRetriever
-	certVerifier *verification.CertVerifier
+	// Retrieval related fields.
+	retrievers []clients.PayloadRetriever
 }
 
 var _ common.EigenDAV2Store = (*Store)(nil)
 
 func NewStore(
 	log logging.Logger,
-	putTries int,
-	rbnRecencyWindowSize uint64,
 	disperser *payloaddispersal.PayloadDisperser,
-	retrievers []clients.PayloadRetriever,
+	putTries int,
 	certVerifier *verification.CertVerifier,
+	rbnRecencyWindowSize uint64,
+	retrievers []clients.PayloadRetriever,
 ) (*Store, error) {
 	if putTries == 0 {
 		return nil, fmt.Errorf(
@@ -126,6 +130,9 @@ func (e Store) Get(ctx context.Context, versionedCert certs.VersionedCert, retur
 // Put disperses a blob for some pre-image and returns the associated RLP encoded certificate commit.
 // TODO: Client polling for different status codes, Mapping status codes to 503 failover
 func (e Store) Put(ctx context.Context, value []byte) ([]byte, error) {
+	if e.disperser == nil {
+		return nil, fmt.Errorf("PUT routes are disabled, did you provide a signer private key?")
+	}
 	e.log.Debug("Dispersing payload to EigenDA V2 network")
 
 	// TODO: https://github.com/Layr-Labs/eigenda/issues/1271


### PR DESCRIPTION
Proxy was previously forced to be provided with a signerPrivateKey. In order to start in read-only mode, we were passing a bogus privateKey (see our .env.example).

Changed our config/flags/examples to allow not passing a SignerPrivateKey and explicitly marking that flag as optional.

This is a request from Celo, who found a few of their operators were confused and kept asking about this.

Note that this change was only made for EigenDA v2 clients, not V1.

### Notes

I do think adding an explicit --read-only flag would be valuable. If people think this would be better to be more explicit, then I can add it. I opted for keeping it simple, but I think the read-only flag would probably be easy to add. We do plan on moving our config to structured config instead of urfave flags like we current use (see this [proposal](https://github.com/Layr-Labs/eigenda/pull/2104/files)), so I personally think it would make more sense to rethink the proxy config structure then (explicitly separate write/read/verify config params).