### PR TITLE
feat(clients): Improve threading model for closing grpc client pool

### DIFF
--- a/api/clients/v2/dispersal/disperser_client.go
+++ b/api/clients/v2/dispersal/disperser_client.go
@@ -202,7 +202,12 @@ func (c *DisperserClient) DisperseBlob(
 
 	probe.SetStage("send_to_disperser")
 
-	reply, err := c.clientPool.GetClient().DisperseBlob(ctx, request)
+	client, err := c.clientPool.GetClient()
+	if err != nil {
+		return nil, nil, fmt.Errorf("get client: %w", err)
+	}
+
+	reply, err := client.DisperseBlob(ctx, request)
 	if err != nil {
 		return nil, nil, api.NewErrorFailover(fmt.Errorf("DisperseBlob rpc: %w", err))
 	}
@@ -220,7 +225,13 @@ func (c *DisperserClient) GetBlobStatus(
 	request := &disperser_rpc.BlobStatusRequest{
 		BlobKey: blobKey[:],
 	}
-	reply, err := c.clientPool.GetClient().GetBlobStatus(ctx, request)
+
+	client, err := c.clientPool.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("get client: %w", err)
+	}
+
+	reply, err := client.GetBlobStatus(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("error while calling GetBlobStatus: %w", err)
 	}
@@ -246,7 +257,13 @@ func (c *DisperserClient) GetPaymentState(ctx context.Context) (*disperser_rpc.G
 		Signature: signature,
 		Timestamp: timestamp,
 	}
-	reply, err := c.clientPool.GetClient().GetPaymentState(ctx, request)
+
+	client, err := c.clientPool.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("get client: %w", err)
+	}
+
+	reply, err := client.GetPaymentState(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("error while calling GetPaymentState: %w", err)
 	}

--- a/api/clients/v2/relay/relay_client.go
+++ b/api/clients/v2/relay/relay_client.go
@@ -258,7 +258,12 @@ func (c *relayClient) getClient(ctx context.Context, key corev2.RelayKey) (relay
 	if !ok {
 		return nil, fmt.Errorf("invalid grpc client for relay key: %v", key)
 	}
-	return clientPool.GetClient(), nil
+
+	client, err := clientPool.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("get client: %w", err)
+	}
+	return client, nil
 }
 
 // initOnceGrpcConnection initializes the GRPC connection for a given relay, and is guaranteed to only be completed


### PR DESCRIPTION
- Prereq for EGDA-2299 ([link](https://linear.app/eigenlabs/issue/EGDA-2299/client-disperser-multiplexing))
- Makes it so that it's safe to close the pool, without causing panics on other processes