### PR TITLE
On-Demand Throttling

### DIFF
--- a/core/meterer/on_demand_meterer.go
+++ b/core/meterer/on_demand_meterer.go
@@ -3,6 +3,8 @@ package meterer
 import (
 	"context"
 	"fmt"
+	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/core/payments"
@@ -17,7 +19,84 @@ type OnDemandMeterer struct {
 	limiter       *rate.Limiter
 	getNow        func() time.Time
 	metrics       *OnDemandMetererMetrics
+	minNumSymbols atomic.Uint32
+}
+
+// OnDemandMetererConfig configures how the meterer refreshes on-chain limits and applies fuzz.
+type OnDemandMetererConfig struct {
+	// RefreshInterval controls how often on-chain limits are fetched.
+	RefreshInterval time.Duration
+	// FuzzFactor is a multiplier applied on top of the on-chain limit to tolerate small drifts.
+	FuzzFactor float64
+}
+
+const (
+	// DefaultOnDemandMetererRefreshInterval is how often the meterer re-reads on-chain limits.
+	DefaultOnDemandMetererRefreshInterval = 5 * time.Minute
+	// DefaultOnDemandMetererFuzzFactor allows 10% additional throughput above on-chain limit.
+	DefaultOnDemandMetererFuzzFactor = 1.1
+)
+
+// WithDefaults fills unset fields with sane defaults.
+func (c OnDemandMetererConfig) WithDefaults() OnDemandMetererConfig {
+	if c.RefreshInterval <= 0 {
+		c.RefreshInterval = DefaultOnDemandMetererRefreshInterval
+	}
+	if c.FuzzFactor == 0 {
+		c.FuzzFactor = DefaultOnDemandMetererFuzzFactor
+	}
+	return c
+}
+
+// Verify ensures config values are valid.
+func (c OnDemandMetererConfig) Verify() error {
+	if c.RefreshInterval <= 0 {
+		return fmt.Errorf("refresh interval must be positive")
+	}
+	if c.FuzzFactor <= 0 {
+		return fmt.Errorf("fuzz factor must be positive")
+	}
+	return nil
+}
+
+type limiterParams struct {
+	limit         rate.Limit
+	burst         int
 	minNumSymbols uint32
+}
+
+// buildLimiterParams loads current on-chain limits and applies fuzz to produce limiter settings.
+func buildLimiterParams(
+	ctx context.Context,
+	paymentVault payments.PaymentVault,
+	fuzzFactor float64,
+) (limiterParams, error) {
+	globalSymbolsPerSecond, err := paymentVault.GetGlobalSymbolsPerSecond(ctx)
+	if err != nil {
+		return limiterParams{}, fmt.Errorf("get global symbols per second: %w", err)
+	}
+
+	globalRatePeriodInterval, err := paymentVault.GetGlobalRatePeriodInterval(ctx)
+	if err != nil {
+		return limiterParams{}, fmt.Errorf("get global rate period interval: %w", err)
+	}
+
+	minNumSymbols, err := paymentVault.GetMinNumSymbols(ctx)
+	if err != nil {
+		return limiterParams{}, fmt.Errorf("get min num symbols: %w", err)
+	}
+
+	limit := rate.Limit(float64(globalSymbolsPerSecond) * fuzzFactor)
+	burst := int(math.Ceil(float64(globalSymbolsPerSecond*globalRatePeriodInterval) * fuzzFactor))
+	if burst < 1 {
+		burst = 1
+	}
+
+	return limiterParams{
+		limit:         limit,
+		burst:         burst,
+		minNumSymbols: minNumSymbols,
+	}, nil
 }
 
 // Creates a new OnDemandMeterer with the specified rate limiting parameters.
@@ -26,31 +105,59 @@ func NewOnDemandMeterer(
 	paymentVault payments.PaymentVault,
 	getNow func() time.Time,
 	metrics *OnDemandMetererMetrics,
+	config OnDemandMetererConfig,
 ) (*OnDemandMeterer, error) {
-	globalSymbolsPerSecond, err := paymentVault.GetGlobalSymbolsPerSecond(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get global symbols per second: %w", err)
+	config = config.WithDefaults()
+	if err := config.Verify(); err != nil {
+		return nil, fmt.Errorf("invalid on-demand meterer config: %w", err)
 	}
 
-	globalRatePeriodInterval, err := paymentVault.GetGlobalRatePeriodInterval(ctx)
+	params, err := buildLimiterParams(ctx, paymentVault, config.FuzzFactor)
 	if err != nil {
-		return nil, fmt.Errorf("get global rate period interval: %w", err)
+		return nil, err
 	}
 
-	minNumSymbols, err := paymentVault.GetMinNumSymbols(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get min num symbols: %w", err)
+	limiter := rate.NewLimiter(params.limit, params.burst)
+
+	m := &OnDemandMeterer{
+		limiter: limiter,
+		getNow:  getNow,
+		metrics: metrics,
 	}
+	m.minNumSymbols.Store(params.minNumSymbols)
 
-	burstSize := int(globalSymbolsPerSecond * globalRatePeriodInterval)
-	limiter := rate.NewLimiter(rate.Limit(globalSymbolsPerSecond), burstSize)
+	go m.refreshLoop(ctx, paymentVault, config)
 
-	return &OnDemandMeterer{
-		limiter:       limiter,
-		getNow:        getNow,
-		metrics:       metrics,
-		minNumSymbols: minNumSymbols,
-	}, nil
+	return m, nil
+}
+
+func (m *OnDemandMeterer) refreshLoop(
+	ctx context.Context,
+	paymentVault payments.PaymentVault,
+	config OnDemandMetererConfig,
+) {
+	ticker := time.NewTicker(config.RefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			params, err := buildLimiterParams(ctx, paymentVault, config.FuzzFactor)
+			if err != nil {
+				// Keep existing values on error; next tick may succeed.
+				continue
+			}
+			m.applyLimiterParams(params)
+		}
+	}
+}
+
+func (m *OnDemandMeterer) applyLimiterParams(params limiterParams) {
+	m.limiter.SetLimit(params.limit)
+	m.limiter.SetBurst(params.burst)
+	m.minNumSymbols.Store(params.minNumSymbols)
 }
 
 // Reserves tokens for a dispersal with the given number of symbols.
@@ -66,7 +173,7 @@ func NewOnDemandMeterer(
 func (m *OnDemandMeterer) MeterDispersal(symbolCount uint32) (*rate.Reservation, error) {
 	now := m.getNow()
 
-	billableSymbols := payments.CalculateBillableSymbols(symbolCount, m.minNumSymbols)
+	billableSymbols := payments.CalculateBillableSymbols(symbolCount, m.minNumSymbols.Load())
 	reservation := m.limiter.ReserveN(now, int(billableSymbols))
 
 	if !reservation.OK() || reservation.DelayFrom(now) > 0 {

--- a/core/meterer/on_demand_meterer_test.go
+++ b/core/meterer/on_demand_meterer_test.go
@@ -20,7 +20,7 @@ func TestMeterDispersal(t *testing.T) {
 	paymentVault.SetGlobalRatePeriodInterval(10)
 	paymentVault.SetMinNumSymbols(100)
 
-	meterer, err := NewOnDemandMeterer(ctx, paymentVault, timeSource, nil)
+	meterer, err := NewOnDemandMeterer(ctx, paymentVault, timeSource, nil, OnDemandMetererConfig{})
 	require.NoError(t, err)
 
 	// blob larger than minNumSymbols
@@ -49,7 +49,7 @@ func TestCancelDispersal(t *testing.T) {
 	paymentVault.SetGlobalRatePeriodInterval(10)
 	paymentVault.SetMinNumSymbols(100)
 
-	meterer, err := NewOnDemandMeterer(ctx, paymentVault, timeSource, nil)
+	meterer, err := NewOnDemandMeterer(ctx, paymentVault, timeSource, nil, OnDemandMetererConfig{})
 	require.NoError(t, err)
 
 	reservation, err := meterer.MeterDispersal(500)


### PR DESCRIPTION
# What it does
- Enforces global on-demand throughput using on-chain PaymentVault parameters.
- Applies a fuzz factor multiplier to tolerate minor clock/scheduling drift.
- Periodically refreshes limits from chain and updates the limiter atomically.

## Config knobs
- `RefreshInterval` (default: 5m) — how often to re-read on-chain limits.
- `FuzzFactor` (default: 1.1) — multiplier on on-chain symbols/sec and burst; must be > 0.

## Flow
```
Controller BuildPaymentAuthorizationHandler
  ├─ contractDirectory.GetContractAddress(PaymentVault)
  ├─ vault.NewPaymentVault(ethClient, addr)          // on-chain client
  └─ meterer.NewOnDemandMeterer(ctx, paymentVault, time.Now, metrics, cfg)
        │ cfg.WithDefaults(): apply RefreshInterval, FuzzFactor
        │
        ├─ buildLimiterParams(ctx, paymentVault, fuzz)
        │     • GetGlobalSymbolsPerSecond()          // on-chain
        │     • GetGlobalRatePeriodInterval()        // on-chain
        │     • GetMinNumSymbols()                   // on-chain
        │     • Apply fuzz to rate and burst
        │
        ├─ init limiter + store minNumSymbols atomically
        └─ refreshLoop(ticker=RefreshInterval):
              every tick → buildLimiterParams(...)
                if success: SetLimit/SetBurst + update minNumSymbols
                if error: keep previous settings

Per dispersal (on-demand)
  └─ MeterDispersal(symbolCount)
        • CalculateBillableSymbols(symbolCount, current minNumSymbols)
        • limiter.ReserveN(now, billable)
            - reject and record exhaustion if not OK or delay > 0
            - record throughput and return reservation if OK
        • CancelDispersal(reservation) returns tokens if needed
```

## Ops notes
- Ensure validators can reach the PaymentVault RPC; refresh loop depends on it.
- Tune `FuzzFactor` and `RefreshInterval` via `OnDemandMetererConfig` (threaded through `PaymentAuthorizationConfig`).
- Metrics: `OnDemandMetererMetrics` tracks throughput and exhaustion counts/symbols.
