### PR TITLE
fix(controller): Configure stale dispersal boundary via CLI

### DIFF
--- a/disperser/cmd/controller/config.go
+++ b/disperser/cmd/controller/config.go
@@ -152,10 +152,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 			MaxNumBlobsPerIteration:     int32(ctx.GlobalInt(flags.MaxNumBlobsPerIterationFlag.Name)),
 			OnchainStateRefreshInterval: ctx.GlobalDuration(flags.OnchainStateRefreshIntervalFlag.Name),
 			NumConcurrentRequests:       ctx.GlobalInt(flags.NumConcurrentEncodingRequestsFlag.Name),
-			// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used
-			// instead of hardcoding. At that point, this field should be removed from here
-			// entirely, and the value will be fetched dynamically at runtime.
-			MaxDispersalAge: 45 * time.Second,
+			MaxDispersalAge:             ctx.GlobalDuration(flags.MaxDispersalAgeFlag.Name),
 		},
 		DispatcherConfig: controller.DispatcherConfig{
 			PullInterval:                          ctx.GlobalDuration(flags.DispatcherPullIntervalFlag.Name),

--- a/disperser/cmd/controller/flags/flags.go
+++ b/disperser/cmd/controller/flags/flags.go
@@ -112,6 +112,13 @@ var (
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "ONCHAIN_STATE_REFRESH_INTERVAL"),
 		Value:    1 * time.Hour,
 	}
+	MaxDispersalAgeFlag = cli.DurationFlag{
+		Name:     common.PrefixFlag(FlagPrefix, "max-dispersal-age"),
+		Usage:    "Maximum age a dispersal request can be before it is discarded",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "MAX_DISPERSAL_AGE"),
+		Value:    45 * time.Second,
+	}
 
 	// Dispatcher Flags
 	DispatcherPullIntervalFlag = cli.DurationFlag{
@@ -345,6 +352,7 @@ var optionalFlags = []cli.Flag{
 	NumConcurrentEncodingRequestsFlag,
 	MaxNumBlobsPerIterationFlag,
 	OnchainStateRefreshIntervalFlag,
+	MaxDispersalAgeFlag,
 	SignatureTickIntervalFlag,
 	FinalizationBlockDelayFlag,
 	NumRequestRetriesFlag,

--- a/disperser/controller/encoding_manager.go
+++ b/disperser/controller/encoding_manager.go
@@ -67,10 +67,6 @@ type EncodingManagerConfig struct {
 	//
 	// Age is determined by the BlobHeader.PaymentMetadata.Timestamp field, which is set by the
 	// client at dispersal request creation time (in nanoseconds since Unix epoch).
-	//
-	// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used instead of including
-	// in this config + hardcoding. At that point, this field will be removed from the config struct entirely, and the
-	// value will be fetched dynamically at runtime.
 	MaxDispersalAge time.Duration
 }
 


### PR DESCRIPTION
- The TODO comments I originally left about eventually using the on-chain config registry for this field were misguided
- Since there isn't any need to coordinate updates to this value, it's overkill to use the onchain registry
- Therefore, I added a CLI flag to configure this field, instead of the "temporary" hardcoded value
