### PR TITLE
refactor(kzg): remove duplicate CeilIntPowerOf2Num function

### DIFF
--- a/encoding/v1/kzg/prover/gnark/multiframe_proof.go
+++ b/encoding/v1/kzg/prover/gnark/multiframe_proof.go
@@ -3,7 +3,6 @@ package gnark
 import (
 	"fmt"
 	"log/slog"
-	"math"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/encoding/v1/fft"
@@ -175,12 +174,4 @@ func (p *KzgMultiProofGnarkBackend) GetSlicesCoeff(polyFr []fr.Element, dimE, j,
 		return nil, err
 	}
 	return tm.GetFFTCoeff()
-}
-
-/*
-returns the power of 2 which is immediately bigger than the input
-*/
-func CeilIntPowerOf2Num(d uint64) uint64 {
-	nextPower := math.Ceil(math.Log2(float64(d)))
-	return uint64(math.Pow(2.0, nextPower))
 }


### PR DESCRIPTION

## **Description:**

Remove duplicate implementation of "next power of 2" logic that already exists in `common/math` package. The `CeilIntPowerOf2Num` function in the gnark backend was unused and duplicated functionality available in `common/math.NextPowOf2u64`.

## Changes

- Remove unused `CeilIntPowerOf2Num` function from `encoding/v1/kzg/prover/gnark/multiframe_proof.go`
- Remove unused `math` import
- Consolidate power-of-2 logic to use existing `common/math.NextPowOf2u64` implementation

