### PR TITLE
feat(proxy): Support multi-serialization (ABI, RLP)

### DIFF
--- a/api/clients/v2/coretypes/eigenda_cert.go
+++ b/api/clients/v2/coretypes/eigenda_cert.go
@@ -1,6 +1,7 @@
 package coretypes
 
 import (
+	"encoding/json"
 	"fmt"
 
 	disperser "github.com/Layr-Labs/eigenda/api/grpc/disperser/v2"
@@ -71,6 +72,19 @@ type EigenDACert interface {
 	// For the theoretical reasoning behind this choice, see
 	// https://www.tedinski.com/2018/02/27/the-expression-problem.html
 	isEigenDACert()
+}
+
+// DeserializeEigenDACert deserializes raw bytes into an EigenDACert
+// based on the provided version and serialization type
+func DeserializeEigenDACert(data []byte, version CertificateVersion, ct CertSerializationType) (EigenDACert, error) {
+	switch version {
+	case VersionTwoCert:
+		return DeserializeEigenDACertV2(data, ct)
+	case VersionThreeCert:
+		return DeserializeEigenDACertV3(data, ct)
+	default:
+		return nil, fmt.Errorf("unsupported certificate version: %d", version)
+	}
 }
 
 var _ EigenDACert = &EigenDACertV2{}
@@ -183,6 +197,63 @@ func (c *EigenDACertV3) Serialize(ct CertSerializationType) ([]byte, error) {
 		return nil, fmt.Errorf("unknown serialization type: %d", ct)
 	}
 
+}
+
+// DeserializeEigenDACertV2 deserializes raw bytes into an EigenDACertV2
+func DeserializeEigenDACertV2(data []byte, ct CertSerializationType) (*EigenDACertV3, error) {
+	switch ct {
+	case CertSerializationRLP:
+		var cert EigenDACertV2
+		if err := rlp.DecodeBytes(data, &cert); err != nil {
+			return nil, fmt.Errorf("rlp decode v2 cert: %w", err)
+		}
+
+		return cert.ToV3(), nil
+
+	case CertSerializationABI:
+		return nil, fmt.Errorf("abi encoding is not supported for legacy v2 cert")
+
+	default:
+		return nil, fmt.Errorf("unknown serialization type: %d", ct)
+	}
+}
+
+// DeserializeEigenDACertV3 deserializes raw bytes into an EigenDACertV3 provided the serialization
+// standard being used
+func DeserializeEigenDACertV3(data []byte, ct CertSerializationType) (*EigenDACertV3, error) {
+	switch ct {
+	case CertSerializationRLP:
+		var cert EigenDACertV3
+		if err := rlp.DecodeBytes(data, &cert); err != nil {
+			return nil, fmt.Errorf("rlp decode v3 cert: %w", err)
+		}
+		return &cert, nil
+
+	case CertSerializationABI:
+		abiMap := make(map[string]interface{})
+		err := v3CertTypeEncodeArgs.UnpackIntoMap(abiMap, data)
+		if err != nil {
+			return nil, fmt.Errorf("unpacking from encoding ABI: %w", err)
+		}
+
+		// use json as intermediary to cast abstract type to bytes to
+		// then deserialize into structured certificate type
+		bytes, err := json.Marshal(abiMap["cert"])
+		if err != nil {
+			return nil, fmt.Errorf("marshalling ABI arg into bytes: %w", err)
+		}
+
+		var cert *EigenDACertV3
+		err = json.Unmarshal(bytes, &cert)
+		if err != nil {
+			return nil, fmt.Errorf("json unmarshal v3 cert: %w", err)
+		}
+
+		return cert, nil
+
+	default:
+		return nil, fmt.Errorf("unknown serialization type: %d", ct)
+	}
 }
 
 // Commitments returns the blob's cryptographic kzg commitments

