### PR TITLE
docs: add recency window special case when 0 case to the spec

### DIFF
--- a/docs/spec/src/integration/spec/6-secure-integration.md
+++ b/docs/spec/src/integration/spec/6-secure-integration.md
@@ -145,6 +145,8 @@ For the ~7-day challenge window overlaps EigenDA availability, we assume there i
 
 In the diagram, the top row shows L1 blocks every 12 s; the smaller squares are L2 blocks every 2 s. Yellow labels mark key artifacts across the batching pipeline: batches → channel → EigenDA blob. Dispersal completes between t=12 s and t=24 s. The resulting certificate has RBN equal to the L1 block at t=0 (two L1 blocks earlier). The cert is then submitted to L1 at t=24 s. Green annotations show the generalized L2→L1 submission, with batches posted to the adjacent L1 block.
 
+However, if the RecencyWindowSize is configured to be 0, the entire recency check is skipped. It is strongly not recommended to set it to 0, as it allows a malicious or misbehaving batcher to submit an AltDACommitment whose blob has been pruned by the DA network.
+
 ### 2. Cert Validation
 
 Cert validation is done inside the `EigenDACertVerifier` contract, which EigenDA deploys as-is, but is also available for rollups to modify and deploy on their own. Specifically, [checkDACert](https://github.com/Layr-Labs/eigenda/blob/2414ed6f11bd28bc631eab4da3d6b576645801b0/contracts/src/periphery/cert/EigenDACertVerifier.sol#L46-L56) is the entry point for validation. This could either be called during a normal eth transaction (either for pessimistic “bridging” like EigenDA V1 used to do, or when uploading a Blob Field Element to a one-step-proof’s [preimage contract](https://specs.optimism.io/fault-proof/index.html#pre-image-oracle)), or be zk proven using a library like [Steel](https://docs.beboundless.xyz/developers/steel/what-is-steel) and [Sp1CC](https://succinctlabs.github.io/sp1-contract-call/).


### PR DESCRIPTION
## Why are these changes needed?

When recency is 0, the recency check is skipped on proxy and hokulea, and this should be documented.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
