### PR TITLE
chore(clients): add error log to debug failed certVerifier ethcalls

### DIFF
--- a/api/clients/v2/verification/cert_verifier.go
+++ b/api/clients/v2/verification/cert_verifier.go
@@ -2,6 +2,7 @@ package verification
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"sync"
 
@@ -96,6 +97,8 @@ func (cv *CertVerifier) CheckDACert(
 		Data: callMsgBytes,
 	}, nil)
 	if err != nil {
+		cv.logger.Error("certVerifier checkDACert call failed", "to", certVerifierAddr,
+			"calldata", hex.EncodeToString(callMsgBytes), "abi-encoded-cert", hex.EncodeToString(certBytes))
 		return &CertVerifierInternalError{Msg: "checkDACert eth call", Err: err}
 	}
 


### PR DESCRIPTION
Currently facing a reverting checkDACert call on our newly deployed hoodi environment.
Hard to reproduce and debug the call without this error log.

> Oct 21 17:59:09.697 DBG directory/contract_directory.go:105 fetched address for contract CERT_VERIFIER_ROUTER: 0x279210416CB120e7169FBdcBE3f0465378a08550                                                                                                                                
Oct 21 17:59:11.704 INF builder/storage_manager_builder.go:255 EigenDA cert verifier address was detected as an EigenDACertVerifierRouter at address (0x279210416CB120e7169FBdcBE3f0465378a08550), using it as such   
                                                      
then fails with
> Oct 21 17:59:30.888 ERR load/load_generator.go:245 failed to disperse blob: failed to disperse payload, Failover: checkDACert failed with blobKey 769e4846094327225fda47e378485687267cf1b78e514df3a5b3c2a0bf6a4943: invalid cert: call to CertVerifier failed with status code 7: Contract Internal error: Bug or misconfiguration in the CertVerifier contract itself. This includes solidity panics and evm reverts.