--- a/api/clients/v2/coretypes/eigenda_cert_test.go
+++ b/api/clients/v2/coretypes/eigenda_cert_test.go
@@ -1,0 +1,231 @@
+package coretypes_test
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
+	contractEigenDACertVerifierV2 "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifierV2"
+	certTypesBinding "github.com/Layr-Labs/eigenda/contracts/bindings/IEigenDACertTypeBindings"
+	coreV2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEigenDACertV3_RLPEncodeDecode tests that V3 certificates can be RLP encoded and decoded successfully
+func TestEigenDACertV3_RLPEncodeDecode(t *testing.T) {
+	// Create a sample V3 certificate
+	cert := createSampleEigenDACertV3()
+
+	// Serialize using RLP
+	encoded, err := cert.Serialize(coretypes.CertSerializationRLP)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	// Deserialize using RLP
+	decoded, err := coretypes.DeserializeEigenDACertV3(encoded, coretypes.CertSerializationRLP)
+	require.NoError(t, err)
+	require.NotNil(t, decoded)
+
+	// Verify the decoded certificate matches the original
+	assertCertV3Equal(t, cert, decoded)
+}
+
+// TestEigenDACertV3_ABIEncodeDecode tests that V3 certificates can be ABI encoded and decoded successfully
+func TestEigenDACertV3_ABIEncodeDecode(t *testing.T) {
+	// Create a sample V3 certificate
+	cert := createSampleEigenDACertV3()
+
+	// Serialize using ABI
+	encoded, err := cert.Serialize(coretypes.CertSerializationABI)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	// Deserialize using ABI
+	decoded, err := coretypes.DeserializeEigenDACertV3(encoded, coretypes.CertSerializationABI)
+	require.NoError(t, err)
+	require.NotNil(t, decoded)
+
+	// Verify the decoded certificate matches the original
+	assertCertV3Equal(t, cert, decoded)
+}
+
+// TestDeserializeEigenDACert tests the generic deserialization function
+func TestDeserializeEigenDACert(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     coretypes.CertificateVersion
+		createCert  func() coretypes.EigenDACert
+		serialType  coretypes.CertSerializationType
+		shouldError bool
+	}{
+		{
+			name:        "V3 RLP",
+			version:     coretypes.VersionThreeCert,
+			createCert:  func() coretypes.EigenDACert { return createSampleEigenDACertV3() },
+			serialType:  coretypes.CertSerializationRLP,
+			shouldError: false,
+		},
+		{
+			name:        "V3 ABI",
+			version:     coretypes.VersionThreeCert,
+			createCert:  func() coretypes.EigenDACert { return createSampleEigenDACertV3() },
+			serialType:  coretypes.CertSerializationABI,
+			shouldError: false,
+		},
+		{
+			name:        "V2 ABI",
+			version:     coretypes.VersionTwoCert,
+			createCert:  func() coretypes.EigenDACert { return createSampleEigenDACertV2() },
+			shouldError: false,
+		},
+		{
+			name:        "Unsupported version",
+			version:     0xFF,
+			createCert:  func() coretypes.EigenDACert { return createSampleEigenDACertV3() },
+			serialType:  coretypes.CertSerializationRLP,
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldError {
+				// Test unsupported version
+				_, err := coretypes.DeserializeEigenDACert([]byte{}, tt.version, tt.serialType)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unsupported certificate version")
+				return
+			}
+
+			cert := tt.createCert()
+			encoded, err := cert.Serialize(tt.serialType)
+			require.NoError(t, err)
+
+			decoded, err := coretypes.DeserializeEigenDACert(encoded, tt.version, tt.serialType)
+			require.NoError(t, err)
+			require.NotNil(t, decoded)
+		})
+	}
+}
+
+// Helper functions to create sample certificates for testing
+func createSampleEigenDACertV2() *coretypes.EigenDACertV2 {
+	return &coretypes.EigenDACertV2{
+		BlobInclusionInfo: contractEigenDACertVerifierV2.EigenDATypesV2BlobInclusionInfo{
+			BlobCertificate: contractEigenDACertVerifierV2.EigenDATypesV2BlobCertificate{
+				BlobHeader: contractEigenDACertVerifierV2.EigenDATypesV2BlobHeaderV2{
+					Version:       1,
+					QuorumNumbers: []byte{0, 1},
+					Commitment: contractEigenDACertVerifierV2.EigenDATypesV2BlobCommitment{
+						Commitment: contractEigenDACertVerifierV2.BN254G1Point{
+							X: big.NewInt(12345),
+							Y: big.NewInt(67890),
+						},
+						LengthCommitment: contractEigenDACertVerifierV2.BN254G2Point{
+							X: [2]*big.Int{big.NewInt(111), big.NewInt(222)},
+							Y: [2]*big.Int{big.NewInt(333), big.NewInt(444)},
+						},
+						LengthProof: contractEigenDACertVerifierV2.BN254G2Point{
+							X: [2]*big.Int{big.NewInt(555), big.NewInt(666)},
+							Y: [2]*big.Int{big.NewInt(777), big.NewInt(888)},
+						},
+						Length: 1024,
+					},
+					PaymentHeaderHash: [32]byte{1, 2, 3},
+				},
+				Signature: []byte{10, 20, 30},
+				RelayKeys: []coreV2.RelayKey{1, 2, 3},
+			},
+			BlobIndex:      5,
+			InclusionProof: []byte{40, 50, 60},
+		},
+		BatchHeader: contractEigenDACertVerifierV2.EigenDATypesV2BatchHeaderV2{
+			BatchRoot:            [32]byte{4, 5, 6},
+			ReferenceBlockNumber: 12345,
+		},
+		NonSignerStakesAndSignature: contractEigenDACertVerifierV2.EigenDATypesV1NonSignerStakesAndSignature{
+			NonSignerQuorumBitmapIndices: []uint32{0, 1},
+			NonSignerPubkeys: []contractEigenDACertVerifierV2.BN254G1Point{
+				{X: big.NewInt(100), Y: big.NewInt(200)},
+			},
+			QuorumApks: []contractEigenDACertVerifierV2.BN254G1Point{
+				{X: big.NewInt(300), Y: big.NewInt(400)},
+			},
+			ApkG2: contractEigenDACertVerifierV2.BN254G2Point{
+				X: [2]*big.Int{big.NewInt(500), big.NewInt(600)},
+				Y: [2]*big.Int{big.NewInt(700), big.NewInt(800)},
+			},
+			Sigma: contractEigenDACertVerifierV2.BN254G1Point{
+				X: big.NewInt(900),
+				Y: big.NewInt(1000),
+			},
+			QuorumApkIndices:      []uint32{0},
+			TotalStakeIndices:     []uint32{0},
+			NonSignerStakeIndices: [][]uint32{{0}},
+		},
+		SignedQuorumNumbers: []byte{0, 1},
+	}
+}
+
+func createSampleEigenDACertV3() *coretypes.EigenDACertV3 {
+	return &coretypes.EigenDACertV3{
+		BlobInclusionInfo: certTypesBinding.EigenDATypesV2BlobInclusionInfo{
+			BlobCertificate: certTypesBinding.EigenDATypesV2BlobCertificate{
+				BlobHeader: certTypesBinding.EigenDATypesV2BlobHeaderV2{
+					Version:       1,
+					QuorumNumbers: []byte{0, 1},
+					Commitment: certTypesBinding.EigenDATypesV2BlobCommitment{
+						Commitment: certTypesBinding.BN254G1Point{
+							X: big.NewInt(12345),
+							Y: big.NewInt(67890),
+						},
+						LengthCommitment: certTypesBinding.BN254G2Point{
+							X: [2]*big.Int{big.NewInt(111), big.NewInt(222)},
+							Y: [2]*big.Int{big.NewInt(333), big.NewInt(444)},
+						},
+						LengthProof: certTypesBinding.BN254G2Point{
+							X: [2]*big.Int{big.NewInt(555), big.NewInt(666)},
+							Y: [2]*big.Int{big.NewInt(777), big.NewInt(888)},
+						},
+						Length: 1024,
+					},
+					PaymentHeaderHash: [32]byte{1, 2, 3},
+				},
+				Signature: []byte{10, 20, 30},
+				RelayKeys: []coreV2.RelayKey{1, 2, 3},
+			},
+			BlobIndex:      5,
+			InclusionProof: []byte{40, 50, 60},
+		},
+		BatchHeader: certTypesBinding.EigenDATypesV2BatchHeaderV2{
+			BatchRoot:            [32]byte{4, 5, 6},
+			ReferenceBlockNumber: 12345,
+		},
+		NonSignerStakesAndSignature: certTypesBinding.EigenDATypesV1NonSignerStakesAndSignature{
+			NonSignerQuorumBitmapIndices: []uint32{0, 1},
+			NonSignerPubkeys: []certTypesBinding.BN254G1Point{
+				{X: big.NewInt(100), Y: big.NewInt(200)},
+			},
+			QuorumApks: []certTypesBinding.BN254G1Point{
+				{X: big.NewInt(300), Y: big.NewInt(400)},
+			},
+			ApkG2: certTypesBinding.BN254G2Point{
+				X: [2]*big.Int{big.NewInt(500), big.NewInt(600)},
+				Y: [2]*big.Int{big.NewInt(700), big.NewInt(800)},
+			},
+			Sigma: certTypesBinding.BN254G1Point{
+				X: big.NewInt(900),
+				Y: big.NewInt(1000),
+			},
+			QuorumApkIndices:      []uint32{0},
+			TotalStakeIndices:     []uint32{0},
+			NonSignerStakeIndices: [][]uint32{{0}},
+		},
+		SignedQuorumNumbers: []byte{0, 1},
+	}
+}
+
+func assertCertV3Equal(t *testing.T, expected, actual *coretypes.EigenDACertV3) {
+	require.True(t, reflect.DeepEqual(expected, actual))
+}

