### PR TITLE
fix: bug with connection pool size for disperser client

### DIFF
--- a/api/clients/v2/dispersal/disperser_client.go
+++ b/api/clients/v2/dispersal/disperser_client.go
@@ -85,11 +85,11 @@ func NewDisperserClient(
 		return nil, fmt.Errorf("metrics must be provided")
 	}
 
-	var connectionCount uint
-	if config.DisperserConnectionCount == 0 {
+	connectionCount := config.DisperserConnectionCount
+	if connectionCount == 0 {
 		connectionCount = 1
 	}
-	if config.DisperserConnectionCount > maxNumberOfConnections {
+	if connectionCount > maxNumberOfConnections {
 		connectionCount = maxNumberOfConnections
 	}
 


### PR DESCRIPTION
## Why are these changes needed?

Fixes bug that resulted in the connection count being ignored in most cases. Will run load test prior to merging this.