### PR TITLE
fix: Allow release branch in workflow validation

### DIFF
--- a/.github/workflows/eigenda-releaser.yaml
+++ b/.github/workflows/eigenda-releaser.yaml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Validate branch is master or another release branch
         run: |
+          branch="${{ github.ref_name }}"
           if [[ "$branch" != "master" && "$branch" != release/* ]]; then
             echo "Error: This workflow can only be run from either master or another release branch"
             exit 1


### PR DESCRIPTION
## Why are these changes needed?

- Release branch names permits omitting patch version
- Should be able to create a release branch off of another release branch

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
