### PR TITLE
feat: Support multiple disperser IDs

### DIFF
--- a/api/clients/v2/multi_dispersal_request_signer.go
+++ b/api/clients/v2/multi_dispersal_request_signer.go
@@ -1,0 +1,82 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+
+	grpc "github.com/Layr-Labs/eigenda/api/grpc/validator"
+	"github.com/pkg/errors"
+)
+
+// MultiDispersalRequestSigner manages multiple disperser IDs and their corresponding signers.
+// It allows signing requests with any configured disperser ID, supporting seamless migration
+// between different disperser identities.
+type MultiDispersalRequestSigner struct {
+	// signers maps disperser ID to its corresponding signer
+	signers map[uint32]DispersalRequestSigner
+	// disperserIDs is the ordered list of disperser IDs (priority order)
+	disperserIDs []uint32
+}
+
+// MultiDispersalRequestSignerConfig configures the multi-signer with disperser IDs and their signers.
+type MultiDispersalRequestSignerConfig struct {
+	// Signers maps each disperser ID to its corresponding signer
+	Signers map[uint32]DispersalRequestSigner
+	// DisperserIDs is the ordered list of IDs to try (in priority order)
+	DisperserIDs []uint32
+}
+
+// NewMultiDispersalRequestSigner creates a new MultiDispersalRequestSigner.
+func NewMultiDispersalRequestSigner(
+	config MultiDispersalRequestSignerConfig,
+) (*MultiDispersalRequestSigner, error) {
+	if len(config.Signers) == 0 {
+		return nil, errors.New("at least one signer is required")
+	}
+	if len(config.DisperserIDs) == 0 {
+		return nil, errors.New("at least one disperser ID is required")
+	}
+
+	// Verify all disperser IDs have corresponding signers
+	for _, id := range config.DisperserIDs {
+		if _, ok := config.Signers[id]; !ok {
+			return nil, fmt.Errorf("no signer configured for disperser ID %d", id)
+		}
+	}
+
+	return &MultiDispersalRequestSigner{
+		signers:      config.Signers,
+		disperserIDs: config.DisperserIDs,
+	}, nil
+}
+
+// SignStoreChunksRequest signs a StoreChunksRequest using the signer for the specified disperser ID.
+// It sets the disperser ID in the request before signing.
+func (m *MultiDispersalRequestSigner) SignStoreChunksRequest(
+	ctx context.Context,
+	request *grpc.StoreChunksRequest,
+	disperserID uint32,
+) ([]byte, error) {
+	signer, ok := m.signers[disperserID]
+	if !ok {
+		return nil, fmt.Errorf("no signer configured for disperser ID %d", disperserID)
+	}
+
+	request.DisperserID = disperserID
+	signature, err := signer.SignStoreChunksRequest(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign with disperser ID %d: %w", disperserID, err)
+	}
+	return signature, nil
+}
+
+// GetDisperserIDs returns the ordered list of disperser IDs.
+func (m *MultiDispersalRequestSigner) GetDisperserIDs() []uint32 {
+	return m.disperserIDs
+}
+
+// HasDisperserID returns true if the signer is configured for the given disperser ID.
+func (m *MultiDispersalRequestSigner) HasDisperserID(id uint32) bool {
+	_, ok := m.signers[id]
+	return ok
+}

--- a/api/clients/v2/multi_dispersal_request_signer_test.go
+++ b/api/clients/v2/multi_dispersal_request_signer_test.go
@@ -1,0 +1,141 @@
+package clients
+
+import (
+	"context"
+	"testing"
+
+	grpc "github.com/Layr-Labs/eigenda/api/grpc/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSigner is a mock DispersalRequestSigner for testing.
+type mockSigner struct {
+	signFunc func(ctx context.Context, request *grpc.StoreChunksRequest) ([]byte, error)
+}
+
+func (m *mockSigner) SignStoreChunksRequest(ctx context.Context, request *grpc.StoreChunksRequest) ([]byte, error) {
+	return m.signFunc(ctx, request)
+}
+
+func TestNewMultiDispersalRequestSigner(t *testing.T) {
+	signer1 := &mockSigner{
+		signFunc: func(ctx context.Context, request *grpc.StoreChunksRequest) ([]byte, error) {
+			return []byte("signature_1"), nil
+		},
+	}
+	signer0 := &mockSigner{
+		signFunc: func(ctx context.Context, request *grpc.StoreChunksRequest) ([]byte, error) {
+			return []byte("signature_0"), nil
+		},
+	}
+
+	t.Run("valid configuration", func(t *testing.T) {
+		config := MultiDispersalRequestSignerConfig{
+			Signers: map[uint32]DispersalRequestSigner{
+				1: signer1,
+				0: signer0,
+			},
+			DisperserIDs: []uint32{1, 0},
+		}
+
+		signer, err := NewMultiDispersalRequestSigner(config)
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+		assert.Equal(t, []uint32{1, 0}, signer.GetDisperserIDs())
+		assert.True(t, signer.HasDisperserID(1))
+		assert.True(t, signer.HasDisperserID(0))
+		assert.False(t, signer.HasDisperserID(2))
+	})
+
+	t.Run("no signers", func(t *testing.T) {
+		config := MultiDispersalRequestSignerConfig{
+			Signers:      map[uint32]DispersalRequestSigner{},
+			DisperserIDs: []uint32{1},
+		}
+
+		signer, err := NewMultiDispersalRequestSigner(config)
+		require.Error(t, err)
+		assert.Nil(t, signer)
+		assert.Contains(t, err.Error(), "at least one signer is required")
+	})
+
+	t.Run("no disperser IDs", func(t *testing.T) {
+		config := MultiDispersalRequestSignerConfig{
+			Signers: map[uint32]DispersalRequestSigner{
+				1: signer1,
+			},
+			DisperserIDs: []uint32{},
+		}
+
+		signer, err := NewMultiDispersalRequestSigner(config)
+		require.Error(t, err)
+		assert.Nil(t, signer)
+		assert.Contains(t, err.Error(), "at least one disperser ID is required")
+	})
+
+	t.Run("disperser ID without signer", func(t *testing.T) {
+		config := MultiDispersalRequestSignerConfig{
+			Signers: map[uint32]DispersalRequestSigner{
+				1: signer1,
+			},
+			DisperserIDs: []uint32{1, 0}, // 0 has no signer
+		}
+
+		signer, err := NewMultiDispersalRequestSigner(config)
+		require.Error(t, err)
+		assert.Nil(t, signer)
+		assert.Contains(t, err.Error(), "no signer configured for disperser ID 0")
+	})
+}
+
+func TestMultiDispersalRequestSigner_SignStoreChunksRequest(t *testing.T) {
+	signer1 := &mockSigner{
+		signFunc: func(ctx context.Context, request *grpc.StoreChunksRequest) ([]byte, error) {
+			return []byte("signature_1"), nil
+		},
+	}
+	signer0 := &mockSigner{
+		signFunc: func(ctx context.Context, request *grpc.StoreChunksRequest) ([]byte, error) {
+			return []byte("signature_0"), nil
+		},
+	}
+
+	config := MultiDispersalRequestSignerConfig{
+		Signers: map[uint32]DispersalRequestSigner{
+			1: signer1,
+			0: signer0,
+		},
+		DisperserIDs: []uint32{1, 0},
+	}
+
+	multiSigner, err := NewMultiDispersalRequestSigner(config)
+	require.NoError(t, err)
+
+	t.Run("sign with ID 1", func(t *testing.T) {
+		request := &grpc.StoreChunksRequest{}
+		signature, err := multiSigner.SignStoreChunksRequest(context.Background(), request, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte("signature_1"), signature)
+		assert.Equal(t, uint32(1), request.GetDisperserID())
+	})
+
+	t.Run("sign with ID 0", func(t *testing.T) {
+		request := &grpc.StoreChunksRequest{}
+		signature, err := multiSigner.SignStoreChunksRequest(context.Background(), request, 0)
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte("signature_0"), signature)
+		assert.Equal(t, uint32(0), request.GetDisperserID())
+	})
+
+	t.Run("sign with unknown ID", func(t *testing.T) {
+		request := &grpc.StoreChunksRequest{}
+		signature, err := multiSigner.SignStoreChunksRequest(context.Background(), request, 99)
+
+		require.Error(t, err)
+		assert.Nil(t, signature)
+		assert.Contains(t, err.Error(), "no signer configured for disperser ID 99")
+	})
+}

