### PR TITLE
perf(inabox): Change the blob version configuration for inabox

### DIFF
--- a/inabox/templates/testconfig-anvil-nochurner.yaml
+++ b/inabox/templates/testconfig-anvil-nochurner.yaml
@@ -15,6 +15,9 @@ deployers:
 eigenda:
   deployer: "default"
 
+# NOTE: This uses a different blob version configuration than live deployments.
+# Live deployments typically use higher coding rates (e.g., 8) with more chunks and operators.
+# TODO: Investigate the revert that occurs when trying to use codingRate 2.
 blobVersions:
   - codingRate: 8
     numChunks: 16

--- a/inabox/templates/testconfig-anvil.yaml
+++ b/inabox/templates/testconfig-anvil.yaml
@@ -13,6 +13,9 @@ deployers:
 eigenda:
   deployer: "default"
 
+# NOTE: This uses a different blob version configuration than live deployments.
+# Live deployments typically use higher coding rates (e.g., 8) with more chunks and operators.
+# TODO: Investigate the revert that occurs when trying to use codingRate 2.
 blobVersions:
   - codingRate: 8
     numChunks: 16


### PR DESCRIPTION
## Why are these changes needed?

Previously we configured the blobversion with 8192 numChunks. @samlaf noticed that we only run 4 operators on inabox so we really don't need 8192 numChunks.

New params:
numChunks: 16
maxNumOperators: 3

Encoding improvements:
```
old:
2025/10/15 13:03:52 INFO RSEncode details input_size_bytes=2048 num_chunks=8192 chunk_length=1 padding_duration=22.917µs extension_duration=4.002958ms frames_duration=12.609875ms total_duration=16.636292ms
2025/10/15 13:03:53 INFO Multiproof Time Decomp total=11.845294917s preproc=3.715917ms msm=486.881333ms fft1=8.320204417s fft2=3.03449325s
new:
2025/10/15 13:08:52 INFO RSEncode details input_size_bytes=2048 num_chunks=16 chunk_length=32 padding_duration=9.583µs extension_duration=198.833µs frames_duration=251.917µs total_duration=460.625µs
2025/10/15 13:08:52 INFO Multiproof Time Decomp total=24.773542ms preproc=133.834µs msm=12.431125ms fft1=10.818166ms fft2=1.390417ms
```


## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
