### PR TITLE
fix(payments): Properly initialize payment metrics

### DIFF
--- a/core/payments/clientledger/client_ledger.go
+++ b/core/payments/clientledger/client_ledger.go
@@ -106,6 +106,12 @@ func NewClientLedger(
 			clientLedger.GetAccountsToUpdate,
 			clientLedger.UpdateReservation)
 		enforce.NilError(err, "new reservation vault monitor")
+
+		// record initial values, so that metrics start out accurate
+		clientLedger.accountantMetricer.RecordReservationBucketCapacity(
+			clientLedger.reservationLedger.GetBucketCapacity())
+		clientLedger.accountantMetricer.RecordReservationPayment(
+			clientLedger.reservationLedger.GetRemainingCapacity())
 	}
 
 	if clientLedger.onDemandLedger != nil {
@@ -118,6 +124,12 @@ func NewClientLedger(
 			clientLedger.GetAccountsToUpdate,
 			clientLedger.UpdateTotalDeposit)
 		enforce.NilError(err, "new on demand vault monitor")
+
+		// record initial values, so that metrics start out accurate
+		clientLedger.accountantMetricer.RecordOnDemandTotalDeposits(
+			clientLedger.onDemandLedger.GetTotalDeposits())
+		clientLedger.accountantMetricer.RecordCumulativePayment(
+			clientLedger.onDemandLedger.GetCumulativePayment())
 	}
 
 	return clientLedger

--- a/core/payments/ondemand/on_demand_ledger.go
+++ b/core/payments/ondemand/on_demand_ledger.go
@@ -235,6 +235,14 @@ func checkForOnDemandSupport(quorumsToCheck []core.QuorumID) error {
 	return nil
 }
 
+// Returns the cumulative payment for this ledger
+func (odl *OnDemandLedger) GetCumulativePayment() *big.Int {
+	odl.lock.Lock()
+	defer odl.lock.Unlock()
+
+	return new(big.Int).Set(odl.cumulativePayment)
+}
+
 // Returns the total deposits for this ledger
 func (odl *OnDemandLedger) GetTotalDeposits() *big.Int {
 	odl.lock.Lock()

--- a/core/payments/reservation/reservation_ledger.go
+++ b/core/payments/reservation/reservation_ledger.go
@@ -202,3 +202,11 @@ func (rl *ReservationLedger) GetBucketCapacity() float64 {
 
 	return rl.leakyBucket.GetCapacity()
 }
+
+// Returns the remaining capacity in the bucket in symbols
+func (rl *ReservationLedger) GetRemainingCapacity() float64 {
+	rl.lock.Lock()
+	defer rl.lock.Unlock()
+
+	return rl.leakyBucket.GetRemainingCapacity()
+}


### PR DESCRIPTION
- Previously, payment metrics were not initialized with the correct values. That meant that a system starting up shows would show incorrect values at first