--- a/disperser/cmd/controller/flags/flags.go
+++ b/disperser/cmd/controller/flags/flags.go
@@ -341,9 +341,19 @@ var (
 	}
 	DisperserIDFlag = cli.Uint64Flag{
 		Name:     common.PrefixFlag(FlagPrefix, "disperser-id"),
-		Usage:    "Unique identifier for this disperser instance. The value specified must match the index of the associated pubkey in the disperser registry",
-		Required: true,
+		Usage:    "Unique identifier for this disperser instance. The value specified must match the index of the associated pubkey in the disperser registry. Deprecated: use --controller-disperser-ids instead for multi-ID support",
+		Required: false,
 		EnvVar:   common.PrefixEnvVar(envVarPrefix, "DISPERSER_ID"),
+	}
+	// Multi Disperser ID Support
+	DisperserIDsFlag = cli.StringFlag{
+		Name: common.PrefixFlag(FlagPrefix, "disperser-ids"),
+		Usage: "Comma-separated list of disperser IDs to use, in priority order (e.g., '1,0'). " +
+			"Each ID requires corresponding credentials via environment variables: " +
+			"CONTROLLER_DISPERSER_ID_{N}_PRIVATE_KEY or CONTROLLER_DISPERSER_ID_{N}_KMS_KEY_ID. " +
+			"If not specified, falls back to --controller-disperser-id for backward compatibility",
+		Required: false,
+		EnvVar:   common.PrefixEnvVar(envVarPrefix, "DISPERSER_IDS"),
 	}
 	SigningRateRetentionPeriodFlag = cli.DurationFlag{
 		Name:     common.PrefixFlag(FlagPrefix, "signing-rate-retention-period"),
@@ -404,7 +414,6 @@ var requiredFlags = []cli.Flag{
 	DispatcherPullIntervalFlag,
 	AttestationTimeoutFlag,
 	BatchAttestationTimeoutFlag,
-	DisperserIDFlag,
 	SigningRateDynamoDbTableNameFlag,
 }
 
@@ -454,6 +463,8 @@ var optionalFlags = []cli.Flag{
 	BlobDispersalRequestBatchSizeFlag,
 	BlobDispersalRequestBackoffPeriodFlag,
 	SigningRateFlushPeriodFlag,
+	DisperserIDFlag,
+	DisperserIDsFlag,
 }
 
 var Flags []cli.Flag

--- a/disperser/controller/disperser_id_error_detector.go
+++ b/disperser/controller/disperser_id_error_detector.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsInvalidDisperserIDError checks if the error is an invalid disperser ID error.
+// These errors occur when a validator rejects a request because it doesn't recognize
+// the disperser ID used to sign the request.
+//
+// The error is identified by:
+// - gRPC status code: InvalidArgument
+// - Error message containing authentication failure patterns related to disperser key/address lookup
+func IsInvalidDisperserIDError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check if this is a gRPC error with InvalidArgument status
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+
+	if st.Code() != codes.InvalidArgument {
+		return false
+	}
+
+	// Check for authentication failure patterns
+	errMsg := st.Message()
+	if !strings.Contains(errMsg, "failed to authenticate") {
+		return false
+	}
+
+	// Check for disperser key/address lookup failures
+	// These indicate the validator doesn't know about this disperser ID
+	return strings.Contains(errMsg, "failed to get disperser key") ||
+		strings.Contains(errMsg, "failed to get disperser address")
+}

--- a/disperser/controller/disperser_id_error_detector_test.go
+++ b/disperser/controller/disperser_id_error_detector_test.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsInvalidDisperserIDError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, IsInvalidDisperserIDError(nil))
+	})
+
+	t.Run("non-gRPC error", func(t *testing.T) {
+		err := errors.New("some error")
+		assert.False(t, IsInvalidDisperserIDError(err))
+	})
+
+	t.Run("wrong gRPC status code", func(t *testing.T) {
+		err := status.Error(codes.Internal, "failed to authenticate request: failed to get disperser key")
+		assert.False(t, IsInvalidDisperserIDError(err))
+	})
+
+	t.Run("InvalidArgument but missing authentication pattern", func(t *testing.T) {
+		err := status.Error(codes.InvalidArgument, "some other error")
+		assert.False(t, IsInvalidDisperserIDError(err))
+	})
+
+	t.Run("InvalidArgument with authentication but missing disperser key/address", func(t *testing.T) {
+		err := status.Error(codes.InvalidArgument, "failed to authenticate request: wrong signature")
+		assert.False(t, IsInvalidDisperserIDError(err))
+	})
+
+	t.Run("valid invalid disperser ID error - disperser key", func(t *testing.T) {
+		err := status.Error(codes.InvalidArgument, "failed to authenticate request: failed to get disperser key")
+		assert.True(t, IsInvalidDisperserIDError(err))
+	})
+
+	t.Run("valid invalid disperser ID error - disperser address", func(t *testing.T) {
+		err := status.Error(codes.InvalidArgument, "failed to authenticate request: failed to get disperser address")
+		assert.True(t, IsInvalidDisperserIDError(err))
+	})
+
+	t.Run("valid error with nested message", func(t *testing.T) {
+		err := status.Error(codes.InvalidArgument, "failed to authenticate request: failed to verify request: failed to get disperser key: key not found")
+		assert.True(t, IsInvalidDisperserIDError(err))
+	})
+
+	t.Run("case sensitivity", func(t *testing.T) {
+		// Should not match if case is different
+		err := status.Error(codes.InvalidArgument, "Failed to Authenticate Request: Failed to Get Disperser Key")
+		assert.False(t, IsInvalidDisperserIDError(err))
+	})
+}

