### PR TITLE
feat: update to forge v1.4.2 in mise

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -5,12 +5,15 @@ libs = ['lib']
 fs_permissions = [{ access = "read-write", path = "./" }]
 
 # We force all warnings to be fixed
-deny_warnings = true
+deny = "warnings"
 # We error warnings from libraries. This should be fixed upstream but I'm lazy.
 # See https://github.com/ethereum/solidity/issues/2675 for an interesting discussion.
 ignored_warnings_from = [
     "lib/eigenlayer-middleware/src/RegistryCoordinator.sol",
 ]
+
+[lint]
+severity = ["high"]
 
 gas_reports = ["*"]
 

--- a/contracts/script/DeployOpenEigenLayer.s.sol
+++ b/contracts/script/DeployOpenEigenLayer.s.sol
@@ -113,8 +113,9 @@ contract DeployOpenEigenLayer is Script, Test {
         strategyManager = StrategyManager(
             address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
         );
-        slasher =
-            Slasher(address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), "")));
+        slasher = Slasher(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
+        );
         eigenPodManager = EigenPodManager(
             address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
         );

--- a/contracts/script/EigenDADeployer.s.sol
+++ b/contracts/script/EigenDADeployer.s.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
-import {PauserRegistry} from
-    "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
+import {
+    PauserRegistry
+} from "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
 import {EmptyContract} from "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 
 import {BLSApkRegistry} from "../lib/eigenlayer-middleware/src/BLSApkRegistry.sol";
@@ -292,8 +293,7 @@ contract EigenDADeployer is DeployOpenEigenLayer {
             for (uint256 i = 0; i < numStrategies; i++) {
                 strategyAndWeightingMultipliers[i] = new IStakeRegistry.StrategyParams[](1);
                 strategyAndWeightingMultipliers[i][0] = IStakeRegistry.StrategyParams({
-                    strategy: IStrategy(address(deployedStrategyArray[i])),
-                    multiplier: 1 ether
+                    strategy: IStrategy(address(deployedStrategyArray[i])), multiplier: 1 ether
                 });
             }
 

--- a/contracts/script/EigenLayerUtils.s.sol
+++ b/contracts/script/EigenLayerUtils.s.sol
@@ -12,7 +12,7 @@ contract EigenLayerUtils {
             if (token == IERC20(address(0))) {
                 payable(tos[i]).transfer(amounts[i]);
             } else {
-                token.transfer(tos[i], amounts[i]);
+                require(token.transfer(tos[i], amounts[i]), "ERC20 transfer failed");
             }
         }
     }

