### PR TITLE
fix(proxy): Add check to ensure relay retriever is not only retriever

### DIFF
--- a/api/proxy/common/client_config_v2.go
+++ b/api/proxy/common/client_config_v2.go
@@ -85,6 +85,13 @@ func (cfg *ClientConfigV2) Check() error {
 		return fmt.Errorf("at least one retriever type must be enabled for using EigenDA V2 backend")
 	}
 
+	// Check that relay retriever is not the only retriever enabled
+	if slices.Contains(cfg.RetrieversToEnable, RelayRetrieverType) {
+		if !slices.Contains(cfg.RetrieversToEnable, ValidatorRetrieverType) {
+			return fmt.Errorf("relay retriever cannot be the only retriever enabled in EigenDA V2 backend")
+		}
+	}
+
 	if slices.Contains(cfg.RetrieversToEnable, ValidatorRetrieverType) {
 		if cfg.EigenDADirectory == "" {
 			return fmt.Errorf("EigenDA directory is required for validator retrieval in EigenDA V2 backend")


### PR DESCRIPTION
Closes DAINT-862

Adds a check to the v2 client config to ensure the relay retriever is not the only payload retriever enabled.

## Why are these changes needed?

A nil pointer dereference occurs when `RetrieversToEnable` is set with only relay enabled. This is due to the ksgVerifier only being initialized when the validator retriever is enabled. Having only relays enabled would be insecure, and is not a configuration we support. Adding a check to detect this configuration issue results in the proxy exiting cleanly and alerting the user of the issue, instead of simply crashing with a nil pointer deference.
