### PR TITLE
fix(payments): Make global meter to use billable symbols

### DIFF
--- a/core/meterer/on_demand_meterer_test.go
+++ b/core/meterer/on_demand_meterer_test.go
@@ -4,24 +4,53 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Layr-Labs/eigenda/core/payments/vault"
 	"github.com/stretchr/testify/require"
 )
 
 var startTime = time.Date(1971, 8, 15, 0, 0, 0, 0, time.UTC)
 
 func TestMeterDispersal(t *testing.T) {
+	ctx := t.Context()
 	timeSource := func() time.Time { return startTime }
-	meterer := NewOnDemandMeterer(100, 10, timeSource, nil)
 
-	reservation, err := meterer.MeterDispersal(500)
+	paymentVault := vault.NewTestPaymentVault()
+	// bucket capacity is 100*10 = 1000 symbols
+	paymentVault.SetGlobalSymbolsPerSecond(100)
+	paymentVault.SetGlobalRatePeriodInterval(10)
+	paymentVault.SetMinNumSymbols(100)
+
+	meterer, err := NewOnDemandMeterer(ctx, paymentVault, timeSource, nil)
+	require.NoError(t, err)
+
+	// blob larger than minNumSymbols
+	reservation, err := meterer.MeterDispersal(850)
 	require.NoError(t, err)
 	require.NotNil(t, reservation)
 	require.True(t, reservation.OK())
+
+	// blob below minNumSymbols - should meter minNumSymbols (100)
+	reservation, err = meterer.MeterDispersal(50)
+	require.NoError(t, err)
+	require.NotNil(t, reservation)
+	require.True(t, reservation.OK())
+
+	// blob below minNumSymbols - should meter minNumSymbols (100), but we've exhausted capacity
+	reservation, err = meterer.MeterDispersal(1)
+	require.Error(t, err, "should have exceeded available meter capacity")
+	require.Nil(t, reservation)
 }
 
 func TestCancelDispersal(t *testing.T) {
+	ctx := t.Context()
 	timeSource := func() time.Time { return startTime }
-	meterer := NewOnDemandMeterer(100, 10, timeSource, nil)
+	paymentVault := vault.NewTestPaymentVault()
+	paymentVault.SetGlobalSymbolsPerSecond(100)
+	paymentVault.SetGlobalRatePeriodInterval(10)
+	paymentVault.SetMinNumSymbols(100)
+
+	meterer, err := NewOnDemandMeterer(ctx, paymentVault, timeSource, nil)
+	require.NoError(t, err)
 
 	reservation, err := meterer.MeterDispersal(500)
 	require.NoError(t, err)

--- a/disperser/controller/payment_authorization.go
+++ b/disperser/controller/payment_authorization.go
@@ -79,16 +79,6 @@ func BuildPaymentAuthorizationHandler(
 		return nil, fmt.Errorf("create payment vault: %w", err)
 	}
 
-	globalSymbolsPerSecond, err := paymentVault.GetGlobalSymbolsPerSecond(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get global symbols per second: %w", err)
-	}
-
-	globalRatePeriodInterval, err := paymentVault.GetGlobalRatePeriodInterval(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get global rate period interval: %w", err)
-	}
-
 	// Create on-demand meterer (use nil metrics if registry is nil)
 	var onDemandMetererMetrics *meterer.OnDemandMetererMetrics
 	if metricsRegistry != nil {
@@ -99,12 +89,15 @@ func BuildPaymentAuthorizationHandler(
 		)
 	}
 
-	onDemandMeterer := meterer.NewOnDemandMeterer(
-		globalSymbolsPerSecond,
-		globalRatePeriodInterval,
+	onDemandMeterer, err := meterer.NewOnDemandMeterer(
+		ctx,
+		paymentVault,
 		time.Now,
 		onDemandMetererMetrics,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("create on-demand meterer: %w", err)
+	}
 
 	// Create on-demand validator (use nil metrics if registry is nil)
 	var onDemandValidatorMetrics *ondemandvalidation.OnDemandValidatorMetrics


### PR DESCRIPTION
- Previous implementation of the global meter wasn't taking billable symbols into account
- There was also a bug discovered while writing the test, where the previous implementation of the `OnDemandMeterer` was incompatible with a custom time source. This wouldn't have any impact in production environments, but broke tests. I've fixed this bug as well in this PR
