### PR TITLE
fix(sigmap-EDA-04): Nil pointer dereference in gRPC connection cleanup

### DIFF
--- a/api/clients/v2/validator/internal/validator_grpc_manager.go
+++ b/api/clients/v2/validator/internal/validator_grpc_manager.go
@@ -75,15 +75,15 @@ func (m *validatorGRPCManager) DownloadChunks(
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSize)),
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection to operator %s: %w", operatorID.Hex(), err)
+	}
 	defer func() {
 		err := conn.Close()
 		if err != nil {
 			m.logger.Error("validator retriever failed to close connection", "err", err)
 		}
 	}()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create connection to operator %s: %w", operatorID.Hex(), err)
-	}
 
 	client := grpcnode.NewRetrievalClient(conn)
 	request := &grpcnode.GetChunksRequest{


### PR DESCRIPTION
Closes DAINT-778

Addresses EDA-04 from the [Sigma Prime audit](https://linear.app/eigenlabs/issue/DAINT-774/address-audit-findings) report by moving the deferred cleanup function to run after the error check. This ensures the cleanup only happens when a valid connection exists.

## Why are these changes needed?

The `DownloadChunks()` function will panic with a nil pointer dereference if `grpc.NewClient()` fails, as the deferred cleanup function attempts to call `Close()` on a nil connection object.
