### PR TITLE
chore(dataapi): fixes flaky TestFetchOperatorDispersalFeed test

### DIFF
--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -275,20 +275,20 @@ const (
 
 func executeRequest(t *testing.T, router *gin.Engine, method, url string) *httptest.ResponseRecorder {
 	t.Helper()
-	
+
 	var lastResponse *httptest.ResponseRecorder
-	
+
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(method, url, nil)
 		router.ServeHTTP(w, req)
-		
+
 		if w.Code == http.StatusOK {
 			return w
 		}
-		
+
 		lastResponse = w
-		
+
 		// Retry only on specific network-related 500 errors from localstack
 		if w.Code == http.StatusInternalServerError && isLocalstackNetworkError(w) {
 			if attempt < maxRetries-1 {
@@ -297,12 +297,12 @@ func executeRequest(t *testing.T, router *gin.Engine, method, url string) *httpt
 				continue
 			}
 		}
-		
+
 		// Non-retryable error or final attempt
 		break
 	}
-	
-	require.Equal(t, http.StatusOK, lastResponse.Code, 
+
+	require.Equal(t, http.StatusOK, lastResponse.Code,
 		"Request failed after %d attempts. Response: %s", maxRetries, lastResponse.Body.String())
 	return lastResponse
 }


### PR DESCRIPTION
TestFetchOperatorDispersalFeed test is flaky due to the test expecting HTTP 200 responses but getting 500s when localstack DynamoDB connections drop temporarily.

```
[GIN] 2025/10/20 - 17:34:08 | 500 |   24.909607ms |       192.0.2.1 | GET      "/v2/operators/.../dispersals?limit=0&direction=backward"
Error #01: failed to fetch dispersals from blob metadata store: ... read tcp 127.0.0.1:44208->127.0.0.1:4574: use of closed network connection
```
Adds retry logic to the executeRequest test helper that retries specifically on the "use of closed network connection" error pattern. Other errors continue to fail immediately.

## Why are these changes needed?

Unblocks yak shaving PR's that are failing merge queue