### PR TITLE
fix(sigmap-EDA-12): Debug print statement in production code

### DIFF
--- a/api/proxy/servers/rest/routing.go
+++ b/api/proxy/servers/rest/routing.go
@@ -167,7 +167,6 @@ func parseReturnEncodedPayloadQueryParam(r *http.Request) bool {
 	if !exists || len(returnEncodedPayloadValues) == 0 {
 		return false
 	}
-	fmt.Println("returnEncodedPayloadValues:", returnEncodedPayloadValues)
 	returnEncodedPayload := strings.ToLower(returnEncodedPayloadValues[0])
 	if returnEncodedPayload == "" || returnEncodedPayload == "true" || returnEncodedPayload == "1" {
 		return true


### PR DESCRIPTION
Closes DAINT-786

Addresses EDA-12  from the [Sigma Prime audit](https://linear.app/eigenlabs/issue/DAINT-774/address-audit-findings) report by removing the debug `fmt.Println()` statement from the `parseReturnEncodedPayloadQueryParam` function.

## Why are these changes needed?

A debug print statement exists in production code that could potentially leak sensitive information through application
logs.
