### PR TITLE
fix: allow returning encoded payload with cache enabled

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -28,7 +28,7 @@ runs:
         token: ${{ github.token }}
         path: ./.github/wiki/
 
-    - uses: jdx/mise-action@v2
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
       env:
         MISE_VERSION: 2024.12.14
       with:

--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -28,7 +28,7 @@ runs:
         token: ${{ github.token }}
         path: ./.github/wiki/
 
-    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+    - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
       env:
         MISE_VERSION: 2024.12.14
       with:

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout EigenDA
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout EigenDA
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout EigenDA
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout EigenDA
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/claude-security-reviewer.yaml
+++ b/.github/workflows/claude-security-reviewer.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 2
           
 
-      - uses: Layr-Labs/security-shared-workflows/actions/claude-pr-review@713409e1ebdd156dcc1b5dced0f0fbb063b0fee5
+      - uses: Layr-Labs/security-shared-workflows/actions/claude-pr-review@330d8ba61084ffcf6027508ec07998c69b36917a
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@0c6a49f1fa56a1d472575da86a94dbc1edb78eda
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           max_turns: "10"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql-scanning.yaml
+++ b/.github/workflows/codeql-scanning.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/codeql-scanning.yaml
+++ b/.github/workflows/codeql-scanning.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/compile-protobufs.yaml
+++ b/.github/workflows/compile-protobufs.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
-      - uses: bufbuild/buf-action@v1
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff
         with:
           setup_only: true #only install buf -- needed by `make protoc` command
       - name: Recompile Protobufs

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -56,7 +56,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -86,7 +86,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: Send GitHub Action trigger data to Slack eigenda-pr channel
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
         with:
           payload: |
             {

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -56,7 +56,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -86,7 +86,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/live-network-tests.yaml
+++ b/.github/workflows/live-network-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/live-network-tests.yaml
+++ b/.github/workflows/live-network-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
         with:
           submodules: recursive
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -42,7 +42,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -69,7 +69,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
         with:
           submodules: recursive
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -42,7 +42,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -69,7 +69,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/test-proxy.yml
+++ b/.github/workflows/test-proxy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/test-proxy.yml
+++ b/.github/workflows/test-proxy.yml
@@ -15,7 +15,7 @@ jobs:
   flags:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
@@ -29,7 +29,7 @@ jobs:
   help-output-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
@@ -41,7 +41,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
@@ -57,7 +57,7 @@ jobs:
   e2e-tests-local:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
@@ -73,7 +73,7 @@ jobs:
   e2e-tests-sepolia:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
@@ -92,7 +92,7 @@ jobs:
   e2e-tests-hoodi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
@@ -111,7 +111,7 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
@@ -127,7 +127,7 @@ jobs:
   build-binary:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
@@ -139,7 +139,7 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - run: BUILD_TAG=dev make docker-build
         working-directory: api/proxy
       # We also test that the docker container starts up correctly.

--- a/.github/workflows/test-proxy.yml
+++ b/.github/workflows/test-proxy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: true
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout EigenDA
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout EigenDA
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout EigenDA
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout EigenDA
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac #v2
         with:
           version: ${{ env.MISE_VERSION }}
           experimental: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,7 +62,7 @@ jobs:
           echo "coverage: $COVERAGE% of statements"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe #v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: main-unit-tests-coverage
@@ -123,7 +123,7 @@ jobs:
           echo "coverage: $COVERAGE% of statements"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe #v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: litt-unit-tests-coverage

--- a/api/proxy/.env.example
+++ b/api/proxy/.env.example
@@ -25,7 +25,7 @@ EIGENDA_PROXY_STORAGE_CACHE_TARGETS=""
 EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX=""
 
 # JSON RPC node endpoint for the Ethereum network.
-EIGENDA_PROXY_EIGENDA_V2_ETH_RPC=https://ethereum-sepolia.rpc.subquery.network/public
+EIGENDA_PROXY_EIGENDA_V2_ETH_RPC=https://eth-sepolia-testnet.api.pocket.network
 
 # The EigenDA network to run on. One of [mainnet, sepolia_testnet, hoodi_testnet].
 # This populates default values for other flags (disperser URL and contract addresses).

--- a/api/proxy/store/eigenda_manager.go
+++ b/api/proxy/store/eigenda_manager.go
@@ -150,12 +150,17 @@ func (m *EigenDAManager) getEigenDAV2(
 	// TODO: would be nice to store blobs instead of payloads in secondary storages, such that we could standardize all
 	// storages and make them all implement the [clients.PayloadRetriever] interface.
 	// We could then get rid of the proxy notion of caches/fallbacks and only have storages.
-	if m.secondary.CachingEnabled() && !opts.ReturnEncodedPayload {
+	if m.secondary.CachingEnabled() {
 		m.log.Debug("Retrieving payload from cached backends")
 		payload, err := m.secondary.MultiSourceRead(ctx,
 			versionedCert.SerializedCert, false, verifyFnForSecondary)
 		if err == nil {
-			return payload, nil
+			if !opts.ReturnEncodedPayload {
+				return payload, nil
+			} else {
+				encodedPayload := coretypes.Payload(payload).ToEncodedPayload()
+				return encodedPayload.Serialize(), nil
+			}
 		}
 		m.log.Warn("Failed to read payload from cache targets", "err", err)
 		readErrors = append(readErrors, fmt.Errorf("read from cache targets: %w", err))

--- a/api/proxy/store/eigenda_manager.go
+++ b/api/proxy/store/eigenda_manager.go
@@ -145,22 +145,22 @@ func (m *EigenDAManager) getEigenDAV2(
 	var readErrors []error
 	// 1 - read payload from cache if enabled
 	// Secondary storages (cache and fallback) store payloads instead of blobs.
-	// For simplicity, we bypass secondary storages when requesting encoded payloads,
-	// since those requests are only for secure integrations and run by provers/challengers.
+	// When ReturnEncodedPayload is requested, we re-encode the stored payload. This is only safe
+	// because there is a single [PayloadEncodingVersion] in use; adding a new encoding version
+	// will require the stored payload to carry (or the cert to identify) its original encoding version.
 	// TODO: would be nice to store blobs instead of payloads in secondary storages, such that we could standardize all
 	// storages and make them all implement the [clients.PayloadRetriever] interface.
 	// We could then get rid of the proxy notion of caches/fallbacks and only have storages.
 	if m.secondary.CachingEnabled() {
-		m.log.Debug("Retrieving payload from cached backends")
+		m.log.Debug("Retrieving payload from cached backends", "returnEncodedPayload", opts.ReturnEncodedPayload)
 		payload, err := m.secondary.MultiSourceRead(ctx,
 			versionedCert.SerializedCert, false, verifyFnForSecondary)
 		if err == nil {
 			if !opts.ReturnEncodedPayload {
 				return payload, nil
-			} else {
-				encodedPayload := coretypes.Payload(payload).ToEncodedPayload()
-				return encodedPayload.Serialize(), nil
 			}
+			encodedPayload := coretypes.Payload(payload).ToEncodedPayload()
+			return encodedPayload.Serialize(), nil
 		}
 		m.log.Warn("Failed to read payload from cache targets", "err", err)
 		readErrors = append(readErrors, fmt.Errorf("read from cache targets: %w", err))
@@ -183,13 +183,20 @@ func (m *EigenDAManager) getEigenDAV2(
 	}
 	readErrors = append(readErrors, fmt.Errorf("read from EigenDA backend: %w", err))
 
-	// 3 - read blob from fallbacks if enabled and data is non-retrievable from EigenDA
-	// Only use fallbacks if we're not requesting encoded payload
-	if m.secondary.FallbackEnabled() && !opts.ReturnEncodedPayload {
-		payloadOrEncodedPayload, err = m.secondary.MultiSourceRead(ctx,
+	// 3 - read payload from fallbacks if enabled and data is non-retrievable from EigenDA.
+	// When ReturnEncodedPayload is requested, we re-encode the stored payload (see cache branch above
+	// for the single-encoding-version caveat). This path is critical for secure integrations after
+	// EigenDA's retention window expires, when the relays/validators no longer serve the encoded payload.
+	if m.secondary.FallbackEnabled() {
+		m.log.Debug("Retrieving payload from fallback backends", "returnEncodedPayload", opts.ReturnEncodedPayload)
+		payload, err := m.secondary.MultiSourceRead(ctx,
 			versionedCert.SerializedCert, true, verifyFnForSecondary)
 		if err == nil {
-			return payloadOrEncodedPayload, nil
+			if !opts.ReturnEncodedPayload {
+				return payload, nil
+			}
+			encodedPayload := coretypes.Payload(payload).ToEncodedPayload()
+			return encodedPayload.Serialize(), nil
 		}
 		readErrors = append(readErrors, fmt.Errorf("read from fallback targets: %w", err))
 	}

--- a/api/proxy/test/testutils/setup.go
+++ b/api/proxy/test/testutils/setup.go
@@ -273,6 +273,13 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 				MaxBlobSizeBytes: maxBlobLengthBytes,
 			}),
 		MemstoreEnabled: useMemory,
+		// The client reservation leaky bucket starts full (see storage_manager_builder.go), so a freshly
+		// started proxy cannot disperse until the bucket leaks. Since every blob is billed as at least
+		// minNumSymbols (4096 on testnets) and the reservation leaks at symbolsPerSecond, there is a ~1s
+		// startup dead-zone where dispersals are rejected with "reservation lacks capacity". A non-zero
+		// PutRetryDelay lets the existing linear backoff in the V2 store span that window, mirroring the
+		// production default (the prod flag defaults to 1s) instead of retrying instantly (sleep=0s).
+		PutRetryDelay: 1 * time.Second,
 		ClientConfigV2: common.ClientConfigV2{
 			DisperserClientCfg: dispersal.DisperserClientConfig{
 				GrpcUri:           fmt.Sprintf("%s:%s", disperserHostname, disperserPort),

--- a/node/grpc/server_v2_test.go
+++ b/node/grpc/server_v2_test.go
@@ -122,12 +122,12 @@ func newTestComponents(t *testing.T, config *node.Config) *testComponents {
 		mockOperatorState.Operators[quorumID] = make(map[core.OperatorID]*core.OperatorInfo)
 		// Add a mock operator to each quorum so chunk location determination works
 		mockOperatorState.Operators[quorumID][opID] = &core.OperatorInfo{
-			Stake:  big.NewInt(100),
-			Index:  0,
+			Stake: big.NewInt(100),
+			Index: 0,
 		}
 		mockOperatorState.Totals[quorumID] = &core.OperatorInfo{
-			Stake:  big.NewInt(100),
-			Index:  1,
+			Stake: big.NewInt(100),
+			Index: 1,
 		}
 	}
 	chainState.On("GetOperatorState", mock.Anything, mock.Anything, mock.Anything).Return(mockOperatorState, nil)

--- a/node/node_internal_test.go
+++ b/node/node_internal_test.go
@@ -387,10 +387,10 @@ func TestGetReachabilityURL_InvalidBase(t *testing.T) {
 func TestConfigureMemoryLimits_ConstantSizes(t *testing.T) {
 	logger := testLogger(t)
 	config := &Config{
-		GCSafetyBufferSizeBytes:      1024,
-		LittDBReadCacheSizeBytes:     2048,
-		LittDBWriteCacheSizeBytes:    2048,
-		StoreChunksBufferSizeBytes:   4096,
+		GCSafetyBufferSizeBytes:    1024,
+		LittDBReadCacheSizeBytes:   2048,
+		LittDBWriteCacheSizeBytes:  2048,
+		StoreChunksBufferSizeBytes: 4096,
 	}
 	err := configureMemoryLimits(logger, config)
 	require.NoError(t, err)
@@ -404,10 +404,10 @@ func TestConfigureMemoryLimits_FractionSizes(t *testing.T) {
 	logger := testLogger(t)
 	// Use small fractions that should not exceed system memory.
 	config := &Config{
-		GCSafetyBufferSizeFraction:      0.01,
-		LittDBReadCacheSizeFraction:     0.01,
-		LittDBWriteCacheSizeFraction:    0.01,
-		StoreChunksBufferSizeFraction:   0.01,
+		GCSafetyBufferSizeFraction:    0.01,
+		LittDBReadCacheSizeFraction:   0.01,
+		LittDBWriteCacheSizeFraction:  0.01,
+		StoreChunksBufferSizeFraction: 0.01,
 	}
 	err := configureMemoryLimits(logger, config)
 	require.NoError(t, err)


### PR DESCRIPTION
## Why are these changes needed?

Previously the Read path of the proxy won't return cached result if `returnEncodedPayload` is enabled. But it is needed. 

This PR fixes it on the GET path, by re-encoding the payload if the `returnEncodedPayload` option is true

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
