### PR TITLE
chore(encoder): Add logger to icicle setup + multiproof

### DIFF
--- a/encoding/kzg/prover/v2/icicle.go
+++ b/encoding/kzg/prover/v2/icicle.go
@@ -25,6 +25,7 @@ func CreateIcicleBackendProver(p *Prover, params encoding.EncodingParams, fs *ff
 		return nil, err
 	}
 	icicleDevice, err := icicle.NewIcicleDevice(icicle.IcicleDeviceConfig{
+		Logger:     p.logger,
 		GPUEnable:  p.Config.GPUEnable,
 		NTTSize:    MAX_NTT_SIZE,
 		FFTPointsT: fftPointsT,
@@ -36,6 +37,7 @@ func CreateIcicleBackendProver(p *Prover, params encoding.EncodingParams, fs *ff
 
 	// Set up icicle multiproof backend
 	multiproofBackend := &icicleprover.KzgMultiProofIcicleBackend{
+		Logger:         p.logger,
 		Fs:             fs,
 		FlatFFTPointsT: icicleDevice.FlatFFTPointsT,
 		NttCfg:         icicleDevice.NttCfg,

--- a/encoding/kzg/prover/v2/icicle/multiframe_proof.go
+++ b/encoding/kzg/prover/v2/icicle/multiframe_proof.go
@@ -4,13 +4,13 @@ package icicle
 
 import (
 	"fmt"
-	"log/slog"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/encoding/fft"
 	"github.com/Layr-Labs/eigenda/encoding/icicle"
+	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/ingonyama-zk/icicle/v3/wrappers/golang/core"
@@ -19,6 +19,7 @@ import (
 )
 
 type KzgMultiProofIcicleBackend struct {
+	Logger         logging.Logger
 	Fs             *fft.FFTSettings
 	FlatFFTPointsT []iciclebn254.Affine
 	NttCfg         core.NTTConfig[[iciclebn254.SCALAR_LIMBS]uint32]
@@ -124,7 +125,7 @@ func (p *KzgMultiProofIcicleBackend) ComputeMultiFrameProofV2(polyFr []fr.Elemen
 
 	end := time.Now()
 
-	slog.Info("Multiproof Time Decomp",
+	p.Logger.Info("Multiproof Time Decomp",
 		"total", end.Sub(begin),
 		"preproc", preprocessDone.Sub(begin),
 		"msm", msmDone.Sub(preprocessDone),

--- a/encoding/rs/icicle.go
+++ b/encoding/rs/icicle.go
@@ -17,6 +17,7 @@ const (
 
 func CreateIcicleBackendEncoder(e *Encoder, params encoding.EncodingParams, fs *fft.FFTSettings) (*ParametrizedEncoder, error) {
 	icicleDevice, err := icicle.NewIcicleDevice(icicle.IcicleDeviceConfig{
+		Logger:    e.logger,
 		GPUEnable: e.Config.GPUEnable,
 		NTTSize:   defaultNTTSize,
 		// No MSM setup needed for encoder


### PR DESCRIPTION
## Why are these changes needed?

Found icicle is missing the logger setup (saw some remaining slog logs).

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