--- a/disperser/controller/mock_node_client_manager.go
+++ b/disperser/controller/mock_node_client_manager.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
+	"github.com/Layr-Labs/eigenda/core"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -14,5 +15,15 @@ var _ NodeClientManager = (*MockClientManager)(nil)
 func (m *MockClientManager) GetClient(host, port string) (clients.NodeClient, error) {
 	args := m.Called(host, port)
 	client, _ := args.Get(0).(clients.NodeClient)
+	return client, args.Error(1)
+}
+
+func (m *MockClientManager) GetClientForValidator(
+	host, port string,
+	validatorID core.OperatorID,
+) (clients.NodeClient, error) {
+	args := m.Called(host, port, validatorID)
+	client, _ := args.Get(0).(clients.NodeClient)
+	//nolint:wrapcheck // Mock method returns error as-is
 	return client, args.Error(1)
 }

--- a/disperser/controller/node_client_manager.go
+++ b/disperser/controller/node_client_manager.go
@@ -1,23 +1,33 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Layr-Labs/eigenda/api/clients/v2"
+	grpc "github.com/Layr-Labs/eigenda/api/grpc/validator"
+	"github.com/Layr-Labs/eigenda/core"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 type NodeClientManager interface {
 	GetClient(host, port string) (clients.NodeClient, error)
+	// GetClientForValidator returns a client for a specific validator, using the appropriate disperser ID
+	// if dual-signer mode is enabled. This method requires dual-signer support to be configured.
+	GetClientForValidator(host, port string, validatorID core.OperatorID) (clients.NodeClient, error)
 }
 
 type nodeClientManager struct {
-	// nodeClients is a cache of node clients keyed by socket address
+	// nodeClients is a cache of node clients keyed by socket address with disperser ID
 	nodeClients   *lru.Cache[string, clients.NodeClient]
 	requestSigner clients.DispersalRequestSigner
 	disperserID   uint32
 	logger        logging.Logger
+
+	// Multi-signer support (optional, nil if not enabled)
+	multiSigner *clients.MultiDispersalRequestSigner
+	idTracker   *ValidatorDisperserIDTracker
 }
 
 var _ NodeClientManager = (*nodeClientManager)(nil)
@@ -44,6 +54,36 @@ func NewNodeClientManager(
 		requestSigner: requestSigner,
 		disperserID:   disperserID,
 		logger:        logger,
+		multiSigner:   nil,
+		idTracker:     nil,
+	}, nil
+}
+
+// NewNodeClientManagerWithMultiSigner creates a NodeClientManager with multi-signer support.
+// This enables the manager to use different disperser IDs for different validators.
+func NewNodeClientManagerWithMultiSigner(
+	cacheSize int,
+	multiSigner *clients.MultiDispersalRequestSigner,
+	idTracker *ValidatorDisperserIDTracker,
+	logger logging.Logger) (NodeClientManager, error) {
+
+	closeClient := func(socket string, value clients.NodeClient) {
+		if err := value.Close(); err != nil {
+			logger.Error("failed to close node client", "err", err)
+		}
+	}
+	nodeClients, err := lru.NewWithEvict(cacheSize, closeClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
+	}
+
+	return &nodeClientManager{
+		nodeClients:   nodeClients,
+		requestSigner: nil, // Not used in multi-signer mode
+		disperserID:   0,   // Not used in multi-signer mode
+		logger:        logger,
+		multiSigner:   multiSigner,
+		idTracker:     idTracker,
 	}, nil
 }
 
@@ -67,4 +107,63 @@ func (m *nodeClientManager) GetClient(host, port string) (clients.NodeClient, er
 	}
 
 	return client, nil
+}
+
+// GetClientForValidator returns a client for a specific validator.
+// In multi-signer mode, it looks up the appropriate disperser ID for the validator
+// and returns a client configured with that ID. In single-signer mode, it falls back
+// to GetClient behavior.
+func (m *nodeClientManager) GetClientForValidator(
+	host, port string,
+	validatorID core.OperatorID,
+) (clients.NodeClient, error) {
+	// If multi-signer mode is not enabled, fall back to single-signer behavior
+	if m.multiSigner == nil {
+		return m.GetClient(host, port)
+	}
+
+	// Get the disperser ID for this validator
+	disperserID := m.idTracker.GetDisperserID(validatorID)
+
+	// Create a signer wrapper for this specific disperser ID
+	signer := &multiSignerWrapper{
+		multiSigner: m.multiSigner,
+		disperserID: disperserID,
+	}
+
+	// Cache key includes disperser ID to allow separate clients per ID
+	cacheKey := fmt.Sprintf("%s:%s:%d", host, port, disperserID)
+	client, ok := m.nodeClients.Get(cacheKey)
+	if !ok {
+		var err error
+		client, err = clients.NewNodeClient(
+			&clients.NodeClientConfig{
+				Hostname:    host,
+				Port:        port,
+				DisperserID: disperserID,
+			},
+			signer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create node client at %s:%s with disperser ID %d: %w",
+				host, port, disperserID, err)
+		}
+
+		m.nodeClients.Add(cacheKey, client)
+	}
+
+	return client, nil
+}
+
+// multiSignerWrapper wraps a MultiDispersalRequestSigner to sign with a specific disperser ID.
+type multiSignerWrapper struct {
+	multiSigner *clients.MultiDispersalRequestSigner
+	disperserID uint32
+}
+
+func (w *multiSignerWrapper) SignStoreChunksRequest(
+	ctx context.Context,
+	request *grpc.StoreChunksRequest,
+) ([]byte, error) {
+	//nolint:wrapcheck // Thin wrapper delegates to underlying signer
+	return w.multiSigner.SignStoreChunksRequest(ctx, request, w.disperserID)
 }

