### PR TITLE
feat(payments): Make sure only authorized dispersers can you on-demand payments

### DIFF
--- a/node/auth/authenticator.go
+++ b/node/auth/authenticator.go
@@ -25,11 +25,11 @@ type RequestAuthenticator interface {
 		request *grpc.StoreChunksRequest,
 		now time.Time) ([]byte, error)
 
-	// CheckOnDemandPaymentAuthorization returns true if the disperser is authorized to disperse the given batch.
+	// IsDisperserAuthorized returns true if the disperser is authorized to disperse the given batch.
 	// Returns true if the batch contains only reservation payments, or if the batch contains on-demand payments
 	// and the disperser is authorized to handle them. Returns false if the batch contains on-demand payments
 	// and the disperser is not authorized.
-	CheckOnDemandPaymentAuthorization(disperserID uint32, batch *corev2.Batch) bool
+	IsDisperserAuthorized(disperserID uint32, batch *corev2.Batch) bool
 }
 
 // keyWithTimeout is a key with that key's expiration time. After a key "expires", it should be reloaded
@@ -126,7 +126,7 @@ func (a *requestAuthenticator) AuthenticateStoreChunksRequest(
 	return hash, nil
 }
 
-func (a *requestAuthenticator) CheckOnDemandPaymentAuthorization(disperserID uint32, batch *corev2.Batch) bool {
+func (a *requestAuthenticator) IsDisperserAuthorized(disperserID uint32, batch *corev2.Batch) bool {
 	hasOnDemand := false
 	for _, cert := range batch.BlobCertificates {
 		if cert.BlobHeader.PaymentMetadata.IsOnDemand() {

--- a/node/auth/authenticator_test.go
+++ b/node/auth/authenticator_test.go
@@ -378,9 +378,9 @@ func TestOnDemandPaymentAuthorization(t *testing.T) {
 		},
 	}
 
-	require.True(t, authenticator.CheckOnDemandPaymentAuthorization(0, onDemandBatch))
-	require.True(t, authenticator.CheckOnDemandPaymentAuthorization(0, reservationBatch))
+	require.True(t, authenticator.IsDisperserAuthorized(0, onDemandBatch))
+	require.True(t, authenticator.IsDisperserAuthorized(0, reservationBatch))
 
-	require.False(t, authenticator.CheckOnDemandPaymentAuthorization(1, onDemandBatch))
-	require.True(t, authenticator.CheckOnDemandPaymentAuthorization(1, reservationBatch))
+	require.False(t, authenticator.IsDisperserAuthorized(1, onDemandBatch))
+	require.True(t, authenticator.IsDisperserAuthorized(1, reservationBatch))
 }

--- a/node/grpc/server_v2.go
+++ b/node/grpc/server_v2.go
@@ -192,7 +192,7 @@ func (s *ServerV2) StoreChunks(ctx context.Context, in *pb.StoreChunksRequest) (
 			return nil, api.NewErrorInvalidArg(fmt.Sprintf("failed to authenticate request: %v", err))
 		}
 
-		if !s.chunkAuthenticator.CheckOnDemandPaymentAuthorization(in.GetDisperserID(), batch) {
+		if !s.chunkAuthenticator.IsDisperserAuthorized(in.GetDisperserID(), batch) {
 			//nolint:wrapcheck
 			return nil, api.NewErrorPermissionDenied(
 				fmt.Sprintf("disperser %d not authorized for on-demand payments", in.GetDisperserID()))


### PR DESCRIPTION
closes EGDA-2235

- This is in preparation for permissionless dispersal
- Validator nodes must only permit on-demand dispersal from authorized dispersers
- Currently it's hardcoded to just the eigenlabs disperser. In the future, this should be configured via the configuration registry