### PR TITLE
fix(contracts): Disallow ejectors from cancelling other ejectors' ejections

### DIFF
--- a/contracts/src/periphery/ejection/EigenDAEjectionManager.sol
+++ b/contracts/src/periphery/ejection/EigenDAEjectionManager.sol
@@ -63,6 +63,7 @@ contract EigenDAEjectionManager is IEigenDAEjectionManager, IEigenDASemVer {
 
     /// @inheritdoc IEigenDAEjectionManager
     function cancelEjectionByEjector(address operator) external onlyEjector(msg.sender) {
+        require(EigenDAEjectionLib.getEjectionRecord(operator).ejector == msg.sender, "only ejector that issued ejection can cancel");
         operator.cancelEjection();
     }
 


### PR DESCRIPTION
Bug identified by llm analysis - see thread [here](https://github.com/Layr-Labs/eigenda/pull/2420/changes#r2621122263)
## Why are these changes needed?
This change ensures that only the ejector that initiated an ejection can cancel it. - otherwise there is a trust assumption on the ejector. In the current implementation an ejector can **cancel ejections made by other ejectors**. 

**Changes**
- require stmt invariant
- unit test

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
