### PR TITLE
fix: Connection resource leak

### DIFF
--- a/api/clients/node_client.go
+++ b/api/clients/node_client.go
@@ -97,6 +97,7 @@ func (c client) GetChunks(
 		}
 		return
 	}
+	defer core.CloseLogOnError(conn, "connection to node client", nil)
 
 	n := grpcnode.NewRetrievalClient(conn)
 	nodeCtx, cancel := context.WithTimeout(ctx, c.timeout)


### PR DESCRIPTION
Closes DAINT-777

Adds connection cleanup in `GetChunks()` immediately after connection creation.

## Why are these changes needed?

The `GetChunks()` function creates gRPC connections to operator nodes but fails to close them, causing connection leaks on every blob retrieval operation that accumulate over time and exhaust available file descriptors.
