### PR TITLE
ci: bind workflow inputs via env in shell steps

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -51,6 +51,8 @@ runs:
 
     - name: Push to wiki
       shell: bash
+      env:
+        INPUT_AMEND: ${{ inputs.amend }}
       run: |
         cd ./.github/wiki/
         git add --all
@@ -58,6 +60,6 @@ runs:
         git config --local user.name  "GitHub Action"
         git config --local user.email "action@github.com"
         git remote set-url --push origin https://${{ github.token }}@github.com/Layr-Labs/eigenda.wiki.git
-        test ${{inputs.amend}} == "true" && \
+        test "$INPUT_AMEND" == "true" && \
           git commit --amend --no-edit   && git push --force-with-lease || \
           git commit -m "Update coverage" && git push https://${{ github.token }}@github.com/Layr-Labs/eigenda.wiki.git

--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -46,9 +46,12 @@ jobs:
         with:
           useConfigFile: true
 
-      - run: |
-          echo "SemVer ${{ env.fullSemVer }} Forced ${{ github.event.inputs.force }}"
-        name: Display SemVer
+      - name: Display SemVer
+        env:
+          FULL_SEMVER: ${{ env.fullSemVer }}
+          FORCE_RELEASE: ${{ github.event.inputs.force }}
+        run: |
+          echo "SemVer $FULL_SEMVER Forced $FORCE_RELEASE"
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/eigenda-releaser.yaml
+++ b/.github/workflows/eigenda-releaser.yaml
@@ -43,26 +43,29 @@ jobs:
           echo "Branch validation passed: running on $branch"
 
       - name: Validate version format
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          version="${{ github.event.inputs.version }}"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Version must be in format x.y.z (e.g., 1.2.3)"
             exit 1
           fi
-          echo "Version format is valid: $version"
+          echo "Version format is valid: $VERSION"
 
       - name: Check if release branch already exists
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          version="${{ github.event.inputs.version }}"
-          if git branch -r | grep -q "origin/release/$version$"; then
-            echo "Error: Release branch release/$version already exists"
+          if git branch -r | grep -q "origin/release/$VERSION$"; then
+            echo "Error: Release branch release/$VERSION already exists"
             exit 1
           fi
-          echo "Release branch for version $version is available"
+          echo "Release branch for version $VERSION is available"
 
       - name: Create and push release branch
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          version="${{ github.event.inputs.version }}"
           git config --global user.name "releaser-bot"
-          git checkout -b "release/$version"
-          git push origin "release/$version"
+          git checkout -b "release/$VERSION"
+          git push origin "release/$VERSION"


### PR DESCRIPTION
## Why are these changes needed?

GitHub Actions expands `${{ ... }}` before the shell runs. Binding `workflow_dispatch` / composite inputs through `env:` keeps those values out of the script text and matches common Actions hardening guidance.

## Checks

- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, in that case, please comment that they are not relevant.
- [ ] I've checked the new test coverage and the coverage percentage didn't drop.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Integration tests
   - [x] This PR is not tested :(

## Summary

- `eigenda-releaser.yaml`: bind `version` via `VERSION`
- `docker-publish-release.yaml`: bind display values via env
- `test-coverage` composite: bind `amend` via `INPUT_AMEND`

No behavior change intended.

Made with [Cursor](https://cursor.com)