### PR TITLE
chore: remove integration team specific code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,2 @@
-# Clients
-# See https://github.com/orgs/Layr-Labs/teams/eigenda-intg
-/api/clients @Layr-Labs/eigenda-intg
-/api/proxy @Layr-Labs/eigenda-intg
-
-# Contracts
-/contracts @pakim249CAL
-
 # Security docs
 /docs/audits @anupsv


### PR DESCRIPTION
## Why are these changes needed?

Fixes code ownership as discussed.
