### PR TITLE
fix(sigmap-timeout): Add timeout to `CheckDACert` call

### DIFF
--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -401,6 +401,9 @@ func buildEigenDAV2Backend(
 		certVerifier,
 		config.ClientConfigV2.RBNRecencyWindowSize,
 		retrievers,
+		// PayloadDisperserCfg.ContractCallTimeout is set by the --eigenda.v2.contract-call-timeout flag, the value
+		// is not read into any other configs. For simplicity the PayloadDisperserCfg value is reused here.
+		config.ClientConfigV2.PayloadDisperserCfg.ContractCallTimeout,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create v2 store: %w", err)


### PR DESCRIPTION
Adds missing timeout to CheckDACert call 

* Adds `contractCallTimeout` to `Store` type
* Updates `NewStore` constructor to set `contractCallTimeout`
* Calls `CheckDACert` with a context with timeout
* Uses timeout value set by `--eigenda.v2.contract-call-timeout` flag