--- a/contracts/script/EjectionManagerDeployer.s.sol
+++ b/contracts/script/EjectionManagerDeployer.s.sol
@@ -62,10 +62,13 @@ contract Deployer_EjectionManager is Script, Test {
         address[] memory ejectors = new address[](1);
         ejectors[0] = ejector;
 
-        TransparentUpgradeableProxy(payable(address(ejectionManager))).upgradeToAndCall(
-            address(ejectionManagerImplementation),
-            abi.encodeWithSelector(EjectionManager.initialize.selector, ejectorOwner, ejectors, quorumEjectionParams)
-        );
+        TransparentUpgradeableProxy(payable(address(ejectionManager)))
+            .upgradeToAndCall(
+                address(ejectionManagerImplementation),
+                abi.encodeWithSelector(
+                    EjectionManager.initialize.selector, ejectorOwner, ejectors, quorumEjectionParams
+                )
+            );
 
         TransparentUpgradeableProxy(payable(address(ejectionManager))).changeAdmin(address(eigenDAProxyAdmin));
 

--- a/contracts/script/GenerateUnitTestHashes.s.sol
+++ b/contracts/script/GenerateUnitTestHashes.s.sol
@@ -18,10 +18,7 @@ contract GenerateHashes is Script {
         DATypesV1.QuorumBlobParam[] memory quorumBlobParam = new DATypesV1.QuorumBlobParam[](1);
 
         quorumBlobParam[0] = DATypesV1.QuorumBlobParam({
-            quorumNumber: 0,
-            adversaryThresholdPercentage: 80,
-            confirmationThresholdPercentage: 100,
-            chunkLength: 10
+            quorumNumber: 0, adversaryThresholdPercentage: 80, confirmationThresholdPercentage: 100, chunkLength: 10
         });
 
         bytes32 quorumBlobParamsHash = keccak256(abi.encode(quorumBlobParam));
@@ -30,10 +27,7 @@ contract GenerateHashes is Script {
         BN254.G1Point memory commitment = BN254.G1Point({X: 1, Y: 2});
 
         quorumBlobParam[0] = DATypesV1.QuorumBlobParam({
-            quorumNumber: 1,
-            adversaryThresholdPercentage: 80,
-            confirmationThresholdPercentage: 100,
-            chunkLength: 10
+            quorumNumber: 1, adversaryThresholdPercentage: 80, confirmationThresholdPercentage: 100, chunkLength: 10
         });
 
         DATypesV1.BlobHeader memory header =

--- a/contracts/script/SetUpEigenDA.s.sol
+++ b/contracts/script/SetUpEigenDA.s.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
-import {PauserRegistry} from
-    "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
+import {
+    PauserRegistry
+} from "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
 import {EmptyContract} from "../lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 
 import {EigenDARegistryCoordinator} from "src/core/EigenDARegistryCoordinator.sol";
@@ -174,9 +175,8 @@ contract SetupEigenDA is EigenDADeployer, EigenLayerUtils {
             vm.startBroadcast(stakerPrivateKeys[i]);
             for (uint256 j = 0; j < numStrategies; j++) {
                 if (stakerTokenAmounts[j][i] > 0) {
-                    deployedStrategyArray[j].underlyingToken().approve(
-                        address(strategyManager), stakerTokenAmounts[j][i]
-                    );
+                    deployedStrategyArray[j].underlyingToken()
+                        .approve(address(strategyManager), stakerTokenAmounts[j][i]);
                     strategyManager.depositIntoStrategy(
                         deployedStrategyArray[j], deployedStrategyArray[j].underlyingToken(), stakerTokenAmounts[j][i]
                     );

--- a/contracts/script/deploy/eigenda/DeployEigenDA.s.sol
+++ b/contracts/script/deploy/eigenda/DeployEigenDA.s.sol
@@ -5,8 +5,9 @@ pragma solidity =0.8.12;
 import {EmptyContract} from "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 import {ProxyAdmin, TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
-import {IDelegationManager} from
-    "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {
+    IDelegationManager
+} from "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import {ISocketRegistry, SocketRegistry} from "lib/eigenlayer-middleware/src/SocketRegistry.sol";
 import {IIndexRegistry} from "lib/eigenlayer-middleware/src/interfaces/IIndexRegistry.sol";
 import {IndexRegistry} from "lib/eigenlayer-middleware/src/IndexRegistry.sol";
@@ -20,10 +21,12 @@ import {PaymentVault} from "src/core/PaymentVault.sol";
 import {IPaymentVault} from "src/core/interfaces/IPaymentVault.sol";
 import {IEigenDADisperserRegistry, EigenDADisperserRegistry} from "src/core/EigenDADisperserRegistry.sol";
 import {EigenDAServiceManager, IServiceManager} from "src/core/EigenDAServiceManager.sol";
-import {IAVSDirectory} from
-    "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
-import {IRewardsCoordinator} from
-    "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
+import {
+    IAVSDirectory
+} from "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {
+    IRewardsCoordinator
+} from "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
 import {
     IPauserRegistry,
     PauserRegistry
@@ -340,9 +343,8 @@ contract DeployEigenDA is Script {
         }
 
         for (uint256 i; i < cfg.relayInfos().length; i++) {
-            IEigenDARelayRegistry(directory.getAddress(AddressDirectoryConstants.RELAY_REGISTRY_NAME)).addRelayInfo(
-                cfg.relayInfos()[i]
-            );
+            IEigenDARelayRegistry(directory.getAddress(AddressDirectoryConstants.RELAY_REGISTRY_NAME))
+                .addRelayInfo(cfg.relayInfos()[i]);
         }
 
         if (msg.sender != cfg.initialOwner()) {
@@ -352,9 +354,8 @@ contract DeployEigenDA is Script {
             accessControl.revokeRole(accessControl.DEFAULT_ADMIN_ROLE(), msg.sender);
             EigenDADisperserRegistry(directory.getAddress(AddressDirectoryConstants.DISPERSER_REGISTRY_NAME))
                 .transferOwnership(cfg.initialOwner());
-            EigenDARelayRegistry(directory.getAddress(AddressDirectoryConstants.RELAY_REGISTRY_NAME)).transferOwnership(
-                cfg.initialOwner()
-            );
+            EigenDARelayRegistry(directory.getAddress(AddressDirectoryConstants.RELAY_REGISTRY_NAME))
+                .transferOwnership(cfg.initialOwner());
         }
 
         vm.stopBroadcast();

--- a/contracts/script/deploy/eigenda/DeployEigenDAConfig.sol
+++ b/contracts/script/deploy/eigenda/DeployEigenDAConfig.sol
@@ -5,8 +5,9 @@ import {IRegistryCoordinator, EigenDARegistryCoordinator} from "src/core/EigenDA
 import {IStakeRegistry} from "lib/eigenlayer-middleware/src/interfaces/IStakeRegistry.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {EigenDATypesV1 as DATypesV1} from "src/core/libraries/v1/EigenDATypesV1.sol";
-import {IPauserRegistry} from
-    "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
+import {
+    IPauserRegistry
+} from "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
 import {IEjectionManager} from "lib/eigenlayer-middleware/src/interfaces/IEjectionManager.sol";
 import "forge-std/StdToml.sol";
 import {EigenDATypesV1} from "src/core/libraries/v1/EigenDATypesV1.sol";
@@ -64,11 +65,7 @@ library InitParamsLib {
         }
     }
 
-    function strategyParams(string memory configData)
-        internal
-        pure
-        returns (IStakeRegistry.StrategyParams[][] memory)
-    {
+    function strategyParams(string memory configData) internal pure returns (IStakeRegistry.StrategyParams[][] memory) {
         bytes memory strategyConfigsRaw =
             stdToml.parseRaw(configData, ".initParams.middleware.registryCoordinator.strategyParams");
         return abi.decode(strategyConfigsRaw, (IStakeRegistry.StrategyParams[][]));
@@ -80,9 +77,10 @@ library InitParamsLib {
     }
 
     function quorumConfirmationThresholdPercentages(string memory configData) internal pure returns (bytes memory) {
-        return stdToml.readBytes(
-            configData, ".initParams.eigenDA.thresholdRegistry.quorumConfirmationThresholdPercentages"
-        );
+        return
+            stdToml.readBytes(
+                configData, ".initParams.eigenDA.thresholdRegistry.quorumConfirmationThresholdPercentages"
+            );
     }
 
     function quorumNumbersRequired(string memory configData) internal pure returns (bytes memory) {

--- a/contracts/src/core/EigenDADirectory.sol
+++ b/contracts/src/core/EigenDADirectory.sol
@@ -26,9 +26,8 @@ contract EigenDADirectory is IEigenDADirectory {
 
     modifier onlyOwner() {
         require(
-            IAccessControl(AddressDirectoryConstants.ACCESS_CONTROL_NAME.getKey().getAddress()).hasRole(
-                AccessControlConstants.OWNER_ROLE, msg.sender
-            ),
+            IAccessControl(AddressDirectoryConstants.ACCESS_CONTROL_NAME.getKey().getAddress())
+                .hasRole(AccessControlConstants.OWNER_ROLE, msg.sender),
             "Caller is not the owner"
         );
         _;

--- a/contracts/src/core/EigenDARegistryCoordinator.sol
+++ b/contracts/src/core/EigenDARegistryCoordinator.sol
@@ -132,7 +132,8 @@ contract EigenDARegistryCoordinator is
 
         // Register the operator in each of the registry contracts and update the operator's
         // quorum bitmap and registration status
-        uint32[] memory numOperatorsPerQuorum = _registerOperator({
+        uint32[] memory numOperatorsPerQuorum =
+        _registerOperator({
             operator: msg.sender,
             operatorId: operatorId,
             quorumNumbers: quorumNumbers,
@@ -183,8 +184,7 @@ contract EigenDARegistryCoordinator is
         bytes memory quorumNumbers = new bytes(1);
         quorumNumbers[0] = bytes1(uint8(quorumNumber));
         _deregisterOperator({
-            operator: blsApkRegistry().pubkeyHashToOperator(operatorToChurn),
-            quorumNumbers: quorumNumbers
+            operator: blsApkRegistry().pubkeyHashToOperator(operatorToChurn), quorumNumbers: quorumNumbers
         });
     }
 
@@ -618,11 +618,10 @@ contract EigenDARegistryCoordinator is
 
         if (historyLength == 0) {
             // No prior bitmap history - push our first entry
-            _operatorBitmapHistory[operatorId].push(
+            _operatorBitmapHistory[operatorId]
+            .push(
                 QuorumBitmapUpdate({
-                    updateBlockNumber: uint32(block.number),
-                    nextUpdateBlockNumber: 0,
-                    quorumBitmap: newBitmap
+                    updateBlockNumber: uint32(block.number), nextUpdateBlockNumber: 0, quorumBitmap: newBitmap
                 })
             );
         } else {
@@ -637,11 +636,10 @@ contract EigenDARegistryCoordinator is
                 lastUpdate.quorumBitmap = newBitmap;
             } else {
                 lastUpdate.nextUpdateBlockNumber = uint32(block.number);
-                _operatorBitmapHistory[operatorId].push(
+                _operatorBitmapHistory[operatorId]
+                .push(
                     QuorumBitmapUpdate({
-                        updateBlockNumber: uint32(block.number),
-                        nextUpdateBlockNumber: 0,
-                        quorumBitmap: newBitmap
+                        updateBlockNumber: uint32(block.number), nextUpdateBlockNumber: 0, quorumBitmap: newBitmap
                     })
                 );
             }

--- a/contracts/src/core/EigenDARegistryCoordinatorStorage.sol
+++ b/contracts/src/core/EigenDARegistryCoordinatorStorage.sol
@@ -15,7 +15,6 @@ abstract contract EigenDARegistryCoordinatorStorage is IRegistryCoordinator {
      *                            CONSTANTS AND IMMUTABLES
      *
      */
-
     /// @notice The EIP-712 typehash for the `DelegationApproval` struct used by the contract
     bytes32 public constant OPERATOR_CHURN_APPROVAL_TYPEHASH = keccak256(
         "OperatorChurnApproval(address registeringOperator,bytes32 registeringOperatorId,OperatorKickParam[] operatorKickParams,bytes32 salt,uint256 expiry)OperatorKickParam(uint8 quorumNumber,address operator)"

--- a/contracts/src/core/EigenDAServiceManager.sol
+++ b/contracts/src/core/EigenDAServiceManager.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.9;
 
 import {Pausable} from "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/permissions/Pausable.sol";
-import {IPauserRegistry} from
-    "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
+import {
+    IPauserRegistry
+} from "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
 import {
     ServiceManagerBase,
     IAVSDirectory,
@@ -51,10 +52,7 @@ contract EigenDAServiceManager is EigenDAServiceManagerStorage, ServiceManagerBa
         BLSSignatureChecker(__registryCoordinator)
         ServiceManagerBase(__avsDirectory, __rewardsCoordinator, __registryCoordinator, __stakeRegistry)
         EigenDAServiceManagerStorage(
-            __eigenDAThresholdRegistry,
-            __eigenDARelayRegistry,
-            __paymentVault,
-            __eigenDADisperserRegistry
+            __eigenDAThresholdRegistry, __eigenDARelayRegistry, __paymentVault, __eigenDADisperserRegistry
         )
     {
         _disableInitializers();
@@ -105,8 +103,7 @@ contract EigenDAServiceManager is EigenDAServiceManagerStorage, ServiceManagerBa
         bytes32 reducedBatchHeaderHash = keccak256(
             abi.encode(
                 DATypesV1.ReducedBatchHeader({
-                    blobHeadersRoot: batchHeader.blobHeadersRoot,
-                    referenceBlockNumber: batchHeader.referenceBlockNumber
+                    blobHeadersRoot: batchHeader.blobHeadersRoot, referenceBlockNumber: batchHeader.referenceBlockNumber
                 })
             )
         );

--- a/contracts/src/core/PaymentVault.sol
+++ b/contracts/src/core/PaymentVault.sol
@@ -104,7 +104,7 @@ contract PaymentVault is OwnableUpgradeable, PaymentVaultStorage {
     }
 
     function withdrawERC20(IERC20 _token, uint256 _amount) external onlyOwner {
-        _token.transfer(owner(), _amount);
+        require(_token.transfer(owner(), _amount), "ERC20 transfer failed");
     }
 
     function _checkQuorumSplit(bytes memory _quorumNumbers, bytes memory _quorumSplits) internal pure {

--- a/contracts/src/core/libraries/v3/address-directory/AddressDirectoryConstants.sol
+++ b/contracts/src/core/libraries/v3/address-directory/AddressDirectoryConstants.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.9;
 
 library AddressDirectoryConstants {
     /// PROXY ADMIN
-
     string internal constant PROXY_ADMIN_NAME = "PROXY_ADMIN";
 
     /// CORE

--- a/contracts/src/integrations/cert/EigenDACertVerifier.sol
+++ b/contracts/src/integrations/cert/EigenDACertVerifier.sol
@@ -62,7 +62,6 @@ contract EigenDACertVerifier is
         UNUSED_HISTORICAL_REQUIRED_QUORUMS_NOT_SUBSET,
         INVALID_CERT, // 400: Certificate is invalid due to some revert from the verification library
         INTERNAL_ERROR // 500: Bug or misconfiguration in the CertVerifier contract itself. This includes solidity panics and evm reverts.
-
     }
 
     constructor(
@@ -118,12 +117,14 @@ contract EigenDACertVerifier is
         // between different execution environments: EVM running onchain during optimistic rollup fraud proofs, zkVM, eth-call with higher gas limit.
         try this.checkDACertReverts(daCert) {
             return uint8(StatusCode.SUCCESS);
-        } catch Error(string memory) /*reason*/ {
+        } catch Error(string memory) {
+            /*reason*/
             // This matches any require(..., "string reason") revert that is pre custom errors,
             // which many of our current eigenlayer-middleware dependencies like the BLSSignatureChecker still use. See:
             // https://github.com/Layr-Labs/eigenlayer-middleware/blob/fe5834371caed60c1d26ab62b5519b0cbdcb42fa/src/BLSSignatureChecker.sol#L96
             return uint8(StatusCode.INVALID_CERT);
-        } catch Panic(uint256) /*errorCode*/ {
+        } catch Panic(uint256) {
+            /*errorCode*/
             // This matches any panic (e.g. arithmetic overflow, division by zero, invalid array access, etc.),
             // which means a bug or misconfiguration of the CertVerifier contract itself.
             return uint8(StatusCode.INTERNAL_ERROR);

--- a/contracts/src/integrations/cert/legacy/v1/EigenDACertVerificationV1Lib.sol
+++ b/contracts/src/integrations/cert/legacy/v1/EigenDACertVerificationV1Lib.sol
@@ -25,9 +25,8 @@ library EigenDACertVerificationV1Lib {
     ) internal view {
         require(
             hashBatchMetadata(blobVerificationProof.batchMetadata)
-                == IEigenDABatchMetadataStorage(batchMetadataStorage).batchIdToBatchMetadataHash(
-                    blobVerificationProof.batchId
-                ),
+                == IEigenDABatchMetadataStorage(batchMetadataStorage)
+                    .batchIdToBatchMetadataHash(blobVerificationProof.batchId),
             "EigenDACertVerificationV1Lib._verifyDACertForQuorums: batchMetadata does not match stored metadata"
         );
 
@@ -46,9 +45,8 @@ library EigenDACertVerificationV1Lib {
         for (uint256 i = 0; i < blobHeader.quorumBlobParams.length; i++) {
             require(
                 uint8(
-                    blobVerificationProof.batchMetadata.batchHeader.quorumNumbers[uint8(
-                        blobVerificationProof.quorumIndices[i]
-                    )]
+                    blobVerificationProof.batchMetadata.batchHeader
+                    .quorumNumbers[uint8(blobVerificationProof.quorumIndices[i])]
                 ) == blobHeader.quorumBlobParams[i].quorumNumber,
                 "EigenDACertVerificationV1Lib._verifyDACertForQuorums: quorumNumber does not match"
             );
@@ -69,9 +67,8 @@ library EigenDACertVerificationV1Lib {
 
             require(
                 uint8(
-                    blobVerificationProof.batchMetadata.batchHeader.signedStakeForQuorums[uint8(
-                        blobVerificationProof.quorumIndices[i]
-                    )]
+                    blobVerificationProof.batchMetadata.batchHeader
+                    .signedStakeForQuorums[uint8(blobVerificationProof.quorumIndices[i])]
                 ) >= blobHeader.quorumBlobParams[i].confirmationThresholdPercentage,
                 "EigenDACertVerificationV1Lib._verifyDACertForQuorums: confirmationThresholdPercentage is not met"
             );
@@ -81,7 +78,9 @@ library EigenDACertVerificationV1Lib {
         }
 
         require(
-            BitmapUtils.isSubsetOf(BitmapUtils.orderedBytesArrayToBitmap(requiredQuorumNumbers), confirmedQuorumsBitmap),
+            BitmapUtils.isSubsetOf(
+                BitmapUtils.orderedBytesArrayToBitmap(requiredQuorumNumbers), confirmedQuorumsBitmap
+            ),
             "EigenDACertVerificationV1Lib._verifyDACertForQuorums: required quorums are not a subset of the confirmed quorums"
         );
     }
@@ -104,9 +103,8 @@ library EigenDACertVerificationV1Lib {
         for (uint256 i = 0; i < blobHeaders.length; ++i) {
             require(
                 hashBatchMetadata(blobVerificationProofs[i].batchMetadata)
-                    == IEigenDABatchMetadataStorage(batchMetadataStorage).batchIdToBatchMetadataHash(
-                        blobVerificationProofs[i].batchId
-                    ),
+                    == IEigenDABatchMetadataStorage(batchMetadataStorage)
+                        .batchIdToBatchMetadataHash(blobVerificationProofs[i].batchId),
                 "EigenDACertVerificationV1Lib._verifyDACertsForQuorums: batchMetadata does not match stored metadata"
             );
 
@@ -125,9 +123,8 @@ library EigenDACertVerificationV1Lib {
             for (uint256 j = 0; j < blobHeaders[i].quorumBlobParams.length; j++) {
                 require(
                     uint8(
-                        blobVerificationProofs[i].batchMetadata.batchHeader.quorumNumbers[uint8(
-                            blobVerificationProofs[i].quorumIndices[j]
-                        )]
+                        blobVerificationProofs[i].batchMetadata.batchHeader
+                        .quorumNumbers[uint8(blobVerificationProofs[i].quorumIndices[j])]
                     ) == blobHeaders[i].quorumBlobParams[j].quorumNumber,
                     "EigenDACertVerificationV1Lib._verifyDACertsForQuorums: quorumNumber does not match"
                 );
@@ -146,9 +143,8 @@ library EigenDACertVerificationV1Lib {
 
                 require(
                     uint8(
-                        blobVerificationProofs[i].batchMetadata.batchHeader.signedStakeForQuorums[uint8(
-                            blobVerificationProofs[i].quorumIndices[j]
-                        )]
+                        blobVerificationProofs[i].batchMetadata.batchHeader
+                        .signedStakeForQuorums[uint8(blobVerificationProofs[i].quorumIndices[j])]
                     ) >= blobHeaders[i].quorumBlobParams[j].confirmationThresholdPercentage,
                     "EigenDACertVerificationV1Lib._verifyDACertsForQuorums: confirmationThresholdPercentage is not met"
                 );
@@ -252,8 +248,7 @@ library EigenDACertVerificationV1Lib {
         returns (DATypesV1.ReducedBatchHeader memory)
     {
         return DATypesV1.ReducedBatchHeader({
-            blobHeadersRoot: batchHeader.blobHeadersRoot,
-            referenceBlockNumber: batchHeader.referenceBlockNumber
+            blobHeadersRoot: batchHeader.blobHeadersRoot, referenceBlockNumber: batchHeader.referenceBlockNumber
         });
     }
 

--- a/contracts/src/integrations/cert/legacy/v1/EigenDACertVerifierV1.sol
+++ b/contracts/src/integrations/cert/legacy/v1/EigenDACertVerifierV1.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.9;
 import {IEigenDAThresholdRegistry} from "src/core/interfaces/IEigenDAThresholdRegistry.sol";
 import {IEigenDABatchMetadataStorage} from "src/core/interfaces/IEigenDABatchMetadataStorage.sol";
 import {IEigenDASignatureVerifier} from "src/core/interfaces/IEigenDASignatureVerifier.sol";
-import {EigenDACertVerificationV1Lib as CertV1Lib} from
-    "src/integrations/cert/legacy/v1/EigenDACertVerificationV1Lib.sol";
+import {
+    EigenDACertVerificationV1Lib as CertV1Lib
+} from "src/integrations/cert/legacy/v1/EigenDACertVerificationV1Lib.sol";
 import {EigenDATypesV1 as DATypesV1} from "src/core/libraries/v1/EigenDATypesV1.sol";
 import {EigenDATypesV2 as DATypesV2} from "src/core/libraries/v2/EigenDATypesV2.sol";
 import {OperatorStateRetriever} from "lib/eigenlayer-middleware/src/OperatorStateRetriever.sol";

--- a/contracts/src/integrations/cert/legacy/v2/EigenDACertVerificationV2Lib.sol
+++ b/contracts/src/integrations/cert/legacy/v2/EigenDACertVerificationV2Lib.sol
@@ -55,7 +55,6 @@ library EigenDACertVerificationV2Lib {
         SECURITY_ASSUMPTIONS_NOT_MET, // Security assumptions not met
         BLOB_QUORUMS_NOT_SUBSET, // Blob quorums not a subset of confirmed quorums
         REQUIRED_QUORUMS_NOT_SUBSET // Required quorums not a subset of blob quorums
-
     }
 
     function verifyDACertV2(
@@ -328,10 +327,13 @@ library EigenDACertVerificationV2Lib {
             signedQuorumNumbers = abi.encodePacked(signedQuorumNumbers, uint8(signedBatch.attestation.quorumNumbers[i]));
         }
 
-        OperatorStateRetriever.CheckSignaturesIndices memory checkSignaturesIndices = operatorStateRetriever
-            .getCheckSignaturesIndices(
-            registryCoordinator, signedBatch.batchHeader.referenceBlockNumber, signedQuorumNumbers, nonSignerOperatorIds
-        );
+        OperatorStateRetriever.CheckSignaturesIndices memory checkSignaturesIndices =
+            operatorStateRetriever.getCheckSignaturesIndices(
+                registryCoordinator,
+                signedBatch.batchHeader.referenceBlockNumber,
+                signedQuorumNumbers,
+                nonSignerOperatorIds
+            );
 
         nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices = checkSignaturesIndices.nonSignerQuorumBitmapIndices;
         nonSignerStakesAndSignature.nonSignerPubkeys = signedBatch.attestation.nonSignerPubkeys;

--- a/contracts/src/integrations/cert/legacy/v2/EigenDACertVerifierV2.sol
+++ b/contracts/src/integrations/cert/legacy/v2/EigenDACertVerifierV2.sol
@@ -4,10 +4,12 @@ pragma solidity ^0.8.9;
 import {IEigenDAThresholdRegistry} from "src/core/interfaces/IEigenDAThresholdRegistry.sol";
 import {IEigenDABatchMetadataStorage} from "src/core/interfaces/IEigenDABatchMetadataStorage.sol";
 import {IEigenDASignatureVerifier} from "src/core/interfaces/IEigenDASignatureVerifier.sol";
-import {EigenDACertVerificationV1Lib as CertV1Lib} from
-    "src/integrations/cert/legacy/v1/EigenDACertVerificationV1Lib.sol";
-import {EigenDACertVerificationV2Lib as CertV2Lib} from
-    "src/integrations/cert/legacy/v2/EigenDACertVerificationV2Lib.sol";
+import {
+    EigenDACertVerificationV1Lib as CertV1Lib
+} from "src/integrations/cert/legacy/v1/EigenDACertVerificationV1Lib.sol";
+import {
+    EigenDACertVerificationV2Lib as CertV2Lib
+} from "src/integrations/cert/legacy/v2/EigenDACertVerificationV2Lib.sol";
 import {OperatorStateRetriever} from "lib/eigenlayer-middleware/src/OperatorStateRetriever.sol";
 import {IRegistryCoordinator} from "src/core/EigenDARegistryCoordinator.sol";
 import {EigenDATypesV2 as DATypesV2} from "src/core/libraries/v2/EigenDATypesV2.sol";

--- a/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
+++ b/contracts/src/integrations/cert/libraries/EigenDACertVerificationLib.sol
@@ -269,10 +269,13 @@ library EigenDACertVerificationLib {
             signedQuorumNumbers = abi.encodePacked(signedQuorumNumbers, uint8(signedBatch.attestation.quorumNumbers[i]));
         }
 
-        OperatorStateRetriever.CheckSignaturesIndices memory checkSignaturesIndices = operatorStateRetriever
-            .getCheckSignaturesIndices(
-            registryCoordinator, signedBatch.batchHeader.referenceBlockNumber, signedQuorumNumbers, nonSignerOperatorIds
-        );
+        OperatorStateRetriever.CheckSignaturesIndices memory checkSignaturesIndices =
+            operatorStateRetriever.getCheckSignaturesIndices(
+                registryCoordinator,
+                signedBatch.batchHeader.referenceBlockNumber,
+                signedQuorumNumbers,
+                nonSignerOperatorIds
+            );
 
         nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices = checkSignaturesIndices.nonSignerQuorumBitmapIndices;
         nonSignerStakesAndSignature.nonSignerPubkeys = signedBatch.attestation.nonSignerPubkeys;

--- a/contracts/src/periphery/ejection/EigenDAEjectionManager.sol
+++ b/contracts/src/periphery/ejection/EigenDAEjectionManager.sol
@@ -114,8 +114,8 @@ contract EigenDAEjectionManager is IEigenDAEjectionManager, IEigenDASemVer {
         BN254.G1Point memory sigma,
         address recipient
     ) external {
-        address blsApkRegistry =
-            IEigenDADirectory(_addressDirectory).getAddress(AddressDirectoryConstants.BLS_APK_REGISTRY_NAME.getKey());
+        address blsApkRegistry = IEigenDADirectory(_addressDirectory)
+            .getAddress(AddressDirectoryConstants.BLS_APK_REGISTRY_NAME.getKey());
 
         (BN254.G1Point memory apk,) = IBLSApkRegistry(blsApkRegistry).getRegisteredPubkey(operator);
         _verifySig(_cancelEjectionMessageHash(operator, recipient), apk, apkG2, sigma);
@@ -218,9 +218,8 @@ contract EigenDAEjectionManager is IEigenDAEjectionManager, IEigenDASemVer {
 
     /// @notice Attempts to eject an operator. If the ejection fails, it catches the error and does nothing.
     function _tryEjectOperator(address operator, bytes memory quorums) internal {
-        address registryCoordinator = IEigenDADirectory(_addressDirectory).getAddress(
-            AddressDirectoryConstants.REGISTRY_COORDINATOR_NAME.getKey()
-        );
+        address registryCoordinator = IEigenDADirectory(_addressDirectory)
+            .getAddress(AddressDirectoryConstants.REGISTRY_COORDINATOR_NAME.getKey());
         try IRegistryCoordinator(registryCoordinator).ejectOperator(operator, quorums) {} catch {}
     }
 
@@ -243,8 +242,8 @@ contract EigenDAEjectionManager is IEigenDAEjectionManager, IEigenDASemVer {
         BN254.G2Point memory apkG2,
         BN254.G1Point memory sigma
     ) internal view {
-        address signatureVerifier =
-            IEigenDADirectory(_addressDirectory).getAddress(AddressDirectoryConstants.SERVICE_MANAGER_NAME.getKey());
+        address signatureVerifier = IEigenDADirectory(_addressDirectory)
+            .getAddress(AddressDirectoryConstants.SERVICE_MANAGER_NAME.getKey());
         (bool paired, bool valid) =
             BLSSignatureChecker(signatureVerifier).trySignatureAndApkVerification(messageHash, apk, apkG2, sigma);
         require(paired, "EigenDAEjectionManager: Pairing failed");
@@ -254,8 +253,9 @@ contract EigenDAEjectionManager is IEigenDAEjectionManager, IEigenDASemVer {
     function _onlyOwner(address sender) internal view virtual {
         require(
             IAccessControl(
-                IEigenDADirectory(_addressDirectory).getAddress(AddressDirectoryConstants.ACCESS_CONTROL_NAME.getKey())
-            ).hasRole(AccessControlConstants.OWNER_ROLE, sender),
+                    IEigenDADirectory(_addressDirectory)
+                        .getAddress(AddressDirectoryConstants.ACCESS_CONTROL_NAME.getKey())
+                ).hasRole(AccessControlConstants.OWNER_ROLE, sender),
             "EigenDAEjectionManager: Caller is not the owner"
         );
     }
@@ -263,8 +263,9 @@ contract EigenDAEjectionManager is IEigenDAEjectionManager, IEigenDASemVer {
     function _onlyEjector(address sender) internal view virtual {
         require(
             IAccessControl(
-                IEigenDADirectory(_addressDirectory).getAddress(AddressDirectoryConstants.ACCESS_CONTROL_NAME.getKey())
-            ).hasRole(AccessControlConstants.EJECTOR_ROLE, sender),
+                    IEigenDADirectory(_addressDirectory)
+                        .getAddress(AddressDirectoryConstants.ACCESS_CONTROL_NAME.getKey())
+                ).hasRole(AccessControlConstants.EJECTOR_ROLE, sender),
             "EigenDAEjectionManager: Caller is not an ejector"
         );
     }

--- a/contracts/test/MockEigenDADeployer.sol
+++ b/contracts/test/MockEigenDADeployer.sol
@@ -154,8 +154,7 @@ contract MockEigenDADeployer is BLSMockAVSDeployer {
         paymentVaultImplementation = PaymentVault(payable(address(new PaymentVault())));
 
         paymentVault = PaymentVault(
-            payable(
-                address(
+            payable(address(
                     new TransparentUpgradeableProxy(
                         address(paymentVaultImplementation),
                         address(proxyAdmin),
@@ -170,8 +169,7 @@ contract MockEigenDADeployer is BLSMockAVSDeployer {
                             globalRatePeriodInterval
                         )
                     )
-                )
-            )
+                ))
         );
 
         mockToken = new ERC20("Mock Token", "MOCK");
@@ -250,13 +248,16 @@ contract MockEigenDADeployer is BLSMockAVSDeployer {
             if (i < 2) {
                 blobHeader.quorumBlobParams[i].quorumNumber = uint8(i);
             } else {
-                blobHeader.quorumBlobParams[i].quorumNumber = uint8(
-                    uint256(
-                        keccak256(
-                            abi.encodePacked(pseudoRandomNumber, "blobHeader.quorumBlobParams[i].quorumNumber", i)
-                        )
-                    )
-                ) % 192;
+                blobHeader.quorumBlobParams[i].quorumNumber =
+                    uint8(
+                            uint256(
+                                keccak256(
+                                    abi.encodePacked(
+                                        pseudoRandomNumber, "blobHeader.quorumBlobParams[i].quorumNumber", i
+                                    )
+                                )
+                            )
+                        ) % 192;
 
                 // make sure it isn't already used
                 while (quorumNumbersUsed[blobHeader.quorumBlobParams[i].quorumNumber]) {
@@ -266,15 +267,19 @@ contract MockEigenDADeployer is BLSMockAVSDeployer {
                 quorumNumbersUsed[blobHeader.quorumBlobParams[i].quorumNumber] = true;
             }
 
-            blobHeader.quorumBlobParams[i].adversaryThresholdPercentage = eigenDAThresholdRegistry
-                .getQuorumAdversaryThresholdPercentage(blobHeader.quorumBlobParams[i].quorumNumber);
+            blobHeader.quorumBlobParams[i].adversaryThresholdPercentage =
+                eigenDAThresholdRegistry.getQuorumAdversaryThresholdPercentage(
+                    blobHeader.quorumBlobParams[i].quorumNumber
+                );
             blobHeader.quorumBlobParams[i].chunkLength = uint32(
                 uint256(
                     keccak256(abi.encodePacked(pseudoRandomNumber, "blobHeader.quorumBlobParams[i].chunkLength", i))
                 )
             );
-            blobHeader.quorumBlobParams[i].confirmationThresholdPercentage = eigenDAThresholdRegistry
-                .getQuorumConfirmationThresholdPercentage(blobHeader.quorumBlobParams[i].quorumNumber);
+            blobHeader.quorumBlobParams[i].confirmationThresholdPercentage =
+                eigenDAThresholdRegistry.getQuorumConfirmationThresholdPercentage(
+                    blobHeader.quorumBlobParams[i].quorumNumber
+                );
         }
         // mark all quorum numbers as unused
         for (uint256 i = 0; i < numQuorumsBlobParams; i++) {

--- a/contracts/test/mock/MockStakeRegistry.sol
+++ b/contracts/test/mock/MockStakeRegistry.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import {IDelegationManager} from
-    "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {
+    IDelegationManager
+} from "lib/eigenlayer-middleware/lib/eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 
 pragma solidity =0.8.12;
 

--- a/contracts/test/unit/EigenDABlobUtilsV1Unit.t.sol
+++ b/contracts/test/unit/EigenDABlobUtilsV1Unit.t.sol
@@ -3,8 +3,9 @@ pragma solidity =0.8.12;
 
 import "../MockEigenDADeployer.sol";
 import {EigenDACertVerifierV1} from "src/integrations/cert/legacy/v1/EigenDACertVerifierV1.sol";
-import {EigenDACertVerificationV1Lib as CertV1Lib} from
-    "src/integrations/cert/legacy/v1/EigenDACertVerificationV1Lib.sol";
+import {
+    EigenDACertVerificationV1Lib as CertV1Lib
+} from "src/integrations/cert/legacy/v1/EigenDACertVerificationV1Lib.sol";
 import {EigenDATypesV1 as DATypesV1} from "src/core/libraries/v1/EigenDATypesV1.sol";
 import {IEigenDABatchMetadataStorage} from "src/core/interfaces/IEigenDABatchMetadataStorage.sol";
 
@@ -49,9 +50,8 @@ contract EigenDABlobUtilsV1Unit is MockEigenDADeployer {
         batchMetadata.signatoryRecordHash = keccak256(abi.encodePacked("signatoryRecordHash"));
         batchMetadata.confirmationBlockNumber = defaultConfirmationBlockNumber;
 
-        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)").with_key(
-            defaultBatchId
-        ).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
+        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)")
+            .with_key(defaultBatchId).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
 
         DATypesV1.BlobVerificationProof memory blobVerificationProof;
         blobVerificationProof.batchId = defaultBatchId;
@@ -93,9 +93,8 @@ contract EigenDABlobUtilsV1Unit is MockEigenDADeployer {
         batchMetadata.batchHeader = batchHeader;
         batchMetadata.signatoryRecordHash = keccak256(abi.encodePacked("signatoryRecordHash"));
         batchMetadata.confirmationBlockNumber = defaultConfirmationBlockNumber;
-        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)").with_key(
-            defaultBatchId
-        ).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
+        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)")
+            .with_key(defaultBatchId).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
         DATypesV1.BlobVerificationProof[] memory blobVerificationProofs = new DATypesV1.BlobVerificationProof[](2);
         blobVerificationProofs[0].batchId = defaultBatchId;
         blobVerificationProofs[1].batchId = defaultBatchId;
@@ -143,9 +142,8 @@ contract EigenDABlobUtilsV1Unit is MockEigenDADeployer {
         // add dummy batch metadata
         DATypesV1.BatchMetadata memory batchMetadata;
 
-        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)").with_key(
-            defaultBatchId
-        ).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
+        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)")
+            .with_key(defaultBatchId).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
 
         DATypesV1.BlobVerificationProof memory blobVerificationProof;
         blobVerificationProof.batchId = defaultBatchId;
@@ -183,9 +181,8 @@ contract EigenDABlobUtilsV1Unit is MockEigenDADeployer {
         batchMetadata.signatoryRecordHash = keccak256(abi.encodePacked("signatoryRecordHash"));
         batchMetadata.confirmationBlockNumber = defaultConfirmationBlockNumber;
 
-        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)").with_key(
-            defaultBatchId
-        ).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
+        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)")
+            .with_key(defaultBatchId).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
 
         DATypesV1.BlobVerificationProof memory blobVerificationProof;
         blobVerificationProof.batchId = defaultBatchId;
@@ -229,9 +226,8 @@ contract EigenDABlobUtilsV1Unit is MockEigenDADeployer {
         batchMetadata.signatoryRecordHash = keccak256(abi.encodePacked("signatoryRecordHash"));
         batchMetadata.confirmationBlockNumber = defaultConfirmationBlockNumber;
 
-        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)").with_key(
-            defaultBatchId
-        ).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
+        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)")
+            .with_key(defaultBatchId).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
 
         DATypesV1.BlobVerificationProof memory blobVerificationProof;
         blobVerificationProof.batchId = defaultBatchId;
@@ -275,9 +271,8 @@ contract EigenDABlobUtilsV1Unit is MockEigenDADeployer {
         batchMetadata.signatoryRecordHash = keccak256(abi.encodePacked("signatoryRecordHash"));
         batchMetadata.confirmationBlockNumber = defaultConfirmationBlockNumber;
 
-        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)").with_key(
-            defaultBatchId
-        ).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
+        stdstore.target(address(eigenDAServiceManager)).sig("batchIdToBatchMetadataHash(uint32)")
+            .with_key(defaultBatchId).checked_write(CertV1Lib.hashBatchMetadata(batchMetadata));
 
         DATypesV1.BlobVerificationProof memory blobVerificationProof;
         blobVerificationProof.batchId = defaultBatchId;

--- a/contracts/test/unit/EigenDARelayRegistryUnit.t.sol
+++ b/contracts/test/unit/EigenDARelayRegistryUnit.t.sol
@@ -18,8 +18,7 @@ contract EigenDARelayRegistryUnit is MockEigenDADeployer {
 
     function test_addRelayInfo() public {
         DATypesV2.RelayInfo memory relayInfo = DATypesV2.RelayInfo({
-            relayAddress: address(uint160(uint256(keccak256(abi.encodePacked("relay"))))),
-            relayURL: "https://relay.com"
+            relayAddress: address(uint160(uint256(keccak256(abi.encodePacked("relay"))))), relayURL: "https://relay.com"
         });
 
         vm.expectEmit(address(eigenDARelayRegistry));
@@ -35,8 +34,7 @@ contract EigenDARelayRegistryUnit is MockEigenDADeployer {
 
     function test_addRelayInfo_revert_notOwner() public {
         DATypesV2.RelayInfo memory relayInfo = DATypesV2.RelayInfo({
-            relayAddress: address(uint160(uint256(keccak256(abi.encodePacked("relay"))))),
-            relayURL: "https://relay.com"
+            relayAddress: address(uint160(uint256(keccak256(abi.encodePacked("relay"))))), relayURL: "https://relay.com"
         });
 
         vm.expectRevert("Ownable: caller is not the owner");

--- a/mise.toml
+++ b/mise.toml
@@ -38,9 +38,9 @@ protoc-gen-go-grpc = "v1.3.0"
 "go:github.com/segmentio/golines" = "0.12.0"
 
 # Forge Dependencies
-forge = "v1.0.0"
-cast = "v1.0.0"
-anvil = "v1.0.0"
+forge = "v1.4.2"
+cast = "v1.4.2"
+anvil = "v1.4.2"
 
 [alias]
 forge = "ubi:foundry-rs/foundry[exe=forge]"


### PR DESCRIPTION
## Why are these changes needed?

* We are out of date on the foundry dependency in mise
* Lint definitions are old
* Etherscan API used is deprecated
* New chain definitions are missing

## Additional Changes

Because of new lint changes in foundry that are enforced in CI, the following non-breaking modifications were done to the contracts.

* forge fmt was run again
* booleans used in ERC20 transfer calls are checked in the PaymentVault (which is not currently planned to be upgraded or deployed again)


## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
