### PR TITLE
chore(subgraphs): repoint preprod-hoodi to redeployed contracts

### DIFF
--- a/subgraphs/eigenda-batch-metadata/templates/preprod-hoodi.json
+++ b/subgraphs/eigenda-batch-metadata/templates/preprod-hoodi.json
@@ -1,5 +1,5 @@
 {
   "network": "hoodi",
-  "EigenDAServiceManager_address": "0x9F3A67f1b56d0B21115A54356c02B2d77f39EA8a",
-  "EigenDAServiceManager_startBlock": 1274225
+  "EigenDAServiceManager_address": "0x527B48fA607e0F07C5003D60F32801c5613D6308",
+  "EigenDAServiceManager_startBlock": 3162021
 }

--- a/subgraphs/eigenda-operator-state/templates/preprod-hoodi.json
+++ b/subgraphs/eigenda-operator-state/templates/preprod-hoodi.json
@@ -1,9 +1,9 @@
 {
   "network": "hoodi",
-  "RegistryCoordinator_address": "0xec03e7038Ca95cB7706a8b129CDE36635CBAF9df",
-  "RegistryCoordinator_startBlock": 1274216,
-  "BLSApkRegistry_address": "0xf2b91361f20040a0f1c2663B49bCAE6CD5ED5B98",
-  "BLSApkRegistry_startBlock": 1274205,
-  "EjectionManager_address": "0xe397F202D271d73EAB6444d634F68278B6274830",
-  "EjectionManager_startBlock": 1274229
+  "RegistryCoordinator_address": "0x51C4476565B982442Afd702Ea6aaa095F5169EFe",
+  "RegistryCoordinator_startBlock": 3162015,
+  "BLSApkRegistry_address": "0xF9A852526c98DeEa3021a1E1362698818e7E236a",
+  "BLSApkRegistry_startBlock": 3162017,
+  "EjectionManager_address": "0xE36e1079b78A6aa69179A773608a5981624fA129",
+  "EjectionManager_startBlock": 3162043
 }

--- a/subgraphs/eigenda-payments/templates/preprod-hoodi.json
+++ b/subgraphs/eigenda-payments/templates/preprod-hoodi.json
@@ -1,5 +1,5 @@
 {
   "network": "hoodi",
-  "PaymentVault_address": "0x6E8772AE295BA1d3Cc89296ccDE017f91335594d",
-  "PaymentVault_startBlock": 1274227
+  "PaymentVault_address": "0xb927F0F1416b59851f2A110074AaF861f142f1d3",
+  "PaymentVault_startBlock": 3162042
 }


### PR DESCRIPTION
The preprod-hoodi EigenDA contracts were redeployed (owner-key recovery) to a fresh, byte-identical contract set. Update the preprod-hoodi subgraph templates to index the new RegistryCoordinator, BLSApkRegistry, EjectionManager, EigenDAServiceManager and PaymentVault addresses, with startBlocks set to each contract's deploy block (~3162015-3162043).

Requires regenerating and redeploying the operator-state, batch-metadata and payments subgraphs to Goldsky.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [ ] This PR is not tested :(