--- a/disperser/controller/validator_disperser_id_tracker.go
+++ b/disperser/controller/validator_disperser_id_tracker.go
@@ -1,0 +1,112 @@
+package controller
+
+import (
+	"sync"
+
+	"github.com/Layr-Labs/eigenda/core"
+)
+
+// ValidatorDisperserIDTracker tracks which disperser ID each validator accepts.
+// This allows the controller to avoid retrying with wrong IDs once a validator's
+// accepted ID is known.
+type ValidatorDisperserIDTracker struct {
+	mu sync.RWMutex
+	// validatorAcceptedID maps validator ID to the disperser ID they accept
+	// If a validator is not in the map, we haven't determined their accepted ID yet
+	validatorAcceptedID map[core.OperatorID]uint32
+	// disperserIDs is the ordered list of disperser IDs to try (in priority order)
+	disperserIDs []uint32
+}
+
+// ValidatorDisperserIDStats contains statistics about validator disperser ID distribution.
+type ValidatorDisperserIDStats struct {
+	// CountByID maps disperser ID to the number of validators using it
+	CountByID map[uint32]int
+	// UnknownCount is the number of validators with unknown/undetermined ID
+	UnknownCount int
+}
+
+// NewValidatorDisperserIDTracker creates a new tracker.
+// disperserIDs should be provided in priority order (first ID is tried first).
+func NewValidatorDisperserIDTracker(disperserIDs []uint32) *ValidatorDisperserIDTracker {
+	return &ValidatorDisperserIDTracker{
+		validatorAcceptedID: make(map[core.OperatorID]uint32),
+		disperserIDs:        disperserIDs,
+	}
+}
+
+// GetDisperserID returns the disperser ID to use for the given validator.
+// If the validator's accepted ID is known, it returns that ID.
+// If unknown, it returns the first ID in the priority list.
+func (t *ValidatorDisperserIDTracker) GetDisperserID(validatorID core.OperatorID) uint32 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if acceptedID, ok := t.validatorAcceptedID[validatorID]; ok {
+		return acceptedID
+	}
+
+	// Unknown validator - return first/highest priority ID
+	if len(t.disperserIDs) > 0 {
+		return t.disperserIDs[0]
+	}
+
+	return 0 // Shouldn't happen if tracker is properly initialized
+}
+
+// RecordSuccess records that a validator successfully accepted a request with the given disperser ID.
+func (t *ValidatorDisperserIDTracker) RecordSuccess(validatorID core.OperatorID, disperserID uint32) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Verify this is a known disperser ID
+	isKnown := false
+	for _, id := range t.disperserIDs {
+		if id == disperserID {
+			isKnown = true
+			break
+		}
+	}
+
+	if isKnown {
+		t.validatorAcceptedID[validatorID] = disperserID
+	}
+}
+
+// RecordFailure records that a validator rejected a request with the given disperser ID.
+// This doesn't change the tracked ID - the controller will try the next ID in the list.
+func (t *ValidatorDisperserIDTracker) RecordFailure(validatorID core.OperatorID, disperserID uint32) {
+	// Failure doesn't update the tracker - we'll try the next ID in the priority list
+	// The tracker only records successful IDs
+}
+
+// GetStats returns statistics about validator disperser ID distribution.
+func (t *ValidatorDisperserIDTracker) GetStats() ValidatorDisperserIDStats {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	stats := ValidatorDisperserIDStats{
+		CountByID: make(map[uint32]int),
+	}
+
+	for _, acceptedID := range t.validatorAcceptedID {
+		stats.CountByID[acceptedID]++
+	}
+
+	return stats
+}
+
+// GetNextDisperserID returns the next disperser ID to try after the given ID failed.
+// Returns the next ID in priority order, or 0 if no more IDs to try.
+func (t *ValidatorDisperserIDTracker) GetNextDisperserID(currentID uint32) uint32 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	for i, id := range t.disperserIDs {
+		if id == currentID && i+1 < len(t.disperserIDs) {
+			return t.disperserIDs[i+1]
+		}
+	}
+
+	return 0 // No more IDs to try
+}

