### PR TITLE
Fix broken mdBook documentation links

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -17,7 +17,7 @@ which will start a local server at `http://localhost:3000` and open your browser
 ## Github Pages
 
 The book is automatically built and deployed to Github Pages on every push to the `main` branch.
-This is done by the Github Actions workflow defined in [../../.github/workflows/mdbook.yaml](../../.github/workflows/mdbook.yaml)
+This is done by the Github Actions workflow defined in [../../.github/workflows/mdbook-publish.yaml](../../.github/workflows/mdbook-publish.yaml)
 
 ## Mermaid Diagrams
 

--- a/docs/spec/src/integration/spec/6-secure-integration.md
+++ b/docs/spec/src/integration/spec/6-secure-integration.md
@@ -56,7 +56,7 @@ When validation fails, the DA Cert is discarded and nothing is forwarded downstr
 - Host provides false recency window size that leads to failure
 
 #### Cert Validity Check Failed
-- DA Cert doesn't satisfy [quorum-attestation constraint](../spec/6-secure-integration.md#2-cert-validation) or the `offchain derivation version` in the DA Cert differs from the immutable one stored in the `EigenDACertVerifier`'s bytecode. For more information, see [upgrade](./7-upgrade.md).
+- DA Cert doesn't satisfy [quorum-attestation constraint](../spec/6-secure-integration.md#2-cert-validation) or the `offchain derivation version` in the DA Cert differs from the immutable one stored in the `EigenDACertVerifier`'s bytecode. For more information, see [upgrade](./7-secure-upgrade.md).
 - Host provides false validity information via preimage oracle
 
 #### Decode Blob Failed


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This fixes two broken links in the mdBook documentation:

- Updates the GitHub Pages workflow link in `docs/spec/README.md` from the missing `mdbook.yaml` file to the existing `mdbook-publish.yaml` workflow.
- Updates the secure integration upgrade link from `7-upgrade.md` to the existing `7-secure-upgrade.md` page.

These are docs-only changes that make the existing references resolve correctly.


## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [x] This PR is not tested :(
