### PR TITLE
fix(dataapi): add blob-aware operator signing accounting

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,7 +62,7 @@ jobs:
           echo "coverage: $COVERAGE% of statements"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe #v5.5.4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: main-unit-tests-coverage
@@ -123,7 +123,7 @@ jobs:
           echo "coverage: $COVERAGE% of statements"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe #v5.5.4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: litt-unit-tests-coverage
@@ -146,4 +146,3 @@ jobs:
             exit 1
           fi
           echo "All test jobs passed successfully"
-

--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -257,6 +257,29 @@ type Batch struct {
 	BlobCertificates []*BlobCertificate
 }
 
+// GetBlobQuorumNumbers returns the quorum set requested by each blob in the batch.
+func (b *Batch) GetBlobQuorumNumbers() ([][]core.QuorumID, error) {
+	if b == nil {
+		return nil, errors.New("batch is nil")
+	}
+	if len(b.BlobCertificates) == 0 {
+		return nil, errors.New("batch must contain at least one blob certificate")
+	}
+
+	blobQuorumNumbers := make([][]core.QuorumID, len(b.BlobCertificates))
+	for i, certificate := range b.BlobCertificates {
+		if certificate == nil || certificate.BlobHeader == nil {
+			return nil, fmt.Errorf("blob certificate %d is missing its header", i)
+		}
+		if len(certificate.BlobHeader.QuorumNumbers) == 0 {
+			return nil, fmt.Errorf("blob certificate %d has no quorums", i)
+		}
+		blobQuorumNumbers[i] = append([]core.QuorumID(nil), certificate.BlobHeader.QuorumNumbers...)
+	}
+
+	return blobQuorumNumbers, nil
+}
+
 func (b *Batch) ToProtobuf() (*commonpb.Batch, error) {
 	if b.BatchHeader == nil {
 		return nil, errors.New("batch header is nil")
@@ -350,6 +373,10 @@ type Attestation struct {
 	QuorumNumbers []core.QuorumID
 	// QuorumResults contains the operators' total signing percentage of the quorum
 	QuorumResults map[core.QuorumID]uint8
+	// BlobQuorumNumbers contains the quorum set requested by each blob in the batch.
+	// It is persisted for signing-accounting queries but is not part of the public
+	// attestation response.
+	BlobQuorumNumbers [][]core.QuorumID `json:"-" dynamodbav:"BlobQuorumNumbers"`
 }
 
 func (a *Attestation) ToProtobuf() (*disperserpb.Attestation, error) {

--- a/core/v2/types.go
+++ b/core/v2/types.go
@@ -376,7 +376,7 @@ type Attestation struct {
 	// BlobQuorumNumbers contains the quorum set requested by each blob in the batch.
 	// It is persisted for signing-accounting queries but is not part of the public
 	// attestation response.
-	BlobQuorumNumbers [][]core.QuorumID `json:"-" dynamodbav:"BlobQuorumNumbers"`
+	BlobQuorumNumbers [][]core.QuorumID `json:"-" dynamodbav:"-"`
 }
 
 func (a *Attestation) ToProtobuf() (*disperserpb.Attestation, error) {

--- a/core/v2/types_test.go
+++ b/core/v2/types_test.go
@@ -67,6 +67,38 @@ func TestConvertBatchToFromProtobuf(t *testing.T) {
 	assert.Equal(t, batch, newBatch)
 }
 
+func TestGetBlobQuorumNumbers(t *testing.T) {
+	batch := &v2.Batch{
+		BlobCertificates: []*v2.BlobCertificate{
+			{BlobHeader: &v2.BlobHeader{QuorumNumbers: []core.QuorumID{0, 1}}},
+			{BlobHeader: &v2.BlobHeader{QuorumNumbers: []core.QuorumID{1}}},
+		},
+	}
+
+	blobQuorumNumbers, err := batch.GetBlobQuorumNumbers()
+	require.NoError(t, err)
+	require.Equal(t, [][]core.QuorumID{{0, 1}, {1}}, blobQuorumNumbers)
+
+	batch.BlobCertificates[0].BlobHeader.QuorumNumbers[0] = 2
+	require.Equal(t, [][]core.QuorumID{{0, 1}, {1}}, blobQuorumNumbers)
+
+	testCases := map[string]*v2.Batch{
+		"nil batch":           nil,
+		"no certificates":     {},
+		"nil certificate":     {BlobCertificates: []*v2.BlobCertificate{nil}},
+		"missing blob header": {BlobCertificates: []*v2.BlobCertificate{{}}},
+		"missing quorums": {
+			BlobCertificates: []*v2.BlobCertificate{{BlobHeader: &v2.BlobHeader{}}},
+		},
+	}
+	for name, invalidBatch := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, err := invalidBatch.GetBlobQuorumNumbers()
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestConvertBlobHeaderToFromProtobuf(t *testing.T) {
 	data := codec.ConvertByPaddingEmptyByte(GETTYSBURG_ADDRESS_BYTES)
 	commitments, err := c.GetCommitmentsForPaddedLength(data)

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -1112,6 +1112,38 @@ func (s *BlobMetadataStore) GetBatch(ctx context.Context, batchHeaderHash [32]by
 	return batch, nil
 }
 
+// GetBatches returns the batches for the given batch header hashes.
+// Note: the returned batches are not necessarily ordered by the input hashes.
+func (s *BlobMetadataStore) GetBatches(ctx context.Context, batchHeaderHashes [][32]byte) ([]*corev2.Batch, error) {
+	keys := make([]map[string]types.AttributeValue, len(batchHeaderHashes))
+	for i, batchHeaderHash := range batchHeaderHashes {
+		keys[i] = map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{
+				Value: batchHeaderKeyPrefix + hex.EncodeToString(batchHeaderHash[:]),
+			},
+			"SK": &types.AttributeValueMemberS{
+				Value: batchSK,
+			},
+		}
+	}
+
+	items, err := s.dynamoDBClient.GetItems(ctx, s.tableName, keys, true)
+	if err != nil {
+		return nil, fmt.Errorf("get batch items: %w", err)
+	}
+
+	batches := make([]*corev2.Batch, len(items))
+	for i, item := range items {
+		batch, err := UnmarshalBatch(item)
+		if err != nil {
+			return nil, err
+		}
+		batches[i] = batch
+	}
+
+	return batches, nil
+}
+
 func (s *BlobMetadataStore) PutBatchHeader(ctx context.Context, batchHeader *corev2.BatchHeader) error {
 	item, err := MarshalBatchHeader(batchHeader)
 	if err != nil {

--- a/disperser/common/v2/blobstore/dynamo_metadata_store.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store.go
@@ -34,16 +34,17 @@ const (
 	AccountBlobIndexName       = "AccountBlobIndex"
 	AccountUpdatedAtIndexName  = "AccountUpdatedAtIndex"
 
-	blobKeyPrefix             = "BlobKey#"
-	dispersalKeyPrefix        = "Dispersal#"
-	batchHeaderKeyPrefix      = "BatchHeader#"
-	blobMetadataSK            = "BlobMetadata"
-	blobCertSK                = "BlobCertificate"
-	dispersalRequestSKPrefix  = "DispersalRequest#"
-	dispersalResponseSKPrefix = "DispersalResponse#"
-	batchHeaderSK             = "BatchHeader"
-	batchSK                   = "BatchInfo"
-	attestationSK             = "Attestation"
+	blobKeyPrefix              = "BlobKey#"
+	dispersalKeyPrefix         = "Dispersal#"
+	batchHeaderKeyPrefix       = "BatchHeader#"
+	blobMetadataSK             = "BlobMetadata"
+	blobCertSK                 = "BlobCertificate"
+	dispersalRequestSKPrefix   = "DispersalRequest#"
+	dispersalResponseSKPrefix  = "DispersalResponse#"
+	batchHeaderSK              = "BatchHeader"
+	batchSK                    = "BatchInfo"
+	attestationSK              = "Attestation"
+	blobQuorumNumbersAttribute = "BlobQuorumNumbers"
 
 	accountPK      = "Account"
 	accountIndexPK = "AccountIndex"
@@ -1965,6 +1966,18 @@ func MarshalAttestation(attestation *corev2.Attestation) (commondynamodb.Item, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal attestation: %w", err)
 	}
+	if len(attestation.BlobQuorumNumbers) > 0 {
+		// [][]QuorumID is otherwise encoded as a DynamoDB binary set, which
+		// rejects duplicate quorum profiles for different blobs. Persist it as
+		// a list of binary values so identical per-blob quorum sets are valid.
+		blobQuorumNumbers := make([]types.AttributeValue, len(attestation.BlobQuorumNumbers))
+		for i, quorumNumbers := range attestation.BlobQuorumNumbers {
+			blobQuorumNumbers[i] = &types.AttributeValueMemberB{
+				Value: append([]byte(nil), quorumNumbers...),
+			}
+		}
+		fields[blobQuorumNumbersAttribute] = &types.AttributeValueMemberL{Value: blobQuorumNumbers}
+	}
 
 	hash, err := attestation.BatchHeader.Hash()
 	if err != nil {
@@ -1983,6 +1996,43 @@ func UnmarshalAttestation(item commondynamodb.Item) (*corev2.Attestation, error)
 	err := attributevalue.UnmarshalMap(item, &attestation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal attestation: %w", err)
+	}
+
+	if value, ok := item[blobQuorumNumbersAttribute]; ok {
+		switch value := value.(type) {
+		case *types.AttributeValueMemberL:
+			attestation.BlobQuorumNumbers = make([][]core.QuorumID, len(value.Value))
+			for i, quorumNumbers := range value.Value {
+				binaryQuorums, ok := quorumNumbers.(*types.AttributeValueMemberB)
+				if !ok {
+					return nil, fmt.Errorf(
+						"failed to unmarshal attestation: %s[%d] is not binary",
+						blobQuorumNumbersAttribute,
+						i,
+					)
+				}
+				attestation.BlobQuorumNumbers[i] = append(
+					[]core.QuorumID(nil),
+					binaryQuorums.Value...,
+				)
+			}
+		case *types.AttributeValueMemberBS:
+			// Accept the representation written by early versions of this
+			// change when every blob quorum set happened to be unique.
+			attestation.BlobQuorumNumbers = make([][]core.QuorumID, len(value.Value))
+			for i, quorumNumbers := range value.Value {
+				attestation.BlobQuorumNumbers[i] = append(
+					[]core.QuorumID(nil),
+					quorumNumbers...,
+				)
+			}
+		default:
+			return nil, fmt.Errorf(
+				"failed to unmarshal attestation: %s has unexpected type %T",
+				blobQuorumNumbersAttribute,
+				value,
+			)
+		}
 	}
 
 	return &attestation, nil

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -1869,6 +1869,11 @@ func TestBlobMetadataStoreBatch(t *testing.T) {
 	b, err := blobMetadataStore.GetBatch(ctx, bhh)
 	require.NoError(t, err)
 	assert.Equal(t, batch, b)
+
+	batches, err := blobMetadataStore.GetBatches(ctx, [][32]byte{bhh})
+	require.NoError(t, err)
+	require.Len(t, batches, 1)
+	assert.Equal(t, batch, batches[0])
 }
 
 func TestBlobMetadataStoreBlobAttestationInfo(t *testing.T) {

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -1925,7 +1925,7 @@ func TestBlobMetadataStoreBlobAttestationInfo(t *testing.T) {
 			0: 100,
 			1: 80,
 		},
-		BlobQuorumNumbers: [][]core.QuorumID{{0, 1}, {1}},
+		BlobQuorumNumbers: [][]core.QuorumID{{0, 1}, {0, 1}},
 	}
 	err = blobMetadataStore.PutAttestation(ctx, attestation)
 	assert.NoError(t, err)
@@ -2103,7 +2103,7 @@ func TestBlobMetadataStoreBatchAttestation(t *testing.T) {
 			0: 100,
 			1: 90,
 		},
-		BlobQuorumNumbers: [][]core.QuorumID{{0, 1}, {1}},
+		BlobQuorumNumbers: [][]core.QuorumID{{0, 1}, {0, 1}},
 	}
 
 	err = blobMetadataStore.PutAttestation(ctx, updatedAttestation)

--- a/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
+++ b/disperser/common/v2/blobstore/dynamo_metadata_store_test.go
@@ -1925,6 +1925,7 @@ func TestBlobMetadataStoreBlobAttestationInfo(t *testing.T) {
 			0: 100,
 			1: 80,
 		},
+		BlobQuorumNumbers: [][]core.QuorumID{{0, 1}, {1}},
 	}
 	err = blobMetadataStore.PutAttestation(ctx, attestation)
 	assert.NoError(t, err)
@@ -2102,6 +2103,7 @@ func TestBlobMetadataStoreBatchAttestation(t *testing.T) {
 			0: 100,
 			1: 90,
 		},
+		BlobQuorumNumbers: [][]core.QuorumID{{0, 1}, {1}},
 	}
 
 	err = blobMetadataStore.PutAttestation(ctx, updatedAttestation)

--- a/disperser/common/v2/blobstore/instrumented_metadata_store.go
+++ b/disperser/common/v2/blobstore/instrumented_metadata_store.go
@@ -3,6 +3,7 @@ package blobstore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/core"
@@ -322,6 +323,20 @@ func (m *InstrumentedMetadataStore) GetBatch(ctx context.Context, batchHeaderHas
 	batch, err := m.metadataStore.GetBatch(ctx, batchHeaderHash)
 	m.recordMetrics("GetBatch", start, err)
 	return batch, err
+}
+
+func (m *InstrumentedMetadataStore) GetBatches(
+	ctx context.Context,
+	batchHeaderHashes [][32]byte,
+) ([]*corev2.Batch, error) {
+	defer m.trackInFlight("GetBatches")()
+	start := time.Now()
+	batches, err := m.metadataStore.GetBatches(ctx, batchHeaderHashes)
+	if err != nil {
+		err = fmt.Errorf("get batches: %w", err)
+	}
+	m.recordMetrics("GetBatches", start, err)
+	return batches, err
 }
 
 func (m *InstrumentedMetadataStore) PutBatchHeader(ctx context.Context, batchHeader *corev2.BatchHeader) error {

--- a/disperser/common/v2/blobstore/instrumented_metadata_store.go
+++ b/disperser/common/v2/blobstore/instrumented_metadata_store.go
@@ -3,7 +3,6 @@ package blobstore
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/core"
@@ -332,11 +331,8 @@ func (m *InstrumentedMetadataStore) GetBatches(
 	defer m.trackInFlight("GetBatches")()
 	start := time.Now()
 	batches, err := m.metadataStore.GetBatches(ctx, batchHeaderHashes)
-	if err != nil {
-		err = fmt.Errorf("get batches: %w", err)
-	}
 	m.recordMetrics("GetBatches", start, err)
-	return batches, err
+	return batches, err //nolint:wrapcheck // Preserve underlying errors consistently with the other instrumented methods.
 }
 
 func (m *InstrumentedMetadataStore) PutBatchHeader(ctx context.Context, batchHeader *corev2.BatchHeader) error {

--- a/disperser/common/v2/blobstore/metadata_store.go
+++ b/disperser/common/v2/blobstore/metadata_store.go
@@ -85,6 +85,7 @@ type MetadataStore interface {
 	// These methods manage batches of blobs that are processed together
 	PutBatch(ctx context.Context, batch *corev2.Batch) error
 	GetBatch(ctx context.Context, batchHeaderHash [32]byte) (*corev2.Batch, error)
+	GetBatches(ctx context.Context, batchHeaderHashes [][32]byte) ([]*corev2.Batch, error)
 	PutBatchHeader(ctx context.Context, batchHeader *corev2.BatchHeader) error
 	DeleteBatchHeader(ctx context.Context, batchHeaderHash [32]byte) error
 	GetBatchHeader(ctx context.Context, batchHeaderHash [32]byte) (*corev2.BatchHeader, error)

--- a/disperser/controller/controller.go
+++ b/disperser/controller/controller.go
@@ -301,6 +301,11 @@ func (c *Controller) HandleSignatures(
 		return errors.New("batchData is required")
 	}
 
+	blobQuorumNumbers, err := batchData.Batch.GetBlobQuorumNumbers()
+	if err != nil {
+		return fmt.Errorf("get blob quorum numbers: %w", err)
+	}
+
 	batchHeaderHash := hex.EncodeToString(batchData.BatchHeaderHash[:])
 	for _, key := range batchData.BlobKeys {
 		err := c.updateBlobStatus(ctx, key, v2.GatheringSignatures)
@@ -315,16 +320,17 @@ func (c *Controller) HandleSignatures(
 	// write an empty attestation before starting to gather signatures, so that it can be queried right away.
 	// the attestation will be periodically updated as signatures are gathered.
 	attestation := &corev2.Attestation{
-		BatchHeader:      batchData.Batch.BatchHeader,
-		AttestedAt:       uint64(time.Now().UnixNano()),
-		NonSignerPubKeys: nil,
-		APKG2:            nil,
-		QuorumAPKs:       nil,
-		Sigma:            nil,
-		QuorumNumbers:    nil,
-		QuorumResults:    nil,
+		BatchHeader:       batchData.Batch.BatchHeader,
+		AttestedAt:        uint64(time.Now().UnixNano()),
+		NonSignerPubKeys:  nil,
+		APKG2:             nil,
+		QuorumAPKs:        nil,
+		Sigma:             nil,
+		QuorumNumbers:     nil,
+		QuorumResults:     nil,
+		BlobQuorumNumbers: blobQuorumNumbers,
 	}
-	err := c.blobMetadataStore.PutAttestation(ctx, attestation)
+	err = c.blobMetadataStore.PutAttestation(ctx, attestation)
 	if err != nil {
 		// this error isn't fatal: a subsequent PutAttestation attempt might succeed
 		c.logger.Error("error calling PutAttestation",
@@ -363,7 +369,7 @@ func (c *Controller) HandleSignatures(
 	finalAttestation := &core.QuorumAttestation{}
 	// continue receiving attestations from the channel until it's closed
 	for receivedQuorumAttestation := range attestationChan {
-		err := c.updateAttestation(ctx, batchData, receivedQuorumAttestation)
+		err := c.updateAttestation(ctx, batchData, blobQuorumNumbers, receivedQuorumAttestation)
 		if err != nil {
 			c.logger.Warnf("error updating attestation for batch %s: %v", batchHeaderHash, err)
 			continue
@@ -387,6 +393,7 @@ func (c *Controller) HandleSignatures(
 func (c *Controller) updateAttestation(
 	ctx context.Context,
 	batchData *batchData,
+	blobQuorumNumbers [][]core.QuorumID,
 	quorumAttestation *core.QuorumAttestation,
 ) error {
 	sortedNonZeroQuorums, quorumPercentages := c.parseQuorumPercentages(quorumAttestation.QuorumResults)
@@ -405,14 +412,15 @@ func (c *Controller) updateAttestation(
 	}
 
 	attestation := &corev2.Attestation{
-		BatchHeader:      batchData.Batch.BatchHeader,
-		AttestedAt:       uint64(time.Now().UnixNano()),
-		NonSignerPubKeys: signatureAggregation.NonSigners,
-		APKG2:            signatureAggregation.AggPubKey,
-		QuorumAPKs:       signatureAggregation.QuorumAggPubKeys,
-		Sigma:            signatureAggregation.AggSignature,
-		QuorumNumbers:    sortedNonZeroQuorums,
-		QuorumResults:    quorumPercentages,
+		BatchHeader:       batchData.Batch.BatchHeader,
+		AttestedAt:        uint64(time.Now().UnixNano()),
+		NonSignerPubKeys:  signatureAggregation.NonSigners,
+		APKG2:             signatureAggregation.AggPubKey,
+		QuorumAPKs:        signatureAggregation.QuorumAggPubKeys,
+		Sigma:             signatureAggregation.AggSignature,
+		QuorumNumbers:     sortedNonZeroQuorums,
+		QuorumResults:     quorumPercentages,
+		BlobQuorumNumbers: blobQuorumNumbers,
 	}
 
 	putAttestationStartTime := time.Now()

--- a/disperser/controller/dispatcher_test.go
+++ b/disperser/controller/dispatcher_test.go
@@ -147,6 +147,10 @@ func TestControllerInsufficientSignatures(t *testing.T) {
 	require.NotNil(t, att.Sigma)
 	require.ElementsMatch(t, att.QuorumNumbers, []core.QuorumID{1})
 	require.InDeltaMapValues(t, map[core.QuorumID]uint8{1: 20}, att.QuorumResults, 0)
+	require.NotEmpty(t, att.BlobQuorumNumbers)
+	for _, quorumNumbers := range att.BlobQuorumNumbers {
+		require.NotEmpty(t, quorumNumbers)
+	}
 
 	// give the signals a moment to be sent
 	time.Sleep(10 * time.Millisecond)
@@ -251,6 +255,7 @@ func TestControllerInsufficientSignatures2(t *testing.T) {
 	require.Len(t, att.QuorumNumbers, 0)
 	require.Len(t, att.QuorumResults, 0)
 	require.Len(t, att.NonSignerPubKeys, 0)
+	require.NotEmpty(t, att.BlobQuorumNumbers)
 
 	// give the signals a moment to be sent
 	time.Sleep(10 * time.Millisecond)

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -705,6 +705,12 @@ const docTemplateV2 = `{
                         "description": "Whether to only return operators with signing rate less than 100% [default: false]",
                         "name": "nonsigner_only",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility accounting mode; blob_quorums supports intervals up to 3600 seconds [default: legacy]",
+                        "name": "accounting",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/disperser/dataapi/docs/v2/V2_docs.go
+++ b/disperser/dataapi/docs/v2/V2_docs.go
@@ -708,7 +708,7 @@ const docTemplateV2 = `{
                     },
                     {
                         "type": "string",
-                        "description": "Responsibility accounting mode; blob_quorums supports intervals up to 3600 seconds [default: legacy]",
+                        "description": "Responsibility accounting mode; blob_quorums supports intervals up to 43200 seconds [default: blob_quorums]",
                         "name": "accounting",
                         "in": "query"
                     }

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -705,7 +705,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Responsibility accounting mode; blob_quorums supports intervals up to 3600 seconds [default: legacy]",
+                        "description": "Responsibility accounting mode; blob_quorums supports intervals up to 43200 seconds [default: blob_quorums]",
                         "name": "accounting",
                         "in": "query"
                     }

--- a/disperser/dataapi/docs/v2/V2_swagger.json
+++ b/disperser/dataapi/docs/v2/V2_swagger.json
@@ -702,6 +702,12 @@
                         "description": "Whether to only return operators with signing rate less than 100% [default: false]",
                         "name": "nonsigner_only",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Responsibility accounting mode; blob_quorums supports intervals up to 3600 seconds [default: legacy]",
+                        "name": "accounting",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -1130,6 +1130,11 @@ paths:
         in: query
         name: nonsigner_only
         type: boolean
+      - description: Responsibility accounting mode; blob_quorums supports intervals
+          up to 3600 seconds [default: legacy]
+        in: query
+        name: accounting
+        type: string
       produces:
       - application/json
       responses:

--- a/disperser/dataapi/docs/v2/V2_swagger.yaml
+++ b/disperser/dataapi/docs/v2/V2_swagger.yaml
@@ -1131,7 +1131,7 @@ paths:
         name: nonsigner_only
         type: boolean
       - description: Responsibility accounting mode; blob_quorums supports intervals
-          up to 3600 seconds [default: legacy]
+          up to 43200 seconds [default: blob_quorums]
         in: query
         name: accounting
         type: string

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -611,7 +611,7 @@ func (s *ServerV2) computeOperatorsSigningInfo(
 		}
 	}
 
-	// Sort by descending order of signing rate and then ascending order of <quorumId, operatorId>.
+	// Sort by descending signing rate, then ascending operator ID and quorum ID.
 	sort.Slice(signingInfo, func(i, j int) bool {
 		if signingInfo[i].SigningPercentage == signingInfo[j].SigningPercentage {
 			if signingInfo[i].OperatorId == signingInfo[j].OperatorId {

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -126,6 +126,7 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 //	@Param		interval		query		int		false	"Fetch operators signing info starting from an interval (in seconds) before the end time [default: 3600]"
 //	@Param		quorums			query		string	false	"Comma separated list of quorum IDs to fetch signing info for [default: 0,1]"
 //	@Param		nonsigner_only	query		boolean	false	"Whether to only return operators with signing rate less than 100% [default: false]"
+//	@Param		accounting		query		string	false	"Responsibility accounting mode; blob_quorums supports intervals up to 3600 seconds [default: legacy]"
 //	@Success	200				{object}	OperatorsSigningInfoResponse
 //	@Failure	400				{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404				{object}	ErrorResponse	"error: Not found"
@@ -207,6 +208,28 @@ func (s *ServerV2) FetchOperatorSigningInfo(c *gin.Context) {
 		}
 	}
 
+	accountingMode := legacySigningInfoAccountingMode
+	if c.Query("accounting") != "" {
+		accountingMode = signingInfoAccountingMode(c.Query("accounting"))
+		if accountingMode != legacySigningInfoAccountingMode && accountingMode != blobQuorumSigningInfoAccountingMode {
+			s.metrics.IncrementInvalidArgRequestNum("FetchOperatorSigningInfo")
+			invalidParamsErrorResponse(c, errors.New("the accounting param must be \"legacy\" or \"blob_quorums\""))
+			return
+		}
+	}
+	if accountingMode == blobQuorumSigningInfoAccountingMode && interval > maxBlobQuorumSigningInfoIntervalSeconds {
+		s.metrics.IncrementInvalidArgRequestNum("FetchOperatorSigningInfo")
+		invalidParamsErrorResponse(
+			c,
+			fmt.Errorf(
+				"the blob_quorums accounting mode supports intervals up to %d seconds, found: %d",
+				maxBlobQuorumSigningInfoIntervalSeconds,
+				interval,
+			),
+		)
+		return
+	}
+
 	startTime := endTime.Add(-time.Duration(interval) * time.Second)
 	if startTime.Before(oldestTime) {
 		startTime = oldestTime
@@ -220,8 +243,18 @@ func (s *ServerV2) FetchOperatorSigningInfo(c *gin.Context) {
 		errorResponse(c, fmt.Errorf("failed to fetch attestation feed from blob metadata store: %w", err))
 		return
 	}
+	if accountingMode == blobQuorumSigningInfoAccountingMode {
+		attestations, err = deduplicateAttestations(attestations)
+		if err != nil {
+			s.metrics.IncrementFailedRequestNum("FetchOperatorSigningInfo")
+			errorResponse(c, fmt.Errorf("failed to deduplicate attestations: %w", err))
+			return
+		}
+	}
 
-	signingInfo, err := s.computeOperatorsSigningInfo(c.Request.Context(), attestations, quorumIds, nonsignerOnly)
+	signingInfo, err := s.computeOperatorsSigningInfo(
+		c.Request.Context(), attestations, quorumIds, nonsignerOnly, accountingMode,
+	)
 	if err != nil {
 		s.metrics.IncrementFailedRequestNum("FetchOperatorSigningInfo")
 		errorResponse(c, fmt.Errorf("failed to compute the operators signing info: %w", err))
@@ -442,6 +475,7 @@ func (s *ServerV2) computeOperatorsSigningInfo(
 	attestations []*corev2.Attestation,
 	quorumIDs []uint8,
 	nonsignerOnly bool,
+	accountingMode signingInfoAccountingMode,
 ) ([]*OperatorSigningInfo, error) {
 	if len(attestations) == 0 {
 		return nil, errors.New("no attestations to compute signing info")
@@ -479,15 +513,33 @@ func (s *ServerV2) computeOperatorsSigningInfo(
 		return nil, err
 	}
 
-	// Compute num batches failed, where numFailed[op][q] is the number of batches
-	// failed to sign for quorum "q" by operator "op".
-	numFailed := computeNumFailed(attestations, operatorQuorumIntervals)
+	var numFailed map[string]map[uint8]int
+	var numResponsible map[string]map[uint8]int
+	var totalNumBatchesPerQuorum map[uint8]int
+	if accountingMode == blobQuorumSigningInfoAccountingMode {
+		profiles, err := s.getBatchQuorumProfiles(ctx, attestations)
+		if err != nil {
+			return nil, fmt.Errorf("get batch quorum profiles: %w", err)
+		}
+		numFailed, numResponsible, totalNumBatchesPerQuorum, err = computeBlobQuorumSigningStats(
+			attestations,
+			profiles,
+			operatorQuorumIntervals,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("compute blob quorum signing stats: %w", err)
+		}
+	} else {
+		// Compute num batches failed, where numFailed[op][q] is the number of batches
+		// failed to sign for quorum "q" by operator "op".
+		numFailed = computeNumFailed(attestations, operatorQuorumIntervals)
 
-	// Compute num batches responsible, where numResponsible[op][q] is the number of batches
-	// that operator "op" are responsible for in quorum "q".
-	numResponsible := computeNumResponsible(attestations, operatorQuorumIntervals)
+		// Compute num batches responsible, where numResponsible[op][q] is the number of batches
+		// that operator "op" are responsible for in quorum "q".
+		numResponsible = computeNumResponsible(attestations, operatorQuorumIntervals)
 
-	totalNumBatchesPerQuorum := computeTotalNumBatchesPerQuorum(attestations)
+		totalNumBatchesPerQuorum = computeTotalNumBatchesPerQuorum(attestations)
+	}
 
 	state, err := s.chainState.GetOperatorState(ctx, uint(endBlock), quorumIDs)
 	if err != nil {

--- a/disperser/dataapi/v2/operators.go
+++ b/disperser/dataapi/v2/operators.go
@@ -126,7 +126,7 @@ func (s *ServerV2) FetchOperatorDispersalFeed(c *gin.Context) {
 //	@Param		interval		query		int		false	"Fetch operators signing info starting from an interval (in seconds) before the end time [default: 3600]"
 //	@Param		quorums			query		string	false	"Comma separated list of quorum IDs to fetch signing info for [default: 0,1]"
 //	@Param		nonsigner_only	query		boolean	false	"Whether to only return operators with signing rate less than 100% [default: false]"
-//	@Param		accounting		query		string	false	"Responsibility accounting mode; blob_quorums supports intervals up to 3600 seconds [default: legacy]"
+//	@Param		accounting		query		string	false	"Responsibility accounting mode; blob_quorums supports intervals up to 43200 seconds [default: blob_quorums]"
 //	@Success	200				{object}	OperatorsSigningInfoResponse
 //	@Failure	400				{object}	ErrorResponse	"error: Bad request"
 //	@Failure	404				{object}	ErrorResponse	"error: Not found"
@@ -208,7 +208,7 @@ func (s *ServerV2) FetchOperatorSigningInfo(c *gin.Context) {
 		}
 	}
 
-	accountingMode := legacySigningInfoAccountingMode
+	accountingMode := blobQuorumSigningInfoAccountingMode
 	if c.Query("accounting") != "" {
 		accountingMode = signingInfoAccountingMode(c.Query("accounting"))
 		if accountingMode != legacySigningInfoAccountingMode && accountingMode != blobQuorumSigningInfoAccountingMode {

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -108,7 +108,8 @@ type ServerV2 struct {
 	blobAttestationInfoResponseCache *lru.Cache[string, *BlobAttestationInfoResponse]
 
 	// KV caches for batches, keyed by batch header hash
-	batchResponseCache *lru.Cache[string, *BatchResponse]
+	batchResponseCache      *lru.Cache[string, *BatchResponse]
+	batchQuorumProfileCache *lru.Cache[string, *batchQuorumProfile]
 
 	// Account cache with TTL
 	accountCache *expirable.LRU[string, *AccountFeedResponse]
@@ -168,6 +169,10 @@ func NewServerV2(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batchResponseCache: %w", err)
 	}
+	batchQuorumProfileCache, err := lru.New[string, *batchQuorumProfile](maxNumKVBatchesToCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create batchQuorumProfileCache: %w", err)
+	}
 
 	accountCache := expirable.NewLRU[string, *AccountFeedResponse](100, nil, accountCacheTTL)
 
@@ -196,6 +201,7 @@ func NewServerV2(
 		blobCertificateCache:             blobCertificateCache,
 		blobAttestationInfoResponseCache: blobAttestationInfoResponseCache,
 		batchResponseCache:               batchResponseCache,
+		batchQuorumProfileCache:          batchQuorumProfileCache,
 		accountCache:                     accountCache,
 	}, nil
 }

--- a/disperser/dataapi/v2/server_v2.go
+++ b/disperser/dataapi/v2/server_v2.go
@@ -169,7 +169,10 @@ func NewServerV2(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batchResponseCache: %w", err)
 	}
-	batchQuorumProfileCache, err := lru.New[string, *batchQuorumProfile](maxNumKVBatchesToCache)
+	// Historical attestations do not contain inline quorum profiles. Keep enough
+	// compact fallback profiles for the full attestation cache window so rollout
+	// queries do not repeatedly reload full batches.
+	batchQuorumProfileCache, err := lru.New[string, *batchQuorumProfile](maxNumBatchesToCache)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create batchQuorumProfileCache: %w", err)
 	}

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -2315,8 +2315,8 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		osi := response.OperatorSigningInfo
 		require.Equal(t, 5, len(osi))
 		checkOperatorSigningInfoEqual(t, osi[0], &serverv2.OperatorSigningInfo{
-			OperatorId:              operatorIds[1].Hex(),
-			OperatorAddress:         operatorAddresses[1].Hex(),
+			OperatorId:              operatorIds[2].Hex(),
+			OperatorAddress:         operatorAddresses[2].Hex(),
 			QuorumId:                0,
 			TotalUnsignedBatches:    0,
 			TotalResponsibleBatches: 1,
@@ -2325,15 +2325,15 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		checkOperatorSigningInfoEqual(t, osi[1], &serverv2.OperatorSigningInfo{
 			OperatorId:              operatorIds[1].Hex(),
 			OperatorAddress:         operatorAddresses[1].Hex(),
-			QuorumId:                1,
+			QuorumId:                0,
 			TotalUnsignedBatches:    0,
 			TotalResponsibleBatches: 1,
 			TotalBatches:            1,
 		})
 		checkOperatorSigningInfoEqual(t, osi[2], &serverv2.OperatorSigningInfo{
-			OperatorId:              operatorIds[2].Hex(),
-			OperatorAddress:         operatorAddresses[2].Hex(),
-			QuorumId:                0,
+			OperatorId:              operatorIds[1].Hex(),
+			OperatorAddress:         operatorAddresses[1].Hex(),
+			QuorumId:                1,
 			TotalUnsignedBatches:    0,
 			TotalResponsibleBatches: 1,
 			TotalBatches:            1,

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -1715,7 +1715,7 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		- Batch:            Batch number
 		- AttestedAt:       Timestamp of attestation (sortkey of this table)
 		- RefBlockNum:      Reference block number
-		- Quorums:          Quorum numbers used by the batch
+		- Quorums:          Quorum numbers materialized in the attestation
 		- Nonsigners:       Operators that didn't sign for the batch
 		- Active operators: Mapping of operator ID to their quorum assignments at the block
 
@@ -1926,9 +1926,8 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 	mockSubgraphApi.On("QueryOperatorAddedToQuorum").Return(operatorAddedToQuorum, nil)
 	mockSubgraphApi.On("QueryOperatorRemovedFromQuorum").Return(operatorRemovedFromQuorum, nil)
 
-	// Create a timeline of test batches
-	// See the above table for the choices of reference block number, quorums and nonsigners
-	// for each batch
+	// Create a timeline of test batches. Batch 5 contains only a quorum 1 blob while
+	// its attestation also contains quorum 0, reproducing a phantom attestation quorum.
 	numBatches := 6
 	now := uint64(time.Now().UnixNano())
 	firstBatchTime := now - uint64(32*time.Minute.Nanoseconds())
@@ -1939,6 +1938,7 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 	}
 	referenceBlockNum := []uint64{1, 3, 2, 2, 4, 5}
 	quorums := [][]uint8{{0, 1}, {1}, {0}, {0, 1}, {0, 1}, {0}}
+	blobQuorums := [][][]uint8{{{0, 1}}, {{1}}, {{0}}, {{0, 1}}, {{1}}, {{0}}}
 	nonsigners := [][]*core.G1Point{
 		{operatorG1s[2]},
 		{operatorG1s[3]},
@@ -1947,17 +1947,35 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		{operatorG1s[2], operatorG1s[4]},
 		{operatorG1s[4]},
 	}
-	dynamoKeys := make([]dynamodb.Key, numBatches)
+	dynamoKeys := make([]dynamodb.Key, 0, numBatches*2)
 	for i := 0; i < numBatches; i++ {
 		attestation := createAttestation(t, referenceBlockNum[i], attestedAt[i], nonsigners[i], quorums[i])
 		err := blobMetadataStore.PutAttestation(ctx, attestation)
 		require.NoError(t, err)
+
+		certificates := make([]*corev2.BlobCertificate, len(blobQuorums[i]))
+		for j, blobQuorumNumbers := range blobQuorums[i] {
+			blobHeader := makeBlobHeaderV2(t)
+			blobHeader.QuorumNumbers = blobQuorumNumbers
+			certificates[j] = &corev2.BlobCertificate{
+				BlobHeader: blobHeader,
+			}
+		}
+		err = blobMetadataStore.PutBatch(ctx, &corev2.Batch{
+			BatchHeader:      attestation.BatchHeader,
+			BlobCertificates: certificates,
+		})
+		require.NoError(t, err)
+
 		bhh, err := attestation.BatchHeader.Hash() // go:nolint QF1008
 		require.NoError(t, err)
-		dynamoKeys[i] = dynamodb.Key{
+		dynamoKeys = append(dynamoKeys, dynamodb.Key{
 			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
 			"SK": &types.AttributeValueMemberS{Value: "Attestation"},
-		}
+		}, dynamodb.Key{
+			"PK": &types.AttributeValueMemberS{Value: "BatchHeader#" + hex.EncodeToString(bhh[:])},
+			"SK": &types.AttributeValueMemberS{Value: "BatchInfo"},
+		})
 	}
 	defer deleteItems(t, dynamoKeys)
 
@@ -2013,6 +2031,8 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 			"/v2/operators/signing-info?quorums=-1",
 			"/v2/operators/signing-info?nonsigner_only=-1",
 			"/v2/operators/signing-info?nonsigner_only=deadbeef",
+			"/v2/operators/signing-info?accounting=unknown",
+			"/v2/operators/signing-info?accounting=blob_quorums&interval=3601",
 		}
 		for _, url := range reqUrls {
 			w := httptest.NewRecorder()
@@ -2082,6 +2102,69 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 			TotalUnsignedBatches:    2,
 			TotalResponsibleBatches: 2,
 			TotalBatches:            5,
+		})
+	})
+
+	t.Run("blob quorum accounting", func(t *testing.T) {
+		w := executeRequest(t, r, http.MethodGet, "/v2/operators/signing-info?accounting=blob_quorums")
+		response := decodeResponseBody[serverv2.OperatorsSigningInfoResponse](t, w)
+		osi := response.OperatorSigningInfo
+		require.Equal(t, 7, len(osi))
+		checkOperatorSigningInfoEqual(t, osi[0], &serverv2.OperatorSigningInfo{
+			OperatorId:              operatorIds[3].Hex(),
+			OperatorAddress:         operatorAddresses[3].Hex(),
+			QuorumId:                0,
+			TotalUnsignedBatches:    0,
+			TotalResponsibleBatches: 2,
+			TotalBatches:            4,
+		})
+		checkOperatorSigningInfoEqual(t, osi[1], &serverv2.OperatorSigningInfo{
+			OperatorId:              operatorIds[1].Hex(),
+			OperatorAddress:         operatorAddresses[1].Hex(),
+			QuorumId:                0,
+			TotalUnsignedBatches:    0,
+			TotalResponsibleBatches: 4,
+			TotalBatches:            4,
+		})
+		checkOperatorSigningInfoEqual(t, osi[2], &serverv2.OperatorSigningInfo{
+			OperatorId:              operatorIds[1].Hex(),
+			OperatorAddress:         operatorAddresses[1].Hex(),
+			QuorumId:                1,
+			TotalUnsignedBatches:    0,
+			TotalResponsibleBatches: 4,
+			TotalBatches:            4,
+		})
+		checkOperatorSigningInfoEqual(t, osi[3], &serverv2.OperatorSigningInfo{
+			OperatorId:              operatorIds[3].Hex(),
+			OperatorAddress:         operatorAddresses[3].Hex(),
+			QuorumId:                1,
+			TotalUnsignedBatches:    1,
+			TotalResponsibleBatches: 2,
+			TotalBatches:            4,
+		})
+		checkOperatorSigningInfoEqual(t, osi[4], &serverv2.OperatorSigningInfo{
+			OperatorId:              operatorIds[2].Hex(),
+			OperatorAddress:         operatorAddresses[2].Hex(),
+			QuorumId:                0,
+			TotalUnsignedBatches:    2,
+			TotalResponsibleBatches: 4,
+			TotalBatches:            4,
+		})
+		checkOperatorSigningInfoEqual(t, osi[5], &serverv2.OperatorSigningInfo{
+			OperatorId:              operatorIds[2].Hex(),
+			OperatorAddress:         operatorAddresses[2].Hex(),
+			QuorumId:                1,
+			TotalUnsignedBatches:    2,
+			TotalResponsibleBatches: 4,
+			TotalBatches:            4,
+		})
+		checkOperatorSigningInfoEqual(t, osi[6], &serverv2.OperatorSigningInfo{
+			OperatorId:              operatorIds[4].Hex(),
+			OperatorAddress:         operatorAddresses[4].Hex(),
+			QuorumId:                0,
+			TotalUnsignedBatches:    1,
+			TotalResponsibleBatches: 1,
+			TotalBatches:            4,
 		})
 	})
 

--- a/disperser/dataapi/v2/server_v2_test.go
+++ b/disperser/dataapi/v2/server_v2_test.go
@@ -1950,6 +1950,7 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 	dynamoKeys := make([]dynamodb.Key, 0, numBatches*2)
 	for i := 0; i < numBatches; i++ {
 		attestation := createAttestation(t, referenceBlockNum[i], attestedAt[i], nonsigners[i], quorums[i])
+		attestation.BlobQuorumNumbers = blobQuorums[i]
 		err := blobMetadataStore.PutAttestation(ctx, attestation)
 		require.NoError(t, err)
 
@@ -2032,7 +2033,7 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 			"/v2/operators/signing-info?nonsigner_only=-1",
 			"/v2/operators/signing-info?nonsigner_only=deadbeef",
 			"/v2/operators/signing-info?accounting=unknown",
-			"/v2/operators/signing-info?accounting=blob_quorums&interval=3601",
+			"/v2/operators/signing-info?accounting=blob_quorums&interval=43201",
 		}
 		for _, url := range reqUrls {
 			w := httptest.NewRecorder()
@@ -2042,8 +2043,8 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		}
 	})
 
-	t.Run("default params", func(t *testing.T) {
-		w := executeRequest(t, r, http.MethodGet, "/v2/operators/signing-info")
+	t.Run("legacy accounting", func(t *testing.T) {
+		w := executeRequest(t, r, http.MethodGet, "/v2/operators/signing-info?accounting=legacy")
 		response := decodeResponseBody[serverv2.OperatorsSigningInfoResponse](t, w)
 		osi := response.OperatorSigningInfo
 		require.Equal(t, 7, len(osi))
@@ -2105,8 +2106,8 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		})
 	})
 
-	t.Run("blob quorum accounting", func(t *testing.T) {
-		w := executeRequest(t, r, http.MethodGet, "/v2/operators/signing-info?accounting=blob_quorums")
+	t.Run("default blob quorum accounting", func(t *testing.T) {
+		w := executeRequest(t, r, http.MethodGet, "/v2/operators/signing-info")
 		response := decodeResponseBody[serverv2.OperatorsSigningInfoResponse](t, w)
 		osi := response.OperatorSigningInfo
 		require.Equal(t, 7, len(osi))
@@ -2168,6 +2169,40 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		})
 	})
 
+	t.Run("default blob quorum accounting with quorum filter", func(t *testing.T) {
+		w := executeRequest(t, r, http.MethodGet, "/v2/operators/signing-info?quorums=0")
+		response := decodeResponseBody[serverv2.OperatorsSigningInfoResponse](t, w)
+
+		var ethOnlySigningInfo *serverv2.OperatorSigningInfo
+		for _, signingInfo := range response.OperatorSigningInfo {
+			require.Equal(t, uint8(0), signingInfo.QuorumId)
+			if signingInfo.OperatorId == operatorIds[4].Hex() {
+				ethOnlySigningInfo = signingInfo
+			}
+		}
+
+		require.NotNil(t, ethOnlySigningInfo)
+		checkOperatorSigningInfoEqual(t, ethOnlySigningInfo, &serverv2.OperatorSigningInfo{
+			OperatorId:              operatorIds[4].Hex(),
+			OperatorAddress:         operatorAddresses[4].Hex(),
+			QuorumId:                0,
+			TotalUnsignedBatches:    1,
+			TotalResponsibleBatches: 1,
+			TotalBatches:            4,
+		})
+	})
+
+	t.Run("12 hour blob quorum accounting interval", func(t *testing.T) {
+		w := executeRequest(
+			t,
+			r,
+			http.MethodGet,
+			"/v2/operators/signing-info?accounting=blob_quorums&interval=43200",
+		)
+		response := decodeResponseBody[serverv2.OperatorsSigningInfoResponse](t, w)
+		require.NotEmpty(t, response.OperatorSigningInfo)
+	})
+
 	t.Run("nonsigner only", func(t *testing.T) {
 		w := executeRequest(t, r, http.MethodGet, "/v2/operators/signing-info?nonsigner_only=true")
 		response := decodeResponseBody[serverv2.OperatorsSigningInfoResponse](t, w)
@@ -2184,7 +2219,7 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		checkOperatorSigningInfoEqual(t, osi[1], &serverv2.OperatorSigningInfo{
 			OperatorId:              operatorIds[2].Hex(),
 			OperatorAddress:         operatorAddresses[2].Hex(),
-			QuorumId:                1,
+			QuorumId:                0,
 			TotalUnsignedBatches:    2,
 			TotalResponsibleBatches: 4,
 			TotalBatches:            4,
@@ -2192,18 +2227,18 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		checkOperatorSigningInfoEqual(t, osi[2], &serverv2.OperatorSigningInfo{
 			OperatorId:              operatorIds[2].Hex(),
 			OperatorAddress:         operatorAddresses[2].Hex(),
-			QuorumId:                0,
-			TotalUnsignedBatches:    3,
-			TotalResponsibleBatches: 5,
-			TotalBatches:            5,
+			QuorumId:                1,
+			TotalUnsignedBatches:    2,
+			TotalResponsibleBatches: 4,
+			TotalBatches:            4,
 		})
 		checkOperatorSigningInfoEqual(t, osi[3], &serverv2.OperatorSigningInfo{
 			OperatorId:              operatorIds[4].Hex(),
 			OperatorAddress:         operatorAddresses[4].Hex(),
 			QuorumId:                0,
-			TotalUnsignedBatches:    2,
-			TotalResponsibleBatches: 2,
-			TotalBatches:            5,
+			TotalUnsignedBatches:    1,
+			TotalResponsibleBatches: 1,
+			TotalBatches:            4,
 		})
 	})
 
@@ -2261,15 +2296,15 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 		// +------------------+-------------------+------------------+--------------+
 		// | <operator,quorum>| Total responsible | Total nonsigning | Signing rate |
 		// +------------------+-------------------+------------------+--------------+
-		// | <2, 0>           |                 2 |                0 |        100%  |
+		// | <2, 0>           |                 1 |                0 |        100%  |
 		// +------------------+-------------------+------------------+--------------+
 		// | <2, 1>           |                 1 |                0 |        100%  |
 		// +------------------+-------------------+------------------+--------------+
-		// | <3, 0>           |                 2 |                1 |         50%  |
+		// | <3, 0>           |                 1 |                0 |        100%  |
 		// +------------------+-------------------+------------------+--------------+
 		// | <3, 1>           |                 1 |                1 |         0%   |
 		// +------------------+-------------------+------------------+--------------+
-		// | <5, 0>           |                 2 |                2 |         0%   |
+		// | <5, 0>           |                 1 |                1 |         0%   |
 		// +------------------+-------------------+------------------+--------------+
 
 		tm := time.Unix(0, int64(now)+1).UTC()
@@ -2284,8 +2319,8 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 			OperatorAddress:         operatorAddresses[1].Hex(),
 			QuorumId:                0,
 			TotalUnsignedBatches:    0,
-			TotalResponsibleBatches: 2,
-			TotalBatches:            2,
+			TotalResponsibleBatches: 1,
+			TotalBatches:            1,
 		})
 		checkOperatorSigningInfoEqual(t, osi[1], &serverv2.OperatorSigningInfo{
 			OperatorId:              operatorIds[1].Hex(),
@@ -2299,17 +2334,17 @@ func TestFetchOperatorSigningInfo(t *testing.T) {
 			OperatorId:              operatorIds[2].Hex(),
 			OperatorAddress:         operatorAddresses[2].Hex(),
 			QuorumId:                0,
-			TotalUnsignedBatches:    1,
-			TotalResponsibleBatches: 2,
-			TotalBatches:            2,
+			TotalUnsignedBatches:    0,
+			TotalResponsibleBatches: 1,
+			TotalBatches:            1,
 		})
 		checkOperatorSigningInfoEqual(t, osi[3], &serverv2.OperatorSigningInfo{
 			OperatorId:              operatorIds[4].Hex(),
 			OperatorAddress:         operatorAddresses[4].Hex(),
 			QuorumId:                0,
-			TotalUnsignedBatches:    2,
-			TotalResponsibleBatches: 2,
-			TotalBatches:            2,
+			TotalUnsignedBatches:    1,
+			TotalResponsibleBatches: 1,
+			TotalBatches:            1,
 		})
 		checkOperatorSigningInfoEqual(t, osi[4], &serverv2.OperatorSigningInfo{
 			OperatorId:              operatorIds[2].Hex(),

--- a/disperser/dataapi/v2/signing_info.go
+++ b/disperser/dataapi/v2/signing_info.go
@@ -1,0 +1,242 @@
+package v2
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/Layr-Labs/eigenda/core"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/Layr-Labs/eigenda/disperser/dataapi"
+)
+
+type signingInfoAccountingMode string
+
+const (
+	legacySigningInfoAccountingMode     signingInfoAccountingMode = "legacy"
+	blobQuorumSigningInfoAccountingMode signingInfoAccountingMode = "blob_quorums"
+
+	maxBlobQuorumSigningInfoIntervalSeconds = 3600
+)
+
+// batchQuorumProfile contains the minimum batch data needed to determine which
+// operators were capable of validating every blob in the batch.
+type batchQuorumProfile struct {
+	blobQuorums [][]core.QuorumID
+	quorums     map[core.QuorumID]struct{}
+}
+
+func newBatchQuorumProfile(batch *corev2.Batch) (*batchQuorumProfile, error) {
+	if batch == nil || batch.BatchHeader == nil {
+		return nil, fmt.Errorf("batch header is required")
+	}
+	if len(batch.BlobCertificates) == 0 {
+		return nil, fmt.Errorf("batch must contain at least one blob certificate")
+	}
+
+	profile := &batchQuorumProfile{
+		blobQuorums: make([][]core.QuorumID, len(batch.BlobCertificates)),
+		quorums:     make(map[core.QuorumID]struct{}),
+	}
+	for i, certificate := range batch.BlobCertificates {
+		if certificate == nil || certificate.BlobHeader == nil {
+			return nil, fmt.Errorf("blob certificate %d is missing its header", i)
+		}
+		if len(certificate.BlobHeader.QuorumNumbers) == 0 {
+			return nil, fmt.Errorf("blob certificate %d has no quorums", i)
+		}
+
+		profile.blobQuorums[i] = append([]core.QuorumID(nil), certificate.BlobHeader.QuorumNumbers...)
+		for _, quorum := range certificate.BlobHeader.QuorumNumbers {
+			profile.quorums[quorum] = struct{}{}
+		}
+	}
+
+	return profile, nil
+}
+
+// operatorIsEligible mirrors the current validator behavior: an operator can
+// sign only when it has a chunk assignment for every blob in the batch.
+func (p *batchQuorumProfile) operatorIsEligible(operatorQuorums []core.QuorumID) bool {
+	for _, blobQuorums := range p.blobQuorums {
+		assigned := false
+		for _, blobQuorum := range blobQuorums {
+			for _, operatorQuorum := range operatorQuorums {
+				if blobQuorum == operatorQuorum {
+					assigned = true
+					break
+				}
+			}
+			if assigned {
+				break
+			}
+		}
+		if !assigned {
+			return false
+		}
+	}
+
+	return true
+}
+
+func deduplicateAttestations(attestations []*corev2.Attestation) ([]*corev2.Attestation, error) {
+	deduplicated := make([]*corev2.Attestation, 0, len(attestations))
+	indices := make(map[string]int, len(attestations))
+
+	for _, attestation := range attestations {
+		if attestation == nil || attestation.BatchHeader == nil {
+			return nil, fmt.Errorf("attestation batch header is required")
+		}
+		batchHeaderHash, err := attestation.BatchHeader.Hash()
+		if err != nil {
+			return nil, fmt.Errorf("hash batch header: %w", err)
+		}
+		key := hex.EncodeToString(batchHeaderHash[:])
+
+		index, ok := indices[key]
+		if !ok {
+			indices[key] = len(deduplicated)
+			deduplicated = append(deduplicated, attestation)
+			continue
+		}
+
+		current := deduplicated[index]
+		if attestation.AttestedAt > current.AttestedAt ||
+			(attestation.AttestedAt == current.AttestedAt && len(attestation.QuorumNumbers) > len(current.QuorumNumbers)) {
+			deduplicated[index] = attestation
+		}
+	}
+
+	return deduplicated, nil
+}
+
+func (s *ServerV2) getBatchQuorumProfiles(
+	ctx context.Context,
+	attestations []*corev2.Attestation,
+) (map[string]*batchQuorumProfile, error) {
+	profiles := make(map[string]*batchQuorumProfile, len(attestations))
+	missingHashes := make([][32]byte, 0)
+	missingKeys := make(map[string]struct{})
+
+	for _, attestation := range attestations {
+		// The controller initially persists an empty attestation without a
+		// non-signer set. Preserve the existing behavior by excluding it.
+		if len(attestation.QuorumNumbers) == 0 {
+			continue
+		}
+
+		batchHeaderHash, err := attestation.BatchHeader.Hash()
+		if err != nil {
+			return nil, fmt.Errorf("hash batch header: %w", err)
+		}
+		key := hex.EncodeToString(batchHeaderHash[:])
+		if profile, ok := s.batchQuorumProfileCache.Get(key); ok {
+			profiles[key] = profile
+			continue
+		}
+		if _, ok := missingKeys[key]; ok {
+			continue
+		}
+		missingKeys[key] = struct{}{}
+		missingHashes = append(missingHashes, batchHeaderHash)
+	}
+
+	if len(missingHashes) > 0 {
+		batches, err := s.blobMetadataStore.GetBatches(ctx, missingHashes)
+		if err != nil {
+			return nil, fmt.Errorf("get batches: %w", err)
+		}
+
+		for _, batch := range batches {
+			profile, err := newBatchQuorumProfile(batch)
+			if err != nil {
+				return nil, fmt.Errorf("create batch quorum profile: %w", err)
+			}
+			batchHeaderHash, err := batch.BatchHeader.Hash()
+			if err != nil {
+				return nil, fmt.Errorf("hash batch header: %w", err)
+			}
+			key := hex.EncodeToString(batchHeaderHash[:])
+			if _, ok := missingKeys[key]; !ok {
+				return nil, fmt.Errorf("received unexpected batch %s", key)
+			}
+			profiles[key] = profile
+			s.batchQuorumProfileCache.Add(key, profile)
+		}
+	}
+
+	for key := range missingKeys {
+		if _, ok := profiles[key]; !ok {
+			return nil, fmt.Errorf("batch quorum profile not found for batch %s", key)
+		}
+	}
+
+	return profiles, nil
+}
+
+func computeBlobQuorumSigningStats(
+	attestations []*corev2.Attestation,
+	profiles map[string]*batchQuorumProfile,
+	operatorQuorumIntervals dataapi.OperatorQuorumIntervals,
+) (map[string]map[uint8]int, map[string]map[uint8]int, map[uint8]int, error) {
+	numFailed := make(map[string]map[uint8]int)
+	numResponsible := make(map[string]map[uint8]int)
+	totalNumBatchesPerQuorum := make(map[uint8]int)
+
+	for _, attestation := range attestations {
+		if len(attestation.QuorumNumbers) == 0 {
+			continue
+		}
+
+		batchHeaderHash, err := attestation.BatchHeader.Hash()
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("hash batch header: %w", err)
+		}
+		key := hex.EncodeToString(batchHeaderHash[:])
+		profile, ok := profiles[key]
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("batch quorum profile not found for batch %s", key)
+		}
+
+		for quorum := range profile.quorums {
+			totalNumBatchesPerQuorum[quorum]++
+		}
+
+		nonSigners := make(map[string]struct{}, len(attestation.NonSignerPubKeys))
+		for _, pubkey := range attestation.NonSignerPubKeys {
+			if pubkey == nil {
+				return nil, nil, nil, fmt.Errorf("attestation contains a nil non-signer public key")
+			}
+			nonSigners[pubkey.GetOperatorID().Hex()] = struct{}{}
+		}
+
+		for operatorID := range operatorQuorumIntervals {
+			operatorQuorums := operatorQuorumIntervals.GetQuorums(
+				operatorID,
+				uint32(attestation.ReferenceBlockNumber),
+			)
+			if !profile.operatorIsEligible(operatorQuorums) {
+				continue
+			}
+
+			for _, quorum := range operatorQuorums {
+				if _, ok := profile.quorums[quorum]; !ok {
+					continue
+				}
+				if _, ok := numResponsible[operatorID]; !ok {
+					numResponsible[operatorID] = make(map[uint8]int)
+				}
+				numResponsible[operatorID][quorum]++
+
+				if _, failed := nonSigners[operatorID]; failed {
+					if _, ok := numFailed[operatorID]; !ok {
+						numFailed[operatorID] = make(map[uint8]int)
+					}
+					numFailed[operatorID][quorum]++
+				}
+			}
+		}
+	}
+
+	return numFailed, numResponsible, totalNumBatchesPerQuorum, nil
+}

--- a/disperser/dataapi/v2/signing_info.go
+++ b/disperser/dataapi/v2/signing_info.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sync"
 
 	"github.com/Layr-Labs/eigenda/core"
 	corev2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/disperser/dataapi"
+	"golang.org/x/sync/errgroup"
 )
 
 type signingInfoAccountingMode string
@@ -16,7 +18,9 @@ const (
 	legacySigningInfoAccountingMode     signingInfoAccountingMode = "legacy"
 	blobQuorumSigningInfoAccountingMode signingInfoAccountingMode = "blob_quorums"
 
-	maxBlobQuorumSigningInfoIntervalSeconds = 3600
+	maxBlobQuorumSigningInfoIntervalSeconds = 12 * 60 * 60
+	batchQuorumProfileLoadChunkSize         = 100
+	batchQuorumProfileLoadConcurrency       = 8
 )
 
 // batchQuorumProfile contains the minimum batch data needed to determine which
@@ -30,24 +34,30 @@ func newBatchQuorumProfile(batch *corev2.Batch) (*batchQuorumProfile, error) {
 	if batch == nil || batch.BatchHeader == nil {
 		return nil, fmt.Errorf("batch header is required")
 	}
-	if len(batch.BlobCertificates) == 0 {
-		return nil, fmt.Errorf("batch must contain at least one blob certificate")
+
+	blobQuorums, err := batch.GetBlobQuorumNumbers()
+	if err != nil {
+		return nil, err
 	}
 
+	return newBatchQuorumProfileFromBlobQuorums(blobQuorums)
+}
+
+func newBatchQuorumProfileFromBlobQuorums(blobQuorums [][]core.QuorumID) (*batchQuorumProfile, error) {
+	if len(blobQuorums) == 0 {
+		return nil, fmt.Errorf("batch must contain at least one blob quorum set")
+	}
 	profile := &batchQuorumProfile{
-		blobQuorums: make([][]core.QuorumID, len(batch.BlobCertificates)),
+		blobQuorums: make([][]core.QuorumID, len(blobQuorums)),
 		quorums:     make(map[core.QuorumID]struct{}),
 	}
-	for i, certificate := range batch.BlobCertificates {
-		if certificate == nil || certificate.BlobHeader == nil {
-			return nil, fmt.Errorf("blob certificate %d is missing its header", i)
-		}
-		if len(certificate.BlobHeader.QuorumNumbers) == 0 {
-			return nil, fmt.Errorf("blob certificate %d has no quorums", i)
+	for i, quorumNumbers := range blobQuorums {
+		if len(quorumNumbers) == 0 {
+			return nil, fmt.Errorf("blob quorum set %d has no quorums", i)
 		}
 
-		profile.blobQuorums[i] = append([]core.QuorumID(nil), certificate.BlobHeader.QuorumNumbers...)
-		for _, quorum := range certificate.BlobHeader.QuorumNumbers {
+		profile.blobQuorums[i] = append([]core.QuorumID(nil), quorumNumbers...)
+		for _, quorum := range quorumNumbers {
 			profile.quorums[quorum] = struct{}{}
 		}
 	}
@@ -130,6 +140,14 @@ func (s *ServerV2) getBatchQuorumProfiles(
 			return nil, fmt.Errorf("hash batch header: %w", err)
 		}
 		key := hex.EncodeToString(batchHeaderHash[:])
+		if len(attestation.BlobQuorumNumbers) > 0 {
+			profile, err := newBatchQuorumProfileFromBlobQuorums(attestation.BlobQuorumNumbers)
+			if err != nil {
+				return nil, fmt.Errorf("create persisted batch quorum profile for batch %s: %w", key, err)
+			}
+			profiles[key] = profile
+			continue
+		}
 		if profile, ok := s.batchQuorumProfileCache.Get(key); ok {
 			profiles[key] = profile
 			continue
@@ -142,26 +160,48 @@ func (s *ServerV2) getBatchQuorumProfiles(
 	}
 
 	if len(missingHashes) > 0 {
-		batches, err := s.blobMetadataStore.GetBatches(ctx, missingHashes)
-		if err != nil {
-			return nil, fmt.Errorf("get batches: %w", err)
+		var profilesMu sync.Mutex
+		group, groupCtx := errgroup.WithContext(ctx)
+		group.SetLimit(batchQuorumProfileLoadConcurrency)
+
+		for start := 0; start < len(missingHashes); start += batchQuorumProfileLoadChunkSize {
+			end := min(start+batchQuorumProfileLoadChunkSize, len(missingHashes))
+			hashes := append([][32]byte(nil), missingHashes[start:end]...)
+			group.Go(func() error {
+				batches, err := s.blobMetadataStore.GetBatches(groupCtx, hashes)
+				if err != nil {
+					return fmt.Errorf("get batches: %w", err)
+				}
+
+				loadedProfiles := make(map[string]*batchQuorumProfile, len(batches))
+				for _, batch := range batches {
+					profile, err := newBatchQuorumProfile(batch)
+					if err != nil {
+						return fmt.Errorf("create batch quorum profile: %w", err)
+					}
+					batchHeaderHash, err := batch.BatchHeader.Hash()
+					if err != nil {
+						return fmt.Errorf("hash batch header: %w", err)
+					}
+					key := hex.EncodeToString(batchHeaderHash[:])
+					if _, ok := missingKeys[key]; !ok {
+						return fmt.Errorf("received unexpected batch %s", key)
+					}
+					loadedProfiles[key] = profile
+				}
+
+				profilesMu.Lock()
+				defer profilesMu.Unlock()
+				for key, profile := range loadedProfiles {
+					profiles[key] = profile
+					s.batchQuorumProfileCache.Add(key, profile)
+				}
+				return nil
+			})
 		}
 
-		for _, batch := range batches {
-			profile, err := newBatchQuorumProfile(batch)
-			if err != nil {
-				return nil, fmt.Errorf("create batch quorum profile: %w", err)
-			}
-			batchHeaderHash, err := batch.BatchHeader.Hash()
-			if err != nil {
-				return nil, fmt.Errorf("hash batch header: %w", err)
-			}
-			key := hex.EncodeToString(batchHeaderHash[:])
-			if _, ok := missingKeys[key]; !ok {
-				return nil, fmt.Errorf("received unexpected batch %s", key)
-			}
-			profiles[key] = profile
-			s.batchQuorumProfileCache.Add(key, profile)
+		if err := group.Wait(); err != nil {
+			return nil, err
 		}
 	}
 

--- a/disperser/dataapi/v2/signing_info.go
+++ b/disperser/dataapi/v2/signing_info.go
@@ -37,7 +37,7 @@ func newBatchQuorumProfile(batch *corev2.Batch) (*batchQuorumProfile, error) {
 
 	blobQuorums, err := batch.GetBlobQuorumNumbers()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get blob quorum numbers: %w", err)
 	}
 
 	return newBatchQuorumProfileFromBlobQuorums(blobQuorums)
@@ -201,7 +201,7 @@ func (s *ServerV2) getBatchQuorumProfiles(
 		}
 
 		if err := group.Wait(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("load historical batch quorum profiles: %w", err)
 		}
 	}
 

--- a/disperser/dataapi/v2/signing_info_test.go
+++ b/disperser/dataapi/v2/signing_info_test.go
@@ -65,6 +65,14 @@ func TestComputeBlobQuorumSigningStats(t *testing.T) {
 	require.NotContains(t, numFailed, dualQuorumID)
 }
 
+func TestNewBatchQuorumProfileFromBlobQuorumsValidation(t *testing.T) {
+	_, err := newBatchQuorumProfileFromBlobQuorums(nil)
+	require.ErrorContains(t, err, "at least one blob quorum set")
+
+	_, err = newBatchQuorumProfileFromBlobQuorums([][]core.QuorumID{{}})
+	require.ErrorContains(t, err, "has no quorums")
+}
+
 func TestDeduplicateAttestationsKeepsLatestUpdate(t *testing.T) {
 	header := &corev2.BatchHeader{BatchRoot: [32]byte{1}, ReferenceBlockNumber: 1}
 	attestations := []*corev2.Attestation{

--- a/disperser/dataapi/v2/signing_info_test.go
+++ b/disperser/dataapi/v2/signing_info_test.go
@@ -1,0 +1,118 @@
+package v2
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/Layr-Labs/eigenda/core"
+	corev2 "github.com/Layr-Labs/eigenda/core/v2"
+	"github.com/Layr-Labs/eigenda/disperser/dataapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeBlobQuorumSigningStats(t *testing.T) {
+	ethOnlyPubkey := core.NewG1Point(big.NewInt(1), big.NewInt(2))
+	dualQuorumPubkey := core.NewG1Point(big.NewInt(3), big.NewInt(4))
+	ethOnlyID := ethOnlyPubkey.GetOperatorID().Hex()
+	dualQuorumID := dualQuorumPubkey.GetOperatorID().Hex()
+
+	operatorQuorumIntervals := dataapi.OperatorQuorumIntervals{
+		ethOnlyID: {
+			0: {{StartBlock: 1, EndBlock: 10}},
+		},
+		dualQuorumID: {
+			0: {{StartBlock: 1, EndBlock: 10}},
+			1: {{StartBlock: 1, EndBlock: 10}},
+		},
+	}
+
+	profiles := make(map[string]*batchQuorumProfile)
+	attestations := []*corev2.Attestation{
+		// A phantom ETH quorum in the attestation must not make an ETH-only
+		// operator responsible for an EIGEN-only blob.
+		newSigningInfoTestBatch(t, 1, 1, [][]core.QuorumID{{1}}, []core.QuorumID{0, 1},
+			[]*core.G1Point{ethOnlyPubkey}, profiles),
+		// An ETH-only batch is part of the ETH-only operator's denominator.
+		newSigningInfoTestBatch(t, 2, 2, [][]core.QuorumID{{0}}, []core.QuorumID{0},
+			[]*core.G1Point{ethOnlyPubkey}, profiles),
+		// The ETH-only operator cannot validate every blob in this batch.
+		newSigningInfoTestBatch(t, 3, 3, [][]core.QuorumID{{0}, {1}}, []core.QuorumID{0, 1},
+			[]*core.G1Point{ethOnlyPubkey}, profiles),
+		// One multi-quorum blob is valid for an ETH-only operator. Quorum 0 is
+		// intentionally absent from the attestation to verify that absence is
+		// not treated as a missed signature.
+		newSigningInfoTestBatch(t, 4, 4, [][]core.QuorumID{{0, 1}}, []core.QuorumID{1},
+			nil, profiles),
+		// Empty attestations have no reliable non-signer set and are excluded.
+		{
+			BatchHeader: &corev2.BatchHeader{BatchRoot: [32]byte{5}, ReferenceBlockNumber: 5},
+			AttestedAt:  5,
+		},
+	}
+
+	numFailed, numResponsible, totalBatches, err := computeBlobQuorumSigningStats(
+		attestations,
+		profiles,
+		operatorQuorumIntervals,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, map[uint8]int{0: 3, 1: 3}, totalBatches)
+	require.Equal(t, map[uint8]int{0: 2}, numResponsible[ethOnlyID])
+	require.Equal(t, map[uint8]int{0: 1}, numFailed[ethOnlyID])
+	require.Equal(t, map[uint8]int{0: 3, 1: 3}, numResponsible[dualQuorumID])
+	require.NotContains(t, numFailed, dualQuorumID)
+}
+
+func TestDeduplicateAttestationsKeepsLatestUpdate(t *testing.T) {
+	header := &corev2.BatchHeader{BatchRoot: [32]byte{1}, ReferenceBlockNumber: 1}
+	attestations := []*corev2.Attestation{
+		{BatchHeader: header, AttestedAt: 1},
+		{BatchHeader: header, AttestedAt: 3, QuorumNumbers: []core.QuorumID{0}},
+		{BatchHeader: header, AttestedAt: 2, QuorumNumbers: []core.QuorumID{0, 1}},
+	}
+
+	deduplicated, err := deduplicateAttestations(attestations)
+	require.NoError(t, err)
+	require.Len(t, deduplicated, 1)
+	require.Same(t, attestations[1], deduplicated[0])
+}
+
+func newSigningInfoTestBatch(
+	t *testing.T,
+	batchRoot byte,
+	attestedAt uint64,
+	blobQuorums [][]core.QuorumID,
+	attestationQuorums []core.QuorumID,
+	nonSigners []*core.G1Point,
+	profiles map[string]*batchQuorumProfile,
+) *corev2.Attestation {
+	t.Helper()
+
+	header := &corev2.BatchHeader{
+		BatchRoot:            [32]byte{batchRoot},
+		ReferenceBlockNumber: attestedAt,
+	}
+	certificates := make([]*corev2.BlobCertificate, len(blobQuorums))
+	for i, quorums := range blobQuorums {
+		certificates[i] = &corev2.BlobCertificate{
+			BlobHeader: &corev2.BlobHeader{QuorumNumbers: quorums},
+		}
+	}
+	profile, err := newBatchQuorumProfile(&corev2.Batch{
+		BatchHeader:      header,
+		BlobCertificates: certificates,
+	})
+	require.NoError(t, err)
+	batchHeaderHash, err := header.Hash()
+	require.NoError(t, err)
+	profiles[hex.EncodeToString(batchHeaderHash[:])] = profile
+
+	return &corev2.Attestation{
+		BatchHeader:      header,
+		AttestedAt:       attestedAt,
+		NonSignerPubKeys: nonSigners,
+		QuorumNumbers:    attestationQuorums,
+	}
+}

--- a/ejector/data_api_signing_rate_lookup.go
+++ b/ejector/data_api_signing_rate_lookup.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/logging"
 )
 
+const blobQuorumSigningInfoAccountingMode = "blob_quorums"
+
 var _ = (*dataApiSigningRateLookup)(nil)
 
 // Uses batch information in dynamoDB to determine signing rates.
@@ -195,9 +197,7 @@ func (srl *dataApiSigningRateLookup) getV2SigningRates(
 	q.Set("end", now.UTC().Format(time.RFC3339))
 	// interval: lookback window in seconds
 	q.Set("interval", strconv.Itoa(int(timeSpan.Seconds())))
-	if omitPerfectSigners {
-		q.Set("nonsigner_only", "true")
-	}
+	q.Set("accounting", blobQuorumSigningInfoAccountingMode)
 	url.RawQuery = q.Encode()
 	// Very verbose, enable for debugging if needed.
 	// srl.logger.Debug("making request to DataAPI", "url", url.String())
@@ -268,6 +268,9 @@ func (srl *dataApiSigningRateLookup) getV2SigningRates(
 
 	signingRates := make([]*validator.ValidatorSigningRate, 0, len(signingRateMap))
 	for _, rate := range signingRateMap {
+		if omitPerfectSigners && rate.GetUnsignedBatches() == 0 {
+			continue
+		}
 		signingRates = append(signingRates, rate)
 	}
 
@@ -303,7 +306,18 @@ func translateV2ToProto(data *dataapiv2.OperatorSigningInfo) (*validator.Validat
 		return nil, fmt.Errorf("error parsing operator ID %s: %w", data.OperatorId, err)
 	}
 
-	signedBatches := data.TotalBatches - data.TotalUnsignedBatches
+	if data.TotalResponsibleBatches < 0 ||
+		data.TotalUnsignedBatches < 0 ||
+		data.TotalUnsignedBatches > data.TotalResponsibleBatches {
+		return nil, fmt.Errorf(
+			"invalid batch counts for operator %s: responsible=%d, unsigned=%d",
+			data.OperatorId,
+			data.TotalResponsibleBatches,
+			data.TotalUnsignedBatches,
+		)
+	}
+
+	signedBatches := data.TotalResponsibleBatches - data.TotalUnsignedBatches
 	unsignedBatches := data.TotalUnsignedBatches
 
 	signingRate := &validator.ValidatorSigningRate{

--- a/ejector/ejector.go
+++ b/ejector/ejector.go
@@ -118,7 +118,7 @@ func (e *Ejector) evaluateValidators() error {
 		e.ejectionCriteriaTimeWindow,
 		nil, // all quorums
 		ProtocolVersionV2,
-		true, // omit perfect signers if possible (data API has inconsistent behavior across v1 and v2)
+		false, // perfect V2 signers must be retained so they can cancel a V1 ejection
 	)
 	if err != nil {
 		return fmt.Errorf("error looking up v2 signing rates: %w", err)

--- a/ejector/signing_rate_lookup_test.go
+++ b/ejector/signing_rate_lookup_test.go
@@ -1,15 +1,116 @@
 package ejector
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Layr-Labs/eigenda/api/grpc/validator"
 	"github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/core"
+	dataapiv2 "github.com/Layr-Labs/eigenda/disperser/dataapi/v2"
 	"github.com/Layr-Labs/eigenda/test"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDataApiV2LookupUsesBlobQuorumResponsibility(t *testing.T) {
+	operatorID := strings.Repeat("01", 32)
+	perfectOperatorID := strings.Repeat("02", 32)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v2/operators/signing-info", r.URL.Path)
+		require.Equal(t, blobQuorumSigningInfoAccountingMode, r.URL.Query().Get("accounting"))
+		require.Equal(t, "43200", r.URL.Query().Get("interval"))
+		require.Empty(t, r.URL.Query().Get("nonsigner_only"))
+
+		err := json.NewEncoder(w).Encode(dataapiv2.OperatorsSigningInfoResponse{
+			OperatorSigningInfo: []*dataapiv2.OperatorSigningInfo{
+				{
+					OperatorId:              operatorID,
+					QuorumId:                0,
+					TotalUnsignedBatches:    0,
+					TotalResponsibleBatches: 10,
+					TotalBatches:            100,
+				},
+				{
+					OperatorId:              operatorID,
+					QuorumId:                1,
+					TotalUnsignedBatches:    1,
+					TotalResponsibleBatches: 1,
+					TotalBatches:            100,
+				},
+				{
+					OperatorId:              perfectOperatorID,
+					QuorumId:                0,
+					TotalUnsignedBatches:    0,
+					TotalResponsibleBatches: 5,
+					TotalBatches:            100,
+				},
+			},
+		})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	lookup := NewDataApiSigningRateLookup(common.TestLogger(t), server.URL, time.Second)
+	signingRates, err := lookup.GetSigningRates(
+		12*time.Hour,
+		nil,
+		ProtocolVersionV2,
+		true,
+	)
+	require.NoError(t, err)
+	require.Len(t, signingRates, 1)
+
+	validatorID, err := core.OperatorIDFromHex(operatorID)
+	require.NoError(t, err)
+	require.Equal(t, validatorID[:], signingRates[0].GetValidatorId())
+	require.Equal(t, uint64(10), signingRates[0].GetSignedBatches())
+	require.Equal(t, uint64(1), signingRates[0].GetUnsignedBatches())
+	require.Equal(t, uint64(10), signingRates[0].GetSignedBytes())
+	require.Equal(t, uint64(1), signingRates[0].GetUnsignedBytes())
+}
+
+func TestEvaluateValidatorsRetainsPerfectV2Signers(t *testing.T) {
+	v1Lookup := &recordingSigningRateLookup{}
+	v2Lookup := &recordingSigningRateLookup{}
+	ejector := &Ejector{
+		logger:                     common.TestLogger(t),
+		signingRateLookupV1:        v1Lookup,
+		signingRateLookupV2:        v2Lookup,
+		ejectionCriteriaTimeWindow: time.Hour,
+	}
+
+	require.NoError(t, ejector.evaluateValidators())
+	require.Equal(t, []bool{true}, v1Lookup.omitPerfectSigners)
+	require.Equal(t, []bool{false}, v2Lookup.omitPerfectSigners)
+}
+
+func TestTranslateV2ToProtoRejectsInvalidResponsibilityCounts(t *testing.T) {
+	_, err := translateV2ToProto(&dataapiv2.OperatorSigningInfo{
+		OperatorId:              strings.Repeat("01", 32),
+		TotalUnsignedBatches:    2,
+		TotalResponsibleBatches: 1,
+	})
+	require.ErrorContains(t, err, "invalid batch counts")
+}
+
+type recordingSigningRateLookup struct {
+	omitPerfectSigners []bool
+}
+
+func (r *recordingSigningRateLookup) GetSigningRates(
+	_ time.Duration,
+	_ []core.QuorumID,
+	_ ProtocolVersion,
+	omitPerfectSigners bool,
+) ([]*validator.ValidatorSigningRate, error) {
+	r.omitPerfectSigners = append(r.omitPerfectSigners, omitPerfectSigners)
+	return nil, nil
+}
 
 func TestDataApiLookup(t *testing.T) {
 	test.SkipInCI(t)


### PR DESCRIPTION
## Why are these changes needed?

The V2 signing-info endpoint derived batch responsibility from `Attestation.QuorumNumbers`. Those quorums reflect which registered quorums accumulated signed stake, not which quorums the blobs requested.

For example, a signer registered in both ETH and EIGEN can make quorum 0 appear in the attestation for an EIGEN-only batch. The legacy accounting path then reports quorum-0-only validators as non-signers for a batch they could not validate and were not responsible for.

Investigation context: https://gist.github.com/mmurrs/cfb4139d0691c47bad6c1d7fff6f1d98

## What changed?

- Make blob-quorum responsibility accounting the default for `/v2/operators/signing-info`.
- Keep `accounting=legacy` as an explicit rollback/debugging escape hatch.
- Determine eligibility from each blob's requested quorum set: an operator is responsible only if it had an assignment for every blob in the batch.
- Attribute responsibility and failures only to blob-requested quorums in which that operator was registered.
- Persist the compact per-blob quorum profile with new controller attestations, avoiding full-batch reads in steady state.
- Retain a historical-record fallback that loads full batches in bounded parallel chunks and caches compact profiles.
- Support the production ejector's 12-hour (`43200` second) lookback.
- Update the ejector to:
  - explicitly request `accounting=blob_quorums`;
  - derive signed batches from `TotalResponsibleBatches`, not `TotalBatches`;
  - aggregate all V2 quorum rows before optionally omitting perfect validators;
  - retain perfect V2 validators in production so V2 activity can cancel an otherwise eligible V1 ejection.
- Exclude empty/in-progress attestations and deduplicate mutable attestation updates by batch-header hash.
- Upgrade the pinned Codecov action to v7 so coverage uploads trust Codecov's migrated signing key.

## Rollout

Deploying the controller first is preferred. New attestations will immediately carry compact blob-quorum profiles; once the maximum lookback has elapsed, the DataAPI/ejector path no longer needs historical full-batch fallback reads.

The fallback remains correct during a simultaneous rollout. Its reads are bounded, parallelized, and cached, but the first cold 12-hour query can still be heavier than steady state.

## Checks

- `go test ./core/v2`
- `go test ./ejector`
- `go test -c ./disperser/dataapi/v2`
- `go test -c ./disperser/controller`
- `go test -c ./disperser/common/v2/blobstore`
- `go vet ./core/v2 ./ejector ./disperser/dataapi/v2 ./disperser/controller ./disperser/common/v2/blobstore`
- `go mod tidy -diff`

The DataAPI/controller integration binaries compile locally. Their full suites require Docker/LocalStack and are left to CI in this environment.

Regression coverage includes:

- quorum-0-only validators and phantom quorum-0 attestations for quorum-1-only blobs;
- endpoint quorum filtering without losing an operator's full membership bitmap;
- separate mixed-quorum blobs and multi-quorum blobs;
- missing attestation quorum entries;
- registration intervals;
- empty and duplicate attestations;
- compact profile persistence and historical fallback;
- the 12-hour production interval;
- ejector responsibility-denominator and cross-quorum aggregation behavior.