--- a/disperser/controller/validator_disperser_id_tracker_test.go
+++ b/disperser/controller/validator_disperser_id_tracker_test.go
@@ -1,0 +1,146 @@
+package controller
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewValidatorDisperserIDTracker(t *testing.T) {
+	tracker := NewValidatorDisperserIDTracker([]uint32{1, 0})
+	assert.NotNil(t, tracker)
+	assert.Equal(t, []uint32{1, 0}, tracker.disperserIDs)
+}
+
+func TestValidatorDisperserIDTracker_GetDisperserID(t *testing.T) {
+	tracker := NewValidatorDisperserIDTracker([]uint32{1, 0})
+	validatorID := core.OperatorID{1, 2, 3}
+
+	t.Run("unknown validator returns primary", func(t *testing.T) {
+		disperserID := tracker.GetDisperserID(validatorID)
+		assert.Equal(t, uint32(1), disperserID)
+	})
+
+	t.Run("known primary validator returns primary", func(t *testing.T) {
+		tracker.RecordSuccess(validatorID, 1)
+		disperserID := tracker.GetDisperserID(validatorID)
+		assert.Equal(t, uint32(1), disperserID)
+	})
+
+	t.Run("known fallback validator returns fallback", func(t *testing.T) {
+		validatorID2 := core.OperatorID{4, 5, 6}
+		tracker.RecordSuccess(validatorID2, 0)
+		disperserID := tracker.GetDisperserID(validatorID2)
+		assert.Equal(t, uint32(0), disperserID)
+	})
+}
+
+func TestValidatorDisperserIDTracker_RecordSuccess(t *testing.T) {
+	tracker := NewValidatorDisperserIDTracker([]uint32{1, 0})
+	validatorID := core.OperatorID{1, 2, 3}
+
+	t.Run("record primary success", func(t *testing.T) {
+		tracker.RecordSuccess(validatorID, 1)
+		assert.Equal(t, uint32(1), tracker.GetDisperserID(validatorID))
+
+		stats := tracker.GetStats()
+		assert.Equal(t, 1, stats.CountByID[1])
+		assert.Equal(t, 0, stats.CountByID[0])
+	})
+
+	t.Run("record fallback success", func(t *testing.T) {
+		validatorID2 := core.OperatorID{4, 5, 6}
+		tracker.RecordSuccess(validatorID2, 0)
+		assert.Equal(t, uint32(0), tracker.GetDisperserID(validatorID2))
+
+		stats := tracker.GetStats()
+		assert.Equal(t, 1, stats.CountByID[1])
+		assert.Equal(t, 1, stats.CountByID[0])
+	})
+
+	t.Run("record unknown disperser ID", func(t *testing.T) {
+		validatorID3 := core.OperatorID{7, 8, 9}
+		// Record success with unknown ID (e.g., 99)
+		tracker.RecordSuccess(validatorID3, 99)
+		// Should still return primary (unknown validators default to primary)
+		assert.Equal(t, uint32(1), tracker.GetDisperserID(validatorID3))
+	})
+}
+
+func TestValidatorDisperserIDTracker_RecordFailure(t *testing.T) {
+	tracker := NewValidatorDisperserIDTracker([]uint32{1, 0})
+	validatorID := core.OperatorID{1, 2, 3}
+
+	t.Run("record failure does not change tracker", func(t *testing.T) {
+		// Failure doesn't update the tracker - just returns the first ID for unknown validators
+		tracker.RecordFailure(validatorID, 1)
+		assert.Equal(t, uint32(1), tracker.GetDisperserID(validatorID))
+
+		stats := tracker.GetStats()
+		assert.Equal(t, 0, stats.CountByID[1])
+		assert.Equal(t, 0, stats.CountByID[0])
+	})
+
+	t.Run("successful ID persists after failure record", func(t *testing.T) {
+		validatorID2 := core.OperatorID{4, 5, 6}
+		tracker.RecordSuccess(validatorID2, 0)
+		tracker.RecordFailure(validatorID2, 0)
+		// Should still be 0
+		assert.Equal(t, uint32(0), tracker.GetDisperserID(validatorID2))
+	})
+}
+
+func TestValidatorDisperserIDTracker_GetStats(t *testing.T) {
+	tracker := NewValidatorDisperserIDTracker([]uint32{1, 0})
+
+	t.Run("initial stats", func(t *testing.T) {
+		stats := tracker.GetStats()
+		assert.Equal(t, 0, stats.CountByID[1])
+		assert.Equal(t, 0, stats.CountByID[0])
+		assert.Equal(t, 0, stats.UnknownCount)
+	})
+
+	t.Run("mixed validator distribution", func(t *testing.T) {
+		// Add 2 validators using ID 1
+		tracker.RecordSuccess(core.OperatorID{1}, 1)
+		tracker.RecordSuccess(core.OperatorID{2}, 1)
+
+		// Add 3 validators using ID 0
+		tracker.RecordSuccess(core.OperatorID{3}, 0)
+		tracker.RecordSuccess(core.OperatorID{4}, 0)
+		tracker.RecordSuccess(core.OperatorID{5}, 0)
+
+		stats := tracker.GetStats()
+		assert.Equal(t, 2, stats.CountByID[1])
+		assert.Equal(t, 3, stats.CountByID[0])
+		assert.Equal(t, 0, stats.UnknownCount)
+	})
+}
+
+func TestValidatorDisperserIDTracker_ThreadSafety(t *testing.T) {
+	tracker := NewValidatorDisperserIDTracker([]uint32{1, 0})
+
+	// Run concurrent operations
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			validatorID := core.OperatorID{byte(idx)}
+
+			// Concurrent reads and writes
+			tracker.GetDisperserID(validatorID)
+			tracker.RecordSuccess(validatorID, 1)
+			tracker.RecordFailure(validatorID, 1)
+			tracker.GetStats()
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify we can still get stats without panic
+	stats := tracker.GetStats()
+	assert.GreaterOrEqual(t, stats.CountByID[0]+stats.CountByID[1], 0)
+}


### PR DESCRIPTION
# Multi-Disperser ID Implementation

## Overview

This document describes the complete flow of the multi-disperser ID feature, from configuration setup through signature verification. This feature enables zero-downtime migration between different disperser identities (e.g., from KMS-based ID=0 to software wallet-based ID=1).

### Important: Terminology

- **Disperser System**: A collection of services (API Server, Batcher, Encoder, Controller, etc.) that work together to disperse blobs
- **Controller Service**: The specific service (`disperser/cmd/controller`) that implements the multi-disperser ID feature and communicates with validators
- **Disperser ID**: A unique identifier for a disperser's signing key registered in the EigenDA Service Manager contract

Throughout this document, when we refer to "the disperser" in the context of signing and validator communication, we specifically mean the **Controller service**.

## Table of Contents

