### PR TITLE
test(clients): move v1 clients live tests holesky->sepolia

### DIFF
--- a/api/clients/eigenda_client_e2e_live_test.go
+++ b/api/clients/eigenda_client_e2e_live_test.go
@@ -13,11 +13,11 @@ import (
 
 const (
 	// Test configuration constants
-	testRPC = "disperser-holesky.eigenda.xyz:443"
+	testRPC = "disperser-testnet-sepolia.eigenda.xyz:443"
 	// TODO: we should use a more reliable RPC provider, injected via secrets
-	testEthRpcUrl                = "https://ethereum-holesky-rpc.publicnode.com"
+	testEthRpcUrl                = "https://ethereum-sepolia-rpc.publicnode.com"
 	testSignerPrivateKeyHex      = "2d23e142a9e86a9175b9dfa213f20ea01f6c1731e09fa6edf895f70fe279cbb1"
-	testSvcManagerAddr           = "0xD4A7E1Bd8015057293f0D0A557088c286942e84b"
+	testSvcManagerAddr           = "0x3a5acf46ba6890B8536420F4900AC9BC45Df4764"
 	testStatusQueryTimeout       = 20 * time.Minute
 	testStatusQueryRetryInterval = 5 * time.Second
 )


### PR DESCRIPTION
Tests were failing because hoodi rpc provider is no longer responding to requests.

Kept the same `testSignerPrivateKeyHex`... which somehow also works. Maybe its also got a v1 reservation on sepolia? Not sure but Test passed locally:
<img width="689" height="126" alt="image" src="https://github.com/user-attachments/assets/f26594f9-669b-442b-bc66-aba7ee87e1e6" />
