### PR TITLE
fix: gpu memory leak by freeing them

### DIFF
--- a/encoding/v2/kzg/prover/backend/gnark/multiframe_proof.go
+++ b/encoding/v2/kzg/prover/backend/gnark/multiframe_proof.go
@@ -120,12 +120,12 @@ func (p *KzgMultiProofBackend) ComputeMultiFrameProofV2(
 
 	secondECNttDone := time.Now()
 
-	p.Logger.Info("Multiproof Time Decomp",
-		"total", secondECNttDone.Sub(begin),
-		"preproc", preprocessDone.Sub(begin),
-		"msm", msmDone.Sub(preprocessDone),
-		"fft1", firstECNttDone.Sub(msmDone),
-		"fft2", secondECNttDone.Sub(firstECNttDone),
+	p.Logger.Info("Multiproof Time Decomp (microseconds)",
+		"total", secondECNttDone.Sub(begin).Microseconds(),
+		"preproc", preprocessDone.Sub(begin).Microseconds(),
+		"msm", msmDone.Sub(preprocessDone).Microseconds(),
+		"fft1", firstECNttDone.Sub(msmDone).Microseconds(),
+		"fft2", secondECNttDone.Sub(firstECNttDone).Microseconds(),
 	)
 
 	return proofs, nil

--- a/encoding/v2/kzg/prover/backend/icicle/multiframe_proof.go
+++ b/encoding/v2/kzg/prover/backend/icicle/multiframe_proof.go
@@ -165,12 +165,12 @@ func (p *KzgMultiProofBackend) ComputeMultiFrameProofV2(ctx context.Context, pol
 
 	end := time.Now()
 
-	p.Logger.Info("Multiproof Time Decomp (ms)",
+	p.Logger.Info("Multiproof Time Decomp (microseconds)",
 		"total", end.Sub(begin).Milliseconds(),
-		"preproc", preprocessDone.Sub(begin).Milliseconds(),
-		"msm", msmDone.Sub(preprocessDone).Milliseconds(),
-		"fft1", firstECNttDone.Sub(msmDone).Milliseconds(),
-		"fft2", secondECNttDone.Sub(firstECNttDone).Milliseconds(),
+		"preproc", preprocessDone.Sub(begin).Microseconds(),
+		"msm", msmDone.Sub(preprocessDone).Microseconds(),
+		"fft1", firstECNttDone.Sub(msmDone).Microseconds(),
+		"fft2", secondECNttDone.Sub(firstECNttDone).Microseconds(),
 	)
 
 	return proofs, nil

--- a/encoding/v2/kzg/prover/prover.go
+++ b/encoding/v2/kzg/prover/prover.go
@@ -197,12 +197,12 @@ func (e *Prover) GetFrames(
 			len(encodeResult.chunks), len(proofs))
 	}
 
-	e.logger.Info("Frame process details (milliseconds)",
+	e.logger.Info("Frame process details (microseconds)",
 		"input_size_bytes", len(inputFr)*encoding.BYTES_PER_SYMBOL,
 		"num_chunks", params.NumChunks,
 		"chunk_length", params.ChunkLength,
-		"rs_encode_duration", encodeResult.duration.Milliseconds(),
-		"multi_proof_duration", getProofsDuration.Milliseconds(),
+		"rs_encode_duration", encodeResult.duration.Microseconds(),
+		"multi_proof_duration", getProofsDuration.Microseconds(),
 	)
 
 	frames := make([]*encoding.Frame, len(proofs))


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes a bug that does not free gpu memory. This PR also moves the msm computation into the main function, as it is cumbersome to return a device pointer with memory allocated to it, but not freed in the same function

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