--- a/api/proxy/common/store.go
+++ b/api/proxy/common/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
 	"github.com/Layr-Labs/eigenda/api/proxy/common/types/certs"
 )
 
@@ -103,15 +104,21 @@ type EigenDAV1Store interface {
 type EigenDAV2Store interface {
 	Store
 	// Put inserts the given value into the key-value (serializedCert-payload) data store.
-	Put(ctx context.Context, payload []byte) (serializedCert []byte, err error)
+	Put(
+		ctx context.Context,
+		payload []byte,
+		serializationType coretypes.CertSerializationType,
+	) (serializedCert []byte, err error)
 	// Get retrieves the given key if it's present in the key-value (serializedCert-payload) data store.
 	// If returnEncodedPayload is true, the payload is returned without decoding.
 	Get(ctx context.Context,
 		versionedCert certs.VersionedCert,
+		serializationType coretypes.CertSerializationType,
 		returnEncodedPayload bool,
 	) (payloadOrEncodedPayload []byte, err error)
 	// VerifyCert verifies the cert validity and rbn recency.
-	VerifyCert(ctx context.Context, versionedCert certs.VersionedCert, l1InclusionBlockNum uint64) error
+	VerifyCert(ctx context.Context, versionedCert certs.VersionedCert,
+		serializationType coretypes.CertSerializationType, l1InclusionBlockNum uint64) error
 }
 
 // SecondaryStore is the interface for a key-value data store that uses keccak(value) as the key.

--- a/api/proxy/common/types/certs/eigenda.go
+++ b/api/proxy/common/types/certs/eigenda.go
@@ -2,6 +2,8 @@ package certs
 
 import (
 	"fmt"
+
+	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
 )
 
 // Version byte that prefixes serialized EigenDACert to identify their type.
@@ -26,6 +28,21 @@ func (v VersionByte) VersionByteString() string {
 		return "EigenDA V2 with V3 Cert"
 	default:
 		return fmt.Sprintf("Unknown (0x%02x)", byte(v))
+	}
+}
+
+// IntoCertVersion converts from a version byte into a
+// DA Cert type version enum
+func (v VersionByte) IntoCertVersion() (coretypes.CertificateVersion, error) {
+	switch v {
+	case V0VersionByte:
+		return 0, fmt.Errorf("V0 DA Commit version corresponds to EigenDAV1 which is unsupported for CertVersion")
+	case V1VersionByte:
+		return coretypes.VersionTwoCert, nil
+	case V2VersionByte:
+		return coretypes.VersionThreeCert, nil
+	default:
+		return 0, fmt.Errorf("unknown version byte (0x%02x)", byte(v))
 	}
 }
 

