### PR TITLE
chore(inabox): Remove InMemoryBlobStore option

### DIFF
--- a/core/thegraph/state_integration_test.go
+++ b/core/thegraph/state_integration_test.go
@@ -43,11 +43,10 @@ func setupTest(t *testing.T) *inaboxtests.InfrastructureHarness {
 
 	// Setup infrastructure using the centralized function
 	config := &inaboxtests.InfrastructureConfig{
-		TemplateName:      templateName,
-		TestName:          testName,
-		InMemoryBlobStore: true, // Graph indexer test doesn't need blob store
-		Logger:            logger,
-		RootPath:          "../../",
+		TemplateName: templateName,
+		TestName:     testName,
+		Logger:       logger,
+		RootPath:     "../../",
 	}
 
 	// Start all the necessary infrastructure like anvil, graph node, and eigenda components

--- a/inabox/tests/integration_suite_test.go
+++ b/inabox/tests/integration_suite_test.go
@@ -18,15 +18,13 @@ var globalInfra *integration.InfrastructureHarness
 
 // Configuration constants from command line flags
 var (
-	templateName      string
-	testName          string
-	inMemoryBlobStore bool
+	templateName string
+	testName     string
 )
 
 func init() {
 	flag.StringVar(&templateName, "config", "testconfig-anvil.yaml", "Name of the config file (in `inabox/templates`)")
 	flag.StringVar(&testName, "testname", "", "Name of the test (in `inabox/testdata`)")
-	flag.BoolVar(&inMemoryBlobStore, "inMemoryBlobStore", false, "whether to use in-memory blob store")
 }
 
 func TestMain(m *testing.M) {
@@ -62,13 +60,12 @@ func setupSuite(logger logging.Logger) error {
 
 	// Setup the global infrastructure
 	config := &integration.InfrastructureConfig{
-		TemplateName:      templateName,
-		TestName:          testName,
-		InMemoryBlobStore: inMemoryBlobStore,
-		Logger:            logger,
-		RelayCount:        4,
-		RootPath:          "../../",
-		ClientLedgerMode:  clientledger.ClientLedgerModeLegacy,
+		TemplateName:     templateName,
+		TestName:         testName,
+		Logger:           logger,
+		RelayCount:       4,
+		RootPath:         "../../",
+		ClientLedgerMode: clientledger.ClientLedgerModeLegacy,
 	}
 	var err error
 	globalInfra, err = integration.SetupInfrastructure(context.Background(), config)

--- a/inabox/tests/payments/reservation_only_test.go
+++ b/inabox/tests/payments/reservation_only_test.go
@@ -53,7 +53,6 @@ func testReservationOnly(t *testing.T, clientLedgerMode clientledger.ClientLedge
 	infraConfig := &integration.InfrastructureConfig{
 		TemplateName:                    "testconfig-anvil.yaml",
 		TestName:                        "",
-		InMemoryBlobStore:               false,
 		Logger:                          test.GetLogger(),
 		RootPath:                        "../../../",
 		RelayCount:                      4,

--- a/inabox/tests/setup_disperser_harness.go
+++ b/inabox/tests/setup_disperser_harness.go
@@ -147,7 +147,6 @@ func SetupDisperserHarness(
 	harness.DynamoDBTables.BlobMetaV2 = config.MetadataTableNameV2
 	harness.S3Buckets.BlobStore = config.S3BucketName
 
-	// Setup LocalStack if not using in-memory blob store
 	localstack, err := setupLocalStackResources(ctx, logger, config)
 	if err != nil {
 		return nil, err

--- a/inabox/tests/setup_disperser_harness.go
+++ b/inabox/tests/setup_disperser_harness.go
@@ -25,11 +25,10 @@ import (
 
 // DisperserHarnessConfig contains the configuration for setting up the disperser harness
 type DisperserHarnessConfig struct {
-	Network           *testcontainers.DockerNetwork
-	TestConfig        *deploy.Config
-	TestName          string
-	InMemoryBlobStore bool
-	LocalStackPort    string
+	Network        *testcontainers.DockerNetwork
+	TestConfig     *deploy.Config
+	TestName       string
+	LocalStackPort string
 
 	// LocalStack resources for blobstore and metadata store
 	MetadataTableName   string
@@ -149,29 +148,24 @@ func SetupDisperserHarness(
 	harness.S3Buckets.BlobStore = config.S3BucketName
 
 	// Setup LocalStack if not using in-memory blob store
-	if !config.InMemoryBlobStore {
-		localstack, err := setupLocalStackResources(ctx, logger, config)
-		if err != nil {
-			return nil, err
-		}
-		harness.LocalStack = localstack
+	localstack, err := setupLocalStackResources(ctx, logger, config)
+	if err != nil {
+		return nil, err
+	}
+	harness.LocalStack = localstack
 
-		// Generate disperser keypair and perform registrations
-		if err := setupDisperserKeypairAndRegistrations(logger, ethClient, config); err != nil {
-			return nil, err
-		}
+	// Generate disperser keypair and perform registrations
+	if err := setupDisperserKeypairAndRegistrations(logger, ethClient, config); err != nil {
+		return nil, err
+	}
 
-		// Start relay goroutines if relay count is specified
-		if config.RelayCount > 0 {
-			if err := startRelays(ctx, logger, ethClient, harness, config); err != nil {
-				return nil, fmt.Errorf("failed to start relays: %w", err)
-			}
-		} else {
-			logger.Warn("Relay count is not specified, skipping relay setup")
+	// Start relay goroutines if relay count is specified
+	if config.RelayCount > 0 {
+		if err := startRelays(ctx, logger, ethClient, harness, config); err != nil {
+			return nil, fmt.Errorf("failed to start relays: %w", err)
 		}
 	} else {
-		// TODO(dmanc): Do the relays even work when not using S3 as the blob store?
-		logger.Info("Using in-memory blob store, skipping LocalStack setup")
+		logger.Warn("Relay count is not specified, skipping relay setup")
 	}
 
 	// Start remaining binaries (disperser, encoder, batcher, etc.)

--- a/inabox/tests/setup_infra.go
+++ b/inabox/tests/setup_infra.go
@@ -15,7 +15,6 @@ import (
 type InfrastructureConfig struct {
 	TemplateName        string
 	TestName            string
-	InMemoryBlobStore   bool
 	Logger              logging.Logger
 	RootPath            string
 	MetadataTableName   string
@@ -87,14 +86,13 @@ func SetupInfrastructure(ctx context.Context, config *InfrastructureConfig) (*In
 
 	// Create infrastructure harness early so we can populate it incrementally
 	infra := &InfrastructureHarness{
-		SharedNetwork:     sharedDockerNetwork,
-		TestConfig:        testConfig,
-		TemplateName:      config.TemplateName,
-		TestName:          testName,
-		InMemoryBlobStore: config.InMemoryBlobStore,
-		LocalStackPort:    "4570",
-		Logger:            config.Logger,
-		Cancel:            infraCancel,
+		SharedNetwork:  sharedDockerNetwork,
+		TestConfig:     testConfig,
+		TemplateName:   config.TemplateName,
+		TestName:       testName,
+		LocalStackPort: "4570",
+		Logger:         config.Logger,
+		Cancel:         infraCancel,
 	}
 
 	// Setup Chain Harness first (Anvil, Graph Node, Contracts, Churner)
@@ -116,7 +114,6 @@ func SetupInfrastructure(ctx context.Context, config *InfrastructureConfig) (*In
 		Network:             sharedDockerNetwork,
 		TestConfig:          testConfig,
 		TestName:            testName,
-		InMemoryBlobStore:   config.InMemoryBlobStore,
 		LocalStackPort:      infra.LocalStackPort,
 		MetadataTableName:   config.MetadataTableName,
 		BucketTableName:     config.BucketTableName,

--- a/inabox/tests/test_harness.go
+++ b/inabox/tests/test_harness.go
@@ -43,11 +43,10 @@ type InfrastructureHarness struct {
 	// TODO: Add harness when we need it
 
 	// Legacy deployment configuration
-	TestConfig        *deploy.Config
-	TemplateName      string
-	TestName          string
-	InMemoryBlobStore bool
-	LocalStackPort    string
+	TestConfig     *deploy.Config
+	TemplateName   string
+	TestName       string
+	LocalStackPort string
 
 	// Logger for the infrastructure components
 	Logger logging.Logger


### PR DESCRIPTION
## Why are these changes needed?

Removing this option for now. Will add back if we find a use case for running in memory blobstore on inabox.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
