### PR TITLE
feat(payments): Update reservation bucket sizes with verdict

### DIFF
--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -733,7 +733,7 @@ func buildReservationLedger(
 		// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used
 		// instead of hardcoding. At that point, this field will be removed from the config struct
 		// entirely, and the value will be fetched dynamically at runtime.
-		30*time.Second,
+		60*time.Second,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new reservation ledger config: %w", err)

--- a/disperser/cmd/controller/config.go
+++ b/disperser/cmd/controller/config.go
@@ -106,7 +106,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used
 		// instead of hardcoding. At that point, this field will be removed from the config struct
 		// entirely, and the value will be fetched dynamically at runtime.
-		75*time.Second,
+		90*time.Second,
 		// this doesn't need to be configurable. there are no plans to ever use a different value
 		ratelimit.OverfillOncePermitted,
 		paymentVaultUpdateInterval,

--- a/disperser/controller/payment_authorization.go
+++ b/disperser/controller/payment_authorization.go
@@ -46,7 +46,7 @@ func DefaultPaymentAuthorizationConfig() *PaymentAuthorizationConfig {
 
 	reservationConfig := reservationvalidation.ReservationLedgerCacheConfig{
 		MaxLedgers:           1024,
-		BucketCapacityPeriod: 75 * time.Second,
+		BucketCapacityPeriod: 90 * time.Second,
 		OverfillBehavior:     ratelimit.OverfillOncePermitted,
 		UpdateInterval:       30 * time.Second,
 	}

--- a/docs/spec/src/protocol/payments/payment_system.md
+++ b/docs/spec/src/protocol/payments/payment_system.md
@@ -67,13 +67,10 @@ dispersals from the dishonest client to the rate of the reservation, and no addi
 expected latency of the system. Specifically:
 `validatorBucketCapacity - clientBucketCapacity = reservationRate * maxSystemLatency`
 - This ensures that honest clients operating at full capacity won't be rejected due to timing discrepancies.
-- Proposed bucket sizing (actual configuration may vary): Client buckets will use 1 minute duration while validator
-buckets use 6 minutes, accommodating up to 5 minutes of system latency.
-- Validators may potentially be configured to leak buckets slightly faster (e.g., 1% faster) than the actual reservation
-rate. This causes validator bucket states to converge toward empty for honest clients operating within their reservation
-limits, as the faster leak rate ensures buckets tracked by the validators drain over time.
-   - The trade-off is that dishonest clients could potentially disperse up to 1% more data than their allotted
-   reservation.
+- Current bucket size configuration: 
+   - Client buckets use a duration of 1 minute.
+   - Disperser buckets use a duration of 1.5 minutes.
+   - Validator buckets use a duration of 2 minutes, accommodating up to 1 minute of system latency.
 
 #### 2.1.3 Leaky Bucket Overfill
 

--- a/inabox/tests/setup_operator_harness.go
+++ b/inabox/tests/setup_operator_harness.go
@@ -222,7 +222,7 @@ func (oh *OperatorHarness) startOperator(
 		var err error
 		reservationLedgerCacheConfig, err = reservationvalidation.NewReservationLedgerCacheConfig(
 			1024,
-			90*time.Second,
+			120*time.Second,
 			ratelimit.OverfillOncePermitted,
 			1*time.Second, // Matches controller and API server update interval
 		)

--- a/node/config.go
+++ b/node/config.go
@@ -404,7 +404,7 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 			// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used
 			// instead of hardcoding. At that point, this field will be removed from the config struct
 			// entirely, and the value will be fetched dynamically at runtime.
-			90*time.Second,
+			120*time.Second,
 			// this is hardcoded: it's a parameter just in case, but it's never expected to change
 			ratelimit.OverfillOncePermitted,
 			ctx.GlobalDuration(flags.PaymentVaultUpdateIntervalFlag.Name),

--- a/test/v2/client/test_client.go
+++ b/test/v2/client/test_client.go
@@ -1050,7 +1050,7 @@ func buildReservationLedger(
 		// TODO(litt3): once the checkpointed onchain config registry is ready, that should be used
 		// instead of hardcoding. At that point, this field will be removed from the config struct
 		// entirely, and the value will be fetched dynamically at runtime.
-		30*time.Second,
+		60*time.Second,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new reservation ledger config: %w", err)


### PR DESCRIPTION
- Closes EGDA-1801 ([link](https://linear.app/eigenlabs/issue/EGDA-1801/determine-what-leaky-bucket-sizes-to-use-for-reservations))
- The verdict was to make client-side bucket 1 minute in duration
- To accommodate 1 minute e2e latency, that yields a validator side bucket of 2 minutes 
- Disperser bucket is in the middle, at 1.5 minutes