### PR TITLE
fix(live-tests): Get rid of remaining nil committer

### DIFF
--- a/test/v2/live/live_network_test.go
+++ b/test/v2/live/live_network_test.go
@@ -499,7 +499,6 @@ func dispersalWithInvalidSignatureTest(t *testing.T, environment string) {
 
 	_, _, err = disperserClient.DisperseBlob(ctx, blob.Serialize(), 0, quorums, nil, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "error accounting blob")
 }
 
 func TestDispersalWithInvalidSignature(t *testing.T) {


### PR DESCRIPTION
- I missed a case where we were passing in a `nil` committer in a live test when I merged [this PR](https://github.com/Layr-Labs/eigenda/pull/2320)
