### PR TITLE
ci: Move encoder-icicle build into its own workflow

### DIFF
--- a/.github/workflows/docker-publish-encoder-icicle.yaml
+++ b/.github/workflows/docker-publish-encoder-icicle.yaml
@@ -1,4 +1,11 @@
+
+# NOTE: encoder-icicle is built in a separate workflow (instead of being included in the main
+# docker-publish workflow) because:
+# 1. It uses a different Dockerfile (icicle.Dockerfile) with GPU-specific dependencies (ICICLE library)
+# 2. It's restricted to linux/amd64 platform only (ICICLE requires NVIDIA GPUs)
+# 3. We've seen OOM on action workflow when ran together with other builds
 name: docker-publish-encoder-icicle
+
 on:
   push:
     branches:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -36,6 +36,11 @@ group "default" {
   targets = ["all"]
 }
 
+# NOTE: encoder-icicle is intentionally excluded from the "all" group and built in a separate
+# workflow (.github/workflows/docker-publish-encoder-icicle.yaml) because:
+# 1. It uses a different Dockerfile (icicle.Dockerfile) with GPU-specific dependencies
+# 2. It's restricted to linux/amd64 platform only (ICICLE requires NVIDIA GPUs)
+# 3. We've seen OOM on action workflow when ran together with other builds
 group "all" {
   targets = [
     "node-group",


### PR DESCRIPTION
## Why are these changes needed?

Seeing issues with this specific docker image, possibly due to it's size relative to the other ones. Attempt to put it on its own workflow to see if that alleviate the problem.

```

System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251015-214314-utc.log' at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset) at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder) at System.Diagnostics.TextWriterTraceListener.Flush() at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id) at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message) at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut) at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args) System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251015-214314-utc.log' at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset) at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder) at System.Diagnostics.TextWriterTraceListener.Flush() at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id) at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message) at GitHub.Runner.Common.Tracing.Error(Exception exception) at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args) Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251015-214314-utc.log' at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset) at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder) at System.Diagnostics.TextWriterTraceListener.Flush() at System.Diagnostics.TraceSource.Flush() at GitHub.Runner.Common.Tracing.Dispose(Boolean disposing) at GitHub.Runner.Common.Tracing.Dispose() at GitHub.Runner.Common.TraceManager.Dispose(Boolean disposing) at GitHub.Runner.Common.TraceManager.Dispose() at GitHub.Runner.Common.HostContext.Dispose(Boolean disposing) at GitHub.Runner.Common.HostContext.Dispose() at GitHub.Runner.Worker.Program.Main(String[] args)
--
```


## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
