### PR TITLE
chore(gitignore): path should have been **/testdata/fuzz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Fuzz examplars are written to disk after fuzzing in these paths.
-**/testdata
+# Fuzz inputs and outputs are written to disk under these dirs.
+# See https://pkg.go.dev/testing#hdr-Fuzzing
+**/testdata/fuzz
 
 inabox/testdata/*
 inabox/anvil.pid


### PR DESCRIPTION
**/testdata is used to put testdata inputs that we want to actually commit to the repo.
Corrected to use the /fuzz subdir, which is what I should have used in the first place.