### PR TITLE
test(proxy): cover storage config parsing

### DIFF
--- a/api/proxy/store/cli.go
+++ b/api/proxy/store/cli.go
@@ -93,17 +93,20 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 
 func ReadConfig(ctx *cli.Context) (Config, error) {
 	backendStrings := ctx.StringSlice(BackendsToEnableFlagName)
-	if len(backendStrings) == 0 {
-		return Config{}, errors.New("backends must not be empty")
-	}
-
 	backends := make([]common.EigenDABackend, 0, len(backendStrings))
 	for _, backendString := range backendStrings {
+		if backendString == "" {
+			continue
+		}
+
 		backend, err := common.StringToEigenDABackend(backendString)
 		if err != nil {
 			return Config{}, fmt.Errorf("string to eigenDA backend: %w", err)
 		}
 		backends = append(backends, backend)
+	}
+	if len(backends) == 0 {
+		return Config{}, errors.New("backends must not be empty")
 	}
 
 	dispersalBackend, err := common.StringToEigenDABackend(ctx.String(DispersalBackendFlagName))

--- a/api/proxy/store/cli_test.go
+++ b/api/proxy/store/cli_test.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/api/proxy/common"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func runWithStorageFlags(t *testing.T, args []string, fn func(ctx *cli.Context)) {
+	t.Helper()
+
+	app := cli.NewApp()
+	app.Flags = CLIFlags("EIGENDA_PROXY", "Storage")
+	app.Action = func(ctx *cli.Context) error {
+		fn(ctx)
+		return nil
+	}
+
+	err := app.Run(args)
+	require.NoError(t, err)
+}
+
+func TestReadConfigDefaultsToV2Backend(t *testing.T) {
+	runWithStorageFlags(t, []string{"test"}, func(ctx *cli.Context) {
+		cfg, err := ReadConfig(ctx)
+
+		require.NoError(t, err)
+		require.Equal(t, []common.EigenDABackend{common.V2EigenDABackend}, cfg.BackendsToEnable)
+		require.Equal(t, common.V2EigenDABackend, cfg.DispersalBackend)
+	})
+}
+
+func TestReadConfigFiltersEmptySecondaryTargets(t *testing.T) {
+	t.Setenv("EIGENDA_PROXY_STORAGE_CACHE_TARGETS", "")
+	t.Setenv("EIGENDA_PROXY_STORAGE_FALLBACK_TARGETS", "")
+
+	runWithStorageFlags(t, []string{"test"}, func(ctx *cli.Context) {
+		cfg, err := ReadConfig(ctx)
+
+		require.NoError(t, err)
+		require.Empty(t, cfg.CacheTargets)
+		require.Empty(t, cfg.FallbackTargets)
+	})
+}
+
+func TestReadConfigRejectsEmptyBackends(t *testing.T) {
+	runWithStorageFlags(t, []string{"test", "--storage.backends-to-enable", ""}, func(ctx *cli.Context) {
+		_, err := ReadConfig(ctx)
+
+		require.ErrorContains(t, err, "backends must not be empty")
+	})
+}


### PR DESCRIPTION
## Why are these changes needed?

This adds coverage for proxy storage CLI configuration parsing. In particular, it verifies that the storage config defaults to the V2 backend, preserves empty cache/fallback target filtering, and rejects an empty backend list after filtering empty values.

The backend parsing path now filters empty backend entries before validation, matching the existing behavior for cache and fallback targets.




## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [x] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [x] Unit tests
   - [x] Integration tests
   - [ ] This PR is not tested :(


- `go test ./api/proxy/store -count=1`
- `go test $(go list ./api/proxy/... | grep -v '/api/proxy/test') -count=1`

`go test ./api/proxy/... -count=1` was not fully runnable locally because `api/proxy/test/...` requires Docker/testcontainers and failed with `rootless Docker not found`.
