### PR TITLE
fix: Decrease `ReputationSelection` test flakiness

### DIFF
--- a/common/reputation/reputation_selector_test.go
+++ b/common/reputation/reputation_selector_test.go
@@ -57,11 +57,9 @@ func TestReputationSelector_EqualWeights(t *testing.T) {
 	}
 
 	// With equal weights, all should be selected roughly equally
-	// Allow for some randomness (within 20% of expected value)
-	expected := 1000 / 3
+	// Allow a lot of wiggle room, to avoid test flakiness
 	for id, count := range selections {
-		require.Greater(t, count, expected-expected/5, "item %s selected too few times", id)
-		require.Less(t, count, expected+expected/5, "item %s selected too many times", id)
+		require.Greater(t, count, 100, "item %s selected too few times", id)
 	}
 }
 


### PR DESCRIPTION
- Makes it vastly less likely for the reputation tests to flake
- Claude assisted napkin math says flake chance went from 3% to 0.0000007%