### PR TITLE
chore: delete rogue printfs

### DIFF
--- a/encoding/v1/kzg/verifier/multiframe.go
+++ b/encoding/v1/kzg/verifier/multiframe.go
@@ -172,7 +172,9 @@ func (v *Verifier) UniversalVerify(params encoding.EncodingParams, samples []Sam
 	// precheck
 	for _, s := range samples {
 		if s.RowIndex >= m {
-			return errors.New("sample.RowIndex and numBlob are inconsistent")
+			return fmt.Errorf(
+				"sample.RowIndex and numBlob are inconsistent: sample has %d rows, but there are only %d blobs",
+				s.RowIndex, m)
 		}
 	}
 

--- a/encoding/v2/kzg/verifier/verifier.go
+++ b/encoding/v2/kzg/verifier/verifier.go
@@ -279,7 +279,9 @@ func (v *Verifier) universalVerify(params encoding.EncodingParams, samples []Sam
 	// precheck
 	for _, s := range samples {
 		if s.RowIndex >= numBlobs {
-			return errors.New("sample.RowIndex and numBlob are inconsistent")
+			return fmt.Errorf(
+				"sample.RowIndex and numBlob are inconsistent: sample has %d rows, but there are only %d blobs",
+				s.RowIndex, numBlobs)
 		}
 	}
 


### PR DESCRIPTION
## Why are these changes needed?
Delete printfs that are spamming traffic generator logs
