### PR TITLE
fix: remove obsolete EthRpcUrlsVar reference from comment

### DIFF
--- a/test/v2/client/test_client_config.go
+++ b/test/v2/client/test_client_config.go
@@ -23,8 +23,6 @@ type TestClientConfig struct {
 	// The disperser's port
 	DisperserPort int `docs:"required"`
 	// The URL(s) to point the eth client to
-	//
-	// Either this or EthRpcUrlsVar must be set. If both are set, EthRpcUrls is used.
 	EthRpcUrls []string `docs:"required"`
 	// The contract address for the EigenDA address directory, where all contract addresses are stored
 	ContractDirectoryAddress string `docs:"required"`


### PR DESCRIPTION
## Why are these changes needed?

Found an outdated comment in `TestClientConfig` that mentions `EthRpcUrlsVar` - a field that doesn't actually exist in the struct. This was probably left over from some refactoring. 

The comment is confusing since it suggests there are two ways to configure RPC URLs, but only `EthRpcUrls` is actually available.

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(
