### PR TITLE
doc(proxy): Add Ethereum RPC failover note to proxy README

### DIFF
--- a/api/proxy/README.md
+++ b/api/proxy/README.md
@@ -384,7 +384,7 @@ A normal (non-archival) Ethereum node is sufficient for running the proxy with c
 1. immutable (eg: [securityThresholds](https://github.com/Layr-Labs/eigenda/blob/a6dd724acdf732af483fd2d9a86325febe7ebdcd/contracts/src/core/EigenDAThresholdRegistryStorage.sol#L30)), or
 2. are upgradeable but have all the historical versions available in contract storage (eg: [versioninedBlobParams](https://github.com/Layr-Labs/eigenda/blob/a6dd724acdf732af483fd2d9a86325febe7ebdcd/contracts/src/core/EigenDAThresholdRegistryStorage.sol#L27))
 
-The proxy interacts with a single RPC endpoint. Load-balancing and/or failover behaviour should be handled by an external proxy, e.g: [erpc](https://github.com/erpc/erpc)
+The proxy interacts with a single RPC endpoint. Load-balancing and/or failover behavior should be handled by an external proxy, e.g: [erpc](https://github.com/erpc/erpc)
 
 #### SRS Points
 


### PR DESCRIPTION
Closes DAINT-789

Adds a note to the Ethereum Node section of the proxy README clarifying that ethereum RPC load-balancing and failover behavior should be handled by an external proxy.
