### PR TITLE
chore(relay): remove unused AuthenticationTimeoutFlag

### DIFF
--- a/relay/cmd/flags/flags.go
+++ b/relay/cmd/flags/flags.go
@@ -228,13 +228,6 @@ var (
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "AUTHENTICATION_KEY_CACHE_SIZE"),
 		Value:    1024 * 1024,
 	}
-	AuthenticationTimeoutFlag = cli.DurationFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "authentication-timeout"),
-		Usage:    "Duration to keep authentication results",
-		Required: false,
-		EnvVar:   common.PrefixEnvVar(envVarPrefix, "AUTHENTICATION_TIMEOUT"),
-		Value:    0, // TODO(cody-littley) remove this feature
-	}
 	AuthenticationDisabledFlag = cli.BoolFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "authentication-disabled"),
 		Usage:    "Disable GetChunks() authentication",
@@ -387,7 +380,6 @@ var optionalFlags = []cli.Flag{
 	GetChunkBytesBurstinessClientFlag,
 	MaxConcurrentGetChunkOpsClientFlag,
 	AuthenticationKeyCacheSizeFlag,
-	AuthenticationTimeoutFlag,
 	AuthenticationDisabledFlag,
 	GetChunksTimeoutFlag,
 	GetBlobTimeoutFlag,


### PR DESCRIPTION

## Why are these changes needed?

Remove dead code - the `AuthenticationTimeoutFlag` was defined but never used in the relay configuration. The flag was included in the CLI flags list but had no corresponding field in the `relay.Config` struct and was not being read in the configuration setup.

This cleanup addresses the existing TODO comment that requested removal of this unused feature.

## Changes

- Removed unused `AuthenticationTimeoutFlag` definition from `relay/cmd/flags/flags.go`
- Removed flag reference from the CLI flags list

**Note:** This is a dead code removal with no functional impact.


