### PR TITLE
fix(dataapi): reduce metrics/summary endpoint start timestamp by prometheus rate interval size

### DIFF
--- a/disperser/dataapi/metrics_handler.go
+++ b/disperser/dataapi/metrics_handler.go
@@ -78,12 +78,17 @@ func (mh *MetricsHandler) GetThroughputTimeseries(ctx context.Context, startTime
 		throughputRateSecs = uint16(sevenDayThroughputRateSecs)
 	}
 
+	// Adjust start time to account for rate interval skipping
+	adjustedStartTime := startTime - int64(throughputRateSecs)
+
 	var result *PrometheusResult
 	var err error
 	if mh.version == V1 {
-		result, err = mh.promClient.QueryDisperserAvgThroughputBlobSizeBytes(ctx, time.Unix(startTime, 0), time.Unix(endTime, 0), throughputRateSecs)
+		result, err = mh.promClient.QueryDisperserAvgThroughputBlobSizeBytes(
+			ctx, time.Unix(adjustedStartTime, 0), time.Unix(endTime, 0), throughputRateSecs)
 	} else {
-		result, err = mh.promClient.QueryDisperserAvgThroughputBlobSizeBytesV2(ctx, time.Unix(startTime, 0), time.Unix(endTime, 0), throughputRateSecs)
+		result, err = mh.promClient.QueryDisperserAvgThroughputBlobSizeBytesV2(
+			ctx, time.Unix(adjustedStartTime, 0), time.Unix(endTime, 0), throughputRateSecs)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Modifies `GetThroughputTimeseries` in `disperser/dataapi/metrics_handler.go` to proactively subtract the rate interval from the start time:
- For queries < 7 days: subtracts 240 seconds (4 minutes)
- For queries ≥ 7 days: subtracts 660 seconds (11 minutes)

The fix ensures that after skipping the first N data points, the returned timestamps align much closer to the originally requested time range. Because return `start_timestamp_secs` is based on prometheus query results, it is possible for the returned `start_timestamp_secs` to not match exactly, but this fix should result in correct range under normal conditions.

## Why are these changes needed?

Dataapi skips the first 240 data points (based on the prometheus rate interval) to avoid incomplete rate calculations. This causes returned results to have a `start_timestamp_secs + 240s` from the originally specified start timestamp.
```
https://dataapi.eigenda.xyz/api/v2/metrics/summary?start=1759834800&end=1759838400
{
  "total_bytes_posted": 10639650372,
  "average_bytes_per_second": 3166562.6107926513,
  "start_timestamp_sec": 1759835040,
  "end_timestamp_sec": 1759838400
}
```

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