--- a/api/proxy/servers/arbitrum_altda/handlers.go
+++ b/api/proxy/servers/arbitrum_altda/handlers.go
@@ -192,7 +192,7 @@ func (h *Handlers) RecoverPayload(
 		return nil, nil
 	}
 
-	payload, err := h.eigenDAManager.Get(ctx, daCert, proxy_common.GETOpts{})
+	payload, err := h.eigenDAManager.Get(ctx, daCert, coretypes.CertSerializationABI, proxy_common.GETOpts{})
 	if err != nil {
 		var dpError *coretypes.DerivationError
 		if errors.As(err, &dpError) {
@@ -242,10 +242,7 @@ func (h *Handlers) Store(
 		return nil, fmt.Errorf("received empty rollup payload")
 	}
 
-	// TODO: These "certBytes" should be ABI encoded before publishing to SequencerInbox
-	//       since the byte committed to onchain are the same bytes being referenced during the
-	//       one step proof
-	certBytes, err := h.eigenDAManager.Put(ctx, message)
+	certBytes, err := h.eigenDAManager.Put(ctx, message, coretypes.CertSerializationABI)
 	if err != nil {
 		return nil, fmt.Errorf("put rollup payload: %w", err)
 	}
@@ -295,7 +292,8 @@ func (h *Handlers) CollectPreimages(
 		return nil, fmt.Errorf("deserialize cert: %w", err)
 	}
 
-	payload, err := h.eigenDAManager.Get(ctx, daCert, proxy_common.GETOpts{})
+	payload, err := h.eigenDAManager.Get(ctx, daCert,
+		coretypes.CertSerializationABI, proxy_common.GETOpts{})
 	if err != nil {
 		var dpError *coretypes.DerivationError
 		if errors.As(err, &dpError) {

--- a/api/proxy/servers/rest/handlers_cert.go
+++ b/api/proxy/servers/rest/handlers_cert.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
 	"github.com/Layr-Labs/eigenda/api/proxy/common"
 	"github.com/Layr-Labs/eigenda/api/proxy/common/proxyerrors"
 	"github.com/Layr-Labs/eigenda/api/proxy/common/types/certs"
@@ -107,6 +108,7 @@ func (svr *Server) handleGetShared(
 	payloadOrEncodedPayload, err := svr.certMgr.Get(
 		r.Context(),
 		versionedCert,
+		coretypes.CertSerializationRLP,
 		common.GETOpts{
 			L1InclusionBlockNum:  l1InclusionBlockNum,
 			ReturnEncodedPayload: returnEncodedPayload,
@@ -198,7 +200,7 @@ func (svr *Server) handlePostShared(
 		return proxyerrors.NewReadRequestBodyError(err, common.MaxServerPOSTRequestBodySize)
 	}
 
-	serializedCert, err := svr.certMgr.Put(r.Context(), payload)
+	serializedCert, err := svr.certMgr.Put(r.Context(), payload, coretypes.CertSerializationRLP)
 	if err != nil {
 		return fmt.Errorf("post request failed: %w", err)
 	}

--- a/api/proxy/servers/rest/handlers_cert_test.go
+++ b/api/proxy/servers/rest/handlers_cert_test.go
@@ -89,7 +89,7 @@ func TestHandlerGet(t *testing.T) {
 			url:  fmt.Sprintf("/get/0x010000%s", testCommitStr),
 			mockBehavior: func() {
 				mockEigenDAManager.EXPECT().
-					Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, fmt.Errorf("internal error"))
 			},
 			expectedCode: http.StatusInternalServerError,
@@ -100,7 +100,7 @@ func TestHandlerGet(t *testing.T) {
 			url:  fmt.Sprintf("/get/0x010000%s", testCommitStr),
 			mockBehavior: func() {
 				mockEigenDAManager.EXPECT().
-					Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]byte(testCommitStr), nil)
 			},
 			expectedCode: http.StatusOK,
@@ -113,7 +113,7 @@ func TestHandlerGet(t *testing.T) {
 			url:  fmt.Sprintf("/get/0x010000%s?l1_inclusion_block_number=100", testCommitStr),
 			mockBehavior: func() {
 				mockEigenDAManager.EXPECT().
-					Get(gomock.Any(), gomock.Any(), gomock.Eq(common.GETOpts{L1InclusionBlockNum: 100})).
+					Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(common.GETOpts{L1InclusionBlockNum: 100})).
 					Return([]byte(testCommitStr), nil)
 			},
 			expectedCode: http.StatusOK,
@@ -170,6 +170,7 @@ func TestHandlerPutSuccess(t *testing.T) {
 			mockBehavior: func() {
 				mockEigenDAManager.EXPECT().Put(
 					gomock.Any(),
+					gomock.Any(),
 					gomock.Any()).Return([]byte(testCommitStr), nil)
 			},
 			expectedCode: http.StatusOK,
@@ -193,6 +194,7 @@ func TestHandlerPutSuccess(t *testing.T) {
 			body: []byte("some data that will successfully be written to EigenDA"),
 			mockBehavior: func() {
 				mockEigenDAManager.EXPECT().Put(
+					gomock.Any(),
 					gomock.Any(),
 					gomock.Any()).Return([]byte(testCommitStr), nil)
 			},
@@ -290,7 +292,7 @@ func TestHandlerPutErrors(t *testing.T) {
 			t.Run(tt.name+" / "+mode.name, func(t *testing.T) {
 				t.Log(tt.name + " / " + mode.name)
 				mockEigenDAManager.EXPECT().
-					Put(gomock.Any(), gomock.Any()).
+					Put(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, tt.mockEigenDAManagerPutReturnedErr)
 
 				req := httptest.NewRequest(

--- a/api/proxy/store/generated_key/memstore/v2/memstore.go
+++ b/api/proxy/store/generated_key/memstore/v2/memstore.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
 	"github.com/Layr-Labs/eigenda/api/proxy/common"
@@ -179,15 +178,21 @@ func (e *MemStore) generateRandomV3Cert(blobContents []byte) (*coretypes.EigenDA
 // Get fetches a value from the store.
 // If returnEncodedPayload is true, it returns the encoded blob without decoding.
 func (e *MemStore) Get(
-	_ context.Context, versionedCert certs.VersionedCert, returnEncodedPayload bool,
+	_ context.Context,
+	versionedCert certs.VersionedCert,
+	serializationType coretypes.CertSerializationType,
+	returnEncodedPayload bool,
 ) ([]byte, error) {
 	blobSerialized, err := e.FetchEntry(crypto.Keccak256Hash(versionedCert.SerializedCert).Bytes())
 	if err != nil {
 		return nil, fmt.Errorf("fetching entry via memstore: %w", err)
 	}
 
-	var v3cert coretypes.EigenDACertV3
-	err = rlp.DecodeBytes(versionedCert.SerializedCert, &v3cert)
+	v3cert, err := coretypes.DeserializeEigenDACertV3(
+		versionedCert.SerializedCert,
+		serializationType,
+	)
+
 	if err != nil {
 		return nil, coretypes.ErrCertParsingFailedDerivationError
 	}
@@ -216,7 +221,9 @@ func (e *MemStore) Get(
 // ephemeral db key = keccak256(pseudo_random_cert)
 // this is done to verify that a rollup must be able to provide
 // the same certificate used in dispersal for retrieval
-func (e *MemStore) Put(_ context.Context, value []byte) ([]byte, error) {
+func (e *MemStore) Put(
+	_ context.Context, value []byte, serializationType coretypes.CertSerializationType,
+) ([]byte, error) {
 	payload := coretypes.Payload(value)
 
 	blob, err := payload.ToBlob(e.polyForm)
@@ -232,9 +239,9 @@ func (e *MemStore) Put(_ context.Context, value []byte) ([]byte, error) {
 		return nil, fmt.Errorf("generating random cert: %w", err)
 	}
 
-	certBytes, err := artificialV3Cert.Serialize(coretypes.CertSerializationRLP)
+	certBytes, err := artificialV3Cert.Serialize(serializationType)
 	if err != nil {
-		return nil, fmt.Errorf("rlp decode v3 cert: %w", err)
+		return nil, fmt.Errorf("serialize v3 cert: %w", err)
 	}
 
 	err = e.InsertEntry(crypto.Keccak256Hash(certBytes).Bytes(), blobSerialized)
@@ -246,7 +253,7 @@ func (e *MemStore) Put(_ context.Context, value []byte) ([]byte, error) {
 }
 
 func (e *MemStore) VerifyCert(
-	_ context.Context, _ certs.VersionedCert, _ uint64,
+	_ context.Context, _ certs.VersionedCert, _ coretypes.CertSerializationType, _ uint64,
 ) error {
 	return nil
 }

--- a/api/proxy/store/generated_key/memstore/v2/memstore_test.go
+++ b/api/proxy/store/generated_key/memstore/v2/memstore_test.go
@@ -43,17 +43,17 @@ func TestGetSet(t *testing.T) {
 	)
 
 	expected := []byte(testPreimage)
-	key, err := msV2.Put(t.Context(), expected)
+	key, err := msV2.Put(t.Context(), expected, coretypes.CertSerializationRLP)
 	require.NoError(t, err)
 
 	cert := certs.NewVersionedCert(key, coretypes.VersionThreeCert)
 
-	actual, err := msV2.Get(t.Context(), cert, false)
+	actual, err := msV2.Get(t.Context(), cert, coretypes.CertSerializationRLP, false)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 
 	// Test getting the encoded payload
-	encodedPayload, err := msV2.Get(t.Context(), cert, true)
+	encodedPayload, err := msV2.Get(t.Context(), cert, coretypes.CertSerializationRLP, true)
 	require.NoError(t, err)
 	require.NotEqual(t, expected, encodedPayload)
 }

--- a/api/proxy/store/generated_key/v2/eigenda.go
+++ b/api/proxy/store/generated_key/v2/eigenda.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Layr-Labs/eigenda/api/proxy/store/generated_key/utils"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/avast/retry-go/v4"
-	"github.com/ethereum/go-ethereum/rlp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -83,28 +82,24 @@ func NewStore(
 //
 // This function is bug-prone as is because it returns []byte which can either be a raw payload or an encoded payload.
 // TODO: Refactor to use [coretypes.EncodedPayload] and [coretypes.Payload] instead of []byte.
-func (e Store) Get(ctx context.Context, versionedCert certs.VersionedCert, returnEncodedPayload bool) ([]byte, error) {
-	var cert coretypes.EigenDACert
+func (e Store) Get(
+	ctx context.Context,
+	versionedCert certs.VersionedCert,
+	serializationType coretypes.CertSerializationType,
+	returnEncodedPayload bool,
+) ([]byte, error) {
+	certTypeVersion, err := versionedCert.Version.IntoCertVersion()
+	if err != nil {
+		return nil, fmt.Errorf("casting into cert version: %w", err)
+	}
 
-	switch versionedCert.Version {
-	case certs.V0VersionByte, certs.V1VersionByte:
-		var v2Cert coretypes.EigenDACertV2
-		err := rlp.DecodeBytes(versionedCert.SerializedCert, &v2Cert)
-		if err != nil {
-			return nil, fmt.Errorf("RLP decoding EigenDA v2 cert: %w", err)
-		}
-		cert = &v2Cert
-
-	case certs.V2VersionByte:
-		var v3Cert coretypes.EigenDACertV3
-		err := rlp.DecodeBytes(versionedCert.SerializedCert, &v3Cert)
-		if err != nil {
-			return nil, fmt.Errorf("RLP decoding EigenDA v3 cert: %w", err)
-		}
-		cert = &v3Cert
-
-	default:
-		return nil, fmt.Errorf("unknown certificate version: %d", versionedCert.Version)
+	cert, err := coretypes.DeserializeEigenDACert(
+		versionedCert.SerializedCert,
+		certTypeVersion,
+		serializationType,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("deserialize cert: %w", err)
 	}
 
 	// Try each retriever in sequence until one succeeds
@@ -132,9 +127,10 @@ func (e Store) Get(ctx context.Context, versionedCert certs.VersionedCert, retur
 	return nil, fmt.Errorf("all retrievers failed: %w", errors.Join(errs...))
 }
 
-// Put disperses a blob for some pre-image and returns the associated RLP encoded certificate commit.
-// TODO: Client polling for different status codes, Mapping status codes to 503 failover
-func (e Store) Put(ctx context.Context, value []byte) ([]byte, error) {
+// Put disperses a blob for some pre-image and returns the associated certificate commit.
+func (e Store) Put(
+	ctx context.Context, value []byte, serializationType coretypes.CertSerializationType,
+) ([]byte, error) {
 	if e.disperser == nil {
 		return nil, fmt.Errorf("PUT routes are disabled, did you provide a signer private key?")
 	}
@@ -203,7 +199,11 @@ func (e Store) Put(ctx context.Context, value []byte) ([]byte, error) {
 	case *coretypes.EigenDACertV2:
 		return nil, fmt.Errorf("EigenDA V2 certs are not supported anymore, use V3 instead")
 	case *coretypes.EigenDACertV3:
-		return cert.Serialize(coretypes.CertSerializationRLP)
+		serialized, err := cert.Serialize(serializationType)
+		if err != nil {
+			return nil, fmt.Errorf("serialize cert: %w", err)
+		}
+		return serialized, nil
 	default:
 		return nil, fmt.Errorf("unsupported cert version: %T", cert)
 	}
@@ -222,8 +222,8 @@ func (e Store) BackendType() common.BackendType {
 // TODO: this whole function should be upstreamed to a new eigenda VerifyingPayloadRetrieval client
 // that would verify certs, and then retrieve the payloads (from relay with fallback to eigenda validators if needed).
 // Then proxy could remain a very thin server wrapper around eigenda clients.
-func (e Store) VerifyCert(ctx context.Context, versionedCert certs.VersionedCert, l1InclusionBlockNum uint64) error {
-	var referenceBlockNumber uint64
+func (e Store) VerifyCert(ctx context.Context, versionedCert certs.VersionedCert,
+	serializationType coretypes.CertSerializationType, l1InclusionBlockNum uint64) error {
 	var sumDACert coretypes.EigenDACert
 
 	switch versionedCert.Version {
@@ -233,28 +233,25 @@ func (e Store) VerifyCert(ctx context.Context, versionedCert certs.VersionedCert
 			"version 0 byte certs should never be verified by the EigenDA V2 store",
 		)
 
-	case certs.V1VersionByte:
-		// convert v2 eigenda cert to v3 cert type for verification against the forward compatible cert verifier
-		var eigenDACertV2 coretypes.EigenDACertV2
-		err := rlp.DecodeBytes(versionedCert.SerializedCert, &eigenDACertV2)
+	case certs.V1VersionByte, certs.V2VersionByte:
+		certTypeVersion, err := versionedCert.Version.IntoCertVersion()
 		if err != nil {
 			return coretypes.NewCertParsingFailedError(
-				hex.EncodeToString(versionedCert.SerializedCert), fmt.Sprintf("RLP decoding EigenDA v2 cert: %v", err))
+				hex.EncodeToString(versionedCert.SerializedCert), fmt.Sprintf("casting to cert type version: %v", err))
 		}
 
-		referenceBlockNumber = eigenDACertV2.ReferenceBlockNumber()
-		sumDACert = &eigenDACertV2
-
-	case certs.V2VersionByte:
-		var eigenDACertV3 coretypes.EigenDACertV3
-		err := rlp.DecodeBytes(versionedCert.SerializedCert, &eigenDACertV3)
+		cert, err := coretypes.DeserializeEigenDACert(
+			versionedCert.SerializedCert,
+			certTypeVersion,
+			serializationType,
+		)
 		if err != nil {
 			return coretypes.NewCertParsingFailedError(
-				hex.EncodeToString(versionedCert.SerializedCert), fmt.Sprintf("RLP decoding EigenDA v3 cert: %v", err))
+				hex.EncodeToString(versionedCert.SerializedCert),
+				fmt.Sprintf("deserialize EigenDA cert: %v", err))
 		}
 
-		referenceBlockNumber = eigenDACertV3.ReferenceBlockNumber()
-		sumDACert = &eigenDACertV3
+		sumDACert = cert
 
 	default:
 		return coretypes.NewCertParsingFailedError(
@@ -263,7 +260,7 @@ func (e Store) VerifyCert(ctx context.Context, versionedCert certs.VersionedCert
 	}
 
 	// check recency first since it requires less processing and no IO vs verifying the cert
-	err := verifyCertRBNRecencyCheck(referenceBlockNumber, l1InclusionBlockNum, e.rbnRecencyWindowSize)
+	err := verifyCertRBNRecencyCheck(sumDACert.ReferenceBlockNumber(), l1InclusionBlockNum, e.rbnRecencyWindowSize)
 	if err != nil {
 		// Already a structured error converted to a 418 HTTP error by the error middleware.
 		return err

--- a/api/proxy/test/mocks/eigen_da_manager.go
+++ b/api/proxy/test/mocks/eigen_da_manager.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	coretypes "github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
 	common "github.com/Layr-Labs/eigenda/api/proxy/common"
 	certs "github.com/Layr-Labs/eigenda/api/proxy/common/types/certs"
 	gomock "go.uber.org/mock/gomock"
@@ -43,18 +44,18 @@ func (m *MockIEigenDAManager) EXPECT() *MockIEigenDAManagerMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockIEigenDAManager) Get(ctx context.Context, versionedCert certs.VersionedCert, opts common.GETOpts) ([]byte, error) {
+func (m *MockIEigenDAManager) Get(ctx context.Context, versionedCert certs.VersionedCert, serializationType coretypes.CertSerializationType, opts common.GETOpts) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, versionedCert, opts)
+	ret := m.ctrl.Call(m, "Get", ctx, versionedCert, serializationType, opts)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockIEigenDAManagerMockRecorder) Get(ctx, versionedCert, opts any) *gomock.Call {
+func (mr *MockIEigenDAManagerMockRecorder) Get(ctx, versionedCert, serializationType, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockIEigenDAManager)(nil).Get), ctx, versionedCert, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockIEigenDAManager)(nil).Get), ctx, versionedCert, serializationType, opts)
 }
 
 // GetDispersalBackend mocks base method.
@@ -72,18 +73,18 @@ func (mr *MockIEigenDAManagerMockRecorder) GetDispersalBackend() *gomock.Call {
 }
 
 // Put mocks base method.
-func (m *MockIEigenDAManager) Put(ctx context.Context, value []byte) ([]byte, error) {
+func (m *MockIEigenDAManager) Put(ctx context.Context, value []byte, serializationType coretypes.CertSerializationType) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", ctx, value)
+	ret := m.ctrl.Call(m, "Put", ctx, value, serializationType)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockIEigenDAManagerMockRecorder) Put(ctx, value any) *gomock.Call {
+func (mr *MockIEigenDAManagerMockRecorder) Put(ctx, value, serializationType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockIEigenDAManager)(nil).Put), ctx, value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockIEigenDAManager)(nil).Put), ctx, value, serializationType)
 }
 
 // SetDispersalBackend mocks base method.


### PR DESCRIPTION
## Changes
- Adds dynamic encoding through a `serializationType` enum which is passed down the application callstack through each server router implementation
- RLP for REST && ABI for ARB Custom DA
- 50% of this PR is just tests

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
