### PR TITLE
fix: allow proxy to start with v4 cert

### DIFF
--- a/api/proxy/store/builder/storage_manager_builder.go
+++ b/api/proxy/store/builder/storage_manager_builder.go
@@ -298,7 +298,7 @@ func buildEigenDAV2Backend(
 		// Note that we also support certV2s, just not V2 CertVerifiers.
 		// This is because we transform certV2s into certV3s and verified using the CertVerifierV3 contract.
 		// However, the serialization logic, as well as some functions needed during the dispersal path (eg. requiredQuorums),
-		// are only compatible/available with CertVerifier V3, hence the requirement here.
+		// are compatible/available with CertVerifier V3 and V4, hence the requirement here.
 		if certVersion != 3 && certVersion != 4 {
 			return nil, fmt.Errorf("this version of proxy is only compatible with CertVerifier V3 or V4 : cert verifier at address %s is version %d",
 				routerOrImmutableVerifierAddr.Hex(), certVersion)


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes a bug that prevents proxy to start when using a certverifier whose the cert version is V4 cert.

## Issue

<img width="1725" height="136" alt="Screenshot 2026-01-08 at 8 27 15 AM" src="https://github.com/user-attachments/assets/ce537a28-76cc-450f-91e0-acc4e70fd424" />

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
