### PR TITLE
feat(payments): Remove cli flags for bucket size

### DIFF
--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -754,9 +754,10 @@ func buildReservationLedger(
 		true,
 		// this is a parameter for flexibility, but there aren't plans to operate with anything other than this value
 		ratelimit.OverfillOncePermitted,
-		// TODO(litt3): is there a different place we should define this? hardcoding makes sense... it's just a
-		// question of *where*
-		time.Minute,
+		// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used
+		// instead of hardcoding. At that point, this field will be removed from the config struct
+		// entirely, and the value will be fetched dynamically at runtime.
+		30*time.Second,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new reservation ledger config: %w", err)

--- a/disperser/cmd/controller/config.go
+++ b/disperser/cmd/controller/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/aws"
@@ -104,7 +105,10 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 
 	reservationConfig, err := reservationvalidation.NewReservationLedgerCacheConfig(
 		ctx.GlobalInt(flags.ReservationPaymentsLedgerCacheSizeFlag.Name),
-		ctx.GlobalDuration(flags.ReservationBucketCapacityPeriodFlag.Name),
+		// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used
+		// instead of hardcoding. At that point, this field will be removed from the config struct
+		// entirely, and the value will be fetched dynamically at runtime.
+		75*time.Second,
 		// this doesn't need to be configurable. there are no plans to ever use a different value
 		ratelimit.OverfillOncePermitted,
 		paymentVaultUpdateInterval,

--- a/disperser/cmd/controller/flags/flags.go
+++ b/disperser/cmd/controller/flags/flags.go
@@ -302,13 +302,6 @@ var (
 		Value:    1024,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "RESERVATION_PAYMENTS_LEDGER_CACHE_SIZE"),
 	}
-	ReservationBucketCapacityPeriodFlag = cli.DurationFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "reservation-bucket-capacity-period"),
-		Usage:    "Duration used to calculate bucket capacity for reservations",
-		Required: false,
-		Value:    60 * time.Second,
-		EnvVar:   common.PrefixEnvVar(envVarPrefix, "RESERVATION_BUCKET_CAPACITY_PERIOD"),
-	}
 	PaymentVaultUpdateIntervalFlag = cli.DurationFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "payment-vault-update-interval"),
 		Usage:    "Interval for checking payment vault updates",
@@ -364,7 +357,6 @@ var optionalFlags = []cli.Flag{
 	OnDemandPaymentsTableNameFlag,
 	OnDemandPaymentsLedgerCacheSizeFlag,
 	ReservationPaymentsLedgerCacheSizeFlag,
-	ReservationBucketCapacityPeriodFlag,
 	PaymentVaultUpdateIntervalFlag,
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -393,7 +393,10 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 	if paymentValidationEnabled {
 		reservationLedgerCacheConfig, err = reservationvalidation.NewReservationLedgerCacheConfig(
 			ctx.GlobalInt(flags.ReservationMaxLedgersFlag.Name),
-			ctx.GlobalDuration(flags.ReservationBucketCapacityPeriodFlag.Name),
+			// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used
+			// instead of hardcoding. At that point, this field will be removed from the config struct
+			// entirely, and the value will be fetched dynamically at runtime.
+			90*time.Second,
 			// this is hardcoded: it's a parameter just in case, but it's never expected to change
 			ratelimit.OverfillOncePermitted,
 			ctx.GlobalDuration(flags.PaymentVaultUpdateIntervalFlag.Name),

--- a/node/flags/flags.go
+++ b/node/flags/flags.go
@@ -582,14 +582,6 @@ var (
 		Value:    1024,
 		EnvVar:   common.PrefixEnvVar(EnvVarPrefix, "RESERVATION_MAX_LEDGERS"),
 	}
-	ReservationBucketCapacityPeriodFlag = cli.DurationFlag{
-		Name:     common.PrefixFlag(FlagPrefix, "reservation-bucket-capacity-period"),
-		Usage:    "Duration used to calculate bucket capacity when creating new reservation ledgers.",
-		Required: false,
-		// TODO(litt3): we need to decide whether this is the default value we actually want to ship
-		Value:  180 * time.Second,
-		EnvVar: common.PrefixEnvVar(EnvVarPrefix, "RESERVATION_BUCKET_CAPACITY_PERIOD"),
-	}
 	PaymentVaultUpdateIntervalFlag = cli.DurationFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "payment-vault-update-interval"),
 		Usage:    "Interval for checking for payment vault updates.",
@@ -745,7 +737,6 @@ var optionalFlags = []cli.Flag{
 	IgnoreVersionForEjectionDefenseFlag,
 	EnablePaymentValidationFlag,
 	ReservationMaxLedgersFlag,
-	ReservationBucketCapacityPeriodFlag,
 	PaymentVaultUpdateIntervalFlag,
 }
 


### PR DESCRIPTION
- When I first implemented these flags, I thought that this was how we'd want to configure bucket size
- Since then, we've decided that we ought to be using an on-chain config directory to configure these fields
- The config directory isn't ready to use yet, but I want to remove these flags for now, since these should never be exposed
- I hard coded some values that represent my best guess for what these should be. We will be able to change these hardcoded values before the new payments system actually goes live. There is an ongoing effort to decide what these should be
