### PR TITLE
fix(validator): ensure random download order initialization

### DIFF
--- a/api/clients/v2/validator/retrieval_worker.go
+++ b/api/clients/v2/validator/retrieval_worker.go
@@ -280,7 +280,8 @@ func newRetrievalWorker(
 
 	// Randomly shuffle download order. Golang map iteration is random(ish), but not completely random.
 	// Map iteration order behaves like a random fixed ordering where you start in a random place and wrap around.
-	rand.Shuffle(len(downloadOrder), func(i, j int) {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rnd.Shuffle(len(downloadOrder), func(i, j int) {
 		downloadOrder[i], downloadOrder[j] = downloadOrder[j], downloadOrder[i]
 	})
 


### PR DESCRIPTION


```markdown
## Why are these changes needed?

Fixes non-random operator download order by seeding the random generator. The global `math/rand` uses a fixed default seed, making the order deterministic across restarts instead of truly random.

## Checks

- [x] I've made sure the tests are passing.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.

```


