### PR TITLE
fix(sigmap-EDA-07): Missing default case in chunk encoding format switch

### DIFF
--- a/api/clients/node_client.go
+++ b/api/clients/node_client.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	grpcnode "github.com/Layr-Labs/eigenda/api/grpc/node"
@@ -130,13 +131,10 @@ func (c client) GetChunks(
 			// For backward compatibility, we fallback the UNKNOWN to GOB
 			chunk, err = new(encoding.Frame).DeserializeGob(data)
 			if err != nil {
-				chunksChan <- RetrievedChunks{
-					OperatorID: opID,
-					Err:        errors.New("UNKNOWN chunk encoding format"),
-					Chunks:     nil,
-				}
-				return
+				err = errors.New("UNKNOWN chunk encoding format")
 			}
+		default:
+			err = fmt.Errorf("unsupported chunk encoding format: %v", reply.GetChunkEncodingFormat())
 		}
 		if err != nil {
 			chunksChan <- RetrievedChunks{


### PR DESCRIPTION
Closes DAINT-781

Addresses EDA-07  from the [Sigma Prime audit](https://linear.app/eigenlabs/issue/DAINT-774/address-audit-findings) report by adding a default case that returns an error for unhandled encoding formats.

## Why are these changes needed?

The `GetChunks()` function in `api/clients/node_client.go` lacks a default case in its switch statement that handles
chunk encoding formats. If a future protobuf version adds a new encoding format (e.g., ZSTD = 3 ) and operator nodes
are upgraded before the client code, the switch statement will fall through with both chunk and err remaining nil.
This causes nil to be assigned to `chunks[i]`, which could lead to nil pointer dereferences downstream.
