### PR TITLE
refactor(inabox): Refactor disperser harness so that only SetupDisperserHarness modifies the harness

### DIFF
--- a/inabox/tests/setup_disperser_harness.go
+++ b/inabox/tests/setup_disperser_harness.go
@@ -100,6 +100,11 @@ type DisperserHarness struct {
 	ControllerServer *server.Server
 }
 
+// TODO: Consider refactoring these component structs into the underlying packages (relay, encoder, controller,
+// apiserver). This would reduce maintenance burden on tests - if the production code changes, the component structs
+// would be updated alongside it. Currently these exist here because production code runs each service as a separate
+// binary, while the test harness runs them as goroutines and needs to return/track the created objects.
+
 // RelayComponents contains the components created by startRelays
 type RelayComponents struct {
 	Servers []*relay.Server


### PR DESCRIPTION
## Why are these changes needed?

Small refactor to make it so that only `SetupDisperserHarness` modifies the disperser harness. The rest of the setup functions simply return the objects created.

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
