### PR TITLE
fix(sigmap-EDA-02): Missing context cancellation

### DIFF
--- a/api/clients/retrieval_client.go
+++ b/api/clients/retrieval_client.go
@@ -199,6 +199,9 @@ func (r *retrievalClient) RetrieveBlobChunks(ctx context.Context,
 		case <-ctx.Done():
 			return nil, fmt.Errorf("context done: %w", ctx.Err())
 		case reply := <-chunksChan:
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("context done: %w", ctx.Err())
+			}
 			if reply.Err != nil {
 				r.logger.Warn("failed to get chunks from operator", "operator", reply.OperatorID.Hex(), "err", reply.Err)
 				continue


### PR DESCRIPTION
Closes DAINT-776

Addresses EDA-02 from the [Sigma Prime audit](https://linear.app/eigenlabs/issue/DAINT-774/address-audit-findings) report by modifying the chunk collection loop to use a select statement that respects context cancellation.

## Why are these changes needed?

The chunk collection loop in `RetrieveBlobChunks()` performs unbuﬀered channel reads without checking context cancellation, causing goroutine leaks and preventing timely cleanup when blob retrieval operations are cancelled.