### PR TITLE
fix: maxQuorumID=191, not 254

### DIFF
--- a/api/clients/v2/disperser_client.go
+++ b/api/clients/v2/disperser_client.go
@@ -174,7 +174,7 @@ func (c *DisperserClient) DisperseBlob(
 	for _, q := range quorums {
 		if q > corev2.MaxQuorumID {
 			//nolint:wrapcheck
-			return nil, nil, api.NewErrorInvalidArg("quorum number must be less than 256")
+			return nil, nil, api.NewErrorInvalidArg(fmt.Sprintf("quorum number %d must be <= %d", q, corev2.MaxQuorumID))
 		}
 	}
 

--- a/core/data.go
+++ b/core/data.go
@@ -42,10 +42,10 @@ type ChunkEncodingFormat = uint8
 type BundleEncodingFormat = uint8
 
 const (
-	// We use uint8 to count the number of quorums, so we can have at most 255 quorums,
-	// which means the max ID can not be larger than 254 (from 0 to 254, there are 255
-	// different IDs).
-	MaxQuorumID = 254
+	// This value should always match the onchain MAX_QUORUM_COUNT value in the EigenDARegistryCoordinator.
+	// https://github.com/Layr-Labs/eigenda/blob/00cc8868b7e2d742fc6584dc1dea312193c8d4c2/contracts/src/core/EigenDARegistryCoordinatorStorage.sol#L36
+	// There are at most 192 quorum numbers, meaning the allowed IDs are [0,191].
+	MaxQuorumID = 191
 
 	// How many bits for the bundle's header.
 	NumBundleHeaderBits = 64

--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -433,8 +433,8 @@ type DispersalResponse struct {
 }
 
 const (
-	// We use uint8 to count the number of quorums, so we can have at most 255 quorums,
-	// which means the max ID can not be larger than 254 (from 0 to 254, there are 255
-	// different IDs).
-	MaxQuorumID = 254
+	// This value should always match the onchain MAX_QUORUM_COUNT value in the EigenDARegistryCoordinator.
+	// https://github.com/Layr-Labs/eigenda/blob/00cc8868b7e2d742fc6584dc1dea312193c8d4c2/contracts/src/core/EigenDARegistryCoordinatorStorage.sol#L36
+	// There are at most 192 quorum numbers, meaning the allowed IDs are [0,191].
+	MaxQuorumID = 191
 )

--- a/node/grpc/server_v2.go
+++ b/node/grpc/server_v2.go
@@ -355,7 +355,9 @@ func (s *ServerV2) GetChunks(ctx context.Context, in *pb.GetChunksRequest) (*pb.
 	}
 
 	if corev2.MaxQuorumID < in.GetQuorumId() {
-		return nil, api.NewErrorInvalidArg(fmt.Sprintf("quorumID %d must be <= maxQuorumID %d", in.GetQuorumId(), corev2.MaxQuorumID))
+		//nolint: wrapcheck
+		return nil, api.NewErrorInvalidArg(
+			fmt.Sprintf("quorumID %d must be <= maxQuorumID %d", in.GetQuorumId(), corev2.MaxQuorumID))
 	}
 
 	// The current sampling scheme will store the same chunks for all quorums, so we always use quorum 0 as the quorum key in storage.

--- a/node/grpc/server_v2.go
+++ b/node/grpc/server_v2.go
@@ -355,7 +355,7 @@ func (s *ServerV2) GetChunks(ctx context.Context, in *pb.GetChunksRequest) (*pb.
 	}
 
 	if corev2.MaxQuorumID < in.GetQuorumId() {
-		return nil, api.NewErrorInvalidArg("invalid quorum ID")
+		return nil, api.NewErrorInvalidArg(fmt.Sprintf("quorumID %d must be <= maxQuorumID %d", in.GetQuorumId(), corev2.MaxQuorumID))
 	}
 
 	// The current sampling scheme will store the same chunks for all quorums, so we always use quorum 0 as the quorum key in storage.


### PR DESCRIPTION
Raised during the integration audit.

This needs to match our onchain value. Not only was it not matching before (actual max value is 192, not 256 since we don't use the full uint8), but also maxQuorumID=254 was wrong even in that interpretation and should have been 255.
