### PR TITLE
fix(sigmap-EDA-01): Incorrect HTTP header key in JSON response

### DIFF
--- a/api/proxy/servers/rest/handlers_misc.go
+++ b/api/proxy/servers/rest/handlers_misc.go
@@ -114,7 +114,7 @@ func (svr *Server) writeJSON(w http.ResponseWriter, r *http.Request, response in
 		return
 	}
 
-	w.Header().Set(contentTypeJSON, "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(jsonData)
 	if err != nil {


### PR DESCRIPTION
Closes DAINT-775

Addresses EDA-01 from the [Sigma Prime audit](https://linear.app/eigenlabs/issue/DAINT-774/address-audit-findings) report by fixing the `Content-Type` key in the HTTP header set by the `writeJSON` handler function.

## Why are these changes needed?

The `writeJSON()` function uses the wrong constant as the HTTP header key. This causes the response to set an
incorrect header that clients cannot parse properly.