### PR TITLE
chore: renamed dispatcher to controller

### DIFF
--- a/disperser/controller/controller.go
+++ b/disperser/controller/controller.go
@@ -106,7 +106,7 @@ func NewController(
 		chainState:             chainState,
 		aggregator:             aggregator,
 		nodeClientManager:      nodeClientManager,
-		logger:                 logger.With("component", "Dispatcher"),
+		logger:                 logger.With("component", "controller"),
 		metrics:                metrics,
 		getNow:                 getNow,
 		cursor:                 nil,
@@ -748,7 +748,7 @@ func (c *Controller) GetOperatorState(
 	// GetIndexedOperatorState should return state for valid quorums only
 	indexedOperatorState, err := c.chainState.GetIndexedOperatorState(ctx, uint(blockNumber), quorumIds)
 	if err != nil {
-		return nil, fmt.Errorf("GetIndexedOperatorSTate: %w", err)
+		return nil, fmt.Errorf("GetIndexedOperatorState: %w", err)
 	}
 	return indexedOperatorState, nil
 }

--- a/inabox/tests/setup_disperser_harness.go
+++ b/inabox/tests/setup_disperser_harness.go
@@ -101,7 +101,7 @@ type DisperserHarness struct {
 	// Controller components
 	// TODO: Refactor into a single struct for controller components
 	EncodingManager  *controller.EncodingManager
-	Dispatcher       *controller.Controller
+	Controller       *controller.Controller
 	ControllerServer *server.Server
 }
 
@@ -279,7 +279,7 @@ func SetupDisperserHarness(
 		return nil, fmt.Errorf("failed to start controller: %w", err)
 	}
 	harness.EncodingManager = controllerComponents.EncodingManager
-	harness.Dispatcher = controllerComponents.Dispatcher
+	harness.Controller = controllerComponents.Dispatcher
 	harness.ControllerServer = controllerComponents.ControllerServer
 
 	// Start API server goroutine


### PR DESCRIPTION
## Why are these changes needed?
Renames the `Dispatcher` struct to `Controller`.