1. [Architecture Overview](#architecture-overview)
2. [Configuration Setup](#configuration-setup)
3. [Disperser Side Flow](#disperser-side-flow)
4. [Validator Side Flow](#validator-side-flow)
5. [Migration Scenario](#migration-scenario)
6. [Error Handling](#error-handling)
7. [Monitoring](#monitoring)

---

## Architecture Overview

### System Architecture

The **Disperser** is a distributed system composed of multiple services. The multi-disperser ID feature is implemented in the **Controller** service:

```
┌────────────────────────────────────────────────────────────┐
│                    Disperser System                        │
│                                                            │
│  ┌──────────────┐  ┌──────────┐  ┌─────────────────────┐   │
│  │  API Server  │─▶│ Batcher  │─▶│     Encoder         │   │
│  │ (user API)   │  │          │  │ (erasure coding)    │   │
│  └──────────────┘  └──────────┘  └──────────┬──────────┘   │
│                                             │              │
│                                             ▼              │
│  ┌───────────────────────────────────────────────────────┐ │
│  │              CONTROLLER SERVICE                       │ │
│  │          (Multi-Disperser ID Feature)                 │ │
│  │                                                       │ │
│  │  ┌──────────────────────────────────────────────────┐ │ │
│  │  │     MultiDispersalRequestSigner                  │ │ │
│  │  │  ┌────────────┐  ┌────────────┐                  │ │ │
│  │  │  │ ID=1 (SW)  │  │ ID=0 (KMS) │                  │ │ │
│  │  │  └────────────┘  └────────────┘                  │ │ │
│  │  └──────────────────────────────────────────────────┘ │ │
│  │  ┌──────────────────────────────────────────────────┐ │ │
│  │  │  ValidatorDisperserIDTracker                     │ │ │
│  │  │  (validator → disperser ID mapping)              │ │ │
│  │  └──────────────────────────────────────────────────┘ │ │
│  │  ┌──────────────────────────────────────────────────┐ │ │
│  │  │  NodeClientManager                               │ │ │
│  │  │  (client cache per validator per ID)             │ │ │
│  │  └──────────────────────────────────────────────────┘ │ │
│  └───────────────────────────────────────────────────────┘ │
└──────────────────────────┬─────────────────────────────────┘
                           │
                           │ gRPC StoreChunks
                           │ (signed request with disperserID)
                           ▼
┌─────────────────────────────────────────────────────────────┐
│                    Validator Network                        │
│  ┌────────────────────────────────────────────────────────┐ │
│  │              Authenticator                             │ │
│  │  1. Extract disperserID from request                   │ │
│  │  2. Lookup disperser key/address from registry         │ │
│  │  3. Verify signature matches                           │ │
│  │  4. Accept/Reject request                              │ │
│  └────────────────────────────────────────────────────────┘ │
└─────────────────────────────────────────────────────────────┘
```

### Disperser Services

| Service | Binary | Purpose | Multi-ID Feature? |
|---------|--------|---------|-------------------|
| **API Server** | `disperser/cmd/apiserver` | Accepts blob dispersal requests from users | No |
| **Batcher** | `disperser/cmd/batcher` | Batches blobs for efficient processing | No |
| **Encoder** | `disperser/cmd/encoder` | Performs erasure coding on blobs | No |
| **Controller** | `disperser/cmd/controller` | **Disperses encoded data to validators** | **✓ Yes** |
| **Data API** | `disperser/cmd/dataapi` | Provides APIs for querying blob data | No |
| **Blob API** | `disperser/cmd/blobapi` | Provides APIs for blob operations | No |

### Key Design Principles

1. **Priority-Based Retry**: Try disperser IDs in order (e.g., [1, 0]) until one succeeds
2. **Automatic Learning**: System tracks which disperser ID each validator accepts
3. **Separate Clients**: Each validator gets a dedicated client per disperser ID
4. **Backward Compatible**: Single-ID mode continues to work without modification

---

## Configuration Setup

### Step 1: Generate Credentials

#### Software Wallet (ID=1)
```bash
# Generate a new private key
openssl ecparam -name secp256k1 -genkey -noout -out disperser_id_1.pem
openssl ec -in disperser_id_1.pem -text -noout

# Extract hex-encoded private key (remove 0x prefix)
export CONTROLLER_DISPERSER_ID_1_PRIVATE_KEY=<hex_key_without_0x>
```

#### KMS (ID=0)
```bash
# Create KMS key in AWS
aws kms create-key --description "EigenDA Disperser ID 0"

# Export the key ID
export CONTROLLER_DISPERSER_ID_0_KMS_KEY_ID=<kms_key_id>
export CONTROLLER_DISPERSER_ID_0_KMS_REGION=us-east-1
```

### Step 2: Register Disperser Keys

Both disperser IDs must be registered in the EigenDA Service Manager contract before use.

```solidity
// Pseudocode - actual registration happens via governance
serviceManager.registerDisperserKey(disperserId: 1, signingKey: <pubkey_from_id_1>)
serviceManager.registerDisperserKey(disperserId: 0, signingKey: <pubkey_from_id_0>)
```

### Step 3: Configure Controller Service

The Controller is deployed as a separate service/binary:

#### Command-Line Flags
```bash
# Start the controller service with multi-ID support
./controller \
  --controller-disperser-ids=1,0 \
  # ... other flags ...
```

#### Environment Variables
```bash
# Credentials for ID=1 (Software Wallet)
export CONTROLLER_DISPERSER_ID_1_PRIVATE_KEY=abc123...

# Credentials for ID=0 (KMS)
export CONTROLLER_DISPERSER_ID_0_KMS_KEY_ID=arn:aws:kms:...
export CONTROLLER_DISPERSER_ID_0_KMS_REGION=us-east-1
```

#### Backward Compatibility (Single-ID Mode)
```bash
# Old way still works
./controller \
  --controller-disperser-id=0 \
  --controller-disperser-kms-key-id=<kms_key>
```

---

## Disperser Side Flow

### Initialization Sequence

```mermaid
sequenceDiagram
    participant Main
    participant Config
    participant MultiSigner
    participant Tracker
    participant NodeClientManager
    participant Controller

    Main->>Config: Parse --controller-disperser-ids=1,0
    Main->>Config: Load credentials from env vars
    Config->>Config: Validate each ID has credentials

    Main->>MultiSigner: Create signers for each ID
    MultiSigner->>MultiSigner: Initialize ID=1 signer (SW)
    MultiSigner->>MultiSigner: Initialize ID=0 signer (KMS)

    Main->>Tracker: NewValidatorDisperserIDTracker([1,0])

    Main->>NodeClientManager: NewNodeClientManagerWithMultiSigner()

    Main->>Controller: NewController(config)
    Controller->>Controller: MultiSignerConfig initialized
```

### Dispersal Flow (Per Validator)

#### Initial State: Unknown Validator

```mermaid
sequenceDiagram
    participant Controller
    participant Tracker
    participant NodeClientManager
    participant Validator

    Note over Tracker: Validator ID unknown
    Controller->>Tracker: GetDisperserID(validatorID)
    Tracker-->>Controller: Returns first ID (1)

    Controller->>NodeClientManager: GetClientForValidator(host, port, validatorID)
    NodeClientManager->>NodeClientManager: Create client with ID=1
    NodeClientManager-->>Controller: NodeClient

    Controller->>Controller: Sign request with ID=1
    Controller->>Validator: StoreChunks(request, signature, disperserID=1)

    alt Validator accepts ID=1
        Validator-->>Controller: Success (signature)
        Controller->>Tracker: RecordSuccess(validatorID, 1)
        Note over Tracker: Validator mapped to ID=1
    else Validator rejects ID=1
        Validator-->>Controller: Error: "failed to authenticate: failed to get disperser key"
        Controller->>Controller: Detect invalid disperser ID error
        Controller->>Tracker: RecordFailure(validatorID, 1)
        Controller->>Tracker: GetNextDisperserID(1)
        Tracker-->>Controller: Returns next ID (0)
        Controller->>Controller: Retry with ID=0
    end
```

#### Retry Logic

```go
// controller.go (simplified)
func (c *Controller) sendChunksToValidator(...) {
    // First attempt
    sig, latency, err := c.attemptStoreChunks(ctx, validatorId, currentDisperserID, ...)

    // If multi-signer mode and invalid disperser ID error
    if c.MultiSignerConfig != nil && IsInvalidDisperserIDError(err) {
        currentID := c.MultiSignerConfig.IDTracker.GetDisperserID(validatorId)
        nextID := c.MultiSignerConfig.IDTracker.GetNextDisperserID(currentID)

        // Retry with each remaining ID
        for nextID != 0 {
            c.logger.Info("validator rejected disperser ID, retrying with next ID",
                "validator", validatorId.Hex(),
                "rejectedID", currentID,
                "nextID", nextID)

            c.metrics.IncrementDisperserIDRetryAttempts()
            c.MultiSignerConfig.IDTracker.RecordFailure(validatorId, currentID)

            // Attempt with next ID
            sig, latency, err = c.attemptStoreChunks(ctx, validatorId, nextID, ...)

            if err == nil {
                // Success!
                c.metrics.IncrementDisperserIDRetrySuccesses()
                c.MultiSignerConfig.IDTracker.RecordSuccess(validatorId, nextID)
                break
            } else if !IsInvalidDisperserIDError(err) {
                // Different error (network, timeout, etc.) - stop retrying
                c.metrics.IncrementDisperserIDRetryFailures()
                break
            }

            currentID = nextID
            nextID = c.MultiSignerConfig.IDTracker.GetNextDisperserID(currentID)
        }
    }

    return sig, latency, err
}
```

#### Subsequent Requests: Known Validator

```mermaid
sequenceDiagram
    participant Controller
    participant Tracker
    participant NodeClientManager
    participant Validator

    Note over Tracker: Validator known to accept ID=0

    Controller->>Tracker: GetDisperserID(validatorID)
    Tracker-->>Controller: Returns recorded ID (0)

    Controller->>NodeClientManager: GetClientForValidator(host, port, validatorID)
    Note over NodeClientManager: Cache hit: {host:port:0}
    NodeClientManager-->>Controller: Cached NodeClient (with ID=0 signer)

    Controller->>Controller: Sign request with ID=0
    Controller->>Validator: StoreChunks(request, signature, disperserID=0)
    Validator-->>Controller: Success (signature)

    Note over Controller: No retry needed - used correct ID immediately
```

### Signing Process

```go
// multi_dispersal_request_signer.go
func (m *MultiDispersalRequestSigner) SignStoreChunksRequest(
    ctx context.Context,
    request *grpc.StoreChunksRequest,
    disperserID uint32,
) ([]byte, error) {
    // 1. Get signer for specific disperser ID
    signer, ok := m.signers[disperserID]
    if !ok {
        return nil, fmt.Errorf("no signer configured for disperser ID %d", disperserID)
    }

    // 2. Set disperser ID in request
    request.DisperserID = disperserID

    // 3. Sign with the appropriate signer (SW wallet or KMS)
    signature, err := signer.SignStoreChunksRequest(ctx, request)
    if err != nil {
        return nil, fmt.Errorf("failed to sign with disperser ID %d: %w", disperserID, err)
    }

    return signature, nil
}
```

### Client Caching

```go
// node_client_manager.go (pseudo-code)
func (m *nodeClientManager) GetClientForValidator(
    host, port string,
    validatorID core.OperatorID,
) (clients.NodeClient, error) {
    // 1. Get the disperser ID this validator accepts
    disperserID := m.idTracker.GetDisperserID(validatorID)

    // 2. Cache key includes disperser ID
    cacheKey := fmt.Sprintf("%s:%s:%d", host, port, disperserID)
    client, ok := m.nodeClients.Get(cacheKey)

    if !ok {
        // 3. Create wrapper that signs with specific disperser ID
        signer := &multiSignerWrapper{
            multiSigner: m.multiSigner,
            disperserID: disperserID,
        }

        // 4. Create client
        client, err = clients.NewNodeClient(
            &clients.NodeClientConfig{
                Hostname:    host,
                Port:        port,
                DisperserID: disperserID,
            },
            signer)

        // 5. Cache for future use
        m.nodeClients.Add(cacheKey, client)
    }

    return client, nil
}
```

---

## Validator Side Flow

### Request Reception and Authentication

```mermaid
sequenceDiagram
    participant Disperser
    participant ValidatorGRPC
    participant Authenticator
    participant Registry
    participant ChunkStore

    Disperser->>ValidatorGRPC: StoreChunks(request, signature, disperserID)
    ValidatorGRPC->>Authenticator: AuthenticateStoreChunksRequest()

    Authenticator->>Authenticator: Extract disperserID from request
    Note over Authenticator: disperserID = 1 or 0

    Authenticator->>Registry: GetDisperserKey(disperserID)

    alt Disperser ID registered
        Registry-->>Authenticator: Returns public key/address
        Authenticator->>Authenticator: Verify signature matches

        alt Signature valid
            Authenticator-->>ValidatorGRPC: Authentication success
            ValidatorGRPC->>ChunkStore: Store chunks
            ChunkStore-->>ValidatorGRPC: Success
            ValidatorGRPC->>ValidatorGRPC: Sign batch header
            ValidatorGRPC-->>Disperser: Return validator signature
        else Signature invalid
            Authenticator-->>ValidatorGRPC: Authentication failed
            ValidatorGRPC-->>Disperser: Error: "invalid signature"
        end
    else Disperser ID not registered
        Registry-->>Authenticator: Error: "disperser key not found"
        Authenticator-->>ValidatorGRPC: Authentication failed
        ValidatorGRPC-->>Disperser: Error: "failed to get disperser key"
    end
```

### Validator Authentication Code

```go
// node/auth/authenticator.go (validator side - pseudo-code)
func (a *Authenticator) AuthenticateStoreChunksRequest(
    ctx context.Context,
    request *grpc.StoreChunksRequest,
    signature []byte,
) error {
    // 1. Extract disperser ID from request
    disperserID := request.DisperserID

    // 2. Get disperser's registered public key/address
    disperserKey, err := a.registry.GetDisperserKey(disperserID)
    if err != nil {
        // This causes "failed to get disperser key" error that triggers retry
        return fmt.Errorf("failed to get disperser key for ID %d: %w", disperserID, err)
    }

    // 3. Hash the request
    hash, err := hashing.HashStoreChunksRequest(request)
    if err != nil {
        return fmt.Errorf("failed to hash request: %w", err)
    }

    // 4. Verify signature
    if !crypto.VerifySignature(disperserKey, hash, signature) {
        return fmt.Errorf("invalid signature for disperser ID %d", disperserID)
    }

    return nil
}
```

### Registry Lookup

The validator queries the EigenDA Service Manager contract to get the registered key for each disperser ID:

```solidity
// EigenDAServiceManager.sol (on-chain -  pseudo-code)
mapping(uint32 => DisperserInfo) public dispersers;

struct DisperserInfo {
    address signingAddress;
    bytes32 signingKeyHash;
}

function getDisperserAddress(uint32 disperserId) public view returns (address) {
    return dispersers[disperserId].signingAddress;
}
```

---

## Migration Scenario

### Phase 1: Pre-Migration (All validators on ID=0)

```
Disperser Config: --controller-disperser-id=0 (single-ID mode)
Validator State:  All validators registered with ID=0

Flow:
  Disperser → signs with ID=0 → Validator → verifies ID=0 → ✓
```

### Phase 2: Enable Multi-ID Mode

```
Disperser Config: --controller-disperser-ids=1,0
                  CONTROLLER_DISPERSER_ID_1_PRIVATE_KEY=<key>
                  CONTROLLER_DISPERSER_ID_0_KMS_KEY_ID=<kms>

Validator State:  Mixed - some upgraded to support ID=1, some still on ID=0

Flow (New Validator - supports ID=1):
  Disperser → tries ID=1 → Validator → verifies ID=1 → ✓
  Tracker: validator mapped to ID=1

Flow (Legacy Validator - only supports ID=0):
  Disperser → tries ID=1 → Validator → rejects (no ID=1 key) → ✗
  Disperser → retries ID=0 → Validator → verifies ID=0 → ✓
  Tracker: validator mapped to ID=0
```

### Phase 3: Monitor Migration Progress

```bash
# Watch validator distribution shift
curl http://localhost:9101/metrics | grep validators_by_disperser_id

# Output shows distribution:
validators_by_disperser_id{disperser_id_type="id_1"} 15  # Increasing
validators_by_disperser_id{disperser_id_type="id_0"} 5   # Decreasing
```

### Phase 4: Complete Migration

When all validators accept ID=1:

```
validators_by_disperser_id{disperser_id_type="id_1"} 20
validators_by_disperser_id{disperser_id_type="id_0"} 0

Switch back to single-ID mode:
  Disperser Config: --controller-disperser-id=1
                    --controller-disperser-private-key=<key>
```

---

## Error Handling

### Error Detection

```go
// disperser_id_error_detector.go (pseudo-code)
func IsInvalidDisperserIDError(err error) bool {
    if err == nil {
        return false
    }

    st, ok := status.FromError(err)
    if !ok {
        return false
    }

    // Must be InvalidArgument
    if st.Code() != codes.InvalidArgument {
        return false
    }

    errMsg := st.Message()

    // Must contain authentication failure
    if !strings.Contains(errMsg, "failed to authenticate") {
        return false
    }

    // Must be due to disperser key/address lookup failure
    return strings.Contains(errMsg, "failed to get disperser key") ||
           strings.Contains(errMsg, "failed to get disperser address")
}
```

### Error Types and Handling

| Error Type | Description | Controller Action |
|------------|-------------|-------------------|
| **Invalid Disperser ID** | Validator doesn't have key for this disperser ID | Retry with next ID in list |
| **Invalid Signature** | Signature doesn't match disperser's registered key | Fail immediately (don't retry) |
| **Network Error** | Connection timeout, unreachable, etc. | Fail immediately (don't retry) |
| **All IDs Exhausted** | All disperser IDs rejected by validator | Mark blob as failed |

### Retry Limits

```go
// Only retry for invalid disperser ID errors
// No retry for:
// - Network errors
// - Timeout errors
// - Invalid signatures
// - Any other errors

// Maximum retries = number of configured disperser IDs - 1
// Example: [1, 0] allows 1 retry (try ID=1, then ID=0)
```

---

## Monitoring

### Key Metrics

#### Prometheus Metrics

```promql
# Retry attempts (should decrease as validators upgrade)
disperser_id_retry_attempts_total

# Retry success rate (should be ~100%)
rate(disperser_id_retry_successes_total[5m]) / rate(disperser_id_retry_attempts_total[5m])

# Retry failures (should be ~0)
disperser_id_retry_failures_total

# Validator distribution by disperser ID
validators_by_disperser_id{disperser_id_type="id_1"}  # New ID - should increase
validators_by_disperser_id{disperser_id_type="id_0"}  # Old ID - should decrease
```

#### Migration Dashboard

```
┌─────────────────────────────────────────────────────┐
│           Disperser ID Migration Status             │
├─────────────────────────────────────────────────────┤
│ Validators on ID=1 (new): ████████████░░  85% (17)  │
│ Validators on ID=0 (old): ███░░░░░░░░░░  15% (3)   │
│                                                     │
│ Retry Rate:     2.5 retries/min  ▼ (decreasing)    │
│ Success Rate:   100%              ✓                 │
│ Failure Rate:   0%                ✓                 │
└─────────────────────────────────────────────────────┘
```

### Alerts

```yaml
# Alert if retry success rate drops below 95%
- alert: DisperserIDRetryFailureHigh
  expr: |
    rate(disperser_id_retry_successes_total[5m]) /
    rate(disperser_id_retry_attempts_total[5m]) < 0.95
  annotations:
    summary: "High disperser ID retry failure rate"

# Alert if retries are happening but not decreasing
- alert: DisperserIDMigrationStalled
  expr: |
    rate(disperser_id_retry_attempts_total[1h]) > 0 AND
    rate(disperser_id_retry_attempts_total[1h] offset 1h) > 0 AND
    abs(rate(disperser_id_retry_attempts_total[1h]) -
        rate(disperser_id_retry_attempts_total[1h] offset 1h)) < 0.1
  annotations:
    summary: "Disperser ID migration appears stalled"
```

---

## Summary

### Flow Sequence (Complete)

1. **Configuration**: Disperser configured with multiple IDs ([1, 0]) and credentials
2. **Registration**: Both disperser IDs registered on-chain with public keys
3. **Initialization**: Controller creates multi-signer and tracker
4. **First Request** to unknown validator:
   - Tracker returns first ID (1)
   - Sign request with ID=1
   - Send to validator
5. **Validator Authentication**:
   - Extract disperserID from request
   - Lookup public key from registry
   - Verify signature
6. **Success Case**: Validator accepts ID=1
   - Record success in tracker
   - Future requests use ID=1 directly
7. **Failure Case**: Validator rejects ID=1
   - Detect "failed to get disperser key" error
   - Get next ID (0) from tracker
   - Retry with ID=0
   - Record success with ID=0
   - Future requests use ID=0 directly
8. **Subsequent Requests**: Use cached client with correct disperser ID
   - No retry needed
   - Fast path

### Key Benefits

- ✅ **Zero Downtime**: No service interruption during migration
- ✅ **Automatic Learning**: System learns validator preferences without manual configuration
- ✅ **Backward Compatible**: Single-ID mode continues to work
- ✅ **Observable**: Clear metrics show migration progress
- ✅ **Efficient**: Cached clients avoid repeated authentication failures

### Testing Coverage

- ✅ Unit tests for all components (tracker, multi-signer, error detector)
- ✅ Integration tests for retry logic
- ✅ Thread-safety tests
- ✅ E2E tests (single-ID mode, backward compatibility)
- ⚠️ Multi-ID E2E tests (optional enhancement)
