### PR TITLE
docs: relax encoded paylaod padding

### DIFF
--- a/docs/spec/src/integration/spec/3-data-structs.md
+++ b/docs/spec/src/integration/spec/3-data-structs.md
@@ -24,7 +24,7 @@ The header carries metadata needed to decode back to the original payload. Becau
 
 Version 0x0 specifies the following transformation from the original payload to a sequence of field element:
 - For every 31 bytes of the payload, insert a zero byte to produce a 32-byte value that is a valid field element.
-- Zero-pad the final chunk so the payload length is a multiple of 32 bytes, and ensure the encoded payload comprises a power-of-two number of 32-byte field elements (32, 64, 128, 256, …) to match EigenDA blob sizing.
+- Pad the final chunk so the payload length is a multiple of 32 bytes, and ensure the encoded payload comprises a power-of-two number of 32-byte field elements (32, 64, 128, 256, …) to match EigenDA blob sizing. We recommend to use 0 for all padding for encoded payload.
 
 ```solidity
 [0x00, version_byte, big-endian uint32 len(payload), 0x00, 0x00,...] +


### PR DESCRIPTION
## Why are these changes needed?

Currently in proxy and in hokulea, we don't check if all the padding in encoded payload are zero. We simply removed them, as the result we should relax our spec, but recommend to use zero padding.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
